### PR TITLE
Interrupt published features with active non-interactive cycles

### DIFF
--- a/internal/orchestrator/lifecycle_delegates.go
+++ b/internal/orchestrator/lifecycle_delegates.go
@@ -1034,9 +1034,17 @@ func (o *Orchestrator) RestartPhase(featureID string, maxIterationsDelta, maxPla
 		_ = o.ExtendFailedPhaseBudget(featureID, maxIterationsDelta, maxPlanIterationsDelta)
 	}
 
-	// Published features with repo cycles (running or failed): clear and
-	// return the per-cycle restart descriptors for the TUI to dispatch.
-	if f.Status == feature.StatusPublished && len(f.RepoCycles) > 0 {
+	// Published/code-ready features with repo cycles (running, failed, or
+	// interrupted): clear and return per-cycle restart descriptors for the
+	// TUI to dispatch. Interrupted post-publish cycles first restore the
+	// feature to the publishable base state so the relaunched cycle is again
+	// treated as active post-publish work rather than a plain phase restart.
+	if (f.Status == feature.StatusPublished || f.Status == feature.StatusCodeReady || f.Status == feature.StatusInterrupted) && len(f.RepoCycles) > 0 {
+		if f.Status == feature.StatusInterrupted {
+			if err := o.restoreStatusForRepoCycleRestart(featureID); err != nil {
+				return RestartOutcome{}, fmt.Errorf("restore status for cycle restart: %w", err)
+			}
+		}
 		restarts, refactor, collectErr := o.CollectAndClearRepoCycleRestarts(featureID)
 		if collectErr != nil {
 			return RestartOutcome{}, fmt.Errorf("collect cycles: %w", collectErr)
@@ -1114,6 +1122,22 @@ func (o *Orchestrator) RestartPhase(featureID string, maxIterationsDelta, maxPla
 	}
 
 	return RestartOutcome{Action: RestartDispatchPhase, Phase: phase}, nil
+}
+
+func (o *Orchestrator) restoreStatusForRepoCycleRestart(featureID string) error {
+	return o.deps.Store.Modify(featureID, func(f *feature.Feature) error {
+		if len(f.PRURLs()) > 0 {
+			f.Status = feature.StatusPublished
+		} else {
+			f.Status = feature.StatusCodeReady
+		}
+		f.CurrentPhase = feature.PhasePublish
+		f.ActiveCycle = nil
+		f.SetActiveCycleType("")
+		f.LastError = ""
+		f.FailureType = ""
+		return nil
+	})
 }
 
 // lookupRoadmapPhaseName returns the friendly name of the given roadmap phase

--- a/internal/orchestrator/lifecycle_delegates_test.go
+++ b/internal/orchestrator/lifecycle_delegates_test.go
@@ -521,6 +521,57 @@ func TestOrchestrator_RestartPhase_PublishedWithRepoCycles_ReturnsRestartList(t 
 	assertLifecycleCall(t, lc, "ClearRepoCycles")
 }
 
+func TestOrchestrator_RestartPhase_InterruptedWithRepoCycles_ReturnsRestartList(t *testing.T) {
+	tmp := t.TempDir()
+	planPath := filepath.Join(tmp, "rebase-plan.md")
+	if err := os.WriteFile(planPath, []byte("rebase plan"), 0o644); err != nil {
+		t.Fatalf("write plan: %v", err)
+	}
+
+	f := &feature.Feature{
+		ID:           "feat-1",
+		Status:       feature.StatusInterrupted,
+		CurrentPhase: feature.PhasePublish,
+		Repos: []feature.FeatureRepo{
+			{Name: "repo-a"},
+		},
+		RepoStates: map[string]*feature.RepoState{
+			"repo-a": {Touched: true, PRURL: "https://github.com/example/repo/pull/1"},
+		},
+		RepoCycles: map[string]*feature.RepoCycleState{
+			"repo-a": {Type: feature.CycleRebase, Status: feature.RepoCycleInterrupted, PlanPath: planPath},
+		},
+	}
+	lc := lifecycleForFeature(f)
+	fs := newFeatureStore(f)
+
+	o := orchestrator.New(orchestrator.Deps{
+		Lifecycle: lc,
+		Store:     fs,
+	}, orchestrator.Hooks{})
+
+	outcome, err := o.RestartPhase("feat-1", 0, 0)
+	if err != nil {
+		t.Fatalf("RestartPhase: %v", err)
+	}
+	if outcome.Action != orchestrator.RestartDispatchRepoCycles {
+		t.Fatalf("Action = %v, want RestartDispatchRepoCycles", outcome.Action)
+	}
+	if len(outcome.RepoCycleRestarts) != 1 {
+		t.Fatalf("expected 1 repo-cycle restart, got %d", len(outcome.RepoCycleRestarts))
+	}
+	if outcome.RepoCycleRestarts[0].RepoName != "repo-a" {
+		t.Errorf("RepoName = %q, want repo-a", outcome.RepoCycleRestarts[0].RepoName)
+	}
+	if outcome.RepoCycleRestarts[0].PlanContent != "rebase plan" {
+		t.Errorf("PlanContent = %q, want %q", outcome.RepoCycleRestarts[0].PlanContent, "rebase plan")
+	}
+	if f.Status != feature.StatusPublished {
+		t.Errorf("Status after restart preparation = %v, want Published", f.Status)
+	}
+	assertLifecycleCall(t, lc, "ClearRepoCycles")
+}
+
 // TestOrchestrator_RestartPhase_RunningResearch_TransitionsToInterrupted
 // ---------------------------------------------------------------------------
 // A feature actively running the research phase moves to StatusInterrupted

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1075,8 +1075,10 @@ func (o *Orchestrator) startFinalReview(featureID string) (PhaseStartResult, err
 	return PhaseStartResult{Outcome: PhaseStarted}, nil
 }
 
-// InterruptFeature stops all sessions for a feature, clears pending help and
-// permission queue flags, and transitions the feature to StatusInterrupted.
+// InterruptFeature stops all sessions for a feature and clears pending help
+// and permission queue flags. Normal phase work and non-interactive
+// post-publish repo cycles transition the feature to StatusInterrupted; tweak-
+// only post-publish cycles keep their published/code-ready feature status.
 // Does NOT clear KBStatus — preserve per-repo KB tracking for resume.
 //
 // Ordering matters: the Interrupted transition is committed BEFORE sessions
@@ -1085,11 +1087,23 @@ func (o *Orchestrator) startFinalReview(featureID string) (PhaseStartResult, err
 // Otherwise the stopped session's last assistant text would surface
 // as failure_type=session_crash and beat FeatureInterrupted to emission.
 func (o *Orchestrator) InterruptFeature(featureID string) error {
-	// Transition to interrupted FIRST so racing completion handlers
-	// (onKBCompleted, onPhaseCompletedDefault, …) observe the terminal
-	// state and skip their failure paths.
-	if err := o.deps.Lifecycle.Transition(featureID, feature.StatusInterrupted); err != nil {
-		return fmt.Errorf("transition to interrupted: %w", err)
+	featureInterrupted := false
+	if f, err := o.deps.Lifecycle.Get(featureID); err == nil &&
+		(f.Status == feature.StatusPublished || f.Status == feature.StatusCodeReady) &&
+		hasActiveRepoCycles(f) {
+		interruptFeature := hasInterruptibleRepoCycles(f)
+		if err := o.interruptActiveRepoCycles(featureID, interruptFeature); err != nil {
+			return fmt.Errorf("interrupt active repo cycles: %w", err)
+		}
+		featureInterrupted = interruptFeature
+	} else {
+		// Transition to interrupted FIRST so racing completion handlers
+		// (onKBCompleted, onPhaseCompletedDefault, …) observe the terminal
+		// state and skip their failure paths.
+		if err := o.deps.Lifecycle.Transition(featureID, feature.StatusInterrupted); err != nil {
+			return fmt.Errorf("transition to interrupted: %w", err)
+		}
+		featureInterrupted = true
 	}
 
 	// Stop any active sessions for this feature.
@@ -1117,22 +1131,26 @@ func (o *Orchestrator) InterruptFeature(featureID string) error {
 		return fmt.Errorf("clear pending flags: %w", err)
 	}
 
-	if o.hooks.OnFeatureInterrupted != nil {
+	if featureInterrupted && o.hooks.OnFeatureInterrupted != nil {
 		o.hooks.OnFeatureInterrupted(featureID)
 	}
-	o.emitEvent(ports.Event{Type: ports.FeatureInterrupted, FeatureID: featureID})
+	if featureInterrupted {
+		o.emitEvent(ports.Event{Type: ports.FeatureInterrupted, FeatureID: featureID})
+	}
 	return nil
 }
 
 // InterruptAllRunning iterates all features; running ones are interrupted
 // (stopping sessions, clearing pending flags, transitioning to interrupted)
 // AND additionally have KBStatus cleared to match the startup sweep.
-// Non-running features (Published, CodeReady) with active repo cycles have
-// running/reviewing cycles marked "failed", their feature-level ActiveCycle
-// failed, and pending help/permission entries cleared, but are NOT
-// transitioned and KBStatus is preserved. CodeReady is the manual_publish=true
-// shape where a tweak/rebase cycle can be in flight while the feature waits
-// for the user to publish.
+// Non-running features (Published, CodeReady) with active non-interactive
+// repo cycles (rebase/review-comments/refactor) are interrupted at the
+// feature level so the dashboard keeps them in the active bucket. Interactive
+// tweak-only cycles keep the pre-existing published/code-ready status and
+// just have their cycle state marked interrupted. KBStatus is preserved for
+// every post-publish cycle shape. CodeReady is the manual_publish=true shape
+// where a tweak/rebase cycle can be in flight while the feature waits for the
+// user to publish.
 func (o *Orchestrator) InterruptAllRunning() error {
 	features, listErr := o.deps.Store.List()
 	if listErr != nil {
@@ -1167,34 +1185,14 @@ func (o *Orchestrator) InterruptAllRunning() error {
 				errs = append(errs, fmt.Errorf("clear KBStatus for %s: %w", f.ID, err))
 			}
 		case (f.Status == feature.StatusPublished || f.Status == feature.StatusCodeReady) && hasActiveRepoCycles(f):
-			// Mark in-flight cycles interrupted (not failed — user quit, cycle
-			// didn't break) and clear pending help/perm entries so the next
-			// launch doesn't show a stale "Agent has a question" banner.
-			if err := o.deps.Store.Modify(f.ID, func(ff *feature.Feature) error {
-				for _, rc := range ff.RepoCycles {
-					if rc.Status == feature.RepoCycleRunning || rc.Status == feature.RepoCycleReviewing {
-						rc.Status = feature.RepoCycleInterrupted
-						rc.LastError = ""
-					}
+			if hasInterruptibleRepoCycles(f) {
+				if err := o.InterruptFeature(f.ID); err != nil {
+					errs = append(errs, fmt.Errorf("interrupt repo cycles for %s: %w", f.ID, err))
 				}
-				if ff.ActiveCycle != nil &&
-					(ff.ActiveCycle.Status == feature.RepoCycleRunning || ff.ActiveCycle.Status == feature.RepoCycleReviewing) {
-					ff.ActiveCycle.Status = feature.RepoCycleInterrupted
-					ff.ActiveCycle.LastError = ""
-				}
-				for i := range ff.HelpQueue {
-					if ff.HelpQueue[i].Pending {
-						ff.HelpQueue[i].Pending = false
-					}
-				}
-				for i := range ff.PermissionsQueue {
-					if ff.PermissionsQueue[i].Pending {
-						ff.PermissionsQueue[i].Pending = false
-					}
-				}
-				return nil
-			}); err != nil {
-				errs = append(errs, fmt.Errorf("mark failed cycles for %s: %w", f.ID, err))
+				continue
+			}
+			if err := o.interruptActiveRepoCycles(f.ID, false); err != nil {
+				errs = append(errs, fmt.Errorf("mark interrupted cycles for %s: %w", f.ID, err))
 			}
 		}
 	}
@@ -1209,11 +1207,64 @@ func (o *Orchestrator) InterruptAllRunning() error {
 // per-repo cycles. Mirrors app.go:10383-10391.
 func hasActiveRepoCycles(f *feature.Feature) bool {
 	for _, rc := range f.RepoCycles {
-		if rc.Status == "running" || rc.Status == "reviewing" {
+		if rc != nil && (rc.Status == feature.RepoCycleRunning || rc.Status == feature.RepoCycleReviewing) {
 			return true
 		}
 	}
 	return false
+}
+
+func hasInterruptibleRepoCycles(f *feature.Feature) bool {
+	for _, rc := range f.RepoCycles {
+		if rc == nil {
+			continue
+		}
+		switch rc.Type {
+		case feature.CycleRebase, feature.CycleReviewComments, feature.CycleRefactor:
+		default:
+			continue
+		}
+		if rc.Status == feature.RepoCycleRunning || rc.Status == feature.RepoCycleReviewing {
+			return true
+		}
+	}
+	return false
+}
+
+func (o *Orchestrator) interruptActiveRepoCycles(featureID string, interruptFeature bool) error {
+	return o.deps.Store.Modify(featureID, func(ff *feature.Feature) error {
+		for _, rc := range ff.RepoCycles {
+			if rc == nil {
+				continue
+			}
+			if rc.Status == feature.RepoCycleRunning || rc.Status == feature.RepoCycleReviewing {
+				rc.Status = feature.RepoCycleInterrupted
+				rc.LastError = ""
+			}
+		}
+		if ff.ActiveCycle != nil &&
+			(ff.ActiveCycle.Status == feature.RepoCycleRunning || ff.ActiveCycle.Status == feature.RepoCycleReviewing) {
+			ff.ActiveCycle.Status = feature.RepoCycleInterrupted
+			ff.ActiveCycle.LastError = ""
+		}
+		if interruptFeature {
+			ff.Status = feature.StatusInterrupted
+			ff.CurrentPhase = feature.PhasePublish
+			ff.LastError = ""
+			ff.FailureType = ""
+		}
+		for i := range ff.HelpQueue {
+			if ff.HelpQueue[i].Pending {
+				ff.HelpQueue[i].Pending = false
+			}
+		}
+		for i := range ff.PermissionsQueue {
+			if ff.PermissionsQueue[i].Pending {
+				ff.PermissionsQueue[i].Pending = false
+			}
+		}
+		return nil
+	})
 }
 
 // HandlePhaseCompletion dispatches a phase-completion result to the

--- a/internal/orchestrator/orchestrator_interrupt_test.go
+++ b/internal/orchestrator/orchestrator_interrupt_test.go
@@ -283,9 +283,10 @@ func TestOrchestrator_InterruptAllRunning_PublishedWithCycles(t *testing.T) {
 		t.Errorf("r3 status = %q, want completed (unchanged)", published.RepoCycles["r3"].Status)
 	}
 
-	// Published stays published.
-	if published.Status != feature.StatusPublished {
-		t.Errorf("published status = %v, should not transition", published.Status)
+	// Non-interactive repo cycles represent active agent work; interruption
+	// should move the feature out of the Published bucket.
+	if published.Status != feature.StatusInterrupted {
+		t.Errorf("published status = %v, want Interrupted", published.Status)
 	}
 
 	// KBStatus preserved.

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -4487,10 +4487,15 @@ func (m AppModel) confirmStop(featureID, featureName string) AppModel {
 
 func (m AppModel) stopFeatureCmd(featureID string) tea.Cmd {
 	return func() tea.Msg {
-		// Published features with active repo cycles: clear cycles but keep
-		// status — Orchestrator.InterruptFeature always transitions to
-		// Interrupted, which would break the Published-with-cycles contract.
-		if f, err := m.featureManager.Get(featureID); err == nil && f.Status == feature.StatusPublished && hasActiveRepoCycles(f) {
+		// Published features with interactive tweak-only cycles cannot be
+		// resumed autonomously, so Stop clears the cycle and returns to the
+		// published baseline. Non-interactive cycles such as rebase go through
+		// InterruptFeature so the feature lands in Interrupted and [r] can
+		// relaunch the saved cycle plan.
+		if f, err := m.featureManager.Get(featureID); err == nil &&
+			f.Status == feature.StatusPublished &&
+			hasActiveRepoCycles(f) &&
+			!hasInterruptibleRepoCycles(f) {
 			if m.orchestrator != nil {
 				m.orchestrator.StopFeatureSessions(featureID)
 				_ = m.orchestrator.ClearRepoCycles(featureID)
@@ -4498,9 +4503,9 @@ func (m AppModel) stopFeatureCmd(featureID string) tea.Cmd {
 			return RefreshFeaturesMsg{}
 		}
 
-		// Normal path: delegate to the orchestrator. It stops sessions,
-		// clears pending help/permission flags, transitions to Interrupted
-		// and fires the OnFeatureInterrupted hook.
+		// Normal path: delegate to the orchestrator. It owns session stop,
+		// pending help/permission cleanup, and whether the feature-level
+		// status should become Interrupted for this kind of work.
 		if m.orchestrator != nil {
 			_ = m.orchestrator.InterruptFeature(featureID)
 		}
@@ -7400,6 +7405,26 @@ func hasRunningRefactorCycle(f *feature.Feature) bool {
 // hasActiveRepoCycles returns true if the feature has any running per-repo cycles.
 func hasActiveRepoCycles(f *feature.Feature) bool {
 	return f.HasActiveRepoCycles()
+}
+
+func hasInterruptibleRepoCycles(f *feature.Feature) bool {
+	if f == nil {
+		return false
+	}
+	for _, rc := range f.RepoCycles {
+		if rc == nil {
+			continue
+		}
+		switch rc.Type {
+		case feature.CycleRebase, feature.CycleReviewComments, feature.CycleRefactor:
+		default:
+			continue
+		}
+		if rc.Status == feature.RepoCycleRunning || rc.Status == feature.RepoCycleReviewing {
+			return true
+		}
+	}
+	return false
 }
 
 // isFeatureQuiescent reports whether the `e` key should offer the edit-

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -2890,6 +2890,36 @@ func TestStopFeatureCmdTransitionsToInterrupted(t *testing.T) {
 	}
 }
 
+func TestStopFeatureCmdPublishedRebaseCycleTransitionsToInterrupted(t *testing.T) {
+	app, fm := newTestAppModel(t)
+
+	f, err := fm.Create("Stop Rebase Test", "desc", []string{"test-repo"}, fm.Config.Defaults.Models, "", "", nil)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	walkFeatureToPublished(t, fm, f.ID)
+	if err := fm.StartRepoCycle(f.ID, "test-repo", feature.CycleRebase); err != nil {
+		t.Fatalf("StartRepoCycle: %v", err)
+	}
+
+	msg := app.stopFeatureCmd(f.ID)()
+	if _, ok := msg.(RefreshFeaturesMsg); !ok {
+		t.Fatalf("expected RefreshFeaturesMsg, got %T", msg)
+	}
+
+	f, _ = fm.Get(f.ID)
+	if f.Status != feature.StatusInterrupted {
+		t.Errorf("feature status = %v, want StatusInterrupted after stopping active rebase", f.Status)
+	}
+	rc, ok := f.RepoCycles["test-repo"]
+	if !ok {
+		t.Fatal("RepoCycles[test-repo] missing")
+	}
+	if rc.Status != feature.RepoCycleInterrupted {
+		t.Errorf("RepoCycles[test-repo].Status = %q, want interrupted", rc.Status)
+	}
+}
+
 func TestStopConfirmCancelIsNoOp(t *testing.T) {
 	app, fm := newTestAppModel(t)
 


### PR DESCRIPTION
## Summary

- Stop and `InterruptAllRunning` now transition Published/CodeReady features to Interrupted whenever a non-interactive post-publish cycle (rebase, review-comments, or refactor) is in flight, so they leave the published dashboard bucket while the agent work runs. Tweak-only cycles still keep their existing published/code-ready status because they cannot be resumed autonomously.
- `RestartPhase` now recognizes the new Interrupted post-publish shape, restores the publishable base status (Published if PRs exist, otherwise CodeReady), and returns the saved per-cycle restart descriptors so `[r]` relaunches the cycle plan instead of falling through to a plain phase restart.
- Centralized the cycle-interruption mutation in `Orchestrator.interruptActiveRepoCycles` and added a shared `hasInterruptibleRepoCycles` predicate used by both the orchestrator and the TUI's `stopFeatureCmd`.

## Test plan

- [x] `make test-fast` (20s)
- [ ] Manual: in a feature with a rebase cycle running post-publish, hit Stop and confirm the feature moves to the Interrupted bucket and `[r]` re-dispatches the rebase plan.
- [ ] Manual: in a feature with a tweak-only cycle, confirm Stop still keeps the feature published and clears the cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)