### PR TITLE
Ignore stale session events from prior incarnations

### DIFF
--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -40,6 +40,7 @@ type SDKEventMsg struct {
 	SessionID string
 	FeatureID string
 	Phase     feature.Phase
+	StartedAt time.Time
 	Message   llm.SDKMessage
 }
 
@@ -51,6 +52,7 @@ type SessionDoneMsg struct {
 	SessionID string
 	FeatureID string
 	Phase     feature.Phase
+	StartedAt time.Time
 	Status    SessionStatus
 }
 
@@ -216,6 +218,7 @@ func (m *Manager) StartSession(id, featureID string, phase feature.Phase, comman
 				SessionID: id,
 				FeatureID: featureID,
 				Phase:     phase,
+				StartedAt: s.StartedAt(),
 				Status:    s.Status(),
 			}
 			// SessionDoneMsg is critical — use blocking send since it's a
@@ -289,6 +292,7 @@ func (m *Manager) handleSessionMessage(s *Session, id, featureID string, phase f
 			SessionID: id,
 			FeatureID: featureID,
 			Phase:     phase,
+			StartedAt: s.StartedAt(),
 			Message:   msg,
 		}
 		select {

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -500,6 +500,7 @@ func NewSession(id, featureID string, phase feature.Phase) *Session {
 		id:                        id,
 		featureID:                 featureID,
 		phase:                     phase,
+		startedAt:                 time.Now(),
 		messageLog:                NewMessageLog(),
 		status:                    SessionRunning,
 		statusCh:                  make(chan string, 1),

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -2238,6 +2238,9 @@ func (m AppModel) handleSDKEvent(msg SDKSessionEventMsg) (tea.Model, tea.Cmd) {
 	if isChatSession(evt.SessionID) || isArtifactReviewSession(evt.SessionID) {
 		return m, m.listenForEvents()
 	}
+	if staleSessionEvent(m.sessionManager.GetSession(evt.SessionID), evt.StartedAt) {
+		return m, m.listenForEvents()
+	}
 
 	var notifyCmd tea.Cmd
 
@@ -2590,6 +2593,9 @@ func (m AppModel) handleSessionDone(msg SessionDoneTUIMsg) (tea.Model, tea.Cmd) 
 	fid := eventFID(done.SessionID, done.FeatureID)
 	sess := m.sessionManager.GetSession(done.SessionID)
 	phase := eventPhase(done.SessionID, done.FeatureID, done.Phase)
+	if staleSessionEvent(sess, done.StartedAt) {
+		return m, m.listenForEvents()
+	}
 
 	// Derive success primarily from the SDK result status (StatusCh),
 	// not the process exit code. A clean exit (SessionDone) does NOT
@@ -2725,6 +2731,14 @@ func (m AppModel) handleSessionDone(msg SessionDoneTUIMsg) (tea.Model, tea.Cmd) 
 	)
 
 	return m, cmd
+}
+
+func staleSessionEvent(sess session.SessionView, eventStartedAt time.Time) bool {
+	if sess == nil || eventStartedAt.IsZero() {
+		return false
+	}
+	currentStartedAt := sess.StartedAt()
+	return !currentStartedAt.IsZero() && !currentStartedAt.Equal(eventStartedAt)
 }
 
 func (m AppModel) completeRegistryOwnedSingleShotPhase(

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -4601,6 +4601,62 @@ func TestHandleSDKEvent_ArtifactPhaseResultSuccessRoutesThroughProtocolValidatio
 	}
 }
 
+func TestHandleSessionDone_StaleRegistryOwnedCompletionDoesNotRetryReplacement(t *testing.T) {
+	app, fm := newTestAppModel(t)
+	app.eventCh = make(chan interface{}, 1)
+	app.lastNotifyTime = make(map[notifyKey]time.Time)
+	f := createFeatureInPhase(t, fm, feature.PhaseInquire)
+	writeTUIPhaseMarkdown(t, fm.Store.BaseDir, f, feature.PhaseInquire, "inquiry.md")
+
+	sm := session.NewManager(nil)
+	sessionID := f.ID + "-inquire"
+	oldSess := session.NewSession(sessionID, f.ID, feature.PhaseInquire)
+	appendAssistantQuestion(t, oldSess)
+	oldStartedAt := oldSess.StartedAt()
+	if oldStartedAt.IsZero() {
+		t.Fatal("old session StartedAt is zero")
+	}
+	sm.RegisterTestSession(oldSess)
+	app.sessionManager = sm
+
+	_, _ = app.handleSDKEvent(SDKSessionEventMsg{
+		Event: session.SDKEventMsg{
+			SessionID: sessionID,
+			FeatureID: f.ID,
+			Phase:     feature.PhaseInquire,
+			StartedAt: oldStartedAt,
+			Message: llm.SDKMessage{
+				Type:    "result",
+				Subtype: "success",
+				Result:  &llm.ResultMessage{Type: "result", Subtype: "success"},
+			},
+		},
+	})
+
+	retrySess := session.NewSession(sessionID, f.ID, feature.PhaseInquire)
+	for retrySess.StartedAt().Equal(oldStartedAt) {
+		time.Sleep(time.Nanosecond)
+		retrySess = session.NewSession(sessionID, f.ID, feature.PhaseInquire)
+	}
+	sm.RegisterTestSession(retrySess)
+
+	_, _ = app.handleSessionDone(SessionDoneTUIMsg{
+		Done: session.SessionDoneMsg{
+			SessionID: sessionID,
+			FeatureID: f.ID,
+			Phase:     feature.PhaseInquire,
+			StartedAt: oldStartedAt,
+			Status:    session.SessionDone,
+		},
+	})
+
+	updated, err := fm.Get(f.ID)
+	if err != nil {
+		t.Fatalf("get feature: %v", err)
+	}
+	assertTUIArtifactPhaseRetry(t, fm, updated, feature.PhaseInquire, agent.PhaseCompleteFile)
+}
+
 func TestHandleSessionDone_ArtifactPhaseSuccessRoutesThroughProtocolValidation(t *testing.T) {
 	for _, tc := range tuiArtifactPhaseCases() {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary
- Stamp every `SDKEventMsg` / `SessionDoneMsg` with the originating session's `StartedAt`, populated when the `Session` is constructed.
- Add `staleSessionEvent` in `internal/tui/app.go` and short-circuit `handleSDKEvent` / `handleSessionDone` when the event's `StartedAt` no longer matches the live session, so late events from a replaced session can't trigger replacement retries.
- Add regression test `TestHandleSessionDone_StaleRegistryOwnedCompletionDoesNotRetryReplacement` covering the registry-owned single-shot path.

## Test plan
- [ ] `make test-fast`
- [ ] Manually replace a single-shot phase session (Inquire/Research/Design) and confirm a late SDK / done event from the prior incarnation no longer triggers a retry on the replacement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)