### PR TITLE
Pause rebase and review-comments cycles on NEED_USER_INPUT

### DIFF
--- a/internal/agent/rebase_loop.go
+++ b/internal/agent/rebase_loop.go
@@ -128,16 +128,19 @@ type RebaseRepoTarget struct {
 //     AtomicPhaseStamp wrote failed (LastError set).
 //   - "interrupted":      shutdown / feature stopped mid-loop. No atomic
 //     stamp; persisted state preserved for restart.
+//   - "need_user_input":  iteration emitted NEED_USER_INPUT — cycle pause
+//     gate; NeedUserInputPath points to the persisted gate artifact.
 //   - "no_op":            no behind repos at loop entry; nothing to do.
 //   - "failed":           dispatch error before iteration began.
 //
 // Repos is the deduplicated, sorted list of behind-subset repo names — the
 // canonical "rebase-staged subset" the AtomicPhaseStamp wrote to.
 type RebaseLoopResult struct {
-	FinalStatus string
-	Iterations  int
-	LastError   string
-	Repos       []string
+	FinalStatus       string
+	Iterations        int
+	LastError         string
+	NeedUserInputPath string
+	Repos             []string
 }
 
 // RunRebaseLoop drives the unified rebase cycle. Cwd at the feature state
@@ -268,7 +271,7 @@ func RunRebaseLoop(cfg RebaseLoopConfig, sm ports.SessionManager) (*RebaseLoopRe
 		StateDir:                   stateDir,
 		AdditionalDirs:             additionalDirsExcludingStateDir(workspace, stateDir),
 		KBInfos:                    cfg.KBInfos,
-		DesignArtifactPath:     cfg.Feature.DesignArtifactPath(),
+		DesignArtifactPath:         cfg.Feature.DesignArtifactPath(),
 		DangerouslySkipPermissions: cfg.DangerouslySkipPermissions,
 		PermissionCache:            cfg.PermissionCache,
 		BuildSession:               cfg.BuildSession,
@@ -347,6 +350,21 @@ func RunRebaseLoop(cfg RebaseLoopConfig, sm ports.SessionManager) (*RebaseLoopRe
 			FinalStatus: "interrupted",
 			Iterations:  loopResult.Iterations,
 			Repos:       repoNames,
+		}, nil
+
+	case "need_user_input":
+		_ = AtomicPhaseStamp(cfg.FeatureStore, AtomicPhaseStampInput{
+			FeatureID: cfg.Feature.ID,
+			Repos:     repoNames,
+			Outcome:   PhaseOutcomeNeedUserInput,
+			GatePath:  loopResult.NeedUserInputPath,
+		})
+		return &RebaseLoopResult{
+			FinalStatus:       "need_user_input",
+			Iterations:        loopResult.Iterations,
+			LastError:         loopResult.LastError,
+			NeedUserInputPath: loopResult.NeedUserInputPath,
+			Repos:             repoNames,
 		}, nil
 
 	default:

--- a/internal/agent/rebase_loop.go
+++ b/internal/agent/rebase_loop.go
@@ -98,6 +98,12 @@ type RebaseLoopConfig struct {
 	GuidelinesDir              string
 	Observer                   *observe.Observer
 
+	// ResumeExistingCycle reuses the current ActiveCycle.Count instead of
+	// opening a new rebase-N directory. Used when resuming a rebase
+	// NEED_USER_INPUT gate so answered prompts carry into the next
+	// iteration of the same cycle.
+	ResumeExistingCycle bool
+
 	// RunImplementFn is a test seam: when non-nil, RunRebaseLoop calls
 	// this instead of RunImplementationLoop so unit tests can drive the
 	// outer loop's state-machine transitions without launching a real
@@ -194,11 +200,24 @@ func RunRebaseLoop(cfg RebaseLoopConfig, sm ports.SessionManager) (*RebaseLoopRe
 	}
 
 	// Increment RebaseCount and set ActiveCycle = {Type: rebase, Status:
-	// running} at loop entry. Both are persisted in the same Modify so a
-	// crash between the two (e.g. another goroutine reads partial state)
-	// cannot observe one without the other.
+	// running} at loop entry. NEED_USER_INPUT resume reuses the existing
+	// ActiveCycle.Count so the next iteration lands in the same rebase-N
+	// artifact directory and can read prior answered gates.
 	rebaseCount := 0
 	if err := cfg.FeatureStore.Modify(cfg.Feature.ID, func(f *feature.Feature) error {
+		if cfg.ResumeExistingCycle {
+			if f.ActiveCycle == nil || f.ActiveCycle.Type != feature.CycleRebase || f.ActiveCycle.Count <= 0 {
+				return fmt.Errorf("resume requested without an active rebase cycle")
+			}
+			rebaseCount = f.ActiveCycle.Count
+			f.ActiveCycle.Status = feature.RepoCycleRunning
+			if f.RebaseCount() < rebaseCount {
+				f.SetRebaseCount(rebaseCount)
+			}
+			f.SetActiveCycleType(feature.CycleRebase)
+			return nil
+		}
+
 		f.SetRebaseCount(f.RebaseCount() + 1)
 		f.SetActiveCycleType(feature.CycleRebase)
 		f.ActiveCycle = &feature.CycleState{

--- a/internal/agent/rebase_loop_test.go
+++ b/internal/agent/rebase_loop_test.go
@@ -410,6 +410,63 @@ func TestRunRebaseLoop_InterruptedPreservesState(t *testing.T) {
 	}
 }
 
+// TestRunRebaseLoop_NeedUserInputSurfacesGate verifies that an agent-authored
+// NEED_USER_INPUT handoff pauses the rebase cycle instead of stamping the
+// staged repos failed.
+func TestRunRebaseLoop_NeedUserInputSurfacesGate(t *testing.T) {
+	stateDir := t.TempDir()
+	store, f, _ := newRebaseTestFeature(t, stateDir, "rebase-nui", []string{"api", "web"})
+	gatePath := filepath.Join(stateDir, "rebase-1", "iteration-01", "need-user-input.yaml")
+
+	cfg := RebaseLoopConfig{
+		Feature:      f,
+		FeatureStore: store,
+		StateDir:     stateDir,
+		BehindRepos: []RebaseRepoTarget{
+			{RepoName: "api", RebaseTarget: "main"},
+			{RepoName: "web", RebaseTarget: "main"},
+		},
+		MaxIterations: 3,
+		RunImplementFn: stubRunImplementFn(&LoopResult{
+			FinalStatus:       "need_user_input",
+			Iterations:        1,
+			LastError:         "Build gate needs a human decision.",
+			NeedUserInputPath: gatePath,
+		}, nil),
+	}
+
+	result, err := RunRebaseLoop(cfg, nil)
+	if err != nil {
+		t.Fatalf("RunRebaseLoop: %v", err)
+	}
+	if result.FinalStatus != "need_user_input" {
+		t.Fatalf("FinalStatus = %q, want need_user_input", result.FinalStatus)
+	}
+	if result.NeedUserInputPath != gatePath {
+		t.Errorf("NeedUserInputPath = %q, want %q", result.NeedUserInputPath, gatePath)
+	}
+
+	loaded, err := store.Load(f.ID)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if loaded.PendingNeedUserInputPath != gatePath {
+		t.Errorf("PendingNeedUserInputPath = %q, want %q", loaded.PendingNeedUserInputPath, gatePath)
+	}
+	for _, name := range []string{"api", "web"} {
+		st := loaded.RepoStates[name]
+		if st == nil || st.LastError != "" {
+			t.Errorf("repo %s = %+v, want prior state without failure", name, st)
+		}
+	}
+	if loaded.ActiveCycle == nil {
+		t.Fatal("ActiveCycle = nil, want preserved at Status=running for gate resume")
+	}
+	if loaded.ActiveCycle.Status != feature.RepoCycleRunning {
+		t.Errorf("ActiveCycle.Status = %q, want running", loaded.ActiveCycle.Status)
+	}
+}
+
 // TestRunRebaseLoop_NoBehindReposShortCircuits verifies the no-op
 // degenerate case: zero behind repos returns FinalStatus=no_op without
 // touching any state.

--- a/internal/agent/rebase_loop_test.go
+++ b/internal/agent/rebase_loop_test.go
@@ -758,6 +758,66 @@ func TestRunRebaseLoop_CrashRecoveryReusesArtifactDir(t *testing.T) {
 	}
 }
 
+func TestRunRebaseLoop_ResumeExistingCycleReusesArtifactDir(t *testing.T) {
+	stateDir := t.TempDir()
+	store, f, _ := newRebaseTestFeature(t, stateDir, "rebase-resume", []string{"api"})
+
+	if err := store.Modify(f.ID, func(ff *feature.Feature) error {
+		ff.SetRebaseCount(1)
+		ff.SetActiveCycleType(feature.CycleRebase)
+		ff.ActiveCycle = &feature.CycleState{
+			Type:   feature.CycleRebase,
+			Status: feature.RepoCycleRunning,
+			Count:  1,
+		}
+		ff.PendingNeedUserInputPath = filepath.Join(stateDir, "gate.yaml")
+		return nil
+	}); err != nil {
+		t.Fatalf("seed paused rebase state: %v", err)
+	}
+	loaded, _ := store.Load(f.ID)
+
+	priorDir := filepath.Join(ActiveRunDir(stateDir, loaded), "rebase-1", "iteration-01")
+	if err := os.MkdirAll(priorDir, 0o755); err != nil {
+		t.Fatalf("seed iteration-01: %v", err)
+	}
+
+	captureFn, captured := capturingRunImplementFn(&LoopResult{FinalStatus: "review_passed", Iterations: 2})
+	cfg := RebaseLoopConfig{
+		Feature:      loaded,
+		FeatureStore: store,
+		StateDir:     stateDir,
+		BehindRepos: []RebaseRepoTarget{
+			{RepoName: "api", RebaseTarget: "main"},
+		},
+		MaxIterations:       3,
+		ResumeExistingCycle: true,
+		RunImplementFn:      captureFn,
+	}
+
+	if _, err := RunRebaseLoop(cfg, nil); err != nil {
+		t.Fatalf("RunRebaseLoop: %v", err)
+	}
+
+	if len(*captured) != 1 {
+		t.Fatalf("captured calls = %d, want 1", len(*captured))
+	}
+	loaded, _ = store.Load(f.ID)
+	if loaded.RebaseCount() != 1 {
+		t.Fatalf("RebaseCount = %d, want 1", loaded.RebaseCount())
+	}
+	wantDir := filepath.Join(ActiveRunDir(stateDir, loaded), "rebase-1")
+	if got := (*captured)[0].ArtifactDir; got != wantDir {
+		t.Fatalf("ArtifactDir = %q, want existing cycle dir %q", got, wantDir)
+	}
+	if _, err := os.Stat(filepath.Join(wantDir, "iteration-01")); err != nil {
+		t.Fatalf("existing iteration-01 missing: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(ActiveRunDir(stateDir, loaded), "rebase-2")); !os.IsNotExist(err) {
+		t.Fatalf("rebase-2 exists after resume; expected no new rebase dir (stat err=%v)", err)
+	}
+}
+
 // TestRunRebaseLoop_ActiveCycleSetAtEntry verifies the cycle entry stamp:
 // before the inner loop runs, ActiveCycle is stamped {Type: rebase,
 // Status: running} so the TUI and observers can see the active cycle.

--- a/internal/agent/review_comments_loop.go
+++ b/internal/agent/review_comments_loop.go
@@ -126,16 +126,19 @@ type ReviewCommentsLoopConfig struct {
 //   - "safety_rail":      consecutive-failure / no-progress rail tripped.
 //   - "interrupted":      shutdown / feature stopped mid-loop. No atomic
 //     stamp; persisted state preserved for restart.
+//   - "need_user_input":  iteration emitted NEED_USER_INPUT — cycle pause
+//     gate; NeedUserInputPath points to the persisted gate artifact.
 //   - "no_op":            no repos with unaddressed comments at entry.
 //   - "failed":           dispatch error before iteration began.
 //
 // Repos is the deduplicated, sorted list of repo names with comments —
 // the canonical staged subset the AtomicPhaseStamp wrote to.
 type ReviewCommentsLoopResult struct {
-	FinalStatus string
-	Iterations  int
-	LastError   string
-	Repos       []string
+	FinalStatus       string
+	Iterations        int
+	LastError         string
+	NeedUserInputPath string
+	Repos             []string
 }
 
 // RunReviewCommentsLoop drives the unified review-comments cycle. Cwd
@@ -275,7 +278,7 @@ func RunReviewCommentsLoop(cfg ReviewCommentsLoopConfig, sm ports.SessionManager
 		StateDir:                   stateDir,
 		AdditionalDirs:             additionalDirsExcludingStateDir(workspace, stateDir),
 		KBInfos:                    cfg.KBInfos,
-		DesignArtifactPath:     cfg.Feature.DesignArtifactPath(),
+		DesignArtifactPath:         cfg.Feature.DesignArtifactPath(),
 		DangerouslySkipPermissions: cfg.DangerouslySkipPermissions,
 		PermissionCache:            cfg.PermissionCache,
 		BuildSession:               cfg.BuildSession,
@@ -345,6 +348,21 @@ func RunReviewCommentsLoop(cfg ReviewCommentsLoopConfig, sm ports.SessionManager
 			FinalStatus: "interrupted",
 			Iterations:  loopResult.Iterations,
 			Repos:       repoNames,
+		}, nil
+
+	case "need_user_input":
+		_ = AtomicPhaseStamp(cfg.FeatureStore, AtomicPhaseStampInput{
+			FeatureID: cfg.Feature.ID,
+			Repos:     repoNames,
+			Outcome:   PhaseOutcomeNeedUserInput,
+			GatePath:  loopResult.NeedUserInputPath,
+		})
+		return &ReviewCommentsLoopResult{
+			FinalStatus:       "need_user_input",
+			Iterations:        loopResult.Iterations,
+			LastError:         loopResult.LastError,
+			NeedUserInputPath: loopResult.NeedUserInputPath,
+			Repos:             repoNames,
 		}, nil
 
 	default:

--- a/internal/agent/review_comments_loop_test.go
+++ b/internal/agent/review_comments_loop_test.go
@@ -365,6 +365,63 @@ func TestRunReviewCommentsLoop_InterruptedPreservesState(t *testing.T) {
 	}
 }
 
+// TestRunReviewCommentsLoop_NeedUserInputSurfacesGate verifies that an
+// ambiguous review-comment decision pauses the cycle instead of stamping
+// staged repos failed.
+func TestRunReviewCommentsLoop_NeedUserInputSurfacesGate(t *testing.T) {
+	stateDir := t.TempDir()
+	store, f, _ := newReviewCommentsTestFeature(t, stateDir, "rc-nui", []string{"api", "web"})
+	gatePath := filepath.Join(stateDir, "review-comments-1", "iteration-01", "need-user-input.yaml")
+
+	cfg := ReviewCommentsLoopConfig{
+		Feature:      f,
+		FeatureStore: store,
+		StateDir:     stateDir,
+		RepoTargets: []ReviewCommentsRepoTarget{
+			makeReviewCommentTarget("api", "https://github.com/example/api/pull/1", 1),
+			makeReviewCommentTarget("web", "https://github.com/example/web/pull/1", 2),
+		},
+		MaxIterations: 3,
+		RunImplementFn: stubRunImplementFn(&LoopResult{
+			FinalStatus:       "need_user_input",
+			Iterations:        1,
+			LastError:         "Reviewer request conflicts with product decision.",
+			NeedUserInputPath: gatePath,
+		}, nil),
+	}
+
+	result, err := RunReviewCommentsLoop(cfg, nil)
+	if err != nil {
+		t.Fatalf("RunReviewCommentsLoop: %v", err)
+	}
+	if result.FinalStatus != "need_user_input" {
+		t.Fatalf("FinalStatus = %q, want need_user_input", result.FinalStatus)
+	}
+	if result.NeedUserInputPath != gatePath {
+		t.Errorf("NeedUserInputPath = %q, want %q", result.NeedUserInputPath, gatePath)
+	}
+
+	loaded, err := store.Load(f.ID)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if loaded.PendingNeedUserInputPath != gatePath {
+		t.Errorf("PendingNeedUserInputPath = %q, want %q", loaded.PendingNeedUserInputPath, gatePath)
+	}
+	for _, name := range []string{"api", "web"} {
+		st := loaded.RepoStates[name]
+		if st == nil || st.LastError != "" {
+			t.Errorf("repo %s = %+v, want prior state without failure", name, st)
+		}
+	}
+	if loaded.ActiveCycle == nil {
+		t.Fatal("ActiveCycle = nil, want preserved at Status=running for gate resume")
+	}
+	if loaded.ActiveCycle.Status != feature.RepoCycleRunning {
+		t.Errorf("ActiveCycle.Status = %q, want running", loaded.ActiveCycle.Status)
+	}
+}
+
 // TestRunReviewCommentsLoop_NoTargetsShortCircuits verifies the no-op
 // degenerate case: zero repos with comments returns FinalStatus=no_op
 // without touching state.

--- a/internal/orchestrator/cycles.go
+++ b/internal/orchestrator/cycles.go
@@ -163,7 +163,7 @@ func (o *Orchestrator) StartRepoCycleImplement(
 		ArtifactDir:                artifactDir,
 		StateDir:                   filepath.Join(baseDir, featureID),
 		RepoName:                   repoName,
-		DesignArtifactPath:     f.DesignArtifactPath(),
+		DesignArtifactPath:         f.DesignArtifactPath(),
 		DangerouslySkipPermissions: pr.DangerouslySkipPermissions,
 		PermissionCache:            pr.PermissionCache,
 		BuildSession:               pr.BuildSession,
@@ -268,7 +268,9 @@ func (o *Orchestrator) restartPausedRepoCycle(featureID, repoName string) error 
 		return fmt.Errorf("no cycle entry for repo %q", repoName)
 	}
 	switch rc.Type {
-	case feature.CycleRebase, feature.CycleReviewComments:
+	case feature.CycleRebase:
+		return o.restartPausedFeatureRebase(featureID, repoName)
+	case feature.CycleReviewComments:
 		_, err := o.restartRepoCycleImplement(featureID, repoName, rc)
 		return err
 	case feature.CycleRefactor:
@@ -276,6 +278,93 @@ func (o *Orchestrator) restartPausedRepoCycle(featureID, repoName string) error 
 	default:
 		return fmt.Errorf("unsupported cycle type %q for repo %q", rc.Type, repoName)
 	}
+}
+
+// restartPausedFeatureRebase re-launches the unified rebase loop after an
+// answered NEED_USER_INPUT gate. Unlike legacy per-repo cycle restarts, rebase
+// owns every behind repo in one flat artifact directory, so resume must route
+// through RunRebaseLoop with ResumeExistingCycle rather than the generic
+// per-repo RunImplementationLoop wrapper.
+func (o *Orchestrator) restartPausedFeatureRebase(featureID, repoName string) error {
+	f, err := o.deps.Lifecycle.Get(featureID)
+	if err != nil {
+		return fmt.Errorf("load feature: %w", err)
+	}
+	behind, err := o.activeRebaseTargets(f)
+	if err != nil {
+		return err
+	}
+	if len(behind) == 0 {
+		return fmt.Errorf("no active rebase cycles to resume for repo %q", repoName)
+	}
+
+	pr := o.deps.PhaseRunner
+	if pr == nil {
+		return errors.New("phase runner not configured")
+	}
+
+	cfg := agent.RebaseLoopConfig{
+		Feature:                    f,
+		FeatureStore:               o.deps.Store,
+		StateDir:                   o.stateDir(),
+		BehindRepos:                behind,
+		Model:                      f.Models.Implementation,
+		ReviewModel:                f.Models.Review,
+		MaxIterations:              f.MaxIterations,
+		MaxConsecFails:             3,
+		MaxConsecNoProgress:        3,
+		KBInfos:                    o.computeKBInfos(f),
+		DangerouslySkipPermissions: pr.DangerouslySkipPermissions,
+		PermissionCache:            pr.PermissionCache,
+		BuildSession:               pr.BuildSession,
+		AskingClause:               pr.AskingClauseForModel(f.Models.Implementation),
+		EffortLevel:                f.EffectivePipeline().EffortLevel(),
+		SkillsDir:                  pr.SkillsDir,
+		GuidelinesDir:              pr.GuidelinesDir,
+		Observer:                   pr.Observer,
+		ResumeExistingCycle:        true,
+	}
+
+	sm := o.deps.Sessions
+	o.cycleWG.Go(func() {
+		runRebaseLoop := o.runRebaseLoopFn
+		if runRebaseLoop == nil {
+			runRebaseLoop = agent.RunRebaseLoop
+		}
+		result, loopErr := runRebaseLoop(cfg, sm)
+		o.handleFeatureRebaseDone(featureID, behind, result, loopErr)
+	})
+	return nil
+}
+
+func (o *Orchestrator) activeRebaseTargets(f *feature.Feature) ([]agent.RebaseRepoTarget, error) {
+	if f == nil {
+		return nil, errors.New("feature is nil")
+	}
+	prURLs := f.PRURLs()
+	var out []agent.RebaseRepoTarget
+	for i := range f.Repos {
+		repo := &f.Repos[i]
+		rc, ok := f.RepoCycles[repo.Name]
+		if !ok || rc == nil || rc.Type != feature.CycleRebase {
+			continue
+		}
+		switch rc.Status {
+		case feature.RepoCycleRunning, feature.RepoCycleNeedUserInput:
+		default:
+			continue
+		}
+		target := o.resolveRebaseTarget(f, repo)
+		if target == "" {
+			return nil, fmt.Errorf("resolve rebase target for repo %q", repo.Name)
+		}
+		out = append(out, agent.RebaseRepoTarget{
+			RepoName:     repo.Name,
+			RebaseTarget: target,
+			PRURL:        prURLs[repo.Name],
+		})
+	}
+	return out, nil
 }
 
 // restartRefactorRepoCycle re-launches a refactor loop for a paused refactor
@@ -378,7 +467,7 @@ func (o *Orchestrator) restartRepoCycleImplement(featureID, repoName string, rc 
 		ArtifactDir:                cycleBaseDir,
 		StateDir:                   filepath.Join(baseDir, featureID),
 		RepoName:                   repoName,
-		DesignArtifactPath:     f.DesignArtifactPath(),
+		DesignArtifactPath:         f.DesignArtifactPath(),
 		DangerouslySkipPermissions: pr.DangerouslySkipPermissions,
 		PermissionCache:            pr.PermissionCache,
 		BuildSession:               pr.BuildSession,

--- a/internal/orchestrator/need_user_input.go
+++ b/internal/orchestrator/need_user_input.go
@@ -140,6 +140,33 @@ func (o *Orchestrator) onRepoCycleNeedUserInput(
 	return nil
 }
 
+func (o *Orchestrator) recordRepoCycleNeedUserInput(
+	featureID, repoName string,
+	cycleType feature.RepoCycleType,
+	gate *agent.LoopResult,
+) {
+	if err := o.onRepoCycleNeedUserInput(featureID, repoName, cycleType, gate); err != nil {
+		o.failRepoCycleGatePersistence(featureID, repoName,
+			fmt.Errorf("%s: persist need-user-input gate for repo %q: %w", cycleType, repoName, err))
+	}
+}
+
+func (o *Orchestrator) failRepoCycleGatePersistence(featureID, repoName string, cause error) {
+	if cause == nil {
+		return
+	}
+	msg := cause.Error()
+	if err := o.deps.Lifecycle.FailRepoCycle(featureID, repoName, msg); err != nil {
+		o.emitEventBlocking(ports.Event{
+			Type:      ports.PhaseCompleted,
+			FeatureID: featureID,
+			Phase:     feature.PhaseImplement,
+			Error:     fmt.Errorf("%s (also failed to mark repo cycle failed: %w)", msg, err),
+			Message:   msg,
+		})
+	}
+}
+
 // handleRepoCycleNeedUserInputDecision handles a cycle-scoped need-user-input
 // decision. Resume validates answers, clears the paused gate fields while
 // preserving cycle Count / Type / artifact anchors, then dispatches to the

--- a/internal/orchestrator/need_user_input.go
+++ b/internal/orchestrator/need_user_input.go
@@ -21,6 +21,7 @@ package orchestrator
 import (
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/doordash-oss/agentic-orchestrator/internal/agent"
@@ -172,18 +173,27 @@ func (o *Orchestrator) handleRepoCycleNeedUserInputDecision(featureID string, d 
 		if !rec.AllAnswered() {
 			return errors.New("cannot resume: every question must have a non-empty answer before resume")
 		}
+		resumeRepos := []string{d.RepoName}
+		if rc.Type == feature.CycleRebase {
+			resumeRepos = repoCycleGateRepos(f, feature.CycleRebase, gatePath, d.RepoName)
+		}
 		// Clear the paused-gate fields but preserve Count, PlanPath, and
 		// Type so the restart seam reuses the existing cycle record. Set
 		// status back to Running so HasActiveRepoCycles still treats the
 		// cycle as in-flight while the restart launches.
 		if err := o.deps.Store.Modify(featureID, func(ff *feature.Feature) error {
-			cycle, ok := ff.RepoCycles[d.RepoName]
-			if !ok || cycle == nil {
-				return fmt.Errorf("repo %q vanished from repo_cycles mid-resume", d.RepoName)
+			for _, name := range resumeRepos {
+				cycle, ok := ff.RepoCycles[name]
+				if !ok || cycle == nil {
+					return fmt.Errorf("repo %q vanished from repo_cycles mid-resume", name)
+				}
+				cycle.Status = feature.RepoCycleRunning
+				cycle.PendingNeedUserInputPath = ""
+				cycle.LastError = ""
 			}
-			cycle.Status = feature.RepoCycleRunning
-			cycle.PendingNeedUserInputPath = ""
-			cycle.LastError = ""
+			if ff.PendingNeedUserInputPath == gatePath {
+				ff.PendingNeedUserInputPath = ""
+			}
 			return nil
 		}); err != nil {
 			return fmt.Errorf("clear cycle gate: %w", err)
@@ -192,12 +202,14 @@ func (o *Orchestrator) handleRepoCycleNeedUserInputDecision(featureID string, d 
 			// Roll back: restore the paused gate so the user can retry or
 			// abort from the same paused state.
 			if rbErr := o.deps.Store.Modify(featureID, func(ff *feature.Feature) error {
-				cycle, ok := ff.RepoCycles[d.RepoName]
-				if !ok || cycle == nil {
-					return fmt.Errorf("repo %q vanished during rollback", d.RepoName)
+				for _, name := range resumeRepos {
+					cycle, ok := ff.RepoCycles[name]
+					if !ok || cycle == nil {
+						return fmt.Errorf("repo %q vanished during rollback", name)
+					}
+					cycle.Status = feature.RepoCycleNeedUserInput
+					cycle.PendingNeedUserInputPath = gatePath
 				}
-				cycle.Status = feature.RepoCycleNeedUserInput
-				cycle.PendingNeedUserInputPath = gatePath
 				return nil
 			}); rbErr != nil {
 				return fmt.Errorf("relaunch cycle: %w (rollback to gate also failed: %v)", err, rbErr)
@@ -213,12 +225,47 @@ func (o *Orchestrator) handleRepoCycleNeedUserInputDecision(featureID string, d 
 		if summary == "" {
 			summary = fmt.Sprintf("user aborted at need-user-input gate for cycle on repo %s", d.RepoName)
 		}
+		abortRepos := []string{d.RepoName}
+		if rc.Type == feature.CycleRebase {
+			abortRepos = repoCycleGateRepos(f, feature.CycleRebase, gatePath, d.RepoName)
+		}
 		// FailRepoCycle clears the gate path and, for refactor cycles, the
 		// feature-level RefactorPrompt. The parent feature stays Published.
-		return o.deps.Lifecycle.FailRepoCycle(featureID, d.RepoName, summary)
+		for _, name := range abortRepos {
+			if err := o.deps.Lifecycle.FailRepoCycle(featureID, name, summary); err != nil {
+				return err
+			}
+		}
+		_ = o.deps.Store.Modify(featureID, func(ff *feature.Feature) error {
+			if ff.PendingNeedUserInputPath == gatePath {
+				ff.PendingNeedUserInputPath = ""
+			}
+			return nil
+		})
+		return nil
 	default:
 		return fmt.Errorf("unknown need-user-input decision %q (want resume|abort)", d.Decision)
 	}
+}
+
+func repoCycleGateRepos(f *feature.Feature, cycleType feature.RepoCycleType, gatePath, fallback string) []string {
+	var names []string
+	if f != nil {
+		for name, rc := range f.RepoCycles {
+			if rc == nil ||
+				rc.Type != cycleType ||
+				rc.Status != feature.RepoCycleNeedUserInput ||
+				rc.PendingNeedUserInputPath != gatePath {
+				continue
+			}
+			names = append(names, name)
+		}
+	}
+	if len(names) == 0 && fallback != "" {
+		names = append(names, fallback)
+	}
+	sort.Strings(names)
+	return names
 }
 
 // handleFeatureNeedUserInputDecision implements the original single-repo /

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -269,6 +269,11 @@ type Orchestrator struct {
 		planPath string,
 		kbInfos ...agent.KBInfo,
 	) (chan *agent.LoopResult, error)
+
+	// runRebaseLoopFn is a test seam over agent.RunRebaseLoop. The default
+	// launches the production unified rebase loop; tests override it to
+	// verify rebase gate routing without booting agent sessions.
+	runRebaseLoopFn func(agent.RebaseLoopConfig, ports.SessionManager) (*agent.RebaseLoopResult, error)
 }
 
 // SetRunImplementationFn installs a test seam that intercepts
@@ -310,6 +315,7 @@ func New(deps Deps, hooks Hooks) *Orchestrator {
 		}
 		return o.deps.PhaseRunner.RunMultiRepoFinalReview(f, kbInfos...)
 	}
+	o.runRebaseLoopFn = agent.RunRebaseLoop
 	return o
 }
 

--- a/internal/orchestrator/rebase_feature.go
+++ b/internal/orchestrator/rebase_feature.go
@@ -283,6 +283,18 @@ func (o *Orchestrator) handleFeatureRebaseDone(
 		// them.
 		return
 
+	case "need_user_input":
+		gate := &agent.LoopResult{
+			FinalStatus:       "need_user_input",
+			Iterations:        result.Iterations,
+			LastError:         result.LastError,
+			NeedUserInputPath: result.NeedUserInputPath,
+		}
+		for _, t := range behind {
+			_ = o.onRepoCycleNeedUserInput(featureID, t.RepoName, feature.CycleRebase, gate)
+		}
+		return
+
 	default:
 		// max_iterations / safety_rail / failed: surface conflict per
 		// repo so the TUI can present the failed cycle.

--- a/internal/orchestrator/rebase_feature.go
+++ b/internal/orchestrator/rebase_feature.go
@@ -295,14 +295,19 @@ func (o *Orchestrator) handleFeatureRebaseDone(
 			NeedUserInputPath: result.NeedUserInputPath,
 		}
 		for _, t := range behind {
-			_ = o.onRepoCycleNeedUserInput(featureID, t.RepoName, feature.CycleRebase, gate)
+			o.recordRepoCycleNeedUserInput(featureID, t.RepoName, feature.CycleRebase, gate)
 		}
-		_ = o.deps.Store.Modify(featureID, func(f *feature.Feature) error {
+		if err := o.deps.Store.Modify(featureID, func(f *feature.Feature) error {
 			if f.PendingNeedUserInputPath == result.NeedUserInputPath {
 				f.PendingNeedUserInputPath = ""
 			}
 			return nil
-		})
+		}); err != nil {
+			for _, t := range behind {
+				o.failRepoCycleGatePersistence(featureID, t.RepoName,
+					fmt.Errorf("rebase: clear stale feature-level need-user-input gate: %w", err))
+			}
+		}
 		return
 
 	default:

--- a/internal/orchestrator/rebase_feature.go
+++ b/internal/orchestrator/rebase_feature.go
@@ -124,7 +124,11 @@ func (o *Orchestrator) startFeatureRebase(
 
 	sm := o.deps.Sessions
 	o.cycleWG.Go(func() {
-		result, loopErr := agent.RunRebaseLoop(cfg, sm)
+		runRebaseLoop := o.runRebaseLoopFn
+		if runRebaseLoop == nil {
+			runRebaseLoop = agent.RunRebaseLoop
+		}
+		result, loopErr := runRebaseLoop(cfg, sm)
 		o.handleFeatureRebaseDone(featureID, behind, result, loopErr)
 	})
 
@@ -293,6 +297,12 @@ func (o *Orchestrator) handleFeatureRebaseDone(
 		for _, t := range behind {
 			_ = o.onRepoCycleNeedUserInput(featureID, t.RepoName, feature.CycleRebase, gate)
 		}
+		_ = o.deps.Store.Modify(featureID, func(f *feature.Feature) error {
+			if f.PendingNeedUserInputPath == result.NeedUserInputPath {
+				f.PendingNeedUserInputPath = ""
+			}
+			return nil
+		})
 		return
 
 	default:

--- a/internal/orchestrator/rebase_feature_internal_test.go
+++ b/internal/orchestrator/rebase_feature_internal_test.go
@@ -15,14 +15,17 @@
 package orchestrator
 
 import (
+	"errors"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/doordash-oss/agentic-orchestrator/internal/agent"
 	"github.com/doordash-oss/agentic-orchestrator/internal/config"
 	"github.com/doordash-oss/agentic-orchestrator/internal/feature"
 	"github.com/doordash-oss/agentic-orchestrator/internal/ports"
+	"github.com/doordash-oss/agentic-orchestrator/test/testutil/mocks"
 )
 
 func TestHandleFeatureRebaseDone_PrePRCodeReadyResumesPublish(t *testing.T) {
@@ -177,6 +180,59 @@ func TestHandleFeatureRebaseDone_NeedUserInputPausesCycle(t *testing.T) {
 	}
 	if st := got.RepoStates["agentic"]; st == nil || st.LastError != "" {
 		t.Errorf("RepoStates[agentic] = %+v, want no failure", st)
+	}
+}
+
+func TestHandleFeatureRebaseDone_NeedUserInputClearFeatureGateErrorFailsCycle(t *testing.T) {
+	const featureID = "feat-rebase-nui-clear-fails"
+	gatePath := filepath.Join(t.TempDir(), "need-user-input.yaml")
+
+	store := mocks.NewMockFeatureStore()
+	modifyCalls := 0
+	store.ModifyFn = func(_ string, fn func(*feature.Feature) error) error {
+		modifyCalls++
+		if modifyCalls == 1 {
+			return fn(&feature.Feature{
+				RepoCycles: map[string]*feature.RepoCycleState{
+					"agentic": {Type: feature.CycleRebase, Status: feature.RepoCycleRunning, Count: 1},
+				},
+				PendingNeedUserInputPath: gatePath,
+			})
+		}
+		return errors.New("store write failed")
+	}
+	lifecycle := mocks.NewMockFeatureLifecycle()
+
+	o := New(Deps{Lifecycle: lifecycle, Store: store}, Hooks{})
+	o.handleFeatureRebaseDone(featureID,
+		[]agent.RebaseRepoTarget{{RepoName: "agentic", RebaseTarget: "main"}},
+		&agent.RebaseLoopResult{
+			FinalStatus:       "need_user_input",
+			Iterations:        1,
+			LastError:         "Build gate needs a human decision.",
+			NeedUserInputPath: gatePath,
+			Repos:             []string{"agentic"},
+		},
+		nil,
+	)
+
+	var failCall *mocks.MockCall
+	for i := range lifecycle.Calls {
+		if lifecycle.Calls[i].Method == "FailRepoCycle" {
+			failCall = &lifecycle.Calls[i]
+			break
+		}
+	}
+	if failCall == nil {
+		t.Fatal("FailRepoCycle was not called")
+	}
+	if got := failCall.Args[1]; got != "agentic" {
+		t.Fatalf("FailRepoCycle repo = %v, want agentic", got)
+	}
+	msg, _ := failCall.Args[2].(string)
+	if !strings.Contains(msg, "rebase: clear stale feature-level need-user-input gate") ||
+		!strings.Contains(msg, "store write failed") {
+		t.Fatalf("FailRepoCycle message = %q, want stale-gate persistence error context", msg)
 	}
 }
 

--- a/internal/orchestrator/rebase_feature_internal_test.go
+++ b/internal/orchestrator/rebase_feature_internal_test.go
@@ -16,11 +16,13 @@ package orchestrator
 
 import (
 	"path/filepath"
+	"reflect"
 	"testing"
 
 	"github.com/doordash-oss/agentic-orchestrator/internal/agent"
 	"github.com/doordash-oss/agentic-orchestrator/internal/config"
 	"github.com/doordash-oss/agentic-orchestrator/internal/feature"
+	"github.com/doordash-oss/agentic-orchestrator/internal/ports"
 )
 
 func TestHandleFeatureRebaseDone_PrePRCodeReadyResumesPublish(t *testing.T) {
@@ -176,4 +178,251 @@ func TestHandleFeatureRebaseDone_NeedUserInputPausesCycle(t *testing.T) {
 	if st := got.RepoStates["agentic"]; st == nil || st.LastError != "" {
 		t.Errorf("RepoStates[agentic] = %+v, want no failure", st)
 	}
+}
+
+func TestHandleNeedUserInputDecision_RebaseResumeRestartsUnifiedLoop(t *testing.T) {
+	stateDir := t.TempDir()
+	store := feature.NewStore(stateDir)
+	mgr := feature.NewManager(store, config.NewDefault())
+	gatePath := writeAnsweredRebaseGate(t, "Resolve generated-file policy.", "Regenerate or preserve generated files?")
+
+	const featureID = "feat-rebase-nui-resume"
+	apiDir := t.TempDir()
+	webDir := t.TempDir()
+	f := &feature.Feature{
+		ID:            featureID,
+		Name:          "Rebase Need User Input Resume",
+		Slug:          "rebase-need-user-input-resume",
+		Status:        feature.StatusPublished,
+		SchemaVersion: feature.SchemaVersionCurrent,
+		MaxIterations: 4,
+		Repos: []feature.FeatureRepo{
+			{Name: "api", Path: apiDir, WorktreePath: apiDir, Branch: "feature/rebase-nui", BaseBranch: "main"},
+			{Name: "web", Path: webDir, WorktreePath: webDir, Branch: "feature/rebase-nui", BaseBranch: "main"},
+		},
+		RepoStates: map[string]*feature.RepoState{
+			"api": {Touched: true, PRURL: "https://github.com/example/api/pull/1"},
+			"web": {Touched: true, PRURL: "https://github.com/example/web/pull/2"},
+		},
+		RepoCycles: map[string]*feature.RepoCycleState{
+			"api": {Type: feature.CycleRebase, Status: feature.RepoCycleRunning, Count: 1},
+			"web": {Type: feature.CycleRebase, Status: feature.RepoCycleRunning, Count: 1},
+		},
+		ActiveCycle:              &feature.CycleState{Type: feature.CycleRebase, Status: feature.RepoCycleRunning, Count: 1},
+		PendingNeedUserInputPath: gatePath,
+	}
+	f.SetRebaseCount(1)
+	if err := store.Save(f); err != nil {
+		t.Fatalf("save feature: %v", err)
+	}
+
+	o := New(Deps{
+		Lifecycle:   mgr,
+		Store:       store,
+		PhaseRunner: agent.NewPhaseRunner(nil, store, stateDir),
+	}, Hooks{})
+
+	behind := []agent.RebaseRepoTarget{
+		{RepoName: "api", RebaseTarget: "main"},
+		{RepoName: "web", RebaseTarget: "main"},
+	}
+	o.handleFeatureRebaseDone(featureID, behind, &agent.RebaseLoopResult{
+		FinalStatus:       "need_user_input",
+		Iterations:        1,
+		LastError:         "Resolve generated-file policy.",
+		NeedUserInputPath: gatePath,
+		Repos:             []string{"api", "web"},
+	}, nil)
+
+	paused, err := mgr.Get(featureID)
+	if err != nil {
+		t.Fatalf("load paused feature: %v", err)
+	}
+	if paused.Status != feature.StatusPublished {
+		t.Fatalf("Status = %q, want published", paused.Status)
+	}
+	if paused.PendingNeedUserInputPath != "" {
+		t.Fatalf("feature-level PendingNeedUserInputPath = %q, want cleared for cycle-scoped gate", paused.PendingNeedUserInputPath)
+	}
+	for _, name := range []string{"api", "web"} {
+		rc := paused.RepoCycles[name]
+		if rc == nil {
+			t.Fatalf("RepoCycles[%s] missing", name)
+		}
+		if rc.Status != feature.RepoCycleNeedUserInput {
+			t.Fatalf("RepoCycles[%s].Status = %q, want need_user_input", name, rc.Status)
+		}
+		if rc.PendingNeedUserInputPath != gatePath {
+			t.Fatalf("RepoCycles[%s].PendingNeedUserInputPath = %q, want %q", name, rc.PendingNeedUserInputPath, gatePath)
+		}
+	}
+
+	captured := make(chan agent.RebaseLoopConfig, 1)
+	o.runRebaseLoopFn = func(cfg agent.RebaseLoopConfig, _ ports.SessionManager) (*agent.RebaseLoopResult, error) {
+		cfgCopy := cfg
+		cfgCopy.BehindRepos = append([]agent.RebaseRepoTarget(nil), cfg.BehindRepos...)
+		if cfg.Feature != nil {
+			featureCopy := *cfg.Feature
+			featureCopy.RepoCycles = make(map[string]*feature.RepoCycleState, len(cfg.Feature.RepoCycles))
+			for name, rc := range cfg.Feature.RepoCycles {
+				if rc == nil {
+					continue
+				}
+				rcCopy := *rc
+				featureCopy.RepoCycles[name] = &rcCopy
+			}
+			cfgCopy.Feature = &featureCopy
+		}
+		captured <- cfgCopy
+		return &agent.RebaseLoopResult{
+			FinalStatus: "review_passed",
+			Repos:       []string{"api", "web"},
+		}, nil
+	}
+
+	if err := o.HandleNeedUserInputDecision(featureID, NeedUserInputDecision{
+		Decision:  "resume",
+		RepoName:  "api",
+		CycleType: feature.CycleRebase,
+	}); err != nil {
+		t.Fatalf("HandleNeedUserInputDecision resume: %v", err)
+	}
+	o.WaitForCycles()
+
+	var cfg agent.RebaseLoopConfig
+	select {
+	case cfg = <-captured:
+	default:
+		t.Fatal("rebase loop was not relaunched")
+	}
+	if !cfg.ResumeExistingCycle {
+		t.Fatal("ResumeExistingCycle = false, want true")
+	}
+	if cfg.Feature == nil || cfg.Feature.RebaseCount() != 1 {
+		t.Fatalf("captured feature RebaseCount = %v, want 1", cfg.Feature)
+	}
+	if got := rebaseTargetNames(cfg.BehindRepos); !reflect.DeepEqual(got, []string{"api", "web"}) {
+		t.Fatalf("BehindRepos = %v, want [api web]", got)
+	}
+	for _, name := range []string{"api", "web"} {
+		rc := cfg.Feature.RepoCycles[name]
+		if rc == nil {
+			t.Fatalf("captured RepoCycles[%s] missing", name)
+		}
+		if rc.Status != feature.RepoCycleRunning {
+			t.Fatalf("captured RepoCycles[%s].Status = %q, want running", name, rc.Status)
+		}
+		if rc.PendingNeedUserInputPath != "" {
+			t.Fatalf("captured RepoCycles[%s].PendingNeedUserInputPath = %q, want cleared", name, rc.PendingNeedUserInputPath)
+		}
+	}
+
+	done, err := mgr.Get(featureID)
+	if err != nil {
+		t.Fatalf("load resumed feature: %v", err)
+	}
+	if done.PendingNeedUserInputPath != "" {
+		t.Fatalf("feature-level PendingNeedUserInputPath after resume = %q, want cleared", done.PendingNeedUserInputPath)
+	}
+	if len(done.RepoCycles) != 0 {
+		t.Fatalf("RepoCycles after successful resumed rebase = %+v, want cleared", done.RepoCycles)
+	}
+}
+
+func TestHandleNeedUserInputDecision_RebaseAbortFailsSharedGateCycles(t *testing.T) {
+	stateDir := t.TempDir()
+	store := feature.NewStore(stateDir)
+	mgr := feature.NewManager(store, config.NewDefault())
+	gatePath := writeAnsweredRebaseGate(t, "User rejected generated-file policy.", "Regenerate or preserve generated files?")
+
+	const featureID = "feat-rebase-nui-abort"
+	f := &feature.Feature{
+		ID:                       featureID,
+		Name:                     "Rebase Need User Input Abort",
+		Slug:                     "rebase-need-user-input-abort",
+		Status:                   feature.StatusPublished,
+		SchemaVersion:            feature.SchemaVersionCurrent,
+		PendingNeedUserInputPath: gatePath,
+		Repos: []feature.FeatureRepo{
+			{Name: "api", Path: t.TempDir(), BaseBranch: "main"},
+			{Name: "web", Path: t.TempDir(), BaseBranch: "main"},
+		},
+		RepoCycles: map[string]*feature.RepoCycleState{
+			"api": {
+				Type:                     feature.CycleRebase,
+				Status:                   feature.RepoCycleNeedUserInput,
+				Count:                    1,
+				PendingNeedUserInputPath: gatePath,
+			},
+			"web": {
+				Type:                     feature.CycleRebase,
+				Status:                   feature.RepoCycleNeedUserInput,
+				Count:                    1,
+				PendingNeedUserInputPath: gatePath,
+			},
+		},
+	}
+	if err := store.Save(f); err != nil {
+		t.Fatalf("save feature: %v", err)
+	}
+
+	o := New(Deps{Lifecycle: mgr, Store: store}, Hooks{})
+	if err := o.HandleNeedUserInputDecision(featureID, NeedUserInputDecision{
+		Decision:  "abort",
+		RepoName:  "api",
+		CycleType: feature.CycleRebase,
+	}); err != nil {
+		t.Fatalf("HandleNeedUserInputDecision abort: %v", err)
+	}
+
+	got, err := mgr.Get(featureID)
+	if err != nil {
+		t.Fatalf("load feature: %v", err)
+	}
+	if got.Status != feature.StatusPublished {
+		t.Fatalf("Status = %q, want published", got.Status)
+	}
+	if got.PendingNeedUserInputPath != "" {
+		t.Fatalf("feature-level PendingNeedUserInputPath = %q, want cleared", got.PendingNeedUserInputPath)
+	}
+	for _, name := range []string{"api", "web"} {
+		rc := got.RepoCycles[name]
+		if rc == nil {
+			t.Fatalf("RepoCycles[%s] missing", name)
+		}
+		if rc.Status != feature.RepoCycleFailed {
+			t.Fatalf("RepoCycles[%s].Status = %q, want failed", name, rc.Status)
+		}
+		if rc.PendingNeedUserInputPath != "" {
+			t.Fatalf("RepoCycles[%s].PendingNeedUserInputPath = %q, want cleared", name, rc.PendingNeedUserInputPath)
+		}
+		if rc.LastError != "User rejected generated-file policy." {
+			t.Fatalf("RepoCycles[%s].LastError = %q", name, rc.LastError)
+		}
+	}
+}
+
+func writeAnsweredRebaseGate(t *testing.T, summary string, prompts ...string) string {
+	t.Helper()
+	rec := agent.NeedUserInputRecord{Summary: summary, Iteration: 1}
+	for i, prompt := range prompts {
+		rec.Questions = append(rec.Questions, agent.NeedUserInputQuestion{
+			Index:  i + 1,
+			Prompt: prompt,
+			Answer: "use the generated-file policy from the feature plan",
+		})
+	}
+	path := filepath.Join(t.TempDir(), agent.NeedUserInputArtifactName)
+	if err := agent.WriteNeedUserInputRecord(path, rec); err != nil {
+		t.Fatalf("write gate artifact: %v", err)
+	}
+	return path
+}
+
+func rebaseTargetNames(targets []agent.RebaseRepoTarget) []string {
+	names := make([]string, 0, len(targets))
+	for _, target := range targets {
+		names = append(names, target.RepoName)
+	}
+	return names
 }

--- a/internal/orchestrator/rebase_feature_internal_test.go
+++ b/internal/orchestrator/rebase_feature_internal_test.go
@@ -15,6 +15,7 @@
 package orchestrator
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/doordash-oss/agentic-orchestrator/internal/agent"
@@ -114,4 +115,65 @@ func TestHandleFeatureRebaseDone_ManualPublishDoesNotResumePublish(t *testing.T)
 		&agent.RebaseLoopResult{FinalStatus: "review_passed", Repos: []string{"agentic"}},
 		nil,
 	)
+}
+
+func TestHandleFeatureRebaseDone_NeedUserInputPausesCycle(t *testing.T) {
+	store := feature.NewStore(t.TempDir())
+	cfg := config.NewDefault()
+	mgr := feature.NewManager(store, cfg)
+	gatePath := filepath.Join(t.TempDir(), "need-user-input.yaml")
+
+	const featureID = "feat-rebase-nui"
+	f := &feature.Feature{
+		ID:            featureID,
+		Name:          "Rebase Need User Input",
+		Slug:          "rebase-need-user-input",
+		Status:        feature.StatusPublished,
+		SchemaVersion: feature.SchemaVersionCurrent,
+		Repos: []feature.FeatureRepo{
+			{Name: "agentic", Path: "/tmp/agentic", Branch: "feature/rebase-need-user-input"},
+		},
+		RepoStates: map[string]*feature.RepoState{
+			"agentic": {Touched: true, PRURL: "https://github.com/example/agentic/pull/1"},
+		},
+		RepoCycles: map[string]*feature.RepoCycleState{
+			"agentic": {Type: feature.CycleRebase, Status: feature.RepoCycleRunning, Count: 1},
+		},
+	}
+	if err := store.Save(f); err != nil {
+		t.Fatalf("save feature: %v", err)
+	}
+
+	o := New(Deps{Lifecycle: mgr, Store: store}, Hooks{})
+	o.handleFeatureRebaseDone(featureID,
+		[]agent.RebaseRepoTarget{{RepoName: "agentic", RebaseTarget: "master"}},
+		&agent.RebaseLoopResult{
+			FinalStatus:       "need_user_input",
+			LastError:         "Build gate needs a human decision.",
+			NeedUserInputPath: gatePath,
+			Repos:             []string{"agentic"},
+		},
+		nil,
+	)
+
+	got, err := mgr.Get(featureID)
+	if err != nil {
+		t.Fatalf("load feature: %v", err)
+	}
+	rc := got.RepoCycles["agentic"]
+	if rc == nil {
+		t.Fatal("RepoCycles[agentic] missing")
+	}
+	if rc.Status != feature.RepoCycleNeedUserInput {
+		t.Fatalf("RepoCycles[agentic].Status = %q, want %q", rc.Status, feature.RepoCycleNeedUserInput)
+	}
+	if rc.PendingNeedUserInputPath != gatePath {
+		t.Errorf("PendingNeedUserInputPath = %q, want %q", rc.PendingNeedUserInputPath, gatePath)
+	}
+	if rc.LastError != "Build gate needs a human decision." {
+		t.Errorf("LastError = %q", rc.LastError)
+	}
+	if st := got.RepoStates["agentic"]; st == nil || st.LastError != "" {
+		t.Errorf("RepoStates[agentic] = %+v, want no failure", st)
+	}
 }

--- a/internal/orchestrator/review_comments_feature.go
+++ b/internal/orchestrator/review_comments_feature.go
@@ -259,6 +259,18 @@ func (o *Orchestrator) handleFeatureReviewCommentsDone(
 		// action handles them.
 		return
 
+	case "need_user_input":
+		gate := &agent.LoopResult{
+			FinalStatus:       "need_user_input",
+			Iterations:        result.Iterations,
+			LastError:         result.LastError,
+			NeedUserInputPath: result.NeedUserInputPath,
+		}
+		for _, t := range targets {
+			_ = o.onRepoCycleNeedUserInput(featureID, t.RepoName, feature.CycleReviewComments, gate)
+		}
+		return
+
 	default:
 		// max_iterations / safety_rail / failed: surface error per
 		// repo so the TUI can present the failed cycle.

--- a/internal/orchestrator/review_comments_feature.go
+++ b/internal/orchestrator/review_comments_feature.go
@@ -267,7 +267,7 @@ func (o *Orchestrator) handleFeatureReviewCommentsDone(
 			NeedUserInputPath: result.NeedUserInputPath,
 		}
 		for _, t := range targets {
-			_ = o.onRepoCycleNeedUserInput(featureID, t.RepoName, feature.CycleReviewComments, gate)
+			o.recordRepoCycleNeedUserInput(featureID, t.RepoName, feature.CycleReviewComments, gate)
 		}
 		return
 

--- a/internal/orchestrator/review_comments_feature_internal_test.go
+++ b/internal/orchestrator/review_comments_feature_internal_test.go
@@ -1,0 +1,90 @@
+// Copyright 2026 DoorDash, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package orchestrator
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/doordash-oss/agentic-orchestrator/internal/agent"
+	"github.com/doordash-oss/agentic-orchestrator/internal/config"
+	"github.com/doordash-oss/agentic-orchestrator/internal/feature"
+	"github.com/doordash-oss/agentic-orchestrator/internal/ports"
+)
+
+func TestHandleFeatureReviewCommentsDone_NeedUserInputPausesCycle(t *testing.T) {
+	store := feature.NewStore(t.TempDir())
+	cfg := config.NewDefault()
+	mgr := feature.NewManager(store, cfg)
+	gatePath := filepath.Join(t.TempDir(), "need-user-input.yaml")
+
+	const featureID = "feat-review-comments-nui"
+	f := &feature.Feature{
+		ID:            featureID,
+		Name:          "Review Comments Need User Input",
+		Slug:          "review-comments-need-user-input",
+		Status:        feature.StatusPublished,
+		SchemaVersion: feature.SchemaVersionCurrent,
+		Repos: []feature.FeatureRepo{
+			{Name: "agentic", Path: "/tmp/agentic", Branch: "feature/review-comments-need-user-input"},
+		},
+		RepoStates: map[string]*feature.RepoState{
+			"agentic": {Touched: true, PRURL: "https://github.com/example/agentic/pull/1"},
+		},
+		RepoCycles: map[string]*feature.RepoCycleState{
+			"agentic": {Type: feature.CycleReviewComments, Status: feature.RepoCycleRunning, Count: 1},
+		},
+	}
+	if err := store.Save(f); err != nil {
+		t.Fatalf("save feature: %v", err)
+	}
+
+	o := New(Deps{Lifecycle: mgr, Store: store}, Hooks{})
+	o.handleFeatureReviewCommentsDone(featureID,
+		[]agent.ReviewCommentsRepoTarget{{
+			RepoName: "agentic",
+			PRURL:    "https://github.com/example/agentic/pull/1",
+			Comments: []ports.ReviewComment{{ID: 1}},
+		}},
+		&agent.ReviewCommentsLoopResult{
+			FinalStatus:       "need_user_input",
+			LastError:         "Reviewer request conflicts with product decision.",
+			NeedUserInputPath: gatePath,
+			Repos:             []string{"agentic"},
+		},
+		nil,
+	)
+
+	got, err := mgr.Get(featureID)
+	if err != nil {
+		t.Fatalf("load feature: %v", err)
+	}
+	rc := got.RepoCycles["agentic"]
+	if rc == nil {
+		t.Fatal("RepoCycles[agentic] missing")
+	}
+	if rc.Status != feature.RepoCycleNeedUserInput {
+		t.Fatalf("RepoCycles[agentic].Status = %q, want %q", rc.Status, feature.RepoCycleNeedUserInput)
+	}
+	if rc.PendingNeedUserInputPath != gatePath {
+		t.Errorf("PendingNeedUserInputPath = %q, want %q", rc.PendingNeedUserInputPath, gatePath)
+	}
+	if rc.LastError != "Reviewer request conflicts with product decision." {
+		t.Errorf("LastError = %q", rc.LastError)
+	}
+	if st := got.RepoStates["agentic"]; st == nil || st.LastError != "" {
+		t.Errorf("RepoStates[agentic] = %+v, want no failure", st)
+	}
+}

--- a/internal/orchestrator/review_comments_feature_internal_test.go
+++ b/internal/orchestrator/review_comments_feature_internal_test.go
@@ -15,13 +15,16 @@
 package orchestrator
 
 import (
+	"errors"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/doordash-oss/agentic-orchestrator/internal/agent"
 	"github.com/doordash-oss/agentic-orchestrator/internal/config"
 	"github.com/doordash-oss/agentic-orchestrator/internal/feature"
 	"github.com/doordash-oss/agentic-orchestrator/internal/ports"
+	"github.com/doordash-oss/agentic-orchestrator/test/testutil/mocks"
 )
 
 func TestHandleFeatureReviewCommentsDone_NeedUserInputPausesCycle(t *testing.T) {
@@ -86,5 +89,48 @@ func TestHandleFeatureReviewCommentsDone_NeedUserInputPausesCycle(t *testing.T) 
 	}
 	if st := got.RepoStates["agentic"]; st == nil || st.LastError != "" {
 		t.Errorf("RepoStates[agentic] = %+v, want no failure", st)
+	}
+}
+
+func TestHandleFeatureReviewCommentsDone_NeedUserInputPersistenceErrorFailsCycle(t *testing.T) {
+	store := mocks.NewMockFeatureStore()
+	store.ModifyFn = func(string, func(*feature.Feature) error) error {
+		return errors.New("store unavailable")
+	}
+	lifecycle := mocks.NewMockFeatureLifecycle()
+
+	o := New(Deps{Lifecycle: lifecycle, Store: store}, Hooks{})
+	o.handleFeatureReviewCommentsDone("feat-review-comments-nui",
+		[]agent.ReviewCommentsRepoTarget{{
+			RepoName: "agentic",
+			PRURL:    "https://github.com/example/agentic/pull/1",
+			Comments: []ports.ReviewComment{{ID: 1}},
+		}},
+		&agent.ReviewCommentsLoopResult{
+			FinalStatus:       "need_user_input",
+			LastError:         "Reviewer request conflicts with product decision.",
+			NeedUserInputPath: filepath.Join(t.TempDir(), "need-user-input.yaml"),
+			Repos:             []string{"agentic"},
+		},
+		nil,
+	)
+
+	var failCall *mocks.MockCall
+	for i := range lifecycle.Calls {
+		if lifecycle.Calls[i].Method == "FailRepoCycle" {
+			failCall = &lifecycle.Calls[i]
+			break
+		}
+	}
+	if failCall == nil {
+		t.Fatal("FailRepoCycle was not called")
+	}
+	if got := failCall.Args[1]; got != "agentic" {
+		t.Fatalf("FailRepoCycle repo = %v, want agentic", got)
+	}
+	msg, _ := failCall.Args[2].(string)
+	if !strings.Contains(msg, "review-comments: persist need-user-input gate") ||
+		!strings.Contains(msg, "store unavailable") {
+		t.Fatalf("FailRepoCycle message = %q, want persistence error context", msg)
 	}
 }


### PR DESCRIPTION
## Summary

Bring the rebase and review-comments cycle loops to parity with the refactor cycle: when an iteration emits `NEED_USER_INPUT`, the staged subset now pauses at `RepoCycleNeedUserInput` with the gate path attached instead of being stamped failed.

- Add `NeedUserInputPath` to `RebaseLoopResult` / `ReviewCommentsLoopResult` and a `need_user_input` branch in `RunRebaseLoop` / `RunReviewCommentsLoop` that calls `AtomicPhaseStamp` with `PhaseOutcomeNeedUserInput` + the gate path before returning.
- Add the matching `need_user_input` arm to `handleFeatureRebaseDone` / `handleFeatureReviewCommentsDone` so every staged repo is routed through `onRepoCycleNeedUserInput`, preserving prior `RepoStates` (no `LastError`) and leaving `ActiveCycle` at `RepoCycleRunning` until the gate is resolved.
- New tests covering both layers:
  - `TestRunRebaseLoop_NeedUserInputSurfacesGate`
  - `TestRunReviewCommentsLoop_NeedUserInputSurfacesGate`
  - `TestHandleFeatureRebaseDone_NeedUserInputPausesCycle`
  - `TestHandleFeatureReviewCommentsDone_NeedUserInputPausesCycle`

## Test plan

- [x] `make test-fast`
- [ ] Manual smoke: drive a rebase / review-comments cycle into a `NEED_USER_INPUT` handoff and confirm the dashboard surfaces the gate per staged repo (cycle status flips to `need_user_input`, repo failures are not written).

## Verification

- Fast suite: `make test-fast` (26s, all green)
- Skipped E2E smoke shell / Isolated integration / E2E Go / TUI observability / Race regression — change is confined to the rebase / review-comments cycle dispatchers; behavior is exercised by the new agent-layer and orchestrator-layer unit tests in the fast suite. Run the heavier tiers if a reviewer wants them before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)