### PR TITLE
Bounded protocol retries for single-shot phases

### DIFF
--- a/internal/agent/contract.go
+++ b/internal/agent/contract.go
@@ -524,18 +524,30 @@ func reportGateViolations(gate ReportGateResult) []ProtocolViolation {
 }
 
 type protocolViolationError struct {
-	msg string
+	msg        string
+	violations []ProtocolViolation
 }
 
 func (e *protocolViolationError) Error() string { return e.msg }
 
 func newProtocolViolationError(role Role, iterDir string, violations []ProtocolViolation) error {
-	return &protocolViolationError{msg: formatProtocolViolationError(role, iterDir, violations)}
+	return &protocolViolationError{
+		msg:        formatProtocolViolationError(role, iterDir, violations),
+		violations: append([]ProtocolViolation(nil), violations...),
+	}
 }
 
 func isProtocolViolationError(err error) bool {
 	var target *protocolViolationError
 	return errors.As(err, &target)
+}
+
+func protocolViolationsFromError(err error) []ProtocolViolation {
+	var target *protocolViolationError
+	if !errors.As(err, &target) {
+		return nil
+	}
+	return append([]ProtocolViolation(nil), target.violations...)
 }
 
 // JoinProtocolViolations renders protocol violations for LastError and review

--- a/internal/agent/plan_validation.go
+++ b/internal/agent/plan_validation.go
@@ -2213,7 +2213,7 @@ func IsArtifactExcluded(name string) bool {
 		return true
 	case strings.HasSuffix(lower, "-prompt.md"):
 		return true
-	case lower == "qa-answers.md":
+	case lower == "qa-answers.md" || lower == ProtocolRetrySidecarFile:
 		return true
 	default:
 		return false

--- a/internal/agent/plan_validation.go
+++ b/internal/agent/plan_validation.go
@@ -2215,6 +2215,8 @@ func IsArtifactExcluded(name string) bool {
 		return true
 	case lower == "qa-answers.md" || lower == ProtocolRetrySidecarFile:
 		return true
+	case strings.HasPrefix(lower, ".protocol-retry-") && strings.HasSuffix(lower, ".yaml"):
+		return true
 	default:
 		return false
 	}

--- a/internal/agent/plan_validation_test.go
+++ b/internal/agent/plan_validation_test.go
@@ -952,6 +952,10 @@ func TestIsArtifactExcluded(t *testing.T) {
 		{"plan.md", false},
 		{"research.md", false},
 		{"qa-answers.md", true},
+		{".protocol-retry.yaml", true},
+		{".protocol-retry-feat-abc123.yaml", true},
+		{"protocol-retry.yaml", false},
+		{".protocol-retry-feat-abc123.txt", false},
 		{"2026-03-13-my-feature.md", false},
 	}
 	for _, tt := range tests {

--- a/internal/agent/protocol_retry.go
+++ b/internal/agent/protocol_retry.go
@@ -29,6 +29,11 @@ const (
 	DefaultMaxConsecutiveProtocolViolations = 3
 )
 
+// KBProtocolRetrySidecarFilename returns the feature-scoped KB retry sidecar filename.
+func KBProtocolRetrySidecarFilename(featureID string) string {
+	return ".protocol-retry-" + featureID + ".yaml"
+}
+
 // ProtocolRetryAction is the bounded retry decision returned after contract validation.
 type ProtocolRetryAction int
 
@@ -57,7 +62,12 @@ type ProtocolRetryDecision struct {
 
 // ReadProtocolRetrySidecar reads a retry sidecar from dir. Missing files are not errors.
 func ReadProtocolRetrySidecar(dir string) (*ProtocolRetrySidecar, error) {
-	path := filepath.Join(dir, ProtocolRetrySidecarFile)
+	return ReadProtocolRetrySidecarAt(dir, ProtocolRetrySidecarFile)
+}
+
+// ReadProtocolRetrySidecarAt reads a retry sidecar with the supplied filename from dir.
+func ReadProtocolRetrySidecarAt(dir, filename string) (*ProtocolRetrySidecar, error) {
+	path := filepath.Join(dir, protocolRetrySidecarFilename(filename))
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -75,6 +85,11 @@ func ReadProtocolRetrySidecar(dir string) (*ProtocolRetrySidecar, error) {
 
 // WriteProtocolRetrySidecar writes a retry sidecar atomically under dir.
 func WriteProtocolRetrySidecar(dir string, sidecar ProtocolRetrySidecar) error {
+	return WriteProtocolRetrySidecarAt(dir, ProtocolRetrySidecarFile, sidecar)
+}
+
+// WriteProtocolRetrySidecarAt writes a retry sidecar atomically under dir with the supplied filename.
+func WriteProtocolRetrySidecarAt(dir, filename string, sidecar ProtocolRetrySidecar) error {
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return fmt.Errorf("creating protocol retry sidecar dir: %w", err)
 	}
@@ -103,7 +118,7 @@ func WriteProtocolRetrySidecar(dir string, sidecar ProtocolRetrySidecar) error {
 	if err := tmp.Close(); err != nil {
 		return fmt.Errorf("closing protocol retry sidecar temp file: %w", err)
 	}
-	if err := os.Rename(tmpName, filepath.Join(dir, ProtocolRetrySidecarFile)); err != nil {
+	if err := os.Rename(tmpName, filepath.Join(dir, protocolRetrySidecarFilename(filename))); err != nil {
 		return fmt.Errorf("renaming protocol retry sidecar temp file: %w", err)
 	}
 	cleanup = false
@@ -112,11 +127,23 @@ func WriteProtocolRetrySidecar(dir string, sidecar ProtocolRetrySidecar) error {
 
 // DeleteProtocolRetrySidecar removes the retry sidecar. Missing files are not errors.
 func DeleteProtocolRetrySidecar(dir string) error {
-	err := os.Remove(filepath.Join(dir, ProtocolRetrySidecarFile))
+	return DeleteProtocolRetrySidecarAt(dir, ProtocolRetrySidecarFile)
+}
+
+// DeleteProtocolRetrySidecarAt removes the retry sidecar with the supplied filename.
+func DeleteProtocolRetrySidecarAt(dir, filename string) error {
+	err := os.Remove(filepath.Join(dir, protocolRetrySidecarFilename(filename)))
 	if err == nil || os.IsNotExist(err) {
 		return nil
 	}
 	return fmt.Errorf("removing protocol retry sidecar: %w", err)
+}
+
+func protocolRetrySidecarFilename(filename string) string {
+	if filename == "" {
+		return ProtocolRetrySidecarFile
+	}
+	return filename
 }
 
 // RemovePhaseCompleteMarker removes only the phase_complete marker. Missing files are not errors.

--- a/internal/agent/protocol_retry.go
+++ b/internal/agent/protocol_retry.go
@@ -1,0 +1,184 @@
+// Copyright 2026 DoorDash, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agent
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	ProtocolRetrySidecarFile                = ".protocol-retry.yaml"
+	DefaultMaxConsecutiveProtocolViolations = 3
+)
+
+// ProtocolRetryAction is the bounded retry decision returned after contract validation.
+type ProtocolRetryAction int
+
+const (
+	ProtocolRetryActionSucceed ProtocolRetryAction = iota
+	ProtocolRetryActionRetry
+	ProtocolRetryActionTerminal
+)
+
+// ProtocolRetrySidecar is the on-disk retry state colocated with phase_complete.
+type ProtocolRetrySidecar struct {
+	Role          Role      `yaml:"role"`
+	ActiveRun     int       `yaml:"active_run"`
+	Consecutive   int       `yaml:"consecutive"`
+	LastViolation string    `yaml:"last_violation"`
+	UpdatedAt     time.Time `yaml:"updated_at"`
+}
+
+// ProtocolRetryDecision tells the caller whether to succeed, retry, or fail terminally.
+type ProtocolRetryDecision struct {
+	Action         ProtocolRetryAction
+	Consecutive    int
+	FormattedError string
+	NewSidecar     *ProtocolRetrySidecar
+}
+
+// ReadProtocolRetrySidecar reads a retry sidecar from dir. Missing files are not errors.
+func ReadProtocolRetrySidecar(dir string) (*ProtocolRetrySidecar, error) {
+	path := filepath.Join(dir, ProtocolRetrySidecarFile)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("reading protocol retry sidecar: %w", err)
+	}
+
+	var sidecar ProtocolRetrySidecar
+	if err := yaml.Unmarshal(data, &sidecar); err != nil {
+		return nil, fmt.Errorf("parsing protocol retry sidecar: %w", err)
+	}
+	return &sidecar, nil
+}
+
+// WriteProtocolRetrySidecar writes a retry sidecar atomically under dir.
+func WriteProtocolRetrySidecar(dir string, sidecar ProtocolRetrySidecar) error {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("creating protocol retry sidecar dir: %w", err)
+	}
+
+	data, err := yaml.Marshal(sidecar)
+	if err != nil {
+		return fmt.Errorf("marshalling protocol retry sidecar: %w", err)
+	}
+
+	tmp, err := os.CreateTemp(dir, ".protocol-retry-*.yaml.tmp")
+	if err != nil {
+		return fmt.Errorf("creating protocol retry sidecar temp file: %w", err)
+	}
+	tmpName := tmp.Name()
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = os.Remove(tmpName)
+		}
+	}()
+
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("writing protocol retry sidecar temp file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("closing protocol retry sidecar temp file: %w", err)
+	}
+	if err := os.Rename(tmpName, filepath.Join(dir, ProtocolRetrySidecarFile)); err != nil {
+		return fmt.Errorf("renaming protocol retry sidecar temp file: %w", err)
+	}
+	cleanup = false
+	return nil
+}
+
+// DeleteProtocolRetrySidecar removes the retry sidecar. Missing files are not errors.
+func DeleteProtocolRetrySidecar(dir string) error {
+	err := os.Remove(filepath.Join(dir, ProtocolRetrySidecarFile))
+	if err == nil || os.IsNotExist(err) {
+		return nil
+	}
+	return fmt.Errorf("removing protocol retry sidecar: %w", err)
+}
+
+// RemovePhaseCompleteMarker removes only the phase_complete marker. Missing files are not errors.
+func RemovePhaseCompleteMarker(dir string) error {
+	err := os.Remove(filepath.Join(dir, PhaseCompleteFile))
+	if err == nil || os.IsNotExist(err) {
+		return nil
+	}
+	return fmt.Errorf("removing phase_complete marker: %w", err)
+}
+
+// DecideProtocolRetry computes the bounded retry action for protocol violations.
+func DecideProtocolRetry(
+	role Role,
+	phaseDir string,
+	currentActiveRun int,
+	sidecar *ProtocolRetrySidecar,
+	violations []ProtocolViolation,
+	maxConsecutive int,
+) ProtocolRetryDecision {
+	if len(violations) == 0 {
+		return ProtocolRetryDecision{Action: ProtocolRetryActionSucceed}
+	}
+
+	consecutive := 1
+	if sidecar != nil && sidecar.ActiveRun == currentActiveRun && sidecar.Role == role {
+		consecutive = sidecar.Consecutive + 1
+	}
+
+	cap := maxConsecutive
+	if cap <= 0 {
+		cap = DefaultMaxConsecutiveProtocolViolations
+	}
+
+	action := ProtocolRetryActionRetry
+	if consecutive >= cap {
+		action = ProtocolRetryActionTerminal
+	}
+
+	lastViolation := JoinProtocolViolations(violations)
+	return ProtocolRetryDecision{
+		Action:         action,
+		Consecutive:    consecutive,
+		FormattedError: FormatSingleShotProtocolViolationError(role, phaseDir, violations),
+		NewSidecar: &ProtocolRetrySidecar{
+			Role:          role,
+			ActiveRun:     currentActiveRun,
+			Consecutive:   consecutive,
+			LastViolation: lastViolation,
+			UpdatedAt:     time.Now().UTC().Round(0),
+		},
+	}
+}
+
+// FormatSingleShotProtocolViolationError renders the canonical protocol violation LastError.
+func FormatSingleShotProtocolViolationError(role Role, dir string, violations []ProtocolViolation) string {
+	if dir == "" {
+		dir = "<unresolved>"
+	}
+	reason := JoinProtocolViolations(violations)
+	if strings.TrimSpace(reason) == "" {
+		reason = "contract validation failed"
+	}
+	return fmt.Sprintf("protocol violation: %s @ %s: %s", role, dir, reason)
+}

--- a/internal/agent/protocol_retry_test.go
+++ b/internal/agent/protocol_retry_test.go
@@ -60,6 +60,105 @@ func TestProtocolRetrySidecarRoundTrip(t *testing.T) {
 	}
 }
 
+func TestKBProtocolRetrySidecarFilename(t *testing.T) {
+	got := KBProtocolRetrySidecarFilename("feat-abc123")
+	want := ".protocol-retry-feat-abc123.yaml"
+	if got != want {
+		t.Fatalf("KBProtocolRetrySidecarFilename() = %q, want %q", got, want)
+	}
+	if got2 := KBProtocolRetrySidecarFilename("feat-abc123"); got2 != got {
+		t.Fatalf("KBProtocolRetrySidecarFilename() second call = %q, want deterministic %q", got2, got)
+	}
+}
+
+func TestProtocolRetrySidecarRoundTripAtKBFilename(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "knowledge-base", "repo-a")
+	filename := KBProtocolRetrySidecarFilename("feat-kb")
+	want := ProtocolRetrySidecar{
+		Role:          RoleKnowledgeBaseBuilder,
+		ActiveRun:     3,
+		Consecutive:   2,
+		LastViolation: "index.md: required artifact missing",
+		UpdatedAt:     time.Date(2026, 5, 18, 12, 34, 56, 0, time.UTC),
+	}
+
+	if err := WriteProtocolRetrySidecarAt(dir, filename, want); err != nil {
+		t.Fatalf("WriteProtocolRetrySidecarAt() error = %v", err)
+	}
+
+	got, err := ReadProtocolRetrySidecarAt(dir, filename)
+	if err != nil {
+		t.Fatalf("ReadProtocolRetrySidecarAt() error = %v", err)
+	}
+	if got == nil {
+		t.Fatal("ReadProtocolRetrySidecarAt() = nil, want sidecar")
+	}
+	if got.Role != want.Role || got.ActiveRun != want.ActiveRun || got.Consecutive != want.Consecutive ||
+		got.LastViolation != want.LastViolation || !got.UpdatedAt.Equal(want.UpdatedAt) {
+		t.Fatalf("sidecar = %#v, want %#v", got, want)
+	}
+}
+
+func TestProtocolRetrySidecarAtFeatureIsolation(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "knowledge-base", "repo-a")
+	current := KBProtocolRetrySidecarFilename("feat-current")
+	other := KBProtocolRetrySidecarFilename("feat-other")
+
+	otherSidecar := ProtocolRetrySidecar{
+		Role:          RoleKnowledgeBaseBuilder,
+		ActiveRun:     1,
+		Consecutive:   3,
+		LastViolation: "prior feature",
+		UpdatedAt:     time.Date(2026, 5, 18, 1, 0, 0, 0, time.UTC),
+	}
+	currentSidecar := ProtocolRetrySidecar{
+		Role:          RoleKnowledgeBaseBuilder,
+		ActiveRun:     2,
+		Consecutive:   1,
+		LastViolation: "current feature",
+		UpdatedAt:     time.Date(2026, 5, 18, 2, 0, 0, 0, time.UTC),
+	}
+
+	if err := WriteProtocolRetrySidecarAt(dir, other, otherSidecar); err != nil {
+		t.Fatalf("WriteProtocolRetrySidecarAt(other) error = %v", err)
+	}
+	gotMissing, err := ReadProtocolRetrySidecarAt(dir, current)
+	if err != nil {
+		t.Fatalf("ReadProtocolRetrySidecarAt(current missing) error = %v", err)
+	}
+	if gotMissing != nil {
+		t.Fatalf("ReadProtocolRetrySidecarAt(current missing) = %#v, want nil", gotMissing)
+	}
+
+	if err := WriteProtocolRetrySidecarAt(dir, current, currentSidecar); err != nil {
+		t.Fatalf("WriteProtocolRetrySidecarAt(current) error = %v", err)
+	}
+	gotCurrent, err := ReadProtocolRetrySidecarAt(dir, current)
+	if err != nil {
+		t.Fatalf("ReadProtocolRetrySidecarAt(current) error = %v", err)
+	}
+	gotOther, err := ReadProtocolRetrySidecarAt(dir, other)
+	if err != nil {
+		t.Fatalf("ReadProtocolRetrySidecarAt(other) error = %v", err)
+	}
+	if gotCurrent == nil || gotCurrent.LastViolation != currentSidecar.LastViolation || gotCurrent.Consecutive != 1 {
+		t.Fatalf("current sidecar = %#v, want %#v", gotCurrent, currentSidecar)
+	}
+	if gotOther == nil || gotOther.LastViolation != otherSidecar.LastViolation || gotOther.Consecutive != 3 {
+		t.Fatalf("other sidecar = %#v, want %#v", gotOther, otherSidecar)
+	}
+
+	if err := DeleteProtocolRetrySidecarAt(dir, current); err != nil {
+		t.Fatalf("DeleteProtocolRetrySidecarAt(current) error = %v", err)
+	}
+	if got, err := ReadProtocolRetrySidecarAt(dir, current); err != nil || got != nil {
+		t.Fatalf("ReadProtocolRetrySidecarAt(current after delete) = %#v, %v; want nil, nil", got, err)
+	}
+	if got, err := ReadProtocolRetrySidecarAt(dir, other); err != nil || got == nil {
+		t.Fatalf("ReadProtocolRetrySidecarAt(other after current delete) = %#v, %v; want preserved", got, err)
+	}
+}
+
 func TestReadProtocolRetrySidecarMissingAndMalformed(t *testing.T) {
 	dir := t.TempDir()
 

--- a/internal/agent/protocol_retry_test.go
+++ b/internal/agent/protocol_retry_test.go
@@ -1,0 +1,290 @@
+// Copyright 2026 DoorDash, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestProtocolRetrySidecarRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	want := ProtocolRetrySidecar{
+		Role:          RoleResearcher,
+		ActiveRun:     7,
+		Consecutive:   2,
+		LastViolation: "phase_complete: SDK reported success but phase_complete was not present",
+		UpdatedAt:     time.Date(2026, 5, 18, 12, 34, 56, 0, time.UTC),
+	}
+
+	if err := WriteProtocolRetrySidecar(dir, want); err != nil {
+		t.Fatalf("WriteProtocolRetrySidecar() error = %v", err)
+	}
+
+	got, err := ReadProtocolRetrySidecar(dir)
+	if err != nil {
+		t.Fatalf("ReadProtocolRetrySidecar() error = %v", err)
+	}
+	if got == nil {
+		t.Fatal("ReadProtocolRetrySidecar() = nil, want sidecar")
+	}
+	if got.Role != want.Role {
+		t.Errorf("Role = %q, want %q", got.Role, want.Role)
+	}
+	if got.ActiveRun != want.ActiveRun {
+		t.Errorf("ActiveRun = %d, want %d", got.ActiveRun, want.ActiveRun)
+	}
+	if got.Consecutive != want.Consecutive {
+		t.Errorf("Consecutive = %d, want %d", got.Consecutive, want.Consecutive)
+	}
+	if got.LastViolation != want.LastViolation {
+		t.Errorf("LastViolation = %q, want %q", got.LastViolation, want.LastViolation)
+	}
+	if !got.UpdatedAt.Equal(want.UpdatedAt) {
+		t.Errorf("UpdatedAt = %s, want %s", got.UpdatedAt.Format(time.RFC3339), want.UpdatedAt.Format(time.RFC3339))
+	}
+}
+
+func TestReadProtocolRetrySidecarMissingAndMalformed(t *testing.T) {
+	dir := t.TempDir()
+
+	got, err := ReadProtocolRetrySidecar(dir)
+	if err != nil {
+		t.Fatalf("ReadProtocolRetrySidecar(missing) error = %v", err)
+	}
+	if got != nil {
+		t.Fatalf("ReadProtocolRetrySidecar(missing) = %#v, want nil", got)
+	}
+
+	if err := os.WriteFile(filepath.Join(dir, ProtocolRetrySidecarFile), []byte("role: ["), 0o644); err != nil {
+		t.Fatalf("write malformed sidecar: %v", err)
+	}
+	if _, err := ReadProtocolRetrySidecar(dir); err == nil {
+		t.Fatal("ReadProtocolRetrySidecar(malformed) error = nil, want error")
+	}
+}
+
+func TestRemovePhaseCompleteMarkerOnlyRemovesMarker(t *testing.T) {
+	dir := t.TempDir()
+	files := map[string]string{
+		PhaseCompleteFile:        "",
+		"artifact.md":            "# artifact\n",
+		ProtocolRetrySidecarFile: "role: researcher\n",
+		"qa-answers.md":          "Q: x\nA: y\n",
+	}
+	for name, body := range files {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+
+	if err := RemovePhaseCompleteMarker(dir); err != nil {
+		t.Fatalf("RemovePhaseCompleteMarker() error = %v", err)
+	}
+	if err := RemovePhaseCompleteMarker(dir); err != nil {
+		t.Fatalf("RemovePhaseCompleteMarker() second call error = %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(dir, PhaseCompleteFile)); !os.IsNotExist(err) {
+		t.Fatalf("phase_complete stat err = %v, want not exist", err)
+	}
+	for _, name := range []string{"artifact.md", ProtocolRetrySidecarFile, "qa-answers.md"} {
+		if _, err := os.Stat(filepath.Join(dir, name)); err != nil {
+			t.Fatalf("%s was removed, want preserved: %v", name, err)
+		}
+	}
+}
+
+func TestProtocolRetryDecision(t *testing.T) {
+	violations := []ProtocolViolation{{
+		Artifact: PhaseCompleteFile,
+		Reason:   "SDK reported success but phase_complete was not present",
+	}}
+	dir := filepath.Join(t.TempDir(), "research")
+	formatted := FormatSingleShotProtocolViolationError(RoleResearcher, dir, violations)
+
+	tests := []struct {
+		name                 string
+		violations           []ProtocolViolation
+		sidecar              *ProtocolRetrySidecar
+		activeRun            int
+		maxConsecutive       int
+		wantAction           ProtocolRetryAction
+		wantConsecutive      int
+		wantNewSidecar       bool
+		wantFormattedError   string
+		wantSidecarActiveRun int
+	}{
+		{
+			name:            "empty_violations_succeed_default_cap",
+			activeRun:       1,
+			wantAction:      ProtocolRetryActionSucceed,
+			wantConsecutive: 0,
+		},
+		{
+			name:                 "first_violation_retries_default_cap",
+			violations:           violations,
+			activeRun:            1,
+			wantAction:           ProtocolRetryActionRetry,
+			wantConsecutive:      1,
+			wantNewSidecar:       true,
+			wantFormattedError:   formatted,
+			wantSidecarActiveRun: 1,
+		},
+		{
+			name:       "consecutive_violation_retries_default_cap",
+			violations: violations,
+			sidecar: &ProtocolRetrySidecar{
+				Role:        RoleResearcher,
+				ActiveRun:   1,
+				Consecutive: 1,
+			},
+			activeRun:            1,
+			wantAction:           ProtocolRetryActionRetry,
+			wantConsecutive:      2,
+			wantNewSidecar:       true,
+			wantFormattedError:   formatted,
+			wantSidecarActiveRun: 1,
+		},
+		{
+			name:       "cross_run_stale_sidecar_resets_default_cap",
+			violations: violations,
+			sidecar: &ProtocolRetrySidecar{
+				Role:        RoleResearcher,
+				ActiveRun:   2,
+				Consecutive: 2,
+			},
+			activeRun:            3,
+			wantAction:           ProtocolRetryActionRetry,
+			wantConsecutive:      1,
+			wantNewSidecar:       true,
+			wantFormattedError:   formatted,
+			wantSidecarActiveRun: 3,
+		},
+		{
+			name:       "role_mismatch_sidecar_resets_default_cap",
+			violations: violations,
+			sidecar: &ProtocolRetrySidecar{
+				Role:        RoleDesigner,
+				ActiveRun:   1,
+				Consecutive: 2,
+			},
+			activeRun:            1,
+			wantAction:           ProtocolRetryActionRetry,
+			wantConsecutive:      1,
+			wantNewSidecar:       true,
+			wantFormattedError:   formatted,
+			wantSidecarActiveRun: 1,
+		},
+		{
+			name:       "exhausted_default_cap",
+			violations: violations,
+			sidecar: &ProtocolRetrySidecar{
+				Role:        RoleResearcher,
+				ActiveRun:   1,
+				Consecutive: 2,
+			},
+			activeRun:            1,
+			wantAction:           ProtocolRetryActionTerminal,
+			wantConsecutive:      DefaultMaxConsecutiveProtocolViolations,
+			wantNewSidecar:       true,
+			wantFormattedError:   formatted,
+			wantSidecarActiveRun: 1,
+		},
+		{
+			name:                 "first_violation_retries_injected_cap",
+			violations:           violations,
+			activeRun:            1,
+			maxConsecutive:       2,
+			wantAction:           ProtocolRetryActionRetry,
+			wantConsecutive:      1,
+			wantNewSidecar:       true,
+			wantFormattedError:   formatted,
+			wantSidecarActiveRun: 1,
+		},
+		{
+			name:       "exhausted_injected_cap",
+			violations: violations,
+			sidecar: &ProtocolRetrySidecar{
+				Role:        RoleResearcher,
+				ActiveRun:   1,
+				Consecutive: 1,
+			},
+			activeRun:            1,
+			maxConsecutive:       2,
+			wantAction:           ProtocolRetryActionTerminal,
+			wantConsecutive:      2,
+			wantNewSidecar:       true,
+			wantFormattedError:   formatted,
+			wantSidecarActiveRun: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := DecideProtocolRetry(RoleResearcher, dir, tt.activeRun, tt.sidecar, tt.violations, tt.maxConsecutive)
+			if got.Action != tt.wantAction {
+				t.Errorf("DecideProtocolRetry().Action = %v, want %v", got.Action, tt.wantAction)
+			}
+			if got.Consecutive != tt.wantConsecutive {
+				t.Errorf("DecideProtocolRetry().Consecutive = %d, want %d", got.Consecutive, tt.wantConsecutive)
+			}
+			if got.FormattedError != tt.wantFormattedError {
+				t.Errorf("DecideProtocolRetry().FormattedError = %q, want %q", got.FormattedError, tt.wantFormattedError)
+			}
+			if (got.NewSidecar != nil) != tt.wantNewSidecar {
+				t.Fatalf("DecideProtocolRetry().NewSidecar nil = %v, want populated %v", got.NewSidecar == nil, tt.wantNewSidecar)
+			}
+			if got.NewSidecar == nil {
+				return
+			}
+			if got.NewSidecar.Role != RoleResearcher {
+				t.Errorf("NewSidecar.Role = %q, want %q", got.NewSidecar.Role, RoleResearcher)
+			}
+			if got.NewSidecar.ActiveRun != tt.wantSidecarActiveRun {
+				t.Errorf("NewSidecar.ActiveRun = %d, want %d", got.NewSidecar.ActiveRun, tt.wantSidecarActiveRun)
+			}
+			if got.NewSidecar.Consecutive != tt.wantConsecutive {
+				t.Errorf("NewSidecar.Consecutive = %d, want %d", got.NewSidecar.Consecutive, tt.wantConsecutive)
+			}
+			if got.NewSidecar.LastViolation != JoinProtocolViolations(tt.violations) {
+				t.Errorf("NewSidecar.LastViolation = %q, want %q", got.NewSidecar.LastViolation, JoinProtocolViolations(tt.violations))
+			}
+			if got.NewSidecar.UpdatedAt.IsZero() {
+				t.Error("NewSidecar.UpdatedAt is zero")
+			}
+		})
+	}
+}
+
+func TestProtocolRetrySidecarExcludedFromArtifactSelection(t *testing.T) {
+	if !IsArtifactExcluded(ProtocolRetrySidecarFile) {
+		t.Fatalf("IsArtifactExcluded(%q) = false, want true", ProtocolRetrySidecarFile)
+	}
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ProtocolRetrySidecarFile), []byte("# not an artifact\n"), 0o644); err != nil {
+		t.Fatalf("write sidecar: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "research.md"), []byte("# research\n"), 0o644); err != nil {
+		t.Fatalf("write markdown: %v", err)
+	}
+	if got := newestPhaseMarkdownArtifact(dir); !strings.HasSuffix(got, "research.md") {
+		t.Fatalf("newestPhaseMarkdownArtifact() = %q, want research.md", got)
+	}
+}

