### PR TITLE
Remove prose hedge detection from progress.md parser

### DIFF
--- a/internal/agent/deferral_feedback_test.go
+++ b/internal/agent/deferral_feedback_test.go
@@ -56,24 +56,6 @@ func TestFormatGateFeedback_UnclosedDeferralRendersSection(t *testing.T) {
 	}
 }
 
-func TestFormatGateFeedback_ProseHedgeRendersSection(t *testing.T) {
-	result := ReportGateResult{
-		Rejected: true,
-		Findings: []ReportGateFinding{{
-			Category: GateCategoryDeferral,
-			Kind:     KindDeferralProseHedge,
-			Detail:   "report prose mentions cross-phase deferral(s) (\"lands in Phase 3\") but the structured `deferrals:` block is empty",
-		}},
-	}
-	out := FormatGateFeedback(result)
-	if !strings.Contains(out, "prose hedge") {
-		t.Errorf("missing prose-hedge section header; got:\n%s", out)
-	}
-	if !strings.Contains(out, "lands in Phase 3") {
-		t.Errorf("missing matched phrase citation; got:\n%s", out)
-	}
-}
-
 func TestFormatGateFeedback_MissingReasonRendersSection(t *testing.T) {
 	result := ReportGateResult{
 		Rejected: true,

--- a/internal/agent/deferral_prompt.go
+++ b/internal/agent/deferral_prompt.go
@@ -23,12 +23,9 @@ import (
 // prompt fragment listing every ledger entry whose DueByPhase matches the
 // given phase and whose status is still open.
 //
-// This is the carry-forward mechanism that keeps prose hedges from
-// cascading silently across phase boundaries. A Phase-1 implement iteration
-// that said "Tailwind lands in Phase 3" created a ledger entry with
-// DueByPhase=3; when the Phase-3 plan and implement prompts are built,
-// this helper surfaces that entry verbatim so the agent cannot claim
-// ignorance.
+// This is the carry-forward mechanism for structured deferrals. When the
+// target phase starts, this helper surfaces due entries verbatim so the agent
+// cannot claim ignorance.
 //
 // Behavior modes:
 //

--- a/internal/agent/progress.go
+++ b/internal/agent/progress.go
@@ -211,25 +211,6 @@ var progressVerificationPathRE = regexp.MustCompile(`(?m)^\s*-\s*\*\*Path\*\*\s*
 // progressVerificationNotesRE matches the optional `**Notes**:` bullet.
 var progressVerificationNotesRE = regexp.MustCompile(`(?m)^\s*-\s*\*\*Notes\*\*\s*:\s*(.+?)\s*$`)
 
-// deferralProseHedgePatterns match prose that declares or implies a
-// cross-phase deferral without emitting a structured deferrals: entry. The
-// parser's job here is detection-asymmetric: if the agent's prose says
-// "we're punting this to Phase 3" but the structured block is empty,
-// reject. Better to force a cheap rewrite than let an unstructured deferral
-// slip past the ledger.
-//
-// (Moved here from report_integrity.go when deferrals migrated out of
-// verification-report.yaml. The patterns themselves are unchanged.)
-var deferralProseHedgePatterns = []*regexp.Regexp{
-	regexp.MustCompile(`(?i)\bdeferred\s+to\s+(?:phase|step)\s+\d+\b`),
-	regexp.MustCompile(`(?i)\blands?\s+in\s+(?:phase|step)\s+\d+\b`),
-	regexp.MustCompile(`(?i)\b(?:phase|step)\s+\d+\s+will\s+(?:add|ship|handle|cover|implement|fix|complete)\b`),
-	regexp.MustCompile(`(?i)\btodo\s*\(\s*(?:phase|step)\s*\d+\s*\)`),
-	regexp.MustCompile(`(?i)\bin\s+a\s+(?:later|future|subsequent|following)\s+(?:phase|step|iteration)\b`),
-	regexp.MustCompile(`(?i)\bwill\s+land\s+(?:in|alongside|with)\s+(?:phase|step|the)\s+\d+\b`),
-	regexp.MustCompile(`(?i)\bpunt(?:ed)?\s+to\s+(?:phase|step)\s+\d+\b`),
-}
-
 // deferralsYAMLDoc is the on-the-wire shape inside the Deferrals fenced YAML
 // block. We accept the empty form (`deferrals: []`, `closed_deferrals: []`)
 // but require both keys to be present so the agent's intent is unambiguous —
@@ -411,20 +392,6 @@ func ParseProgressMd(path, expectedVerificationPath string) (*ParsedProgress, er
 		}
 	}
 	validateQuestionsSectionPlacement(body, parsed)
-
-	// Prose-hedge detection: if the agent wrote "lands in Phase 3" anywhere
-	// in progress.md outside the Deferrals YAML block but the structured
-	// deferrals: list is empty, that's a smell. Same logic the report
-	// integrity gate used to apply against verification-report.yaml prose.
-	if len(parsed.Deferrals) == 0 {
-		hedges := findProgressDeferralHedges(body)
-		if len(hedges) > 0 {
-			parsed.ProtocolViolations = append(parsed.ProtocolViolations, fmt.Sprintf(
-				"progress.md prose mentions future-phase work (%s) but `deferrals:` is empty — use a deferral only for Agentic-owned work due in a numbered roadmap phase; otherwise rewrite the prose or use NEED_USER_INPUT",
-				strings.Join(quoteUnique(hedges), ", "),
-			))
-		}
-	}
 
 	return parsed, nil
 }
@@ -696,63 +663,4 @@ func splitStateTokenAndNote(body string) (token, note string) {
 	}
 	note = strings.TrimSpace(strings.Join(lines[tokenIdx+1:], "\n"))
 	return token, note
-}
-
-// findProgressDeferralHedges scans the document for prose that implies a
-// cross-phase deferral without a structured entry. Returns matched
-// substrings (deduped) for feedback quotation. The agent's structured
-// `deferrals:` YAML block is excluded from the scan to avoid false
-// positives on YAML field values.
-func findProgressDeferralHedges(body string) []string {
-	scan := stripFencedBlocks(body)
-	seen := map[string]struct{}{}
-	var out []string
-	for _, re := range deferralProseHedgePatterns {
-		for _, m := range re.FindAllString(scan, -1) {
-			key := strings.ToLower(strings.TrimSpace(m))
-			if _, ok := seen[key]; ok {
-				continue
-			}
-			seen[key] = struct{}{}
-			out = append(out, m)
-		}
-	}
-	return out
-}
-
-// stripFencedBlocks removes ```...``` and ~~~...~~~ fenced regions from s
-// so prose-hedge regexes don't false-positive on YAML field values that
-// happen to contain "lands in Phase 3" inside the structured block.
-func stripFencedBlocks(s string) string {
-	out := s
-	for _, fence := range []string{"```", "~~~"} {
-		for {
-			start := strings.Index(out, fence)
-			if start < 0 {
-				break
-			}
-			end := strings.Index(out[start+len(fence):], fence)
-			if end < 0 {
-				break
-			}
-			out = out[:start] + out[start+len(fence)+end+len(fence):]
-		}
-	}
-	return out
-}
-
-// quoteUnique returns each string wrapped in quotes, deduped by lowercase
-// comparison. Used to render prose-hedge findings inline in feedback.
-func quoteUnique(in []string) []string {
-	seen := map[string]struct{}{}
-	var out []string
-	for _, s := range in {
-		key := strings.ToLower(strings.TrimSpace(s))
-		if _, ok := seen[key]; ok {
-			continue
-		}
-		seen[key] = struct{}{}
-		out = append(out, fmt.Sprintf("%q", s))
-	}
-	return out
 }

--- a/internal/agent/progress_parse_test.go
+++ b/internal/agent/progress_parse_test.go
@@ -427,7 +427,7 @@ func TestParseProgressMd_VerificationPathMismatch(t *testing.T) {
 	}
 }
 
-func TestParseProgressMd_DetectsProseHedge(t *testing.T) {
+func TestParseProgressMd_AllowsFuturePhaseProse(t *testing.T) {
 	dir := t.TempDir()
 	iterDir := filepath.Join(dir, "iteration-01")
 	_ = os.MkdirAll(iterDir, 0o755)
@@ -436,7 +436,7 @@ func TestParseProgressMd_DetectsProseHedge(t *testing.T) {
 ## Iteration Handoff
 
 ### Completed this iteration
-- Base styles shipped; Tailwind lands in Phase 3.
+- Fixed prior feedback: progress.md used to mention "lands in Phase 8" while deferrals were empty.
 
 ### Remaining from the plan
 
@@ -463,17 +463,8 @@ SUCCESS
 	path := filepath.Join(dir, "progress.md")
 	_ = os.WriteFile(path, []byte(body), 0o644)
 	parsed, _ := ParseProgressMd(path, filepath.Join(iterDir, "verification-report.yaml"))
-	if parsed.OK() {
-		t.Fatalf("expected violation for prose-only deferral hedge")
-	}
-	hit := false
-	for _, v := range parsed.ProtocolViolations {
-		if strings.Contains(v, "lands in Phase 3") {
-			hit = true
-		}
-	}
-	if !hit {
-		t.Errorf("expected prose-hedge violation citing the matched phrase; got %v", parsed.ProtocolViolations)
+	if !parsed.OK() {
+		t.Fatalf("expected future-phase prose to stay out of protocol validation; got %v", parsed.ProtocolViolations)
 	}
 }
 

--- a/internal/agent/report_integrity.go
+++ b/internal/agent/report_integrity.go
@@ -40,10 +40,7 @@ const (
 	// didn't.
 	GateCategoryHedge ReportGateCategory = "hedge"
 
-	// GateCategoryDeferral covers cross-phase commitment failures: either
-	// the agent hedged in prose (e.g. "lands in Phase 3") without emitting
-	// a structured deferrals: entry, or a ledger deferral is due this
-	// phase and neither closed nor re-deferred.
+	// GateCategoryDeferral covers structured cross-phase commitment failures.
 	GateCategoryDeferral ReportGateCategory = "deferral"
 )
 
@@ -65,7 +62,6 @@ const (
 	KindSubstituteItem        ReportGateKind = "invalid_substitute_item"
 	KindPolicyViolation       ReportGateKind = "policy_violation"
 	KindEvidenceFile          ReportGateKind = "invalid_evidence_file"
-	KindDeferralProseHedge    ReportGateKind = "deferral_prose_hedge"
 	KindDeferralUnclosed      ReportGateKind = "deferral_unclosed_due_this_phase"
 	KindDeferralMissingReason ReportGateKind = "deferral_missing_reason"
 )
@@ -535,11 +531,6 @@ func validateContractBackedChecks(result *ReportGateResult, report *Verification
 //     reason-less deferrals produce a thin ledger useful to no downstream
 //     reader. Reject them at the source.
 //
-// Prose-hedge detection on progress.md (the third historical check) lives
-// in the progress.md parser itself (ParseProgressMd) — it is enforced
-// before this function is called and surfaces as a ProtocolViolations
-// entry rather than a gate finding.
-//
 // currentPhase == 0 disables check (1) — useful during pipelines that
 // haven't reached the roadmap phase boundary yet.
 //
@@ -753,14 +744,6 @@ func formatDeferralFindings(findings []ReportGateFinding) string {
 		}
 		b.WriteString("\n")
 	}
-	if fs := byKind[KindDeferralProseHedge]; len(fs) > 0 {
-		fmt.Fprintf(&b, "**%d prose hedge%s found without a matching structured entry.** Use `deferrals:` only for Agentic-owned work due in a numbered roadmap phase; otherwise rewrite the prose or ask the user:\n\n",
-			len(fs), plural(len(fs)))
-		for _, f := range fs {
-			fmt.Fprintf(&b, "- %s\n", f.Detail)
-		}
-		b.WriteString("\n")
-	}
 	if fs := byKind[KindDeferralMissingReason]; len(fs) > 0 {
 		fmt.Fprintf(&b, "**%d deferral%s missing a `reason`.** Every entry must cite why work is being punted (read by the target phase's planner and by chronic-slippage audits):\n\n",
 			len(fs), plural(len(fs)))
@@ -772,7 +755,6 @@ func formatDeferralFindings(findings []ReportGateFinding) string {
 	// Forward-compat for any future deferral kinds added to the enum.
 	handled := map[ReportGateKind]bool{
 		KindDeferralUnclosed:      true,
-		KindDeferralProseHedge:    true,
 		KindDeferralMissingReason: true,
 	}
 	for kind, fs := range byKind {


### PR DESCRIPTION
## Summary
- Drop the regex-based prose hedge detection (e.g. "lands in Phase 3" without a structured `deferrals:` entry) from the `progress.md` parser and the report integrity gate.
- Remove the `KindDeferralProseHedge` gate kind, the `deferralProseHedgePatterns` regex set, and the `findProgressDeferralHedges`/`stripFencedBlocks`/`quoteUnique` helpers along with their feedback section.
- Update tests and doc comments so legitimate future-phase prose (including agent self-reports of fixing prior feedback) no longer trips a protocol violation.

The structured deferral checks (`KindDeferralUnclosed`, `KindDeferralMissingReason`) remain in place — only the prose heuristic is removed.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/agent/...`
- [ ] Confirm no remaining references to `KindDeferralProseHedge` or `deferralProseHedgePatterns` outside this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)