### PR TITLE
Summarize Agent tool use in live preview

### DIFF
--- a/internal/tui/live_preview.go
+++ b/internal/tui/live_preview.go
@@ -1170,7 +1170,7 @@ func livePreviewToolInputSummary(toolName string, input json.RawMessage) string 
 		return stringField(parsed, "path")
 	case "WebFetch":
 		return stringField(parsed, "url")
-	case "Task":
+	case "Agent", "Task":
 		return firstNonEmpty(stringField(parsed, "description"), stringField(parsed, "prompt"))
 	}
 	return livePreviewJSONSummary(input)

--- a/internal/tui/live_preview_test.go
+++ b/internal/tui/live_preview_test.go
@@ -359,6 +359,14 @@ func TestLivePreviewTranscriptSummaries(t *testing.T) {
 			want: []string{"Bash: go test ./internal/tui -run LivePreview"},
 		},
 		{
+			name: "agent tool use summarizes description",
+			messages: []llm.SDKMessage{
+				assistantMessage(llm.ContentBlock{Type: "tool_use", ID: "toolu_agent", Name: "Agent", Input: rawJSON(`{"description":"Explore KB completion handler","prompt":"This long delegated prompt should not render in the dashboard preview tail."}`)}),
+			},
+			want:    []string{"Agent: Explore KB completion handler"},
+			notWant: []string{"long delegated prompt", `"prompt"`},
+		},
+		{
 			name: "successful tool result",
 			messages: []llm.SDKMessage{
 				assistantMessage(llm.ContentBlock{Type: "tool_use", ID: "toolu_2", Name: "Read", Input: rawJSON(`{"file_path":"internal/tui/live_preview.go"}`)}),


### PR DESCRIPTION
## Summary
- Live preview's tool summarizer only matched the legacy `Task` tool name, so `Agent` invocations were rendered as raw JSON containing the full delegated prompt.
- Extend the switch to cover both `Agent` and `Task`, surfacing the agent description (falling back to the prompt) in the transcript tail.
- Add a test asserting that an `Agent` tool use shows the description and does not leak the full prompt body.

## Test plan
- [ ] `go test ./internal/tui -run LivePreview`

🤖 Generated with [Claude Code](https://claude.com/claude-code)