### PR TITLE
Restart failed inquire/research within the same phase

### DIFF
--- a/internal/orchestrator/lifecycle_delegates.go
+++ b/internal/orchestrator/lifecycle_delegates.go
@@ -1062,8 +1062,16 @@ func (o *Orchestrator) RestartPhase(featureID string, maxIterationsDelta, maxPla
 		// fix) — pressing Restart should recover it via plain re-dispatch.
 	case feature.StatusFailed:
 		switch phase {
-		case feature.PhaseKnowledgeBase, feature.PhaseInquire, feature.PhaseResearch:
+		case feature.PhaseKnowledgeBase:
 			if err := o.TransitionTo(featureID, feature.StatusCreated); err != nil {
+				return RestartOutcome{}, err
+			}
+		case feature.PhaseInquire:
+			if err := o.TransitionTo(featureID, feature.StatusInquiring); err != nil {
+				return RestartOutcome{}, err
+			}
+		case feature.PhaseResearch:
+			if err := o.TransitionTo(featureID, feature.StatusResearching); err != nil {
 				return RestartOutcome{}, err
 			}
 		case feature.PhaseBrainstorm:

--- a/internal/orchestrator/lifecycle_delegates_test.go
+++ b/internal/orchestrator/lifecycle_delegates_test.go
@@ -556,6 +556,56 @@ func TestOrchestrator_RestartPhase_RunningResearch_TransitionsToInterrupted(t *t
 	}
 }
 
+func TestOrchestrator_RestartPhase_FailedSingleShotPhase_TransitionsToSamePhaseStartableStatus(t *testing.T) {
+	tests := []struct {
+		name       string
+		phase      feature.Phase
+		wantStatus feature.Status
+	}{
+		{
+			name:       "failed inquire restarts inquire",
+			phase:      feature.PhaseInquire,
+			wantStatus: feature.StatusInquiring,
+		},
+		{
+			name:       "failed research restarts research",
+			phase:      feature.PhaseResearch,
+			wantStatus: feature.StatusResearching,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := &feature.Feature{
+				ID:           "feat-1",
+				Status:       feature.StatusFailed,
+				CurrentPhase: tt.phase,
+			}
+			lc := lifecycleForFeature(f)
+			fs := newFeatureStore(f)
+
+			o := orchestrator.New(orchestrator.Deps{
+				Lifecycle: lc,
+				Store:     fs,
+			}, orchestrator.Hooks{})
+
+			outcome, err := o.RestartPhase("feat-1", 0, 0)
+			if err != nil {
+				t.Fatalf("RestartPhase: %v", err)
+			}
+			if outcome.Action != orchestrator.RestartDispatchPhase {
+				t.Fatalf("Action = %v, want RestartDispatchPhase", outcome.Action)
+			}
+			if outcome.Phase != tt.phase {
+				t.Errorf("Phase = %v, want %v", outcome.Phase, tt.phase)
+			}
+			if f.Status != tt.wantStatus {
+				t.Errorf("Status = %v, want %v", f.Status, tt.wantStatus)
+			}
+		})
+	}
+}
+
 // TestOrchestrator_RestartPhase_InterruptedFeature_KeepsStatus
 // ---------------------------------------------------------------------------
 // A feature already at StatusInterrupted needs no transition — StartFeature

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -1055,6 +1055,8 @@ func TestRestartFromFailedResearchPhase(t *testing.T) {
 	_ = fm.Transition(f.ID, feature.StatusResearching)
 	_ = fm.Transition(f.ID, feature.StatusFailed)
 	f, _ = fm.Get(f.ID)
+	f.CurrentPhase = feature.PhaseResearch
+	_ = fm.Store.Save(f)
 
 	sm := session.NewManager(nil)
 	app.sessionManager = sm
@@ -1063,8 +1065,8 @@ func TestRestartFromFailedResearchPhase(t *testing.T) {
 	_ = cmd()
 
 	f, _ = fm.Get(f.ID)
-	if f.Status != feature.StatusCreated {
-		t.Errorf("feature status = %v, want StatusCreated after restart from Failed+PhaseResearch", f.Status)
+	if f.Status != feature.StatusResearching {
+		t.Errorf("feature status = %v, want StatusResearching after restart from Failed+PhaseResearch", f.Status)
 	}
 }
 


### PR DESCRIPTION
## Summary
- `RestartPhase` previously sent any failed `Inquire` or `Research` phase back to `StatusCreated`, which restarts the feature from the `KnowledgeBase` phase instead of the phase the user pressed Restart from.
- Map each failed single-shot phase to its own startable status (`PhaseInquire → StatusInquiring`, `PhaseResearch → StatusResearching`) so a restart resumes in place. `PhaseKnowledgeBase` still goes back to `StatusCreated`.
- Updated the existing `TestRestartFromFailedResearchPhase` expectation and added a table-driven orchestrator test covering the failed-inquire and failed-research restart paths.

## Test plan
- [x] `go test ./internal/orchestrator/... -run TestOrchestrator_RestartPhase -count=1`
- [x] `go test ./internal/tui/... -run TestRestartFromFailed -count=1`
- [ ] `make test-fast`

## Verification
- Fast suite: pending (ran targeted orchestrator + TUI restart tests locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)