--- a/internal/agent/refactor_feature_loop.go
+++ b/internal/agent/refactor_feature_loop.go
@@ -44,7 +44,6 @@
 package agent
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -259,14 +258,20 @@ func RunRefactorFeatureLoop(cfg RefactorFeatureLoopConfig, sm ports.SessionManag
 		}
 	}
 
-	maxPlanFailures := cfg.MaxConsecFails
-	if maxPlanFailures <= 0 {
-		maxPlanFailures = 3
+	sidecar, err := ReadProtocolRetrySidecar(artifactDir)
+	if err != nil {
+		errMsg := err.Error()
+		_ = markActiveCycleFailedRefactor(cfg.FeatureStore, cfg.Feature.ID, errMsg)
+		return &RefactorFeatureLoopResult{
+			FinalStatus: "failed",
+			LastError:   errMsg,
+			ArtifactDir: artifactDir,
+		}, fmt.Errorf("refactor feature loop: read protocol retry sidecar: %w", err)
 	}
 
 	var planPath string
-	for attempt := 1; attempt <= maxPlanFailures; attempt++ {
-		if err := clearRefactorPlanAttemptArtifacts(artifactDir); err != nil {
+	for {
+		if err := RemovePhaseCompleteMarker(artifactDir); err != nil {
 			_ = markActiveCycleFailedRefactor(cfg.FeatureStore, cfg.Feature.ID, err.Error())
 			return &RefactorFeatureLoopResult{
 				FinalStatus: "failed",
@@ -277,16 +282,54 @@ func RunRefactorFeatureLoop(cfg RefactorFeatureLoopConfig, sm ports.SessionManag
 		candidate, planErr := planRunner(artifactDir)
 		if planErr != nil {
 			if isProtocolViolationError(planErr) {
-				errMsg := planErr.Error()
-				if attempt >= maxPlanFailures {
+				decision := DecideProtocolRetry(
+					RoleRefactorPlanStep,
+					artifactDir,
+					cfg.Feature.ActiveRun,
+					sidecar,
+					protocolViolationsFromError(planErr),
+					cfg.MaxConsecFails,
+				)
+				if decision.NewSidecar != nil {
+					if err := WriteProtocolRetrySidecar(artifactDir, *decision.NewSidecar); err != nil {
+						errMsg := err.Error()
+						_ = markActiveCycleFailedRefactor(cfg.FeatureStore, cfg.Feature.ID, errMsg)
+						return &RefactorFeatureLoopResult{
+							FinalStatus: "failed",
+							LastError:   errMsg,
+							ArtifactDir: artifactDir,
+						}, fmt.Errorf("refactor feature loop: write protocol retry sidecar: %w", err)
+					}
+					sidecar = decision.NewSidecar
+				}
+				switch decision.Action {
+				case ProtocolRetryActionRetry:
+					continue
+				case ProtocolRetryActionTerminal:
+					errMsg := planErr.Error()
 					_ = markActiveCycleFailedRefactor(cfg.FeatureStore, cfg.Feature.ID, errMsg)
 					return &RefactorFeatureLoopResult{
 						FinalStatus: "protocol_violation",
 						LastError:   errMsg,
 						ArtifactDir: artifactDir,
 					}, nil
+				case ProtocolRetryActionSucceed:
+					errMsg := planErr.Error()
+					_ = markActiveCycleFailedRefactor(cfg.FeatureStore, cfg.Feature.ID, errMsg)
+					return &RefactorFeatureLoopResult{
+						FinalStatus: "failed",
+						LastError:   errMsg,
+						ArtifactDir: artifactDir,
+					}, fmt.Errorf("refactor feature loop: protocol violation had no violations: %w", planErr)
+				default:
+					errMsg := fmt.Sprintf("unknown protocol retry action %d", decision.Action)
+					_ = markActiveCycleFailedRefactor(cfg.FeatureStore, cfg.Feature.ID, errMsg)
+					return &RefactorFeatureLoopResult{
+						FinalStatus: "failed",
+						LastError:   errMsg,
+						ArtifactDir: artifactDir,
+					}, fmt.Errorf("refactor feature loop: %s", errMsg)
 				}
-				continue
 			}
 			_ = markActiveCycleFailedRefactor(cfg.FeatureStore, cfg.Feature.ID, planErr.Error())
 			return &RefactorFeatureLoopResult{
@@ -295,6 +338,7 @@ func RunRefactorFeatureLoop(cfg RefactorFeatureLoopConfig, sm ports.SessionManag
 				ArtifactDir: artifactDir,
 			}, fmt.Errorf("refactor feature loop: plan step: %w", planErr)
 		}
+		_ = DeleteProtocolRetrySidecar(artifactDir)
 		planPath = candidate
 		break
 	}
@@ -606,9 +650,9 @@ func runRefactorPlanStep(in refactorPlanStepInput, sm ports.SessionManager) (str
 		AskingClause:  asking,
 	})
 
-	// Clear stale completion and plan artifacts BEFORE spawning so every
-	// validated plan belongs to this marker-bearing attempt.
-	if err := clearRefactorPlanAttemptArtifacts(in.ArtifactDir); err != nil {
+	// Clear stale completion marker before spawning. Refactor-plan retries
+	// intentionally leave markdown and retry sidecars in place.
+	if err := RemovePhaseCompleteMarker(in.ArtifactDir); err != nil {
 		return "", err
 	}
 
@@ -673,26 +717,6 @@ func runRefactorPlanStep(in refactorPlanStepInput, sm ports.SessionManager) (str
 		return "", fmt.Errorf("validating refactor plan step contract: validated without plan path")
 	}
 	return outcome.PlanMarkdownPath, nil
-}
-
-func clearRefactorPlanAttemptArtifacts(artifactDir string) error {
-	if err := os.Remove(filepath.Join(artifactDir, PhaseCompleteFile)); err != nil && !errors.Is(err, os.ErrNotExist) {
-		return fmt.Errorf("remove stale %s: %w", PhaseCompleteFile, err)
-	}
-
-	matches, err := filepath.Glob(filepath.Join(artifactDir, "*.md"))
-	if err != nil {
-		return fmt.Errorf("glob refactor-plan artifacts: %w", err)
-	}
-	for _, match := range matches {
-		if IsArtifactExcluded(filepath.Base(match)) {
-			continue
-		}
-		if err := os.Remove(match); err != nil && !errors.Is(err, os.ErrNotExist) {
-			return fmt.Errorf("remove stale refactor-plan artifact %s: %w", match, err)
-		}
-	}
-	return nil
 }
 
 // buildRefactorPlanPrompt composes the user prompt for the refactor-plan

--- a/internal/agent/refactor_feature_loop_test.go
+++ b/internal/agent/refactor_feature_loop_test.go
@@ -778,7 +778,7 @@ func TestRunRefactorFeatureLoop_PlanStepProtocolViolationTripsAfterBudget(t *tes
 	}
 }
 
-func TestRunRefactorFeatureLoop_PlanStepProtocolViolationClearsStalePlanBetweenAttempts(t *testing.T) {
+func TestRunRefactorFeatureLoop_PlanStepProtocolViolationPreservesPlanBetweenAttempts(t *testing.T) {
 	stateDir := t.TempDir()
 	store, f, _ := newRefactorTestFeature(t, stateDir, "refactor-plan-stale", []string{"api"})
 	calls := 0
@@ -822,24 +822,22 @@ func TestRunRefactorFeatureLoop_PlanStepProtocolViolationClearsStalePlanBetweenA
 			}
 		},
 		RunImplementFn: func(ImplementConfig, ports.SessionManager) (*LoopResult, error) {
-			t.Fatal("RunImplementFn must not run when retry only writes a fresh marker")
-			return nil, nil
+			return &LoopResult{FinalStatus: "review_passed", Iterations: 1}, nil
 		},
 	}
 
 	result, err := RunRefactorFeatureLoop(cfg, nil)
 	if err != nil {
-		t.Fatalf("RunRefactorFeatureLoop() error = %v, want nil protocol result", err)
+		t.Fatalf("RunRefactorFeatureLoop() error = %v", err)
 	}
 	if calls != 2 {
 		t.Fatalf("plan calls = %d, want 2", calls)
 	}
-	if result.FinalStatus != "protocol_violation" {
-		t.Fatalf("FinalStatus = %q, want protocol_violation", result.FinalStatus)
+	if result.FinalStatus != "review_passed" {
+		t.Fatalf("FinalStatus = %q, want review_passed", result.FinalStatus)
 	}
-	if !strings.Contains(result.LastError, "refactor-plan.md") ||
-		!strings.Contains(result.LastError, "missing") {
-		t.Fatalf("LastError = %q, want missing refactor-plan.md protocol violation", result.LastError)
+	if _, err := os.Stat(filepath.Join(result.ArtifactDir, "refactor-plan.md")); err != nil {
+		t.Fatalf("refactor-plan.md stat error = %v, want preserved between attempts", err)
 	}
 }
 
@@ -926,7 +924,7 @@ func TestRunRefactorPlanStep_MissingPhaseCompleteReturnsProtocolViolation(t *tes
 	}
 }
 
-func TestRunRefactorPlanStep_StalePlanWithFreshMarkerReturnsProtocolViolation(t *testing.T) {
+func TestRunRefactorPlanStep_StalePlanWithFreshMarkerReturnsPlan(t *testing.T) {
 	stateDir := t.TempDir()
 	artifactDir := filepath.Join(stateDir, "runs", "run-001", "refactor-1")
 	scriptsDir := t.TempDir()
@@ -946,17 +944,15 @@ func TestRunRefactorPlanStep_StalePlanWithFreshMarkerReturnsProtocolViolation(t 
 	sm := session.NewManager(make(chan interface{}, 10))
 	defer sm.Shutdown()
 
-	_, err := runRefactorPlanStep(refactorPlanStepTestInput(t, store, f, stateDir, artifactDir, planScript), sm)
-	if err == nil {
-		t.Fatal("runRefactorPlanStep() error = nil, want protocol violation")
+	got, err := runRefactorPlanStep(refactorPlanStepTestInput(t, store, f, stateDir, artifactDir, planScript), sm)
+	if err != nil {
+		t.Fatalf("runRefactorPlanStep() error = %v", err)
 	}
-	if !strings.Contains(err.Error(), "protocol violation: refactor_plan_step @") ||
-		!strings.Contains(err.Error(), "refactor-plan.md") ||
-		!strings.Contains(err.Error(), "missing") {
-		t.Fatalf("error = %q, want stale plan ignored and missing refactor-plan.md violation", err)
+	if got != stalePlanPath {
+		t.Fatalf("plan path = %q, want %q", got, stalePlanPath)
 	}
-	if _, statErr := os.Stat(stalePlanPath); !errors.Is(statErr, os.ErrNotExist) {
-		t.Fatalf("stale refactor-plan.md stat error = %v, want os.ErrNotExist", statErr)
+	if _, statErr := os.Stat(stalePlanPath); statErr != nil {
+		t.Fatalf("stale refactor-plan.md stat error = %v, want preserved", statErr)
 	}
 }
 

--- a/internal/feature/feature.go
+++ b/internal/feature/feature.go
@@ -16,6 +16,7 @@ package feature
 
 import (
 	"fmt"
+	"path/filepath"
 	"sort"
 	"strings"
 	"time"
@@ -424,7 +425,9 @@ func (s *Status) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		"PlanNeedsReview":     StatusPlanNeedsReview,
 		"Inquiring":           StatusInquiring,
 		"InquireReady":        StatusInquireReady,
+		"BrainstormReady":     StatusDesignReady, // legacy pre-design rename
 		"DesignReady":         StatusDesignReady,
+		"Brainstorming":       StatusDesigning, // legacy pre-design rename
 		"Designing":           StatusDesigning,
 		"PromptNeedsReview":   StatusPromptNeedsReview,
 		"InquiryNeedsReview":  StatusInquiryNeedsReview,
@@ -675,6 +678,7 @@ func (f *Feature) syncShadowsToRun() {
 	if f.run == nil {
 		return
 	}
+	normalizeLegacyArtifactAliases(f.Artifacts)
 	r := f.run
 	r.StartedAt = f.StartedAt
 	r.CurrentIteration = f.CurrentIteration
@@ -716,6 +720,7 @@ func (f *Feature) syncRunToShadows() {
 		return
 	}
 	r := f.run
+	normalizeLegacyArtifactAliases(r.Artifacts)
 	f.StartedAt = r.StartedAt
 	f.CurrentIteration = r.CurrentIteration
 	f.ReviewingGate = r.ReviewingGate
@@ -749,6 +754,27 @@ func (f *Feature) syncRunToShadows() {
 	f.CurrentPhaseStatus = r.CurrentPhaseStatus
 }
 
+func normalizeLegacyArtifactAliases(artifacts map[string]string) {
+	if artifacts == nil {
+		return
+	}
+	if strings.TrimSpace(artifacts["design"]) != "" {
+		return
+	}
+	legacy := strings.TrimSpace(artifacts["brainstorm"])
+	if legacy == "" {
+		return
+	}
+	artifacts["design"] = legacyDesignArtifactPath(legacy)
+}
+
+func legacyDesignArtifactPath(path string) string {
+	if filepath.IsAbs(path) || strings.ContainsAny(path, `/\`) {
+		return path
+	}
+	return filepath.Join("brainstorm", path)
+}
+
 // validTransitions maps each status to the set of statuses it can transition to.
 var validTransitions = map[Status][]Status{
 	StatusCreated:             {StatusInquiring, StatusResearching, StatusBuildingKB, StatusPlanReady, StatusFailed},
@@ -756,8 +782,8 @@ var validTransitions = map[Status][]Status{
 	StatusBuildingKB:          {StatusCreated, StatusFailed, StatusInterrupted},
 	StatusInquiring:           {StatusInquireReady, StatusFailed, StatusInterrupted},
 	StatusInquireReady:        {StatusResearching, StatusFailed},
-	StatusDesignReady:     {StatusDesigning, StatusFailed},
-	StatusDesigning:       {StatusPlanReady, StatusFailed, StatusInterrupted},
+	StatusDesignReady:         {StatusDesigning, StatusFailed},
+	StatusDesigning:           {StatusPlanReady, StatusFailed, StatusInterrupted},
 	StatusPlanReady:           {StatusPlanning, StatusFailed},
 	StatusPlanning:            {StatusImplementReady, StatusPlanNeedsReview, StatusFailed, StatusInterrupted},
 	StatusImplementReady:      {StatusImplementing, StatusFailed},

--- a/internal/feature/feature_test.go
+++ b/internal/feature/feature_test.go
@@ -16,6 +16,7 @@ package feature
 
 import (
 	"bytes"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -362,6 +363,61 @@ func TestStatusYAMLLegacyInt(t *testing.T) {
 		if got != tt.want {
 			t.Errorf("legacy int %s: got %v, want %v", tt.yaml, got, tt.want)
 		}
+	}
+}
+
+func TestStatusYAMLLegacyBrainstormAliases(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		yaml string
+		want Status
+	}{
+		{"BrainstormReady", StatusDesignReady},
+		{"Brainstorming", StatusDesigning},
+	}
+	for _, tt := range tests {
+		t.Run(tt.yaml, func(t *testing.T) {
+			var got Status
+			if err := yaml.Unmarshal([]byte(tt.yaml), &got); err != nil {
+				t.Fatalf("Unmarshal(%q) error = %v", tt.yaml, err)
+			}
+			if got != tt.want {
+				t.Errorf("Unmarshal(%q) = %v, want %v", tt.yaml, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeLegacyArtifactAliasesAddsDesignFromBrainstorm(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		in   map[string]string
+		want string
+	}{
+		{
+			name: "legacy basename uses brainstorm directory",
+			in:   map[string]string{"brainstorm": "brainstorm.md"},
+			want: filepath.Join("brainstorm", "brainstorm.md"),
+		},
+		{
+			name: "absolute legacy path is preserved",
+			in:   map[string]string{"brainstorm": "/tmp/brainstorm.md"},
+			want: "/tmp/brainstorm.md",
+		},
+		{
+			name: "existing design wins",
+			in:   map[string]string{"design": "design.md", "brainstorm": "brainstorm.md"},
+			want: "design.md",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			normalizeLegacyArtifactAliases(tt.in)
+			if got := tt.in["design"]; got != tt.want {
+				t.Errorf("normalizeLegacyArtifactAliases() design = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/feature/store.go
+++ b/internal/feature/store.go
@@ -259,6 +259,7 @@ func (s *Store) loadRunUnlocked(featureID string, runNumber int) (*Run, error) {
 	if err := yaml.Unmarshal(data, &r); err != nil {
 		return nil, fmt.Errorf("parsing run file: %w", err)
 	}
+	normalizeLegacyArtifactAliases(r.Artifacts)
 	return &r, nil
 }
 

--- a/internal/feature/store_test.go
+++ b/internal/feature/store_test.go
@@ -957,6 +957,63 @@ artifacts: {}
 	}
 }
 
+func TestStoreLoadMigratesLegacyBrainstormStatusAndArtifact(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	store := NewStore(dir)
+
+	const featureID = "legacy-brainstorm-001"
+	featureDir := filepath.Join(dir, featureID)
+	runDir := filepath.Join(featureDir, "runs", "run-001")
+	if err := os.MkdirAll(runDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	featureYAML := fmt.Sprintf(`id: %s
+name: Legacy Brainstorm Feature
+slug: legacy-brainstorm-feature
+description: legacy brainstorm status
+created: 2026-01-01T00:00:00Z
+status: BrainstormReady
+current_phase: 7
+repos:
+  - name: repo-a
+    path: /tmp/a
+models: {}
+exit_criteria: ""
+inquireness: medium
+active_run: 1
+run_count: 1
+schema_version: %d
+`, featureID, SchemaVersionCurrent)
+	if err := os.WriteFile(filepath.Join(featureDir, "feature.yaml"), []byte(featureYAML), 0o644); err != nil {
+		t.Fatalf("write feature.yaml: %v", err)
+	}
+
+	runYAML := `run_number: 1
+artifacts:
+  brainstorm: brainstorm.md
+`
+	if err := os.WriteFile(filepath.Join(runDir, "run.yaml"), []byte(runYAML), 0o644); err != nil {
+		t.Fatalf("write run.yaml: %v", err)
+	}
+
+	loaded, err := store.Load(featureID)
+	if err != nil {
+		t.Fatalf("Load() error = %v; want nil", err)
+	}
+	if loaded.Status != StatusDesignReady {
+		t.Errorf("loaded.Status = %v, want %v", loaded.Status, StatusDesignReady)
+	}
+	wantArtifact := filepath.Join("brainstorm", "brainstorm.md")
+	if got := loaded.Artifacts["design"]; got != wantArtifact {
+		t.Errorf("loaded.Artifacts[design] = %q, want %q", got, wantArtifact)
+	}
+	if got := loaded.Run().Artifacts["design"]; got != wantArtifact {
+		t.Errorf("loaded.Run().Artifacts[design] = %q, want %q", got, wantArtifact)
+	}
+}
+
 // TestStoreLoadCurrentSchemaIgnoresLegacyJiraKeys verifies that a feature.yaml
 // at SchemaVersionCurrent that still contains legacy jira_ticket / jira_base_url
 // keys (left over from a pre-Jira-removal state dir) loads successfully, and

--- a/internal/orchestrator/completion.go
+++ b/internal/orchestrator/completion.go
@@ -207,12 +207,78 @@ func (o *Orchestrator) onKBCompleted(featureID string, input PhaseCompletionInpu
 		return nil
 	}
 
-	ok, err := o.validateKBCompletionContract(featureID, repoName)
+	_, kbDir, violations, err := o.validateKBCompletionContract(repoName)
 	if err != nil {
 		return err
 	}
-	if !ok {
+
+	if kbDir == "" && len(violations) > 0 {
+		errMsg := formatSingleShotProtocolViolationError(agent.RoleKnowledgeBaseBuilder, kbDir, violations)
+		if repoName != "" {
+			_ = o.deps.Lifecycle.MarkRepoKBFailed(featureID, repoName, errMsg)
+		}
+		if o.deps.Sessions != nil {
+			for _, s := range o.deps.Sessions.FeatureSessions(featureID) {
+				_ = o.deps.Sessions.StopSession(s.ID())
+			}
+		}
+		o.emitPhaseCompleted(featureID, feature.PhaseKnowledgeBase, errors.New(errMsg))
+		err := o.markFailedWithEvent(featureID, feature.FailureProtocolViolation, errMsg)
+		o.wakeKBWaiters(featureID)
+		return err
+	}
+
+	sidecarFilename := agent.KBProtocolRetrySidecarFilename(featureID)
+	sidecar, err := agent.ReadProtocolRetrySidecarAt(kbDir, sidecarFilename)
+	if err != nil {
+		return fmt.Errorf("read knowledge base retry sidecar: %w", err)
+	}
+	decision := agent.DecideProtocolRetry(
+		agent.RoleKnowledgeBaseBuilder,
+		kbDir,
+		f.ActiveRun,
+		sidecar,
+		violations,
+		agent.DefaultMaxConsecutiveProtocolViolations,
+	)
+	switch decision.Action {
+	case agent.ProtocolRetryActionSucceed:
+		if err := agent.DeleteProtocolRetrySidecarAt(kbDir, sidecarFilename); err != nil {
+			return fmt.Errorf("delete knowledge base retry sidecar: %w", err)
+		}
+	case agent.ProtocolRetryActionRetry:
+		if decision.NewSidecar != nil {
+			if err := agent.WriteProtocolRetrySidecarAt(kbDir, sidecarFilename, *decision.NewSidecar); err != nil {
+				return fmt.Errorf("write knowledge base retry sidecar: %w", err)
+			}
+		}
+		if err := agent.RemovePhaseCompleteMarker(kbDir); err != nil {
+			return fmt.Errorf("remove knowledge base phase_complete marker: %w", err)
+		}
+		if _, err := o.startKB(featureID); err != nil {
+			return fmt.Errorf("retry knowledge base: %w", err)
+		}
 		return nil
+	case agent.ProtocolRetryActionTerminal:
+		if decision.NewSidecar != nil {
+			if err := agent.WriteProtocolRetrySidecarAt(kbDir, sidecarFilename, *decision.NewSidecar); err != nil {
+				return fmt.Errorf("write terminal knowledge base retry sidecar: %w", err)
+			}
+		}
+		if repoName != "" {
+			_ = o.deps.Lifecycle.MarkRepoKBFailed(featureID, repoName, decision.FormattedError)
+		}
+		if o.deps.Sessions != nil {
+			for _, s := range o.deps.Sessions.FeatureSessions(featureID) {
+				_ = o.deps.Sessions.StopSession(s.ID())
+			}
+		}
+		o.emitPhaseCompleted(featureID, feature.PhaseKnowledgeBase, errors.New(decision.FormattedError))
+		err := o.markFailedWithEvent(featureID, feature.FailureProtocolViolation, decision.FormattedError)
+		o.wakeKBWaiters(featureID)
+		return err
+	default:
+		return fmt.Errorf("unknown knowledge base protocol retry action %d", decision.Action)
 	}
 
 	// Mark KB fresh on disk — best-effort, failures don't block the phase.
@@ -256,8 +322,9 @@ func (o *Orchestrator) onKBCompleted(featureID string, input PhaseCompletionInpu
 	return o.advanceToNextPhase(featureID, feature.PhaseKnowledgeBase)
 }
 
-func (o *Orchestrator) validateKBCompletionContract(featureID, repoName string) (bool, error) {
+func (o *Orchestrator) validateKBCompletionContract(repoName string) (agent.Outcome, string, []agent.ProtocolViolation, error) {
 	var violations []agent.ProtocolViolation
+	var outcome agent.Outcome
 	kbDir := ""
 
 	baseDir := o.stateDir()
@@ -281,34 +348,20 @@ func (o *Orchestrator) validateKBCompletionContract(featureID, repoName string) 
 			})
 		}
 
-		_, contractViolations, err := validateAgentContract(
+		var contractViolations []agent.ProtocolViolation
+		var err error
+		outcome, contractViolations, err = validateAgentContract(
 			feature.PhaseKnowledgeBase,
 			agent.RoleKnowledgeBaseBuilder,
 			kbDir,
 		)
 		if err != nil {
-			return false, fmt.Errorf("validating knowledge base contract: %w", err)
+			return agent.Outcome{}, kbDir, nil, fmt.Errorf("validating knowledge base contract: %w", err)
 		}
 		violations = append(violations, contractViolations...)
 	}
 
-	if len(violations) == 0 {
-		return true, nil
-	}
-
-	errMsg := formatSingleShotProtocolViolationError(agent.RoleKnowledgeBaseBuilder, kbDir, violations)
-	if repoName != "" {
-		_ = o.deps.Lifecycle.MarkRepoKBFailed(featureID, repoName, errMsg)
-	}
-	if o.deps.Sessions != nil {
-		for _, s := range o.deps.Sessions.FeatureSessions(featureID) {
-			_ = o.deps.Sessions.StopSession(s.ID())
-		}
-	}
-	o.emitPhaseCompleted(featureID, feature.PhaseKnowledgeBase, errors.New(errMsg))
-	err := o.markFailedWithEvent(featureID, feature.FailureProtocolViolation, errMsg)
-	o.wakeKBWaiters(featureID)
-	return false, err
+	return outcome, kbDir, violations, nil
 }
 
 // findRepo returns the FeatureRepo with the given name.

--- a/internal/orchestrator/completion.go
+++ b/internal/orchestrator/completion.go
@@ -52,6 +52,8 @@ var errFinalReviewInterrupted = errors.New("final review interrupted")
 
 var errPlanRevisionDispatched = errors.New("missing evidence routed to phase-plan revision")
 
+var validateAgentContract = agent.Validate
+
 var finalReviewRootOrchestrationArtifacts = []string{
 	agent.PhaseCompleteFile,
 	"progress.md",
@@ -94,14 +96,7 @@ func (o *Orchestrator) emitPhaseCompleted(featureID string, phase feature.Phase,
 }
 
 func formatSingleShotProtocolViolationError(role agent.Role, dir string, violations []agent.ProtocolViolation) string {
-	if dir == "" {
-		dir = "<unresolved>"
-	}
-	reason := agent.JoinProtocolViolations(violations)
-	if strings.TrimSpace(reason) == "" {
-		reason = "contract validation failed"
-	}
-	return fmt.Sprintf("protocol violation: %s @ %s: %s", role, dir, reason)
+	return agent.FormatSingleShotProtocolViolationError(role, dir, violations)
 }
 
 // markFailedWithEvent transitions the feature to StatusFailed via lifecycle
@@ -286,7 +281,7 @@ func (o *Orchestrator) validateKBCompletionContract(featureID, repoName string) 
 			})
 		}
 
-		_, contractViolations, err := agent.Validate(
+		_, contractViolations, err := validateAgentContract(
 			feature.PhaseKnowledgeBase,
 			agent.RoleKnowledgeBaseBuilder,
 			kbDir,
@@ -382,12 +377,53 @@ func (o *Orchestrator) onArtifactPhaseCompletedWithKey(
 		return nil
 	}
 
-	outcome, phaseDir, ok, err := o.validateArtifactPhaseCompletionContract(featureID, input, f, phaseKey)
+	outcome, phaseDir, violations, err := o.validateArtifactPhaseCompletionContract(input, f, phaseKey)
 	if err != nil {
 		return err
 	}
-	if !ok {
-		return nil
+	if phaseDir == "" && len(violations) > 0 {
+		errMsg := formatSingleShotProtocolViolationError(artifactPhaseRoleMust(input.Phase), phaseDir, violations)
+		o.emitPhaseCompleted(featureID, input.Phase, errors.New(errMsg))
+		return o.markFailedWithEvent(featureID, feature.FailureProtocolViolation, errMsg)
+	}
+
+	sidecar, err := agent.ReadProtocolRetrySidecar(phaseDir)
+	if err != nil {
+		return fmt.Errorf("read %s retry sidecar: %w", phaseKey, err)
+	}
+	decision := agent.DecideProtocolRetry(
+		artifactPhaseRoleMust(input.Phase),
+		phaseDir,
+		f.ActiveRun,
+		sidecar,
+		violations,
+		agent.DefaultMaxConsecutiveProtocolViolations,
+	)
+	switch decision.Action {
+	case agent.ProtocolRetryActionSucceed:
+		if err := agent.DeleteProtocolRetrySidecar(phaseDir); err != nil {
+			return fmt.Errorf("delete %s retry sidecar: %w", phaseKey, err)
+		}
+	case agent.ProtocolRetryActionRetry:
+		if decision.NewSidecar != nil {
+			if err := agent.WriteProtocolRetrySidecar(phaseDir, *decision.NewSidecar); err != nil {
+				return fmt.Errorf("write %s retry sidecar: %w", phaseKey, err)
+			}
+		}
+		if err := agent.RemovePhaseCompleteMarker(phaseDir); err != nil {
+			return fmt.Errorf("remove %s phase_complete marker: %w", phaseKey, err)
+		}
+		return o.retryArtifactPhase(featureID, input.Phase)
+	case agent.ProtocolRetryActionTerminal:
+		if decision.NewSidecar != nil {
+			if err := agent.WriteProtocolRetrySidecar(phaseDir, *decision.NewSidecar); err != nil {
+				return fmt.Errorf("write terminal %s retry sidecar: %w", phaseKey, err)
+			}
+		}
+		o.emitPhaseCompleted(featureID, input.Phase, errors.New(decision.FormattedError))
+		return o.markFailedWithEvent(featureID, feature.FailureProtocolViolation, decision.FormattedError)
+	default:
+		return fmt.Errorf("unknown protocol retry action %d", decision.Action)
 	}
 
 	if err := o.deps.Store.Modify(featureID, func(ff *feature.Feature) error {
@@ -413,6 +449,29 @@ func (o *Orchestrator) onArtifactPhaseCompletedWithKey(
 	return o.advanceToNextPhase(featureID, input.Phase)
 }
 
+func artifactPhaseRoleMust(phase feature.Phase) agent.Role {
+	role, _ := artifactPhaseRole(phase)
+	return role
+}
+
+func (o *Orchestrator) retryArtifactPhase(featureID string, phase feature.Phase) error {
+	var err error
+	switch phase {
+	case feature.PhaseInquire:
+		_, err = o.startInquire(featureID)
+	case feature.PhaseResearch:
+		_, err = o.startResearch(featureID)
+	case feature.PhaseDesign:
+		_, err = o.startDesign(featureID)
+	default:
+		return fmt.Errorf("no artifact phase starter for %s", phase)
+	}
+	if err != nil {
+		return fmt.Errorf("restart %s: %w", phase, err)
+	}
+	return nil
+}
+
 func artifactPhasePersistsQALog(phaseKey string) bool {
 	switch phaseKey {
 	case "inquire", "research", "design":
@@ -436,35 +495,39 @@ func artifactPhaseRole(phase feature.Phase) (agent.Role, bool) {
 }
 
 func (o *Orchestrator) validateArtifactPhaseCompletionContract(
-	featureID string,
 	input PhaseCompletionInput,
 	f *feature.Feature,
 	phaseKey string,
-) (agent.Outcome, string, bool, error) {
+) (agent.Outcome, string, []agent.ProtocolViolation, error) {
 	role, ok := artifactPhaseRole(input.Phase)
 	if !ok {
-		return agent.Outcome{}, "", false, fmt.Errorf("no artifact phase role for %s", input.Phase)
+		return agent.Outcome{}, "", nil, fmt.Errorf("no artifact phase role for %s", input.Phase)
 	}
 
 	baseDir := o.stateDir()
 	refPrefix := f.RefactorPrefix()
-	phaseDir := filepath.Join(agent.ActiveRunDir(baseDir, f), refPrefix, phaseKey)
+	phaseDir := ""
+	if baseDir != "" {
+		phaseDir = filepath.Join(agent.ActiveRunDir(baseDir, f), refPrefix, phaseKey)
+	}
 	var violations []agent.ProtocolViolation
 	if baseDir == "" {
 		violations = append(violations, agent.ProtocolViolation{
 			Artifact: "artifact-phase",
 			Reason:   "state directory is empty",
 		})
-	} else if !agent.HasPhaseComplete(phaseDir) {
+		return agent.Outcome{}, phaseDir, violations, nil
+	}
+	if !agent.HasPhaseComplete(phaseDir) {
 		violations = append(violations, agent.ProtocolViolation{
 			Artifact: agent.PhaseCompleteFile,
 			Reason:   "SDK reported success but phase_complete was not present",
 		})
 	}
 
-	outcome, contractViolations, err := agent.Validate(input.Phase, role, phaseDir)
+	outcome, contractViolations, err := validateAgentContract(input.Phase, role, phaseDir)
 	if err != nil {
-		return agent.Outcome{}, phaseDir, false, fmt.Errorf("validating %s contract: %w", phaseKey, err)
+		return agent.Outcome{}, phaseDir, nil, fmt.Errorf("validating %s contract: %w", phaseKey, err)
 	}
 	violations = append(violations, contractViolations...)
 	if len(violations) == 0 && strings.TrimSpace(outcome.PhaseArtifactPath) == "" {
@@ -473,16 +536,7 @@ func (o *Orchestrator) validateArtifactPhaseCompletionContract(
 			Reason:   "contract validation did not return an artifact path",
 		})
 	}
-	if len(violations) == 0 {
-		return outcome, phaseDir, true, nil
-	}
-
-	errMsg := formatSingleShotProtocolViolationError(role, phaseDir, violations)
-	o.emitPhaseCompleted(featureID, input.Phase, errors.New(errMsg))
-	if err := o.markFailedWithEvent(featureID, feature.FailureProtocolViolation, errMsg); err != nil {
-		return agent.Outcome{}, phaseDir, false, err
-	}
-	return agent.Outcome{}, phaseDir, false, nil
+	return outcome, phaseDir, violations, nil
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/orchestrator/completion_retry_internal_test.go
+++ b/internal/orchestrator/completion_retry_internal_test.go
@@ -20,6 +20,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/doordash-oss/agentic-orchestrator/internal/agent"
 	"github.com/doordash-oss/agentic-orchestrator/internal/feature"
@@ -115,5 +116,186 @@ func TestArtifactPhaseCompletionValidationInfraErrorBubbles(t *testing.T) {
 			t.Fatalf("PhaseCompleted emitted on infra validation error: %#v", ev)
 		}
 	default:
+	}
+}
+
+func TestKBCompletionValidationInfraErrorBubbles(t *testing.T) {
+	oldValidate := validateAgentContract
+	validateAgentContract = func(feature.Phase, agent.Role, string) (agent.Outcome, []agent.ProtocolViolation, error) {
+		return agent.Outcome{}, nil, errors.New("kb parser exploded")
+	}
+	t.Cleanup(func() {
+		validateAgentContract = oldValidate
+	})
+
+	stateDir := t.TempDir()
+	kbDir := agent.KBStateDir(stateDir, "repo-a")
+	if err := os.MkdirAll(kbDir, 0o755); err != nil {
+		t.Fatalf("mkdir kb dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(kbDir, agent.PhaseCompleteFile), nil, 0o644); err != nil {
+		t.Fatalf("write phase_complete: %v", err)
+	}
+
+	f := &feature.Feature{
+		ID:            "feat-infra",
+		Status:        feature.StatusBuildingKB,
+		CurrentPhase:  feature.PhaseKnowledgeBase,
+		Pipeline:      feature.PipelineLarge,
+		ActiveRun:     1,
+		SchemaVersion: feature.SchemaVersionCurrent,
+		Repos:         []feature.FeatureRepo{{Name: "repo-a", Path: "/tmp/repo-a"}},
+	}
+	store := feature.NewStore(stateDir)
+	if err := store.Save(f); err != nil {
+		t.Fatalf("save feature: %v", err)
+	}
+	lc := mocks.NewMockFeatureLifecycle()
+	lc.GetFn = store.Load
+	lc.MarkFailedFn = func(id, ft, msg string) error {
+		return store.Modify(id, func(ff *feature.Feature) error {
+			ff.Status = feature.StatusFailed
+			ff.FailureType = ft
+			ff.LastError = msg
+			return nil
+		})
+	}
+	sm := mocks.NewMockSessionManager()
+	o := New(Deps{
+		Lifecycle: lc,
+		Store:     store,
+		Sessions:  sm,
+	}, Hooks{})
+
+	err := o.onKBCompleted(f.ID, PhaseCompletionInput{
+		Phase:     feature.PhaseKnowledgeBase,
+		SessionID: f.ID + "-kb-repo-a",
+		Success:   true,
+	})
+	if err == nil {
+		t.Fatal("onKBCompleted() error = nil, want validation error")
+	}
+	if !strings.Contains(err.Error(), "validating knowledge base contract") || !strings.Contains(err.Error(), "kb parser exploded") {
+		t.Fatalf("onKBCompleted() error = %v, want wrapped validation error", err)
+	}
+	reloaded, err := store.Load(f.ID)
+	if err != nil {
+		t.Fatalf("load feature: %v", err)
+	}
+	if reloaded.FailureType != "" || reloaded.LastError != "" {
+		t.Fatalf("FailureType/LastError = %q/%q, want empty", reloaded.FailureType, reloaded.LastError)
+	}
+	if _, err := os.Stat(filepath.Join(kbDir, agent.KBProtocolRetrySidecarFilename(f.ID))); !os.IsNotExist(err) {
+		t.Fatalf("sidecar stat err = %v, want not exist", err)
+	}
+	for _, call := range lc.Calls {
+		switch call.Method {
+		case "MarkRepoKBFailed", "MarkFailed":
+			t.Fatalf("%s called on infra validation error; calls=%#v", call.Method, lc.Calls)
+		}
+	}
+	if got := len(sm.StopCalls); got != 0 {
+		t.Fatalf("StopSession calls = %d, want 0", got)
+	}
+	select {
+	case ev := <-o.Events():
+		if ev.Type == ports.PhaseCompleted {
+			t.Fatalf("PhaseCompleted emitted on infra validation error: %#v", ev)
+		}
+	default:
+	}
+}
+
+func TestKBCompletionRetryPreservesIndexAndState(t *testing.T) {
+	oldValidate := validateAgentContract
+	validateAgentContract = func(feature.Phase, agent.Role, string) (agent.Outcome, []agent.ProtocolViolation, error) {
+		return agent.Outcome{}, []agent.ProtocolViolation{{
+			Artifact: "index.md",
+			Reason:   "synthetic validator violation",
+		}}, nil
+	}
+	t.Cleanup(func() {
+		validateAgentContract = oldValidate
+	})
+
+	stateDir := t.TempDir()
+	kbDir := agent.KBStateDir(stateDir, "repo-a")
+	if err := os.MkdirAll(kbDir, 0o755); err != nil {
+		t.Fatalf("mkdir kb dir: %v", err)
+	}
+	indexPath := agent.KBPath(kbDir)
+	indexBytes := []byte("# existing KB\n\ncontent\n")
+	if err := os.WriteFile(indexPath, indexBytes, 0o644); err != nil {
+		t.Fatalf("write index.md: %v", err)
+	}
+	if err := agent.SaveKBState(kbDir, &agent.KBState{
+		HeadCommit:  "old-head",
+		LastUpdated: time.Date(2026, 5, 18, 12, 0, 0, 0, time.UTC),
+		Version:     1,
+	}); err != nil {
+		t.Fatalf("SaveKBState() error = %v", err)
+	}
+	statePath := filepath.Join(kbDir, "state.json")
+	stateBytes, err := os.ReadFile(statePath)
+	if err != nil {
+		t.Fatalf("read state.json: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(kbDir, agent.PhaseCompleteFile), nil, 0o644); err != nil {
+		t.Fatalf("write phase_complete: %v", err)
+	}
+
+	f := &feature.Feature{
+		ID:            "feat-preserve",
+		Status:        feature.StatusBuildingKB,
+		CurrentPhase:  feature.PhaseKnowledgeBase,
+		Pipeline:      feature.PipelineLarge,
+		ActiveRun:     1,
+		SchemaVersion: feature.SchemaVersionCurrent,
+		Repos:         []feature.FeatureRepo{{Name: "repo-a", Path: "/tmp/repo-a"}},
+	}
+	store := feature.NewStore(stateDir)
+	if err := store.Save(f); err != nil {
+		t.Fatalf("save feature: %v", err)
+	}
+	lc := mocks.NewMockFeatureLifecycle()
+	lc.GetFn = store.Load
+	lc.ListFn = func() ([]*feature.Feature, error) { return []*feature.Feature{f}, nil }
+	o := New(Deps{
+		Lifecycle: lc,
+		Store:     store,
+		CmdRunner: mocks.NewMockCommandRunner(),
+	}, Hooks{})
+
+	if err := o.onKBCompleted(f.ID, PhaseCompletionInput{
+		Phase:     feature.PhaseKnowledgeBase,
+		SessionID: f.ID + "-kb-repo-a",
+		Success:   true,
+	}); err != nil {
+		t.Fatalf("onKBCompleted() error = %v", err)
+	}
+
+	gotIndex, err := os.ReadFile(indexPath)
+	if err != nil {
+		t.Fatalf("read index.md after retry: %v", err)
+	}
+	if string(gotIndex) != string(indexBytes) {
+		t.Fatalf("index.md changed: got %q, want %q", gotIndex, indexBytes)
+	}
+	gotState, err := os.ReadFile(statePath)
+	if err != nil {
+		t.Fatalf("read state.json after retry: %v", err)
+	}
+	if string(gotState) != string(stateBytes) {
+		t.Fatalf("state.json changed: got %q, want %q", gotState, stateBytes)
+	}
+	if _, err := os.Stat(filepath.Join(kbDir, agent.PhaseCompleteFile)); !os.IsNotExist(err) {
+		t.Fatalf("phase_complete stat err = %v, want removed", err)
+	}
+	sidecar, err := agent.ReadProtocolRetrySidecarAt(kbDir, agent.KBProtocolRetrySidecarFilename(f.ID))
+	if err != nil {
+		t.Fatalf("ReadProtocolRetrySidecarAt() error = %v", err)
+	}
+	if sidecar == nil || sidecar.Consecutive != 1 {
+		t.Fatalf("sidecar = %#v, want consecutive=1", sidecar)
 	}
 }

--- a/internal/orchestrator/completion_retry_internal_test.go
+++ b/internal/orchestrator/completion_retry_internal_test.go
@@ -1,0 +1,119 @@
+// Copyright 2026 DoorDash, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package orchestrator
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/doordash-oss/agentic-orchestrator/internal/agent"
+	"github.com/doordash-oss/agentic-orchestrator/internal/feature"
+	"github.com/doordash-oss/agentic-orchestrator/internal/ports"
+	"github.com/doordash-oss/agentic-orchestrator/test/testutil/mocks"
+)
+
+func TestArtifactPhaseCompletionValidationInfraErrorBubbles(t *testing.T) {
+	oldValidate := validateAgentContract
+	validateAgentContract = func(feature.Phase, agent.Role, string) (agent.Outcome, []agent.ProtocolViolation, error) {
+		return agent.Outcome{}, nil, errors.New("parser exploded")
+	}
+	t.Cleanup(func() {
+		validateAgentContract = oldValidate
+	})
+
+	stateDir := t.TempDir()
+	f := &feature.Feature{
+		ID:            "feat-infra-error",
+		Status:        feature.StatusInquiring,
+		CurrentPhase:  feature.PhaseInquire,
+		Pipeline:      feature.PipelineLarge,
+		ActiveRun:     1,
+		RunCount:      1,
+		SchemaVersion: feature.SchemaVersionCurrent,
+	}
+	phaseDir := filepath.Join(agent.ActiveRunDir(stateDir, f), "inquire")
+	if err := os.MkdirAll(phaseDir, 0o755); err != nil {
+		t.Fatalf("mkdir phase dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(phaseDir, agent.PhaseCompleteFile), nil, 0o644); err != nil {
+		t.Fatalf("write phase_complete: %v", err)
+	}
+
+	store := feature.NewStore(stateDir)
+	if err := store.Save(f); err != nil {
+		t.Fatalf("save feature: %v", err)
+	}
+	lc := mocks.NewMockFeatureLifecycle()
+	lc.GetFn = func(id string) (*feature.Feature, error) {
+		return store.Load(id)
+	}
+	lc.CompleteInquireFn = func(id string) error {
+		return store.Modify(id, func(ff *feature.Feature) error {
+			ff.Status = feature.StatusInquireReady
+			return nil
+		})
+	}
+	lc.MarkFailedFn = func(id, ft, msg string) error {
+		return store.Modify(id, func(ff *feature.Feature) error {
+			ff.Status = feature.StatusFailed
+			ff.FailureType = ft
+			ff.LastError = msg
+			return nil
+		})
+	}
+
+	o := New(Deps{
+		Lifecycle:   lc,
+		Store:       store,
+		PhaseRunner: &agent.PhaseRunner{StateDir: stateDir},
+	}, Hooks{})
+
+	err := o.onArtifactPhaseCompleted(f.ID, PhaseCompletionInput{
+		Phase:   feature.PhaseInquire,
+		Success: true,
+	}, "inquire", lc.CompleteInquire)
+	if err == nil {
+		t.Fatal("onArtifactPhaseCompleted() error = nil, want validation error")
+	}
+	if !strings.Contains(err.Error(), "validating inquire contract") || !strings.Contains(err.Error(), "parser exploded") {
+		t.Fatalf("onArtifactPhaseCompleted() error = %v, want wrapped validation error", err)
+	}
+
+	reloaded, err := store.Load(f.ID)
+	if err != nil {
+		t.Fatalf("load feature: %v", err)
+	}
+	if reloaded.FailureType == feature.FailureProtocolViolation {
+		t.Fatalf("FailureType = %q, want no protocol violation marking", reloaded.FailureType)
+	}
+	if _, err := os.Stat(filepath.Join(phaseDir, agent.ProtocolRetrySidecarFile)); !os.IsNotExist(err) {
+		t.Fatalf("sidecar stat err = %v, want not exist", err)
+	}
+	for _, call := range lc.Calls {
+		if call.Method == "MarkFailed" {
+			t.Fatalf("MarkFailed called on infra validation error; calls=%#v", lc.Calls)
+		}
+	}
+	select {
+	case ev := <-o.Events():
+		if ev.Type == ports.PhaseCompleted {
+			t.Fatalf("PhaseCompleted emitted on infra validation error: %#v", ev)
+		}
+	default:
+	}
+}

--- a/internal/orchestrator/completion_test.go
+++ b/internal/orchestrator/completion_test.go
@@ -53,6 +53,107 @@ func writeKBCompletionArtifacts(t *testing.T, stateDir, repoName string, withMar
 	return kbDir
 }
 
+type kbRetryFixture struct {
+	orchestrator *orchestrator.Orchestrator
+	feature      *feature.Feature
+	store        *featureStore
+	runner       *capturingPhaseRunner
+	lifecycle    *mocks.MockFeatureLifecycle
+	kbDir        string
+}
+
+func newKBRetryFixture(t *testing.T, featureID string, repoNames ...string) kbRetryFixture {
+	t.Helper()
+	cpr := newCapturingPhaseRunner(t)
+	repos := make([]feature.FeatureRepo, 0, len(repoNames))
+	kbStatus := make(map[string]string, len(repoNames))
+	for _, name := range repoNames {
+		repos = append(repos, feature.FeatureRepo{Name: name, Path: filepath.Join(t.TempDir(), name)})
+		kbStatus[name] = "running"
+	}
+	f := &feature.Feature{
+		ID:            featureID,
+		Status:        feature.StatusBuildingKB,
+		CurrentPhase:  feature.PhaseKnowledgeBase,
+		Pipeline:      feature.PipelineLarge,
+		ActiveRun:     1,
+		RunCount:      1,
+		SchemaVersion: feature.SchemaVersionCurrent,
+		Repos:         repos,
+		KBStatus:      kbStatus,
+	}
+	fs := newFeatureStore(f)
+	lc := lifecycleForFeature(f)
+	lc.GetFn = fs.Load
+	lc.ListFn = fs.List
+	lc.MarkFailedFn = func(id, ft, msg string) error {
+		return fs.Modify(id, func(ff *feature.Feature) error {
+			ff.Status = feature.StatusFailed
+			ff.FailureType = ft
+			ff.LastError = msg
+			return nil
+		})
+	}
+	lc.MarkRepoKBCompletedFn = func(id, repoName string) error {
+		return fs.Modify(id, func(ff *feature.Feature) error {
+			ff.KBStatus[repoName] = "completed"
+			return nil
+		})
+	}
+	lc.MarkRepoKBFailedFn = func(id, repoName, msg string) error {
+		return fs.Modify(id, func(ff *feature.Feature) error {
+			ff.KBStatus[repoName] = "failed: " + msg
+			return nil
+		})
+	}
+	lc.AllKBsCompletedFn = func(id string) (bool, error) { return false, nil }
+
+	o := orchestrator.New(orchestrator.Deps{
+		Lifecycle:   lc,
+		Store:       fs,
+		Sessions:    cpr.sm,
+		PhaseRunner: cpr.pr,
+		CmdRunner:   cpr.cmd,
+	}, orchestrator.Hooks{})
+
+	return kbRetryFixture{
+		orchestrator: o,
+		feature:      f,
+		store:        fs,
+		runner:       cpr,
+		lifecycle:    lc,
+		kbDir:        agent.KBStateDir(cpr.stateDir, repoNames[0]),
+	}
+}
+
+func readKBRetrySidecar(t *testing.T, kbDir, featureID string) *agent.ProtocolRetrySidecar {
+	t.Helper()
+	sidecar, err := agent.ReadProtocolRetrySidecarAt(kbDir, agent.KBProtocolRetrySidecarFilename(featureID))
+	if err != nil {
+		t.Fatalf("ReadProtocolRetrySidecarAt() error = %v", err)
+	}
+	if sidecar == nil {
+		t.Fatal("KB retry sidecar = nil, want retry state")
+	}
+	return sidecar
+}
+
+func releaseKBLockForRetry(t *testing.T, kbDir, featureID string) {
+	t.Helper()
+	if err := agent.ReleaseKBLock(kbDir, featureID); err != nil {
+		t.Fatalf("ReleaseKBLock() error = %v", err)
+	}
+}
+
+func loadKBRetryFeature(t *testing.T, fix kbRetryFixture) *feature.Feature {
+	t.Helper()
+	f, err := fix.store.Load(fix.feature.ID)
+	if err != nil {
+		t.Fatalf("load feature: %v", err)
+	}
+	return f
+}
+
 // onKBCompleted success + not-all-done: PhaseCompleted is NOT emitted yet;
 // advance is NOT called. Just MarkRepoKBCompleted is recorded.
 func TestOrchestrator_HandlePhaseCompletion_KB_Success_NotAllDone(t *testing.T) {
@@ -189,109 +290,339 @@ func TestOrchestrator_HandlePhaseCompletion_KB_Success_AllDone(t *testing.T) {
 }
 
 func TestOrchestrator_HandlePhaseCompletion_KB_MissingPhaseCompleteProtocolViolation(t *testing.T) {
-	stateDir := t.TempDir()
-	writeKBCompletionArtifacts(t, stateDir, "repo-a", false, true)
-
-	f := &feature.Feature{
-		ID:           "feat-no-marker",
-		Status:       feature.StatusBuildingKB,
-		CurrentPhase: feature.PhaseKnowledgeBase,
-		Pipeline:     feature.PipelineLarge,
-		Repos:        []feature.FeatureRepo{{Name: "repo-a", Path: "/tmp/repo-a"}},
+	fix := newKBRetryFixture(t, "feat-no-marker", "repo-a", "repo-b", "repo-c")
+	writeKBCompletionArtifacts(t, fix.runner.stateDir, "repo-a", false, true)
+	fix.runner.sm.FeatureSessionsFn = func(id string) []session.SessionView {
+		return []session.SessionView{
+			newStubSessionHandle(id+"-kb-repo-b", id, feature.PhaseKnowledgeBase, "repo-b"),
+			newStubSessionHandle(id+"-kb-repo-c", id, feature.PhaseKnowledgeBase, "repo-c"),
+		}
 	}
-	lc := lifecycleForFeature(f)
-	lc.MarkRepoKBFailedFn = func(id, repoName, msg string) error { return nil }
-	lc.MarkFailedFn = func(id, ft, msg string) error { return nil }
-	fs := newFeatureStore(f)
 
-	var failureType, failureMsg string
-	o := orchestrator.New(orchestrator.Deps{
-		Lifecycle:   lc,
-		Store:       fs,
-		PhaseRunner: &agent.PhaseRunner{StateDir: stateDir},
-		CmdRunner:   mocks.NewMockCommandRunner(),
-	}, orchestrator.Hooks{
-		OnFeatureFailed: func(id, ft, msg string) {
-			failureType = ft
-			failureMsg = msg
-		},
-	})
-
-	if err := o.HandlePhaseCompletion(f.ID, orchestrator.PhaseCompletionInput{
+	if err := fix.orchestrator.HandlePhaseCompletion(fix.feature.ID, orchestrator.PhaseCompletionInput{
 		Phase:     feature.PhaseKnowledgeBase,
-		SessionID: f.ID + "-kb-repo-a",
+		SessionID: fix.feature.ID + "-kb-repo-a",
 		Success:   true,
 	}); err != nil {
 		t.Fatalf("HandlePhaseCompletion() error = %v", err)
 	}
 
-	if failureType != feature.FailureProtocolViolation {
-		t.Fatalf("failure type = %q, want %q", failureType, feature.FailureProtocolViolation)
+	reloaded := loadKBRetryFeature(t, fix)
+	if reloaded.Status != feature.StatusBuildingKB {
+		t.Fatalf("Status = %s, want %s", reloaded.Status, feature.StatusBuildingKB)
 	}
-	if !strings.Contains(failureMsg, agent.PhaseCompleteFile) {
-		t.Fatalf("failure message = %q, want phase_complete", failureMsg)
+	if reloaded.FailureType != "" || reloaded.LastError != "" {
+		t.Fatalf("FailureType/LastError = %q/%q, want empty", reloaded.FailureType, reloaded.LastError)
 	}
-	assertLifecycleCall(t, lc, "MarkRepoKBFailed")
-	assertLifecycleCall(t, lc, "MarkFailed")
-	refuteLifecycleCall(t, lc, "MarkRepoKBCompleted")
-	refuteLifecycleCall(t, lc, "CompleteKnowledgeBase")
+	if got := reloaded.KBStatus["repo-a"]; got != "running" {
+		t.Fatalf("KBStatus[repo-a] = %q, want unchanged running", got)
+	}
+	sidecar := readKBRetrySidecar(t, fix.kbDir, fix.feature.ID)
+	if sidecar.Role != agent.RoleKnowledgeBaseBuilder || sidecar.ActiveRun != reloaded.ActiveRun || sidecar.Consecutive != 1 {
+		t.Fatalf("sidecar = %#v, want role=%s active_run=%d consecutive=1", sidecar, agent.RoleKnowledgeBaseBuilder, reloaded.ActiveRun)
+	}
+	if !strings.Contains(sidecar.LastViolation, agent.PhaseCompleteFile) {
+		t.Fatalf("sidecar.LastViolation = %q, want phase_complete", sidecar.LastViolation)
+	}
+	if _, err := os.Stat(filepath.Join(fix.kbDir, agent.PhaseCompleteFile)); !os.IsNotExist(err) {
+		t.Fatalf("phase_complete stat err = %v, want removed/missing", err)
+	}
+	if got := len(fix.runner.capturedByPhase(feature.PhaseKnowledgeBase)); got != 1 {
+		t.Fatalf("KB retry starts = %d, want 1", got)
+	}
+	if got := fix.runner.capturedByPhase(feature.PhaseKnowledgeBase)[0].RepoName; got != "repo-a" {
+		t.Fatalf("retried repo = %q, want repo-a", got)
+	}
+	if got := len(fix.runner.sm.StopCalls); got != 0 {
+		t.Fatalf("StopSession calls = %d, want 0", got)
+	}
+	refuteLifecycleCall(t, fix.lifecycle, "MarkRepoKBFailed")
+	refuteLifecycleCall(t, fix.lifecycle, "MarkFailed")
+	refuteLifecycleCall(t, fix.lifecycle, "MarkRepoKBCompleted")
+	refuteLifecycleCall(t, fix.lifecycle, "CompleteKnowledgeBase")
 
-	events := drainEvents(o)
-	if !hasEventType(events, ports.PhaseCompleted) {
-		t.Error("expected PhaseCompleted error event")
+	events := drainEvents(fix.orchestrator)
+	if hasEventType(events, ports.PhaseCompleted) {
+		t.Fatalf("PhaseCompleted emitted on retry: %#v", events)
 	}
 	if !hasEventType(events, ports.FeatureFailed) {
-		t.Error("expected FeatureFailed event")
+		return
 	}
+	t.Fatalf("FeatureFailed emitted on retry: %#v", events)
 }
 
 func TestOrchestrator_HandlePhaseCompletion_KB_MissingIndexProtocolViolation(t *testing.T) {
-	stateDir := t.TempDir()
-	writeKBCompletionArtifacts(t, stateDir, "repo-a", true, false)
+	fix := newKBRetryFixture(t, "feat-no-index", "repo-a")
+	writeKBCompletionArtifacts(t, fix.runner.stateDir, "repo-a", true, false)
 
-	f := &feature.Feature{
-		ID:           "feat-no-index",
-		Status:       feature.StatusBuildingKB,
-		CurrentPhase: feature.PhaseKnowledgeBase,
-		Pipeline:     feature.PipelineLarge,
-		Repos:        []feature.FeatureRepo{{Name: "repo-a", Path: "/tmp/repo-a"}},
-	}
-	lc := lifecycleForFeature(f)
-	lc.MarkRepoKBFailedFn = func(id, repoName, msg string) error { return nil }
-	lc.MarkFailedFn = func(id, ft, msg string) error { return nil }
-	fs := newFeatureStore(f)
-
-	var failureType, failureMsg string
-	o := orchestrator.New(orchestrator.Deps{
-		Lifecycle:   lc,
-		Store:       fs,
-		PhaseRunner: &agent.PhaseRunner{StateDir: stateDir},
-		CmdRunner:   mocks.NewMockCommandRunner(),
-	}, orchestrator.Hooks{
-		OnFeatureFailed: func(id, ft, msg string) {
-			failureType = ft
-			failureMsg = msg
-		},
-	})
-
-	if err := o.HandlePhaseCompletion(f.ID, orchestrator.PhaseCompletionInput{
+	if err := fix.orchestrator.HandlePhaseCompletion(fix.feature.ID, orchestrator.PhaseCompletionInput{
 		Phase:     feature.PhaseKnowledgeBase,
-		SessionID: f.ID + "-kb-repo-a",
+		SessionID: fix.feature.ID + "-kb-repo-a",
 		Success:   true,
 	}); err != nil {
 		t.Fatalf("HandlePhaseCompletion() error = %v", err)
 	}
 
-	if failureType != feature.FailureProtocolViolation {
-		t.Fatalf("failure type = %q, want %q", failureType, feature.FailureProtocolViolation)
+	reloaded := loadKBRetryFeature(t, fix)
+	if reloaded.FailureType != "" || reloaded.LastError != "" {
+		t.Fatalf("FailureType/LastError = %q/%q, want empty", reloaded.FailureType, reloaded.LastError)
 	}
-	if !strings.Contains(failureMsg, "index.md") {
-		t.Fatalf("failure message = %q, want index.md", failureMsg)
+	if got := reloaded.KBStatus["repo-a"]; got != "running" {
+		t.Fatalf("KBStatus[repo-a] = %q, want unchanged running", got)
 	}
-	assertLifecycleCall(t, lc, "MarkRepoKBFailed")
-	assertLifecycleCall(t, lc, "MarkFailed")
-	refuteLifecycleCall(t, lc, "MarkRepoKBCompleted")
-	refuteLifecycleCall(t, lc, "CompleteKnowledgeBase")
+	sidecar := readKBRetrySidecar(t, fix.kbDir, fix.feature.ID)
+	if sidecar.Consecutive != 1 || !strings.Contains(sidecar.LastViolation, "index.md") {
+		t.Fatalf("sidecar = %#v, want first index.md retry", sidecar)
+	}
+	if _, err := os.Stat(filepath.Join(fix.kbDir, agent.PhaseCompleteFile)); !os.IsNotExist(err) {
+		t.Fatalf("phase_complete stat err = %v, want removed", err)
+	}
+	if got := len(fix.runner.capturedByPhase(feature.PhaseKnowledgeBase)); got != 1 {
+		t.Fatalf("KB retry starts = %d, want 1", got)
+	}
+	refuteLifecycleCall(t, fix.lifecycle, "MarkRepoKBFailed")
+	refuteLifecycleCall(t, fix.lifecycle, "MarkFailed")
+	refuteLifecycleCall(t, fix.lifecycle, "MarkRepoKBCompleted")
+	refuteLifecycleCall(t, fix.lifecycle, "CompleteKnowledgeBase")
+	if events := drainEvents(fix.orchestrator); hasEventType(events, ports.PhaseCompleted) {
+		t.Fatalf("PhaseCompleted emitted on retry: %#v", events)
+	}
+}
+
+func TestOrchestrator_HandlePhaseCompletion_KB_RetryThenSuccessCompletesRepo(t *testing.T) {
+	fix := newKBRetryFixture(t, "feat-retry-success", "repo-a")
+	writeKBCompletionArtifacts(t, fix.runner.stateDir, "repo-a", false, true)
+
+	if err := fix.orchestrator.HandlePhaseCompletion(fix.feature.ID, orchestrator.PhaseCompletionInput{
+		Phase:     feature.PhaseKnowledgeBase,
+		SessionID: fix.feature.ID + "-kb-repo-a",
+		Success:   true,
+	}); err != nil {
+		t.Fatalf("first HandlePhaseCompletion() error = %v", err)
+	}
+	releaseKBLockForRetry(t, fix.kbDir, fix.feature.ID)
+	drainEvents(fix.orchestrator)
+
+	writeKBCompletionArtifacts(t, fix.runner.stateDir, "repo-a", true, true)
+	if err := fix.orchestrator.HandlePhaseCompletion(fix.feature.ID, orchestrator.PhaseCompletionInput{
+		Phase:     feature.PhaseKnowledgeBase,
+		SessionID: fix.feature.ID + "-kb-repo-a",
+		Success:   true,
+	}); err != nil {
+		t.Fatalf("second HandlePhaseCompletion() error = %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(fix.kbDir, agent.KBProtocolRetrySidecarFilename(fix.feature.ID))); !os.IsNotExist(err) {
+		t.Fatalf("sidecar stat err = %v, want removed", err)
+	}
+	reloaded := loadKBRetryFeature(t, fix)
+	if got := reloaded.KBStatus["repo-a"]; got != "completed" {
+		t.Fatalf("KBStatus[repo-a] = %q, want completed", got)
+	}
+	if got := countLifecycleCalls(fix.lifecycle, "MarkRepoKBCompleted"); got != 1 {
+		t.Fatalf("MarkRepoKBCompleted calls = %d, want 1", got)
+	}
+	refuteLifecycleCall(t, fix.lifecycle, "MarkRepoKBFailed")
+	refuteLifecycleCall(t, fix.lifecycle, "MarkFailed")
+	if got := len(fix.runner.capturedByPhase(feature.PhaseKnowledgeBase)); got != 1 {
+		t.Fatalf("KB retry starts = %d, want 1", got)
+	}
+	if events := drainEvents(fix.orchestrator); hasEventType(events, ports.PhaseCompleted) {
+		t.Fatalf("PhaseCompleted emitted before all repos completed: %#v", events)
+	}
+}
+
+func TestOrchestrator_HandlePhaseCompletion_KB_ThirdViolationTerminates(t *testing.T) {
+	fix := newKBRetryFixture(t, "feat-third-violation", "repo-a", "repo-b")
+	writeKBCompletionArtifacts(t, fix.runner.stateDir, "repo-a", false, true)
+	fix.runner.sm.FeatureSessionsFn = func(id string) []session.SessionView {
+		return []session.SessionView{
+			newStubSessionHandle(id+"-kb-repo-b", id, feature.PhaseKnowledgeBase, "repo-b"),
+		}
+	}
+
+	for attempt := 1; attempt <= agent.DefaultMaxConsecutiveProtocolViolations; attempt++ {
+		if attempt > 1 {
+			releaseKBLockForRetry(t, fix.kbDir, fix.feature.ID)
+		}
+		if err := fix.orchestrator.HandlePhaseCompletion(fix.feature.ID, orchestrator.PhaseCompletionInput{
+			Phase:     feature.PhaseKnowledgeBase,
+			SessionID: fix.feature.ID + "-kb-repo-a",
+			Success:   true,
+		}); err != nil {
+			t.Fatalf("HandlePhaseCompletion(attempt %d) error = %v", attempt, err)
+		}
+	}
+
+	violations := []agent.ProtocolViolation{{
+		Artifact: agent.PhaseCompleteFile,
+		Reason:   "SDK reported success but phase_complete was not present",
+	}}
+	wantErr := agent.FormatSingleShotProtocolViolationError(agent.RoleKnowledgeBaseBuilder, fix.kbDir, violations)
+	reloaded := loadKBRetryFeature(t, fix)
+	if reloaded.FailureType != feature.FailureProtocolViolation {
+		t.Fatalf("FailureType = %q, want %q", reloaded.FailureType, feature.FailureProtocolViolation)
+	}
+	if reloaded.LastError != wantErr {
+		t.Fatalf("LastError = %q, want %q", reloaded.LastError, wantErr)
+	}
+	if got := reloaded.KBStatus["repo-a"]; got != "failed: "+wantErr {
+		t.Fatalf("KBStatus[repo-a] = %q, want failed with terminal error", got)
+	}
+	sidecar := readKBRetrySidecar(t, fix.kbDir, fix.feature.ID)
+	if sidecar.Consecutive != agent.DefaultMaxConsecutiveProtocolViolations {
+		t.Fatalf("sidecar.Consecutive = %d, want %d", sidecar.Consecutive, agent.DefaultMaxConsecutiveProtocolViolations)
+	}
+	if got := countLifecycleCalls(fix.lifecycle, "MarkRepoKBFailed"); got != 1 {
+		t.Fatalf("MarkRepoKBFailed calls = %d, want 1", got)
+	}
+	if got := countLifecycleCalls(fix.lifecycle, "MarkFailed"); got != 1 {
+		t.Fatalf("MarkFailed calls = %d, want 1", got)
+	}
+	if got := len(fix.runner.sm.StopCalls); got != 1 {
+		t.Fatalf("StopSession calls = %d, want 1", got)
+	}
+	if got := len(fix.runner.capturedByPhase(feature.PhaseKnowledgeBase)); got != agent.DefaultMaxConsecutiveProtocolViolations-1 {
+		t.Fatalf("KB retry starts = %d, want %d", got, agent.DefaultMaxConsecutiveProtocolViolations-1)
+	}
+	events := drainEvents(fix.orchestrator)
+	if got := countPhaseCompletedEvents(events, feature.PhaseKnowledgeBase); got != 1 {
+		t.Fatalf("PhaseCompleted events = %d, want 1; events=%#v", got, events)
+	}
+}
+
+func TestOrchestrator_HandlePhaseCompletion_KB_SidecarScoping(t *testing.T) {
+	t.Run("stale_active_run_resets", func(t *testing.T) {
+		fix := newKBRetryFixture(t, "feat-stale-run", "repo-a")
+		writeKBCompletionArtifacts(t, fix.runner.stateDir, "repo-a", false, true)
+		if err := agent.WriteProtocolRetrySidecarAt(fix.kbDir, agent.KBProtocolRetrySidecarFilename(fix.feature.ID), agent.ProtocolRetrySidecar{
+			Role:          agent.RoleKnowledgeBaseBuilder,
+			ActiveRun:     fix.feature.ActiveRun + 1,
+			Consecutive:   2,
+			LastViolation: "stale run",
+			UpdatedAt:     time.Now().UTC(),
+		}); err != nil {
+			t.Fatalf("WriteProtocolRetrySidecarAt() error = %v", err)
+		}
+
+		if err := fix.orchestrator.HandlePhaseCompletion(fix.feature.ID, orchestrator.PhaseCompletionInput{
+			Phase:     feature.PhaseKnowledgeBase,
+			SessionID: fix.feature.ID + "-kb-repo-a",
+			Success:   true,
+		}); err != nil {
+			t.Fatalf("HandlePhaseCompletion() error = %v", err)
+		}
+
+		reloaded := loadKBRetryFeature(t, fix)
+		if reloaded.FailureType != "" {
+			t.Fatalf("FailureType = %q, want empty", reloaded.FailureType)
+		}
+		sidecar := readKBRetrySidecar(t, fix.kbDir, fix.feature.ID)
+		if sidecar.ActiveRun != fix.feature.ActiveRun || sidecar.Consecutive != 1 {
+			t.Fatalf("sidecar = %#v, want active_run=%d consecutive=1", sidecar, fix.feature.ActiveRun)
+		}
+	})
+
+	t.Run("matching_active_run_terminates", func(t *testing.T) {
+		fix := newKBRetryFixture(t, "feat-matching-run", "repo-a")
+		writeKBCompletionArtifacts(t, fix.runner.stateDir, "repo-a", false, true)
+		if err := agent.WriteProtocolRetrySidecarAt(fix.kbDir, agent.KBProtocolRetrySidecarFilename(fix.feature.ID), agent.ProtocolRetrySidecar{
+			Role:          agent.RoleKnowledgeBaseBuilder,
+			ActiveRun:     fix.feature.ActiveRun,
+			Consecutive:   2,
+			LastViolation: "prior run",
+			UpdatedAt:     time.Now().UTC(),
+		}); err != nil {
+			t.Fatalf("WriteProtocolRetrySidecarAt() error = %v", err)
+		}
+
+		if err := fix.orchestrator.HandlePhaseCompletion(fix.feature.ID, orchestrator.PhaseCompletionInput{
+			Phase:     feature.PhaseKnowledgeBase,
+			SessionID: fix.feature.ID + "-kb-repo-a",
+			Success:   true,
+		}); err != nil {
+			t.Fatalf("HandlePhaseCompletion() error = %v", err)
+		}
+
+		reloaded := loadKBRetryFeature(t, fix)
+		if reloaded.FailureType != feature.FailureProtocolViolation {
+			t.Fatalf("FailureType = %q, want %q", reloaded.FailureType, feature.FailureProtocolViolation)
+		}
+		sidecar := readKBRetrySidecar(t, fix.kbDir, fix.feature.ID)
+		if sidecar.Consecutive != agent.DefaultMaxConsecutiveProtocolViolations {
+			t.Fatalf("sidecar.Consecutive = %d, want %d", sidecar.Consecutive, agent.DefaultMaxConsecutiveProtocolViolations)
+		}
+	})
+
+	t.Run("other_feature_sidecar_ignored", func(t *testing.T) {
+		fix := newKBRetryFixture(t, "feat-current", "repo-a")
+		writeKBCompletionArtifacts(t, fix.runner.stateDir, "repo-a", false, true)
+		otherFilename := agent.KBProtocolRetrySidecarFilename("feat-other")
+		otherSidecar := agent.ProtocolRetrySidecar{
+			Role:          agent.RoleKnowledgeBaseBuilder,
+			ActiveRun:     fix.feature.ActiveRun,
+			Consecutive:   3,
+			LastViolation: "other feature terminal",
+			UpdatedAt:     time.Date(2026, 5, 18, 1, 2, 3, 0, time.UTC),
+		}
+		if err := agent.WriteProtocolRetrySidecarAt(fix.kbDir, otherFilename, otherSidecar); err != nil {
+			t.Fatalf("WriteProtocolRetrySidecarAt(other) error = %v", err)
+		}
+
+		if err := fix.orchestrator.HandlePhaseCompletion(fix.feature.ID, orchestrator.PhaseCompletionInput{
+			Phase:     feature.PhaseKnowledgeBase,
+			SessionID: fix.feature.ID + "-kb-repo-a",
+			Success:   true,
+		}); err != nil {
+			t.Fatalf("HandlePhaseCompletion() error = %v", err)
+		}
+
+		reloaded := loadKBRetryFeature(t, fix)
+		if reloaded.FailureType != "" {
+			t.Fatalf("FailureType = %q, want empty", reloaded.FailureType)
+		}
+		current := readKBRetrySidecar(t, fix.kbDir, fix.feature.ID)
+		if current.Consecutive != 1 {
+			t.Fatalf("current sidecar.Consecutive = %d, want 1", current.Consecutive)
+		}
+		other, err := agent.ReadProtocolRetrySidecarAt(fix.kbDir, otherFilename)
+		if err != nil {
+			t.Fatalf("ReadProtocolRetrySidecarAt(other) error = %v", err)
+		}
+		if other == nil || other.Consecutive != otherSidecar.Consecutive || other.LastViolation != otherSidecar.LastViolation {
+			t.Fatalf("other sidecar = %#v, want preserved %#v", other, otherSidecar)
+		}
+	})
+}
+
+func TestOrchestrator_HandlePhaseCompletion_KB_SessionCrashDoesNotReadSidecar(t *testing.T) {
+	fix := newKBRetryFixture(t, "feat-crash", "repo-a")
+	if err := os.MkdirAll(fix.kbDir, 0o755); err != nil {
+		t.Fatalf("mkdir kb dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(fix.kbDir, agent.KBProtocolRetrySidecarFilename(fix.feature.ID)), []byte("role: ["), 0o644); err != nil {
+		t.Fatalf("write malformed sidecar: %v", err)
+	}
+
+	if err := fix.orchestrator.HandlePhaseCompletion(fix.feature.ID, orchestrator.PhaseCompletionInput{
+		Phase:       feature.PhaseKnowledgeBase,
+		SessionID:   fix.feature.ID + "-kb-repo-a",
+		Success:     false,
+		ErrorDetail: "kb crashed",
+	}); err != nil {
+		t.Fatalf("HandlePhaseCompletion() error = %v", err)
+	}
+
+	reloaded := loadKBRetryFeature(t, fix)
+	if reloaded.FailureType != feature.FailureSessionCrash {
+		t.Fatalf("FailureType = %q, want %q", reloaded.FailureType, feature.FailureSessionCrash)
+	}
+	if got := len(fix.runner.capturedByPhase(feature.PhaseKnowledgeBase)); got != 0 {
+		t.Fatalf("KB retry starts = %d, want 0", got)
+	}
+	if got := countLifecycleCalls(fix.lifecycle, "MarkRepoKBFailed"); got != 1 {
+		t.Fatalf("MarkRepoKBFailed calls = %d, want 1", got)
+	}
 }
 
 // onKBCompleted terminal-state guard: when feature.Status != BuildingKB, the

--- a/internal/orchestrator/completion_test.go
+++ b/internal/orchestrator/completion_test.go
@@ -510,27 +510,211 @@ func loadStoredFeature(t *testing.T, store *feature.Store, featureID string) *fe
 	return f
 }
 
+type artifactPhaseRetryFixture struct {
+	orchestrator *orchestrator.Orchestrator
+	feature      *feature.Feature
+	store        *feature.Store
+	runner       *capturingPhaseRunner
+	phaseDir     string
+	lifecycle    *mocks.MockFeatureLifecycle
+}
+
+func newArtifactPhaseRetryFixture(t *testing.T, tc artifactPhaseCase, checkpoints feature.Checkpoints) artifactPhaseRetryFixture {
+	t.Helper()
+
+	cpr := newCapturingPhaseRunner(t)
+	stateDir := cpr.stateDir
+	f := &feature.Feature{
+		ID:            "feat-retry-" + tc.phaseKey,
+		Status:        tc.status,
+		CurrentPhase:  tc.phase,
+		Pipeline:      feature.PipelineLarge,
+		ActiveRun:     1,
+		RunCount:      1,
+		SchemaVersion: feature.SchemaVersionCurrent,
+		Checkpoints:   checkpoints,
+		Artifacts:     make(map[string]string),
+	}
+	seedPriorInteractiveArtifacts(t, stateDir, f, tc)
+
+	store := feature.NewStore(stateDir)
+	if err := store.Save(f); err != nil {
+		t.Fatalf("save feature: %v", err)
+	}
+
+	lc := lifecycleForFeature(f)
+	lc.GetFn = func(id string) (*feature.Feature, error) {
+		return store.Load(id)
+	}
+	lc.MarkFailedFn = func(id, ft, msg string) error {
+		return store.Modify(id, func(ff *feature.Feature) error {
+			ff.Status = feature.StatusFailed
+			ff.FailureType = ft
+			ff.LastError = msg
+			return nil
+		})
+	}
+	lc.CompleteInquireFn = func(id string) error {
+		return store.Modify(id, func(ff *feature.Feature) error {
+			ff.Status = feature.StatusInquireReady
+			return nil
+		})
+	}
+	lc.CompleteResearchFn = func(id string) error {
+		return store.Modify(id, func(ff *feature.Feature) error {
+			ff.Status = feature.StatusDesignReady
+			return nil
+		})
+	}
+	lc.CompleteDesignFn = func(id string) error {
+		return store.Modify(id, func(ff *feature.Feature) error {
+			ff.Status = feature.StatusPlanReady
+			return nil
+		})
+	}
+	lc.StartInquireFn = func(id string) error {
+		return store.Modify(id, func(ff *feature.Feature) error {
+			ff.Status = feature.StatusInquiring
+			return nil
+		})
+	}
+	lc.StartResearchFn = func(id string) error {
+		return store.Modify(id, func(ff *feature.Feature) error {
+			ff.Status = feature.StatusResearching
+			return nil
+		})
+	}
+	lc.StartDesignFn = func(id string) error {
+		return store.Modify(id, func(ff *feature.Feature) error {
+			ff.Status = feature.StatusDesigning
+			return nil
+		})
+	}
+
+	o := orchestrator.New(orchestrator.Deps{
+		Lifecycle:   lc,
+		Store:       store,
+		Sessions:    cpr.sm,
+		PhaseRunner: cpr.pr,
+		CmdRunner:   cpr.cmd,
+	}, orchestrator.Hooks{})
+
+	return artifactPhaseRetryFixture{
+		orchestrator: o,
+		feature:      f,
+		store:        store,
+		runner:       cpr,
+		phaseDir:     filepath.Join(agent.ActiveRunDir(stateDir, f), tc.phaseKey),
+		lifecycle:    lc,
+	}
+}
+
+func seedPriorInteractiveArtifacts(t *testing.T, stateDir string, f *feature.Feature, tc artifactPhaseCase) {
+	t.Helper()
+	switch tc.phase {
+	case feature.PhaseResearch:
+		f.Artifacts["inquire"] = writePhaseMarkdown(t, stateDir, f, "inquire", "inquire.md")
+	case feature.PhaseDesign:
+		f.Artifacts["inquire"] = writePhaseMarkdown(t, stateDir, f, "inquire", "inquire.md")
+		f.Artifacts["research"] = writePhaseMarkdown(t, stateDir, f, "research", "research.md")
+	}
+}
+
+func artifactPhaseRoleForTest(t *testing.T, phase feature.Phase) agent.Role {
+	t.Helper()
+	switch phase {
+	case feature.PhaseInquire:
+		return agent.RoleInquirer
+	case feature.PhaseResearch:
+		return agent.RoleResearcher
+	case feature.PhaseDesign:
+		return agent.RoleDesigner
+	default:
+		t.Fatalf("unknown artifact phase %s", phase)
+		return ""
+	}
+}
+
+func retrySuccessCheckpointForTest(phase feature.Phase) feature.Checkpoints {
+	switch phase {
+	case feature.PhaseInquire:
+		return feature.Checkpoints{InquiryReview: true}
+	case feature.PhaseResearch:
+		return feature.Checkpoints{ResearchReview: true}
+	case feature.PhaseDesign:
+		return feature.Checkpoints{DesignReview: true}
+	default:
+		return feature.Checkpoints{}
+	}
+}
+
+func countPhaseCompletedEvents(events []ports.Event, phase feature.Phase) int {
+	count := 0
+	for _, ev := range events {
+		if ev.Type == ports.PhaseCompleted && ev.Phase == phase {
+			count++
+		}
+	}
+	return count
+}
+
+func assertFirstArtifactRetry(t *testing.T, fix artifactPhaseRetryFixture, tc artifactPhaseCase, wantViolation string) {
+	t.Helper()
+	reloaded := loadStoredFeature(t, fix.store, fix.feature.ID)
+	if reloaded.Status != tc.status {
+		t.Fatalf("Status = %s, want %s", reloaded.Status, tc.status)
+	}
+	if reloaded.FailureType != "" {
+		t.Fatalf("FailureType = %q, want empty", reloaded.FailureType)
+	}
+	if reloaded.LastError != "" {
+		t.Fatalf("LastError = %q, want empty", reloaded.LastError)
+	}
+
+	sidecar, err := agent.ReadProtocolRetrySidecar(fix.phaseDir)
+	if err != nil {
+		t.Fatalf("ReadProtocolRetrySidecar() error = %v", err)
+	}
+	if sidecar == nil {
+		t.Fatal("sidecar = nil, want retry state")
+	}
+	if sidecar.Consecutive != 1 {
+		t.Fatalf("sidecar.Consecutive = %d, want 1", sidecar.Consecutive)
+	}
+	if sidecar.ActiveRun != reloaded.ActiveRun {
+		t.Fatalf("sidecar.ActiveRun = %d, want %d", sidecar.ActiveRun, reloaded.ActiveRun)
+	}
+	if sidecar.Role != artifactPhaseRoleForTest(t, tc.phase) {
+		t.Fatalf("sidecar.Role = %q, want %q", sidecar.Role, artifactPhaseRoleForTest(t, tc.phase))
+	}
+	if !strings.Contains(sidecar.LastViolation, wantViolation) {
+		t.Fatalf("sidecar.LastViolation = %q, want %q", sidecar.LastViolation, wantViolation)
+	}
+	if _, err := os.Stat(filepath.Join(fix.phaseDir, agent.PhaseCompleteFile)); !os.IsNotExist(err) {
+		t.Fatalf("phase_complete stat err = %v, want removed", err)
+	}
+	if got := len(fix.runner.capturedByPhase(tc.phase)); got != 1 {
+		t.Fatalf("starter captures for %s = %d, want 1", tc.phase, got)
+	}
+	if events := drainEvents(fix.orchestrator); hasEventType(events, ports.PhaseCompleted) {
+		t.Fatalf("PhaseCompleted emitted on retry: %#v", events)
+	}
+}
+
 func TestOrchestrator_HandlePhaseCompletion_ArtifactPhaseMissingPhaseCompleteProtocolViolation(t *testing.T) {
 	for _, tc := range artifactPhaseCases() {
 		t.Run(tc.name, func(t *testing.T) {
-			o, f, store := newArtifactPhaseOrchestratorFixture(t, tc)
-			stateDir := store.BaseDir
-			writePhaseMarkdown(t, stateDir, f, tc.phaseKey, "artifact.md")
+			fix := newArtifactPhaseRetryFixture(t, tc, feature.Checkpoints{})
+			writePhaseMarkdown(t, fix.store.BaseDir, fix.feature, tc.phaseKey, "artifact.md")
 
-			if err := o.HandlePhaseCompletion(f.ID, orchestrator.PhaseCompletionInput{
+			if err := fix.orchestrator.HandlePhaseCompletion(fix.feature.ID, orchestrator.PhaseCompletionInput{
 				Phase:   tc.phase,
 				Success: true,
 			}); err != nil {
 				t.Fatalf("HandlePhaseCompletion() error = %v", err)
 			}
 
-			reloaded := loadStoredFeature(t, store, f.ID)
-			if reloaded.FailureType != feature.FailureProtocolViolation {
-				t.Fatalf("FailureType = %s, want %s", reloaded.FailureType, feature.FailureProtocolViolation)
-			}
-			if !strings.Contains(reloaded.LastError, agent.PhaseCompleteFile) {
-				t.Fatalf("LastError = %q, want phase_complete violation", reloaded.LastError)
-			}
+			assertFirstArtifactRetry(t, fix, tc, agent.PhaseCompleteFile)
 		})
 	}
 }
@@ -538,23 +722,204 @@ func TestOrchestrator_HandlePhaseCompletion_ArtifactPhaseMissingPhaseCompletePro
 func TestOrchestrator_HandlePhaseCompletion_ArtifactPhaseMissingMarkdownProtocolViolation(t *testing.T) {
 	for _, tc := range artifactPhaseCases() {
 		t.Run(tc.name, func(t *testing.T) {
-			o, f, store := newArtifactPhaseOrchestratorFixture(t, tc)
-			stateDir := store.BaseDir
-			writePhaseComplete(t, stateDir, f, tc.phaseKey)
+			fix := newArtifactPhaseRetryFixture(t, tc, feature.Checkpoints{})
+			writePhaseComplete(t, fix.store.BaseDir, fix.feature, tc.phaseKey)
 
-			if err := o.HandlePhaseCompletion(f.ID, orchestrator.PhaseCompletionInput{
+			if err := fix.orchestrator.HandlePhaseCompletion(fix.feature.ID, orchestrator.PhaseCompletionInput{
 				Phase:   tc.phase,
 				Success: true,
 			}); err != nil {
 				t.Fatalf("HandlePhaseCompletion() error = %v", err)
 			}
 
-			reloaded := loadStoredFeature(t, store, f.ID)
-			if reloaded.FailureType != feature.FailureProtocolViolation {
-				t.Fatalf("FailureType = %s, want %s", reloaded.FailureType, feature.FailureProtocolViolation)
+			assertFirstArtifactRetry(t, fix, tc, "markdown")
+		})
+	}
+}
+
+func TestOrchestrator_HandlePhaseCompletion_ArtifactPhaseRetryThenSuccessAdvances(t *testing.T) {
+	for _, tc := range artifactPhaseCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			fix := newArtifactPhaseRetryFixture(t, tc, retrySuccessCheckpointForTest(tc.phase))
+			writePhaseComplete(t, fix.store.BaseDir, fix.feature, tc.phaseKey)
+
+			if err := fix.orchestrator.HandlePhaseCompletion(fix.feature.ID, orchestrator.PhaseCompletionInput{
+				Phase:   tc.phase,
+				Success: true,
+			}); err != nil {
+				t.Fatalf("first HandlePhaseCompletion() error = %v", err)
 			}
-			if !strings.Contains(reloaded.LastError, "markdown") {
-				t.Fatalf("LastError = %q, want markdown violation", reloaded.LastError)
+			drainEvents(fix.orchestrator)
+
+			writePhaseComplete(t, fix.store.BaseDir, fix.feature, tc.phaseKey)
+			artifactPath := writePhaseMarkdown(t, fix.store.BaseDir, fix.feature, tc.phaseKey, tc.phaseKey+".md")
+			if err := fix.orchestrator.HandlePhaseCompletion(fix.feature.ID, orchestrator.PhaseCompletionInput{
+				Phase:   tc.phase,
+				Success: true,
+			}); err != nil {
+				t.Fatalf("second HandlePhaseCompletion() error = %v", err)
+			}
+
+			if _, err := agent.ReadProtocolRetrySidecar(fix.phaseDir); err != nil {
+				t.Fatalf("ReadProtocolRetrySidecar() error = %v", err)
+			}
+			if _, err := os.Stat(filepath.Join(fix.phaseDir, agent.ProtocolRetrySidecarFile)); !os.IsNotExist(err) {
+				t.Fatalf("sidecar stat err = %v, want removed", err)
+			}
+
+			reloaded := loadStoredFeature(t, fix.store, fix.feature.ID)
+			if got := reloaded.Artifacts[tc.phaseKey]; got != artifactPath {
+				t.Fatalf("Artifacts[%q] = %q, want %q", tc.phaseKey, got, artifactPath)
+			}
+			assertLifecycleCall(t, fix.lifecycle, "Complete"+strings.Title(tc.phaseKey))
+
+			events := drainEvents(fix.orchestrator)
+			if got := countPhaseCompletedEvents(events, tc.phase); got != 1 {
+				t.Fatalf("PhaseCompleted events = %d, want 1; events=%#v", got, events)
+			}
+			if !hasEventType(events, ports.ReviewRequired) {
+				t.Fatalf("ReviewRequired event missing after successful retry; events=%#v", events)
+			}
+		})
+	}
+}
+
+func TestOrchestrator_HandlePhaseCompletion_ArtifactPhaseThirdViolationTerminates(t *testing.T) {
+	for _, tc := range artifactPhaseCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			fix := newArtifactPhaseRetryFixture(t, tc, feature.Checkpoints{})
+			for attempt := 1; attempt <= agent.DefaultMaxConsecutiveProtocolViolations; attempt++ {
+				if err := fix.orchestrator.HandlePhaseCompletion(fix.feature.ID, orchestrator.PhaseCompletionInput{
+					Phase:   tc.phase,
+					Success: true,
+				}); err != nil {
+					t.Fatalf("HandlePhaseCompletion(attempt %d) error = %v", attempt, err)
+				}
+			}
+
+			reloaded := loadStoredFeature(t, fix.store, fix.feature.ID)
+			if reloaded.FailureType != feature.FailureProtocolViolation {
+				t.Fatalf("FailureType = %q, want %q", reloaded.FailureType, feature.FailureProtocolViolation)
+			}
+			role := artifactPhaseRoleForTest(t, tc.phase)
+			_, contractViolations, err := agent.Validate(tc.phase, role, fix.phaseDir)
+			if err != nil {
+				t.Fatalf("Validate() error = %v", err)
+			}
+			violations := []agent.ProtocolViolation{{
+				Artifact: agent.PhaseCompleteFile,
+				Reason:   "SDK reported success but phase_complete was not present",
+			}}
+			violations = append(violations, contractViolations...)
+			wantErr := agent.FormatSingleShotProtocolViolationError(role, fix.phaseDir, violations)
+			if reloaded.LastError != wantErr {
+				t.Fatalf("LastError = %q, want %q", reloaded.LastError, wantErr)
+			}
+
+			sidecar, err := agent.ReadProtocolRetrySidecar(fix.phaseDir)
+			if err != nil {
+				t.Fatalf("ReadProtocolRetrySidecar() error = %v", err)
+			}
+			if sidecar == nil || sidecar.Consecutive != agent.DefaultMaxConsecutiveProtocolViolations {
+				t.Fatalf("sidecar = %#v, want consecutive %d", sidecar, agent.DefaultMaxConsecutiveProtocolViolations)
+			}
+			if got := len(fix.runner.capturedByPhase(tc.phase)); got != agent.DefaultMaxConsecutiveProtocolViolations-1 {
+				t.Fatalf("starter captures for %s = %d, want %d", tc.phase, got, agent.DefaultMaxConsecutiveProtocolViolations-1)
+			}
+			events := drainEvents(fix.orchestrator)
+			if got := countPhaseCompletedEvents(events, tc.phase); got != 1 {
+				t.Fatalf("PhaseCompleted events = %d, want 1; events=%#v", got, events)
+			}
+		})
+	}
+}
+
+func TestOrchestrator_HandlePhaseCompletion_ArtifactPhaseSidecarRestartRegression(t *testing.T) {
+	for _, tc := range artifactPhaseCases() {
+		t.Run(tc.name+"_survives_restart", func(t *testing.T) {
+			fix := newArtifactPhaseRetryFixture(t, tc, feature.Checkpoints{})
+			if err := agent.WriteProtocolRetrySidecar(fix.phaseDir, agent.ProtocolRetrySidecar{
+				Role:          artifactPhaseRoleForTest(t, tc.phase),
+				ActiveRun:     fix.feature.ActiveRun,
+				Consecutive:   2,
+				LastViolation: "prior violation",
+				UpdatedAt:     time.Now().UTC(),
+			}); err != nil {
+				t.Fatalf("WriteProtocolRetrySidecar() error = %v", err)
+			}
+
+			if err := fix.orchestrator.HandlePhaseCompletion(fix.feature.ID, orchestrator.PhaseCompletionInput{
+				Phase:   tc.phase,
+				Success: true,
+			}); err != nil {
+				t.Fatalf("HandlePhaseCompletion() error = %v", err)
+			}
+
+			reloaded := loadStoredFeature(t, fix.store, fix.feature.ID)
+			if reloaded.FailureType != feature.FailureProtocolViolation {
+				t.Fatalf("FailureType = %q, want %q", reloaded.FailureType, feature.FailureProtocolViolation)
+			}
+		})
+
+		t.Run(tc.name+"_stale_active_run_resets", func(t *testing.T) {
+			fix := newArtifactPhaseRetryFixture(t, tc, feature.Checkpoints{})
+			if err := agent.WriteProtocolRetrySidecar(fix.phaseDir, agent.ProtocolRetrySidecar{
+				Role:          artifactPhaseRoleForTest(t, tc.phase),
+				ActiveRun:     fix.feature.ActiveRun + 1,
+				Consecutive:   2,
+				LastViolation: "prior violation",
+				UpdatedAt:     time.Now().UTC(),
+			}); err != nil {
+				t.Fatalf("WriteProtocolRetrySidecar() error = %v", err)
+			}
+
+			if err := fix.orchestrator.HandlePhaseCompletion(fix.feature.ID, orchestrator.PhaseCompletionInput{
+				Phase:   tc.phase,
+				Success: true,
+			}); err != nil {
+				t.Fatalf("HandlePhaseCompletion() error = %v", err)
+			}
+
+			reloaded := loadStoredFeature(t, fix.store, fix.feature.ID)
+			if reloaded.Status != tc.status {
+				t.Fatalf("Status = %s, want %s", reloaded.Status, tc.status)
+			}
+			sidecar, err := agent.ReadProtocolRetrySidecar(fix.phaseDir)
+			if err != nil {
+				t.Fatalf("ReadProtocolRetrySidecar() error = %v", err)
+			}
+			if sidecar == nil || sidecar.Consecutive != 1 || sidecar.ActiveRun != fix.feature.ActiveRun {
+				t.Fatalf("sidecar = %#v, want fresh active_run=%d consecutive=1", sidecar, fix.feature.ActiveRun)
+			}
+		})
+	}
+}
+
+func TestOrchestrator_HandlePhaseCompletion_ArtifactPhaseSessionCrashDoesNotReadSidecar(t *testing.T) {
+	for _, tc := range artifactPhaseCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			fix := newArtifactPhaseRetryFixture(t, tc, feature.Checkpoints{})
+			if err := os.MkdirAll(fix.phaseDir, 0o755); err != nil {
+				t.Fatalf("mkdir phase dir: %v", err)
+			}
+			if err := os.WriteFile(filepath.Join(fix.phaseDir, agent.ProtocolRetrySidecarFile), []byte("role: ["), 0o644); err != nil {
+				t.Fatalf("write malformed sidecar: %v", err)
+			}
+
+			if err := fix.orchestrator.HandlePhaseCompletion(fix.feature.ID, orchestrator.PhaseCompletionInput{
+				Phase:       tc.phase,
+				Success:     false,
+				ErrorDetail: "session crashed",
+			}); err != nil {
+				t.Fatalf("HandlePhaseCompletion() error = %v", err)
+			}
+
+			reloaded := loadStoredFeature(t, fix.store, fix.feature.ID)
+			if reloaded.FailureType != feature.FailureSessionCrash {
+				t.Fatalf("FailureType = %q, want %q", reloaded.FailureType, feature.FailureSessionCrash)
+			}
+			if got := len(fix.runner.capturedByPhase(tc.phase)); got != 0 {
+				t.Fatalf("starter captures for %s = %d, want 0", tc.phase, got)
 			}
 		})
 	}

--- a/internal/orchestrator/context.go
+++ b/internal/orchestrator/context.go
@@ -62,6 +62,16 @@ func (o *Orchestrator) computeKBInfos(f *feature.Feature) []agent.KBInfo {
 // artifact without reading its content. Mirrors app.go:9695-9742 but reads
 // the state dir from PhaseRunner rather than TUI state.
 func (o *Orchestrator) resolveArtifactPath(f *feature.Feature, phase string) string {
+	if path := o.resolveArtifactPathForKey(f, phase); path != "" {
+		return path
+	}
+	if phase == "design" {
+		return o.resolveArtifactPathForKey(f, "brainstorm")
+	}
+	return ""
+}
+
+func (o *Orchestrator) resolveArtifactPathForKey(f *feature.Feature, phase string) string {
 	baseDir := o.stateDir()
 	artifactPath, ok := f.Artifacts[phase]
 	if !ok || artifactPath == "" {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -567,9 +567,15 @@ func (o *Orchestrator) startKB(featureID string) (PhaseStartResult, error) {
 
 	// Check freshness for all repos.
 	freshness := make(map[string]bool, len(f.Repos))
+	activeKBRepos := o.activeKBSessionRepos(featureID)
 	allFresh := true
 	baseDir := o.stateDir()
 	for _, repo := range f.Repos {
+		if activeKBRepos[repo.Name] {
+			freshness[repo.Name] = false
+			allFresh = false
+			continue
+		}
 		isFresh := false
 		// Without a resolved base dir, agent.KBStateDir would read from CWD;
 		// treat that as "not fresh" rather than consulting stray files.
@@ -609,6 +615,9 @@ func (o *Orchestrator) startKB(featureID string) (PhaseStartResult, error) {
 
 	if o.deps.PhaseRunner != nil {
 		for _, repo := range f.Repos {
+			if activeKBRepos[repo.Name] {
+				continue
+			}
 			if freshness[repo.Name] {
 				// Fresh repo in the mixed case: refresh codebase index,
 				// immediately mark completed in per-repo tracking.
@@ -630,6 +639,26 @@ func (o *Orchestrator) startKB(featureID string) (PhaseStartResult, error) {
 	// from a prior locked attempt.
 	o.clearKBWaitMessage(featureID)
 	return PhaseStartResult{Outcome: PhaseStarted}, nil
+}
+
+func (o *Orchestrator) activeKBSessionRepos(featureID string) map[string]bool {
+	active := make(map[string]bool)
+	if o.deps.Sessions == nil {
+		return active
+	}
+	for _, s := range o.deps.Sessions.FeatureSessions(featureID) {
+		if s == nil || !s.IsActive() || s.Phase() != feature.PhaseKnowledgeBase {
+			continue
+		}
+		repoName := s.RepoName()
+		if repoName == "" {
+			repoName = agent.RepoNameFromKBSession(s.ID())
+		}
+		if repoName != "" {
+			active[repoName] = true
+		}
+	}
+	return active
 }
 
 // markKBWaiting records that the feature couldn't acquire the KB lock for the

--- a/internal/orchestrator/orchestrator_phaserunner_test.go
+++ b/internal/orchestrator/orchestrator_phaserunner_test.go
@@ -878,6 +878,56 @@ func TestOrchestrator_StartPlan_RoadmapPhase_WhenPlanning_SkipsTransition(t *tes
 	}
 }
 
+func TestOrchestrator_StartPlan_UsesLegacyBrainstormArtifactDir(t *testing.T) {
+	stateDir := t.TempDir()
+	store := feature.NewStore(stateDir)
+	featureID := "feat-legacy-brainstorm-plan"
+	f := &feature.Feature{
+		ID:            featureID,
+		Name:          "Legacy Brainstorm Plan",
+		Slug:          "legacy-brainstorm-plan",
+		Description:   "resume planning from a pre-rename brainstorm artifact",
+		Created:       time.Now().Truncate(time.Second),
+		Status:        feature.StatusPlanReady,
+		CurrentPhase:  feature.PhasePlan,
+		Pipeline:      feature.PipelineLarge,
+		Inquireness:   feature.InquirenessMedium,
+		Repos:         []feature.FeatureRepo{{Name: "repo1", Path: stateDir}},
+		ActiveRun:     1,
+		RunCount:      1,
+		SchemaVersion: feature.SchemaVersionCurrent,
+	}
+	if err := store.Save(f); err != nil {
+		t.Fatalf("save feature: %v", err)
+	}
+
+	brainstormDir := filepath.Join(agent.ActiveRunDir(stateDir, f), "brainstorm")
+	if err := os.MkdirAll(brainstormDir, 0o755); err != nil {
+		t.Fatalf("mkdir brainstorm dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(brainstormDir, "brainstorm.md"), []byte("# Legacy Brainstorm\n"), 0o644); err != nil {
+		t.Fatalf("write brainstorm artifact: %v", err)
+	}
+
+	mgr := feature.NewManager(store, nil)
+	o := orchestrator.New(orchestrator.Deps{
+		Lifecycle: mgr,
+		Store:     store,
+	}, orchestrator.Hooks{})
+
+	if err := o.StartFeature(featureID); err != nil {
+		t.Fatalf("StartFeature() error = %v; want nil", err)
+	}
+
+	loaded, err := store.Load(featureID)
+	if err != nil {
+		t.Fatalf("load feature: %v", err)
+	}
+	if loaded.Status != feature.StatusPlanning {
+		t.Errorf("loaded.Status = %v, want %v", loaded.Status, feature.StatusPlanning)
+	}
+}
+
 func TestOrchestrator_StartPlan_RoadmapPhase_WhenNotPlanning_Transitions(t *testing.T) {
 	cpr := newCapturingPhaseRunner(t)
 	cpr.sm.StartSessionFn = func(id, featureID string, phase feature.Phase,

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -4400,17 +4400,21 @@ func TestHandleSDKEvent_KBResultSuccessRoutesThroughProtocolValidation(t *testin
 	if err != nil {
 		t.Fatalf("get feature: %v", err)
 	}
-	if updated.Status != feature.StatusFailed {
-		t.Fatalf("status = %v, want Failed", updated.Status)
+	if updated.Status != feature.StatusBuildingKB {
+		t.Fatalf("status = %v, want BuildingKB first retry", updated.Status)
 	}
-	if updated.FailureType != feature.FailureProtocolViolation {
-		t.Fatalf("failure type = %q, want %q", updated.FailureType, feature.FailureProtocolViolation)
+	if updated.FailureType != "" {
+		t.Fatalf("failure type = %q, want empty on first retry", updated.FailureType)
 	}
-	if updated.FailureType == feature.FailureMissingArtifact || strings.Contains(updated.LastError, "missing_artifact") {
-		t.Fatalf("KB must not use missing-artifact failure path: type=%q error=%q", updated.FailureType, updated.LastError)
+	if updated.LastError != "" {
+		t.Fatalf("LastError = %q, want empty on first retry", updated.LastError)
 	}
-	if !strings.Contains(updated.LastError, agent.PhaseCompleteFile) {
-		t.Fatalf("LastError = %q, want phase_complete protocol violation", updated.LastError)
+	sidecar, err := agent.ReadProtocolRetrySidecarAt(kbDir, agent.KBProtocolRetrySidecarFilename(f.ID))
+	if err != nil {
+		t.Fatalf("ReadProtocolRetrySidecarAt() error = %v", err)
+	}
+	if sidecar == nil || sidecar.Consecutive != 1 || !strings.Contains(sidecar.LastViolation, agent.PhaseCompleteFile) {
+		t.Fatalf("sidecar = %#v, want first phase_complete retry", sidecar)
 	}
 }
 
@@ -4458,14 +4462,21 @@ func TestHandleSessionDone_KBSuccessRoutesThroughProtocolValidation(t *testing.T
 	if err != nil {
 		t.Fatalf("get feature: %v", err)
 	}
-	if updated.Status != feature.StatusFailed {
-		t.Fatalf("status = %v, want Failed", updated.Status)
+	if updated.Status != feature.StatusBuildingKB {
+		t.Fatalf("status = %v, want BuildingKB first retry", updated.Status)
 	}
-	if updated.FailureType != feature.FailureProtocolViolation {
-		t.Fatalf("failure type = %q, want %q", updated.FailureType, feature.FailureProtocolViolation)
+	if updated.FailureType != "" {
+		t.Fatalf("failure type = %q, want empty on first retry", updated.FailureType)
 	}
-	if !strings.Contains(updated.LastError, agent.PhaseCompleteFile) {
-		t.Fatalf("LastError = %q, want phase_complete protocol violation", updated.LastError)
+	if updated.LastError != "" {
+		t.Fatalf("LastError = %q, want empty on first retry", updated.LastError)
+	}
+	sidecar, err := agent.ReadProtocolRetrySidecarAt(kbDir, agent.KBProtocolRetrySidecarFilename(f.ID))
+	if err != nil {
+		t.Fatalf("ReadProtocolRetrySidecarAt() error = %v", err)
+	}
+	if sidecar == nil || sidecar.Consecutive != 1 || !strings.Contains(sidecar.LastViolation, agent.PhaseCompleteFile) {
+		t.Fatalf("sidecar = %#v, want first phase_complete retry", sidecar)
 	}
 }
 

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -1531,7 +1531,41 @@ func TestHandleSDKEvent_AskUserQuestionControlRequestAddsQuestionHelp(t *testing
 	}
 }
 
-func TestHandleSDKEvent_ResearchSuccessWithoutArtifactMarksProtocolViolation(t *testing.T) {
+func assertTUIArtifactPhaseRetry(t *testing.T, fm *feature.Manager, f *feature.Feature, phase feature.Phase, wantViolation string) {
+	t.Helper()
+	updated, err := fm.Get(f.ID)
+	if err != nil {
+		t.Fatalf("get feature: %v", err)
+	}
+	if updated.Status != statusForPhase(phase) {
+		t.Fatalf("status = %v, want %v", updated.Status, statusForPhase(phase))
+	}
+	if updated.FailureType != "" {
+		t.Fatalf("FailureType = %q, want empty", updated.FailureType)
+	}
+	if updated.LastError != "" {
+		t.Fatalf("LastError = %q, want empty", updated.LastError)
+	}
+	phaseDir := filepath.Join(agent.ActiveRunDir(fm.Store.BaseDir, updated), phase.DirName())
+	sidecar, err := agent.ReadProtocolRetrySidecar(phaseDir)
+	if err != nil {
+		t.Fatalf("ReadProtocolRetrySidecar() error = %v", err)
+	}
+	if sidecar == nil {
+		t.Fatal("retry sidecar = nil, want sidecar")
+	}
+	if sidecar.Consecutive != 1 {
+		t.Fatalf("sidecar.Consecutive = %d, want 1", sidecar.Consecutive)
+	}
+	if !strings.Contains(sidecar.LastViolation, wantViolation) {
+		t.Fatalf("sidecar.LastViolation = %q, want %q", sidecar.LastViolation, wantViolation)
+	}
+	if _, err := os.Stat(filepath.Join(phaseDir, agent.PhaseCompleteFile)); !os.IsNotExist(err) {
+		t.Fatalf("phase_complete stat err = %v, want removed", err)
+	}
+}
+
+func TestHandleSDKEvent_ResearchSuccessWithoutArtifactRetriesProtocolViolation(t *testing.T) {
 	app, fm := newTestAppModel(t)
 	app.lastNotifyTime = make(map[notifyKey]time.Time)
 	app.eventCh = make(chan interface{}, 1)
@@ -1578,16 +1612,7 @@ func TestHandleSDKEvent_ResearchSuccessWithoutArtifactMarksProtocolViolation(t *
 
 	_, _ = app.handleSDKEvent(msg)
 
-	f, _ = fm.Get(f.ID)
-	if f.Status != feature.StatusFailed {
-		t.Fatalf("feature status = %v, want Failed", f.Status)
-	}
-	if f.FailureType != feature.FailureProtocolViolation {
-		t.Fatalf("FailureType = %q, want %q", f.FailureType, feature.FailureProtocolViolation)
-	}
-	if !strings.Contains(f.LastError, agent.PhaseCompleteFile) || !strings.Contains(f.LastError, "markdown artifact") {
-		t.Fatalf("LastError = %q, want protocol violation with phase_complete and markdown artifact details", f.LastError)
-	}
+	assertTUIArtifactPhaseRetry(t, fm, f, feature.PhaseResearch, agent.PhaseCompleteFile)
 }
 
 func TestPhaseOutputSuggestsQuestion_MultilineAssistantQuestionStillDetected(t *testing.T) {
@@ -1780,16 +1805,14 @@ func TestHandleSessionDone_RegistryOwnedSuccessDoesNotCreateQuestionHelp(t *test
 	_, _ = app.handleSessionDone(doneMsg)
 
 	f, _ = fm.Get(f.ID)
-	if f.Status != feature.StatusFailed {
-		t.Errorf("status = %v, want Failed", f.Status)
+	if f.Status != feature.StatusInquiring {
+		t.Errorf("status = %v, want Inquiring", f.Status)
 	}
-	if f.FailureType != feature.FailureProtocolViolation {
-		t.Fatalf("FailureType = %q, want %q", f.FailureType, feature.FailureProtocolViolation)
-	}
+	assertTUIArtifactPhaseRetry(t, fm, f, feature.PhaseInquire, agent.PhaseCompleteFile)
 	assertNoPendingQuestionHelp(t, f)
 }
 
-func TestHandleSessionDone_SuccessWithoutArtifactMarksProtocolViolation(t *testing.T) {
+func TestHandleSessionDone_SuccessWithoutArtifactRetriesProtocolViolation(t *testing.T) {
 	app, fm := newTestAppModel(t)
 	app.lastNotifyTime = make(map[notifyKey]time.Time)
 	app.eventCh = make(chan interface{}, 1)
@@ -1830,16 +1853,7 @@ func TestHandleSessionDone_SuccessWithoutArtifactMarksProtocolViolation(t *testi
 
 	_, _ = app.handleSessionDone(doneMsg)
 
-	f, _ = fm.Get(f.ID)
-	if f.Status != feature.StatusFailed {
-		t.Fatalf("feature status = %v, want Failed", f.Status)
-	}
-	if f.FailureType != feature.FailureProtocolViolation {
-		t.Fatalf("FailureType = %q, want %q", f.FailureType, feature.FailureProtocolViolation)
-	}
-	if !strings.Contains(f.LastError, agent.PhaseCompleteFile) || !strings.Contains(f.LastError, "markdown artifact") {
-		t.Fatalf("LastError = %q, want protocol violation with phase_complete and markdown artifact details", f.LastError)
-	}
+	assertTUIArtifactPhaseRetry(t, fm, f, feature.PhaseResearch, agent.PhaseCompleteFile)
 }
 
 func TestPublishDescGeneratedForwarded(t *testing.T) {
@@ -4570,12 +4584,7 @@ func TestHandleSDKEvent_ArtifactPhaseResultSuccessRoutesThroughProtocolValidatio
 			if err != nil {
 				t.Fatalf("get feature: %v", err)
 			}
-			if updated.FailureType != feature.FailureProtocolViolation {
-				t.Fatalf("FailureType = %s, want %s", updated.FailureType, feature.FailureProtocolViolation)
-			}
-			if !strings.Contains(updated.LastError, agent.PhaseCompleteFile) {
-				t.Fatalf("LastError = %q, want phase_complete protocol violation", updated.LastError)
-			}
+			assertTUIArtifactPhaseRetry(t, fm, updated, tc.phase, agent.PhaseCompleteFile)
 			assertNoPendingQuestionHelp(t, updated)
 		})
 	}
@@ -4610,12 +4619,7 @@ func TestHandleSessionDone_ArtifactPhaseSuccessRoutesThroughProtocolValidation(t
 			if err != nil {
 				t.Fatalf("get feature: %v", err)
 			}
-			if updated.FailureType != feature.FailureProtocolViolation {
-				t.Fatalf("FailureType = %s, want %s", updated.FailureType, feature.FailureProtocolViolation)
-			}
-			if !strings.Contains(updated.LastError, agent.PhaseCompleteFile) {
-				t.Fatalf("LastError = %q, want phase_complete protocol violation", updated.LastError)
-			}
+			assertTUIArtifactPhaseRetry(t, fm, updated, tc.phase, agent.PhaseCompleteFile)
 			assertNoPendingQuestionHelp(t, updated)
 		})
 	}

--- a/internal/tui/dashboard_test.go
+++ b/internal/tui/dashboard_test.go
@@ -1471,6 +1471,42 @@ func TestFormatStatus_PublishedActiveReviewCommentsCycle(t *testing.T) {
 	}
 }
 
+func TestDashboardStatusShowsActiveArtifactPhaseDuringProtocolRetry(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name        string
+		status      feature.Status
+		current     feature.Phase
+		consecutive int
+		want        string
+	}{
+		{"inquire_first_retry", feature.StatusInquiring, feature.PhaseInquire, 1, "Inquiring"},
+		{"research_second_retry", feature.StatusResearching, feature.PhaseResearch, 2, "Researching"},
+		{"design_second_retry", feature.StatusDesigning, feature.PhaseDesign, 2, "Designing"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := &feature.Feature{
+				ID:           tt.name,
+				Name:         tt.name,
+				Slug:         tt.name,
+				Status:       tt.status,
+				CurrentPhase: tt.current,
+				FailureType:  "",
+				LastError:    "",
+			}
+			got := formatStatus(f)
+			if !strings.Contains(got, tt.want) {
+				t.Fatalf("formatStatus() = %q, want active label %q for retry streak %d", got, tt.want, tt.consecutive)
+			}
+			if strings.Contains(got, "Failed") || strings.Contains(got, "protocol violation") {
+				t.Fatalf("formatStatus() = %q, want active phase during retry streak %d", got, tt.consecutive)
+			}
+		})
+	}
+}
+
 func TestFormatStatus_RepoPausedOnInput_StylesAsWaitingInput(t *testing.T) {
 	t.Parallel()
 	// Schema v3 always routes implement completion through the multi-repo

--- a/internal/tui/dashboard_test.go
+++ b/internal/tui/dashboard_test.go
@@ -1507,6 +1507,52 @@ func TestDashboardStatusShowsActiveArtifactPhaseDuringProtocolRetry(t *testing.T
 	}
 }
 
+func TestDashboardStatusShowsBuildingKBDuringProtocolRetry(t *testing.T) {
+	t.Parallel()
+	for _, consecutive := range []int{1, 2} {
+		t.Run(fmt.Sprintf("kb_retry_%d", consecutive), func(t *testing.T) {
+			f := &feature.Feature{
+				ID:           fmt.Sprintf("feat-kb-retry-%d", consecutive),
+				Name:         "KB Retry",
+				Slug:         "kb-retry",
+				Status:       feature.StatusBuildingKB,
+				CurrentPhase: feature.PhaseKnowledgeBase,
+				Repos:        []feature.FeatureRepo{{Name: "repo-a"}},
+				KBStatus:     map[string]string{"repo-a": "building"},
+				FailureType:  "",
+				LastError:    "",
+			}
+			got := formatStatus(f)
+			if !strings.Contains(got, "Building KB") {
+				t.Fatalf("formatStatus() = %q, want Building KB for retry streak %d", got, consecutive)
+			}
+			if strings.Contains(got, "Failed") || strings.Contains(got, "protocol violation") {
+				t.Fatalf("formatStatus() = %q, want in-progress KB during retry streak %d", got, consecutive)
+			}
+		})
+	}
+}
+
+func TestDashboardStatusShowsTerminalKBProtocolViolation(t *testing.T) {
+	t.Parallel()
+	f := &feature.Feature{
+		ID:           "feat-kb-terminal",
+		Name:         "KB Terminal",
+		Slug:         "kb-terminal",
+		Status:       feature.StatusFailed,
+		CurrentPhase: feature.PhaseKnowledgeBase,
+		FailureType:  feature.FailureProtocolViolation,
+		LastError:    "protocol violation: knowledge_base_builder @ /tmp/kb: index.md: missing",
+	}
+	got := formatStatus(f)
+	if !strings.Contains(got, "Failed") || !strings.Contains(got, "protocol violation") {
+		t.Fatalf("formatStatus() = %q, want terminal protocol violation", got)
+	}
+	if strings.Contains(got, "Building KB") {
+		t.Fatalf("formatStatus() = %q, should not render active KB after terminal failure", got)
+	}
+}
+
 func TestFormatStatus_RepoPausedOnInput_StylesAsWaitingInput(t *testing.T) {
 	t.Parallel()
 	// Schema v3 always routes implement completion through the multi-repo

--- a/internal/tui/detail_test.go
+++ b/internal/tui/detail_test.go
@@ -15,6 +15,7 @@
 package tui
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -358,6 +359,52 @@ func TestDetailStatusShowsActiveArtifactPhaseDuringProtocolRetry(t *testing.T) {
 				t.Fatalf("DetailModel.View() rendered failure during retry streak %d:\n%s", tt.consecutive, view)
 			}
 		})
+	}
+}
+
+func TestDetailStatusShowsBuildingKBDuringProtocolRetry(t *testing.T) {
+	t.Parallel()
+	for _, consecutive := range []int{1, 2} {
+		t.Run(fmt.Sprintf("kb_retry_%d", consecutive), func(t *testing.T) {
+			f := &feature.Feature{
+				ID:           fmt.Sprintf("feat-kb-retry-%d", consecutive),
+				Slug:         "kb-retry",
+				Status:       feature.StatusBuildingKB,
+				CurrentPhase: feature.PhaseKnowledgeBase,
+				Repos:        []feature.FeatureRepo{{Name: "repo-a"}},
+				KBStatus:     map[string]string{"repo-a": "building"},
+				FailureType:  "",
+				LastError:    "",
+			}
+			view := NewDetailModel(f, "").View()
+			if !strings.Contains(view, "Building Knowledge Base") && !strings.Contains(view, "BuildingKB") {
+				t.Fatalf("DetailModel.View() missing active KB label for retry streak %d:\n%s", consecutive, view)
+			}
+			if strings.Contains(view, "Failure Info") || strings.Contains(view, "protocol violation") {
+				t.Fatalf("DetailModel.View() rendered failure during KB retry streak %d:\n%s", consecutive, view)
+			}
+		})
+	}
+}
+
+func TestDetailStatusShowsTerminalKBProtocolViolation(t *testing.T) {
+	t.Parallel()
+	f := &feature.Feature{
+		ID:           "feat-kb-terminal",
+		Slug:         "kb-terminal",
+		Status:       feature.StatusFailed,
+		CurrentPhase: feature.PhaseKnowledgeBase,
+		FailureType:  feature.FailureProtocolViolation,
+		LastError:    "protocol violation: knowledge_base_builder @ /tmp/kb: index.md: missing",
+	}
+	view := NewDetailModel(f, "").View()
+	for _, want := range []string{"Failed (protocol violation)", "Failure Info", "knowledge_base_builder", "index.md"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("DetailModel.View() missing %q for terminal KB protocol violation:\n%s", want, view)
+		}
+	}
+	if strings.Contains(view, "Building KB") {
+		t.Fatalf("DetailModel.View() rendered active KB after terminal failure:\n%s", view)
 	}
 }
 

--- a/internal/tui/detail_test.go
+++ b/internal/tui/detail_test.go
@@ -326,6 +326,41 @@ func TestProtocolViolationFailureRendering(t *testing.T) {
 	}
 }
 
+func TestDetailStatusShowsActiveArtifactPhaseDuringProtocolRetry(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name        string
+		status      feature.Status
+		current     feature.Phase
+		consecutive int
+		want        string
+	}{
+		{"inquire_first_retry", feature.StatusInquiring, feature.PhaseInquire, 1, "Inquiring"},
+		{"research_second_retry", feature.StatusResearching, feature.PhaseResearch, 2, "Researching"},
+		{"design_second_retry", feature.StatusDesigning, feature.PhaseDesign, 2, "Designing"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := &feature.Feature{
+				ID:           tt.name,
+				Slug:         tt.name,
+				Status:       tt.status,
+				CurrentPhase: tt.current,
+				FailureType:  "",
+				LastError:    "",
+			}
+			view := NewDetailModel(f, "").View()
+			if !strings.Contains(view, tt.want) {
+				t.Fatalf("DetailModel.View() missing active label %q for retry streak %d:\n%s", tt.want, tt.consecutive, view)
+			}
+			if strings.Contains(view, "Failure Info") || strings.Contains(view, "protocol violation") {
+				t.Fatalf("DetailModel.View() rendered failure during retry streak %d:\n%s", tt.consecutive, view)
+			}
+		})
+	}
+}
+
 func TestDetailViewFailedNoContext(t *testing.T) {
 	t.Parallel()
 	// Legacy features with no failure context still render correctly

--- a/internal/tui/grill_me_smoke_test.go
+++ b/internal/tui/grill_me_smoke_test.go
@@ -134,6 +134,9 @@ func TestInquirePhase_GrillMe_SmokeEndToEnd(t *testing.T) {
 			if err := os.WriteFile(artifactPath, []byte("# inquire\n"), 0o644); err != nil {
 				t.Fatalf("write artifact: %v", err)
 			}
+			if err := os.WriteFile(filepath.Join(phaseDir, agent.PhaseCompleteFile), nil, 0o644); err != nil {
+				t.Fatalf("write phase_complete: %v", err)
+			}
 			qaPath := filepath.Join(phaseDir, "qa-answers.md")
 			if err := os.WriteFile(qaPath, []byte(grillMeSmokeStaleQAFile), 0o644); err != nil {
 				t.Fatalf("pre-write stale qa-answers.md: %v", err)
@@ -158,21 +161,7 @@ func TestInquirePhase_GrillMe_SmokeEndToEnd(t *testing.T) {
 			}
 			_, _ = app.handleSessionDone(doneMsg)
 
-			// (e) Drive the orchestrator gate the same way handleSessionDone
-			// would dispatch in production: a PhaseCompletedMsg flows through
-			// handlePhaseCompleted into HandlePhaseCompletion. We invoke the
-			// orchestrator directly with the same input so the gate exercises
-			// the production code path without reaching into Bubble Tea
-			// command-batch plumbing.
-			if err := app.orchestrator.HandlePhaseCompletion(f.ID, orchestrator.PhaseCompletionInput{
-				Phase:     feature.PhaseInquire,
-				SessionID: sess.ID(),
-				Success:   true,
-			}); err != nil {
-				t.Fatalf("HandlePhaseCompletion: %v", err)
-			}
-
-			// (f) Both gates honored: the transcript is written from the
+			// (e) Both gates honored: the transcript is written from the
 			// session Q&A log, not from stale agent-authored bytes.
 			got, err := os.ReadFile(qaPath)
 			if err != nil {
@@ -246,6 +235,9 @@ func TestInquirePhase_GrillMe_AutoPickSmokeEndToEnd(t *testing.T) {
 	}
 	if err := os.WriteFile(filepath.Join(phaseDir, "inquire.md"), []byte("# inquire\n"), 0o644); err != nil {
 		t.Fatalf("write inquire artifact: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(phaseDir, agent.PhaseCompleteFile), nil, 0o644); err != nil {
+		t.Fatalf("write phase_complete: %v", err)
 	}
 	qaPath := filepath.Join(phaseDir, "qa-answers.md")
 	if err := os.WriteFile(qaPath, []byte(grillMeSmokeStaleQAFile), 0o644); err != nil {
@@ -340,13 +332,6 @@ drained:
 			Status:    session.SessionDone,
 		},
 	})
-	if err := app.orchestrator.HandlePhaseCompletion(f.ID, orchestrator.PhaseCompletionInput{
-		Phase:     feature.PhaseInquire,
-		SessionID: sess.ID(),
-		Success:   true,
-	}); err != nil {
-		t.Fatalf("HandlePhaseCompletion: %v", err)
-	}
 	got, err := os.ReadFile(qaPath)
 	if err != nil {
 		t.Fatalf("read qa-answers.md: %v", err)

--- a/test/e2e/tui_test.go
+++ b/test/e2e/tui_test.go
@@ -107,6 +107,16 @@ func phaseAwareBuildSessionFn(researchScript, designScript, planScript, implScri
 	if len(extraScripts) > 0 {
 		phasePlanScript = extraScripts[0]
 	}
+	// extraScripts[1] = knowledge-base script (optional)
+	var kbScript string
+	if len(extraScripts) > 1 {
+		kbScript = extraScripts[1]
+	}
+	// extraScripts[2] = inquire script (optional)
+	var inquireScript string
+	if len(extraScripts) > 2 {
+		inquireScript = extraScripts[2]
+	}
 	return func(opts agent.BuildSessionOpts) ([]string, []string, *session.SessionOpts, error) {
 		sessOpts := &session.SessionOpts{
 			PIDDir:        opts.PIDDir,
@@ -123,6 +133,10 @@ func phaseAwareBuildSessionFn(researchScript, designScript, planScript, implScri
 
 		var script string
 		switch {
+		case opts.Phase == feature.PhaseInquire && inquireScript != "":
+			script = inquireScript
+		case opts.Phase == feature.PhaseKnowledgeBase && kbScript != "":
+			script = kbScript
 		case strings.Contains(opts.Prompt, "# Feature Context") && strings.Contains(opts.Prompt, "## Research Findings"):
 			script = designScript
 		case strings.Contains(opts.Prompt, "# Planning Context"):
@@ -385,8 +399,21 @@ func TestTUI_FeatureFailsMidChain(t *testing.T) {
 		t.Fatalf("Create: %v", err)
 	}
 
+	runDir := agent.ActiveRunDir(stateDir, f)
+
+	// Inquire mock: succeeds (with phase_complete for TUI to detect completion)
+	inquireDir := filepath.Join(runDir, "inquire")
+	inquireArtifact := filepath.Join(inquireDir, "inquire.md")
+	inquireScript := testutil.WriteScript(t, scriptsDir, "inquire.sh", fmt.Sprintf(
+		`%s
+mkdir -p "%s"
+echo "# Inquire Output" > "%s"
+touch "%s/phase_complete"
+%s
+`, testutil.JSONLInit, inquireDir, inquireArtifact, inquireDir, testutil.JSONLSuccess))
+
 	// Research mock: succeeds (with phase_complete for TUI to detect completion)
-	researchDir := filepath.Join(stateDir, f.ID, "research")
+	researchDir := filepath.Join(runDir, "research")
 	researchArtifact := filepath.Join(researchDir, "research.md")
 	researchScript := testutil.WriteScript(t, scriptsDir, "research.sh", fmt.Sprintf(
 		`%s
@@ -397,7 +424,7 @@ touch "%s/phase_complete"
 `, testutil.JSONLInit, researchDir, researchArtifact, researchDir, testutil.JSONLSuccess))
 
 	// Design mock: creates design artifact and phase_complete.
-	designDir := filepath.Join(stateDir, f.ID, "design")
+	designDir := filepath.Join(runDir, "design")
 	designArtifact := filepath.Join(designDir, "design.md")
 	designScript := testutil.WriteScript(t, scriptsDir, "design.sh", fmt.Sprintf(
 		`%s
@@ -407,13 +434,22 @@ touch "%s/phase_complete"
 %s
 `, testutil.JSONLInit, designDir, designArtifact, designDir, testutil.JSONLSuccess))
 
+	kbDir := agent.KBStateDir(stateDir, "test-repo")
+	kbScript := testutil.WriteScript(t, scriptsDir, "kb.sh", fmt.Sprintf(
+		`%s
+mkdir -p "%s"
+echo "# Knowledge Base" > "%s"
+touch "%s/phase_complete"
+%s
+`, testutil.JSONLInit, kbDir, agent.KBPath(kbDir), kbDir, testutil.JSONLSuccess))
+
 	// Plan mock: emits init then exits non-zero
 	planScript := testutil.WriteScript(t, scriptsDir, "plan.sh",
 		testutil.JSONLInit+"\n"+testutil.JSONLError("planning failed")+"\nexit 1\n")
 
 	pr := agent.NewPhaseRunner(sm, fm.Store, stateDir)
 	pr.CommandRunner = agent.NewExecCommandRunner()
-	pr.BuildSessionFn = phaseAwareBuildSessionFn(researchScript, designScript, planScript, "", planScript)
+	pr.BuildSessionFn = phaseAwareBuildSessionFn(researchScript, designScript, planScript, "", planScript, "", kbScript, inquireScript)
 
 	orch := newTestOrchestrator(fm, sm, pr)
 	app, err := tui.NewAppModel(fm, sm, orch, nil, eventCh, tui.WithPhaseRunner(pr))

--- a/test/integration/refactor_feature_loop_test.go
+++ b/test/integration/refactor_feature_loop_test.go
@@ -15,6 +15,7 @@
 package integration
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -22,10 +23,12 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/doordash-oss/agentic-orchestrator/internal/agent"
 	"github.com/doordash-oss/agentic-orchestrator/internal/feature"
 	"github.com/doordash-oss/agentic-orchestrator/internal/ports"
+	"github.com/doordash-oss/agentic-orchestrator/internal/session"
 	"github.com/doordash-oss/agentic-orchestrator/test/testutil"
 )
 
@@ -328,4 +331,413 @@ func sliceContains(haystack []string, needle string) bool {
 		}
 	}
 	return false
+}
+
+func TestRefactorFeatureLoop_ProtocolViolation_FirstViolationRetriesThenSucceeds(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	fix := newRefactorProtocolFixture(t, "refactor-retry-success")
+	markerStatePath := filepath.Join(fix.tmpDir, "marker-state.txt")
+	markerPath := filepath.Join(fix.artifactDir, agent.PhaseCompleteFile)
+	scripts := []string{
+		writeRefactorPlanSessionScript(t, fix, "missing-plan.sh", false, true, nil),
+		writeRefactorPlanSessionScript(t, fix, "success.sh", true, true, []string{
+			fmt.Sprintf(`if [ -e %q ]; then printf present > %q; else printf absent > %q; fi`, markerPath, markerStatePath, markerStatePath),
+		}),
+	}
+
+	result, runErr, calls := runRefactorProtocolLoopWithScripts(t, fix, scripts, 0)
+	if runErr != nil {
+		t.Fatalf("RunRefactorFeatureLoop() error = %v", runErr)
+	}
+	if result.FinalStatus != "review_passed" {
+		t.Fatalf("FinalStatus = %q, want review_passed", result.FinalStatus)
+	}
+	if calls != 2 {
+		t.Fatalf("refactor-plan calls = %d, want 2", calls)
+	}
+	if got := readTrimmedFile(t, markerStatePath); got != "absent" {
+		t.Fatalf("phase_complete at second attempt start = %q, want absent", got)
+	}
+	assertNoRefactorSidecar(t, fix.artifactDir)
+}
+
+func TestRefactorFeatureLoop_ProtocolViolation_ThreeConsecutiveViolationsTerminate(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	fix := newRefactorProtocolFixture(t, "refactor-three-violations")
+	scripts := []string{
+		writeRefactorPlanSessionScript(t, fix, "missing-plan-1.sh", false, true, nil),
+		writeRefactorPlanSessionScript(t, fix, "missing-plan-2.sh", false, true, nil),
+		writeRefactorPlanSessionScript(t, fix, "missing-plan-3.sh", false, true, nil),
+	}
+
+	result, runErr, calls := runRefactorProtocolLoopWithScripts(t, fix, scripts, 0)
+	if runErr != nil {
+		t.Fatalf("RunRefactorFeatureLoop() error = %v, want nil protocol result", runErr)
+	}
+	if calls != agent.DefaultMaxConsecutiveProtocolViolations {
+		t.Fatalf("refactor-plan calls = %d, want %d", calls, agent.DefaultMaxConsecutiveProtocolViolations)
+	}
+	if result.FinalStatus != "protocol_violation" {
+		t.Fatalf("FinalStatus = %q, want protocol_violation", result.FinalStatus)
+	}
+	wantErr := refactorPlanValidationError(t, fix.artifactDir)
+	if result.LastError != wantErr {
+		t.Fatalf("LastError = %q, want %q", result.LastError, wantErr)
+	}
+
+	sidecar := readRefactorSidecar(t, fix.artifactDir)
+	if sidecar.Consecutive != agent.DefaultMaxConsecutiveProtocolViolations {
+		t.Fatalf("sidecar.Consecutive = %d, want %d", sidecar.Consecutive, agent.DefaultMaxConsecutiveProtocolViolations)
+	}
+	if sidecar.Role != agent.RoleRefactorPlanStep {
+		t.Fatalf("sidecar.Role = %q, want %q", sidecar.Role, agent.RoleRefactorPlanStep)
+	}
+	if sidecar.ActiveRun != fix.feature.ActiveRun {
+		t.Fatalf("sidecar.ActiveRun = %d, want %d", sidecar.ActiveRun, fix.feature.ActiveRun)
+	}
+	if sidecar.LastViolation == "" {
+		t.Fatal("sidecar.LastViolation is empty")
+	}
+	if sidecar.UpdatedAt.IsZero() {
+		t.Fatal("sidecar.UpdatedAt is zero")
+	}
+
+	got, err := fix.store.Load(fix.feature.ID)
+	if err != nil {
+		t.Fatalf("load feature: %v", err)
+	}
+	if got.ActiveCycle == nil || got.ActiveCycle.Status != feature.RepoCycleFailed {
+		t.Fatalf("ActiveCycle = %+v, want failed", got.ActiveCycle)
+	}
+	if got.ActiveCycle.LastError != wantErr {
+		t.Fatalf("ActiveCycle.LastError = %q, want %q", got.ActiveCycle.LastError, wantErr)
+	}
+}
+
+func TestRefactorFeatureLoop_ProtocolViolation_RestartSurvival(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	fix := newRefactorProtocolFixture(t, "refactor-restart-survival")
+	seedRefactorSidecar(t, fix, fix.feature.ActiveRun, 2)
+	scripts := []string{
+		writeRefactorPlanSessionScript(t, fix, "missing-plan.sh", false, true, nil),
+	}
+
+	result, runErr, calls := runRefactorProtocolLoopWithScripts(t, fix, scripts, 0)
+	if runErr != nil {
+		t.Fatalf("RunRefactorFeatureLoop() error = %v, want nil protocol result", runErr)
+	}
+	if calls != 1 {
+		t.Fatalf("refactor-plan calls = %d, want 1", calls)
+	}
+	if result.FinalStatus != "protocol_violation" {
+		t.Fatalf("FinalStatus = %q, want protocol_violation", result.FinalStatus)
+	}
+	sidecar := readRefactorSidecar(t, fix.artifactDir)
+	if sidecar.Consecutive != agent.DefaultMaxConsecutiveProtocolViolations {
+		t.Fatalf("sidecar.Consecutive = %d, want %d", sidecar.Consecutive, agent.DefaultMaxConsecutiveProtocolViolations)
+	}
+}
+
+func TestRefactorFeatureLoop_ProtocolViolation_StaleActiveRunResetsCounter(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	fix := newRefactorProtocolFixture(t, "refactor-stale-active-run")
+	seedRefactorSidecar(t, fix, fix.feature.ActiveRun+99, 2)
+	captureDir := filepath.Join(fix.tmpDir, "captured-sidecar")
+	scripts := []string{
+		writeRefactorPlanSessionScript(t, fix, "missing-plan.sh", false, true, nil),
+		writeRefactorPlanSessionScript(t, fix, "success.sh", true, true, []string{
+			fmt.Sprintf(`mkdir -p %q`, captureDir),
+			fmt.Sprintf(`cp %q %q`, filepath.Join(fix.artifactDir, agent.ProtocolRetrySidecarFile), filepath.Join(captureDir, agent.ProtocolRetrySidecarFile)),
+		}),
+	}
+
+	result, runErr, calls := runRefactorProtocolLoopWithScripts(t, fix, scripts, 0)
+	if runErr != nil {
+		t.Fatalf("RunRefactorFeatureLoop() error = %v", runErr)
+	}
+	if result.FinalStatus != "review_passed" {
+		t.Fatalf("FinalStatus = %q, want review_passed", result.FinalStatus)
+	}
+	if calls != 2 {
+		t.Fatalf("refactor-plan calls = %d, want 2", calls)
+	}
+	captured := readRefactorSidecar(t, captureDir)
+	if captured.Consecutive != 1 {
+		t.Fatalf("captured sidecar.Consecutive = %d, want 1", captured.Consecutive)
+	}
+	if captured.ActiveRun != fix.feature.ActiveRun {
+		t.Fatalf("captured sidecar.ActiveRun = %d, want %d", captured.ActiveRun, fix.feature.ActiveRun)
+	}
+	assertNoRefactorSidecar(t, fix.artifactDir)
+}
+
+func TestRefactorFeatureLoop_NonProtocolErrorDoesNotRetry(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	fix := newRefactorProtocolFixture(t, "refactor-non-protocol")
+	planErr := errors.New("planner exploded")
+	calls := 0
+	cfg := baseRefactorProtocolConfig(fix)
+	cfg.RunRefactorPlanFn = func(string) (string, error) {
+		calls++
+		return "", planErr
+	}
+	cfg.RunImplementFn = func(agent.ImplementConfig, ports.SessionManager) (*agent.LoopResult, error) {
+		t.Fatal("RunImplementFn must not run after non-protocol plan error")
+		return nil, nil
+	}
+
+	result, runErr := agent.RunRefactorFeatureLoop(cfg, nil)
+	if runErr == nil {
+		t.Fatalf("RunRefactorFeatureLoop() error = nil, want wrapped plan error")
+	}
+	if !errors.Is(runErr, planErr) {
+		t.Fatalf("RunRefactorFeatureLoop() error = %v, want errors.Is planner error", runErr)
+	}
+	if calls != 1 {
+		t.Fatalf("refactor-plan calls = %d, want 1", calls)
+	}
+	if result == nil || result.FinalStatus != "failed" {
+		t.Fatalf("result = %+v, want failed result", result)
+	}
+	if result.LastError != planErr.Error() {
+		t.Fatalf("LastError = %q, want %q", result.LastError, planErr.Error())
+	}
+	assertNoRefactorSidecar(t, fix.artifactDir)
+}
+
+func TestRefactorFeatureLoop_ProtocolViolation_SuccessDeletesPriorSidecar(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	fix := newRefactorProtocolFixture(t, "refactor-prior-sidecar")
+	seedRefactorSidecar(t, fix, fix.feature.ActiveRun, 1)
+	captureDir := filepath.Join(fix.tmpDir, "captured-sidecar")
+	scripts := []string{
+		writeRefactorPlanSessionScript(t, fix, "missing-plan.sh", false, true, nil),
+		writeRefactorPlanSessionScript(t, fix, "success.sh", true, true, []string{
+			fmt.Sprintf(`mkdir -p %q`, captureDir),
+			fmt.Sprintf(`cp %q %q`, filepath.Join(fix.artifactDir, agent.ProtocolRetrySidecarFile), filepath.Join(captureDir, agent.ProtocolRetrySidecarFile)),
+		}),
+	}
+
+	result, runErr, calls := runRefactorProtocolLoopWithScripts(t, fix, scripts, 0)
+	if runErr != nil {
+		t.Fatalf("RunRefactorFeatureLoop() error = %v", runErr)
+	}
+	if result.FinalStatus != "review_passed" {
+		t.Fatalf("FinalStatus = %q, want review_passed", result.FinalStatus)
+	}
+	if calls != 2 {
+		t.Fatalf("refactor-plan calls = %d, want 2", calls)
+	}
+	captured := readRefactorSidecar(t, captureDir)
+	if captured.Consecutive != 2 {
+		t.Fatalf("captured sidecar.Consecutive = %d, want 2", captured.Consecutive)
+	}
+	assertNoRefactorSidecar(t, fix.artifactDir)
+}
+
+type refactorProtocolFixture struct {
+	tmpDir      string
+	stateDir    string
+	scriptsDir  string
+	artifactDir string
+	store       *feature.Store
+	feature     *feature.Feature
+}
+
+func newRefactorProtocolFixture(t *testing.T, featureID string) refactorProtocolFixture {
+	t.Helper()
+	tmp := t.TempDir()
+	stateDir := filepath.Join(tmp, "state")
+	scriptsDir := filepath.Join(tmp, "scripts")
+	repoDir := filepath.Join(tmp, "repo")
+	for _, dir := range []string{stateDir, scriptsDir, repoDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+
+	store := feature.NewStore(stateDir)
+	f := &feature.Feature{
+		ID:             featureID,
+		Name:           "Refactor protocol retry",
+		Slug:           featureID,
+		Description:    "Refactor retry test fixture",
+		Status:         feature.StatusPublished,
+		ActiveRun:      1,
+		RunCount:       1,
+		SchemaVersion:  feature.SchemaVersionCurrent,
+		RefactorPrompt: "tighten retry behavior",
+		Repos: []feature.FeatureRepo{
+			{Name: "repo", Path: repoDir, WorktreePath: repoDir, Branch: "feature/test", BaseBranch: "main"},
+		},
+		RepoStates: map[string]*feature.RepoState{
+			"repo": {Touched: true, PRURL: "https://github.com/example/repo/pull/1"},
+		},
+		MaxIterations: 3,
+	}
+	if err := store.Save(f); err != nil {
+		t.Fatalf("save feature: %v", err)
+	}
+	loaded, err := store.Load(f.ID)
+	if err != nil {
+		t.Fatalf("reload feature: %v", err)
+	}
+	artifactDir := filepath.Join(agent.ActiveRunDir(stateDir, loaded), "refactor-1")
+	if err := os.MkdirAll(artifactDir, 0o755); err != nil {
+		t.Fatalf("mkdir artifact dir: %v", err)
+	}
+	return refactorProtocolFixture{
+		tmpDir:      tmp,
+		stateDir:    stateDir,
+		scriptsDir:  scriptsDir,
+		artifactDir: artifactDir,
+		store:       store,
+		feature:     loaded,
+	}
+}
+
+func baseRefactorProtocolConfig(fix refactorProtocolFixture) agent.RefactorFeatureLoopConfig {
+	return agent.RefactorFeatureLoopConfig{
+		Feature:       fix.feature,
+		FeatureStore:  fix.store,
+		StateDir:      fix.stateDir,
+		Prompt:        "tighten retry behavior",
+		Model:         "agent",
+		PlanningModel: "planner",
+		MaxIterations: 3,
+		RunImplementFn: func(agent.ImplementConfig, ports.SessionManager) (*agent.LoopResult, error) {
+			return &agent.LoopResult{FinalStatus: "review_passed", Iterations: 1}, nil
+		},
+	}
+}
+
+func runRefactorProtocolLoopWithScripts(t *testing.T, fix refactorProtocolFixture, scripts []string, maxConsecFails int) (*agent.RefactorFeatureLoopResult, error, int) {
+	t.Helper()
+	eventCh := make(chan interface{}, 100)
+	sm := session.NewManager(eventCh)
+	t.Cleanup(sm.Shutdown)
+
+	calls := 0
+	cfg := baseRefactorProtocolConfig(fix)
+	cfg.MaxConsecFails = maxConsecFails
+	cfg.BuildSession = func(opts agent.BuildSessionOpts) ([]string, []string, *ports.SessionOpts, error) {
+		if calls >= len(scripts) {
+			return nil, nil, nil, fmt.Errorf("unexpected refactor-plan attempt %d", calls+1)
+		}
+		script := scripts[calls]
+		calls++
+		return []string{"bash", script}, nil, &ports.SessionOpts{
+			PIDDir:        opts.PIDDir,
+			PermHandler:   opts.PermHandler,
+			InitialPrompt: opts.Prompt,
+			RepoName:      opts.RepoName,
+			LogPath:       opts.LogPath,
+		}, nil
+	}
+
+	result, err := agent.RunRefactorFeatureLoop(cfg, sm)
+	return result, err, calls
+}
+
+func writeRefactorPlanSessionScript(t *testing.T, fix refactorProtocolFixture, name string, writePlan, touchMarker bool, beforeSuccess []string) string {
+	t.Helper()
+	planPath := filepath.Join(fix.artifactDir, "refactor-plan.md")
+	lines := []string{
+		testutil.JSONLInit,
+		fmt.Sprintf("mkdir -p %q", fix.artifactDir),
+	}
+	lines = append(lines, beforeSuccess...)
+	if writePlan {
+		lines = append(lines, fmt.Sprintf("cat > %q <<'PLAN_EOF'\n%s\nPLAN_EOF", planPath, refactorProtocolPlanText()))
+	}
+	if touchMarker {
+		lines = append(lines, fmt.Sprintf("touch %q", filepath.Join(fix.artifactDir, agent.PhaseCompleteFile)))
+	}
+	lines = append(lines, testutil.JSONLSuccess)
+	return testutil.WriteScript(t, fix.scriptsDir, name, strings.Join(lines, "\n")+"\n")
+}
+
+func refactorProtocolPlanText() string {
+	return "# Refactor: retry coverage\n\n" +
+		"## Tasks\n\n" +
+		"### Task 1: update retry handling\n\n" +
+		"**Repo:** repo\n\n" +
+		"Use the shared retry helper for refactor-plan protocol violations.\n\n" +
+		"#### Automated Verification:\n" +
+		"- [ ] retry tests pass: `go test ./test/integration/...`\n"
+}
+
+func seedRefactorSidecar(t *testing.T, fix refactorProtocolFixture, activeRun, consecutive int) {
+	t.Helper()
+	if err := agent.WriteProtocolRetrySidecar(fix.artifactDir, agent.ProtocolRetrySidecar{
+		Role:          agent.RoleRefactorPlanStep,
+		ActiveRun:     activeRun,
+		Consecutive:   consecutive,
+		LastViolation: "prior violation",
+		UpdatedAt:     time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("WriteProtocolRetrySidecar() error = %v", err)
+	}
+}
+
+func readRefactorSidecar(t *testing.T, dir string) *agent.ProtocolRetrySidecar {
+	t.Helper()
+	sidecar, err := agent.ReadProtocolRetrySidecar(dir)
+	if err != nil {
+		t.Fatalf("ReadProtocolRetrySidecar(%s) error = %v", dir, err)
+	}
+	if sidecar == nil {
+		t.Fatalf("ReadProtocolRetrySidecar(%s) = nil, want sidecar", dir)
+	}
+	return sidecar
+}
+
+func assertNoRefactorSidecar(t *testing.T, dir string) {
+	t.Helper()
+	sidecar, err := agent.ReadProtocolRetrySidecar(dir)
+	if err != nil {
+		t.Fatalf("ReadProtocolRetrySidecar(%s) error = %v", dir, err)
+	}
+	if sidecar != nil {
+		t.Fatalf("ReadProtocolRetrySidecar(%s) = %#v, want nil", dir, sidecar)
+	}
+	if _, err := os.Stat(filepath.Join(dir, agent.ProtocolRetrySidecarFile)); !os.IsNotExist(err) {
+		t.Fatalf("sidecar stat error = %v, want os.ErrNotExist", err)
+	}
+}
+
+func refactorPlanValidationError(t *testing.T, artifactDir string) string {
+	t.Helper()
+	_, violations, err := agent.Validate(feature.PhasePlan, agent.RoleRefactorPlanStep, artifactDir)
+	if err != nil {
+		t.Fatalf("Validate() error = %v", err)
+	}
+	return agent.FormatSingleShotProtocolViolationError(agent.RoleRefactorPlanStep, artifactDir, violations)
+}
+
+func readTrimmedFile(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return strings.TrimSpace(string(data))
 }


### PR DESCRIPTION
## Summary

- Single-shot phases (Inquire, Research, Brainstorm, per-repo Knowledge Base, refactor-plan) now recover from protocol violations by retrying the same phase with the exact contract violation as feedback, terminating only after 3 consecutive violations. Previously a single malformed turn (e.g. a plain-text question or a missing `phase_complete` marker) failed the whole feature, inconsistent with how Implementation / Plan / Final Review already behaved.
- Adds a shared `agent.DecideProtocolRetry` helper plus a `<artifactDir>/.protocol-retry.yaml` sidecar (`internal/agent/protocol_retry.go`) that tracks consecutive-violation budget, survives orchestrator restarts, and resets when `active_run` drifts. Cleanup between attempts now goes through `RemovePhaseCompleteMarker` — only `phase_complete` is removed, leaving artifacts in place for forensic inspection. The helper is consulted purely as a budget/decision oracle; terminal `LastError` text remains byte-identical to today's planner error string.
- Phase 3 retires the private synchronous retry loop in `refactor_feature_loop.go` and the bespoke `clearRefactorPlanAttemptArtifacts` helper, routing refactor-plan through the same shared primitive used by event-driven callers. Wiring through completion/orchestrator/feature-store (`completion.go`, `orchestrator.go`, `feature/store.go`) and TUI rendering (`app_test.go`, `dashboard_test.go`, `detail_test.go`) is updated to surface the new state consistently.

## Test plan

- [ ] `go build ./...`
- [ ] `go vet ./...`
- [ ] `go test ./... -race`
- [ ] `go test ./test/integration/...` — covers the new `TestRefactorFeatureLoop_ProtocolViolation_*` cases (first-violation-then-success, three-consecutive-terminate, restart survival, cross-run staleness reset, non-protocol error path, success-deletes-prior-sidecar) plus the unchanged `TestRefactorFeatureLoop_Integration_3RepoCrossRepoEdit` success path
- [ ] `bash test/e2e/smoke.sh`
- [ ] `go test ./test/eval/...`
- [ ] Manual: in a sandboxed `--state-dir`, induce a refactor-plan protocol violation (delete `refactor-plan.md` between dispatch and validation, or stub a planner that omits `phase_complete`); confirm the first violation does not mark the active cycle failed, `<artifactDir>/.protocol-retry.yaml` contains `consecutive: 1`, the next attempt proceeds, and that two further consecutive violations trigger `markActiveCycleFailedRefactor` with the canonical `protocol violation: refactor-plan-step @ <artifactDir>: …` `LastError`
- [ ] Manual: replace the violating planner with a satisfying one after one violation; confirm `<artifactDir>/.protocol-retry.yaml` is removed on success and the refactor cycle proceeds to its review iterations as today

---

*Generated with [Agentic](https://github.com/doordash-oss/agentic-orchestrator)*