### PR TITLE
Redesign wizard repo + branch selection UX

### DIFF
--- a/internal/feature/manager.go
+++ b/internal/feature/manager.go
@@ -108,11 +108,20 @@ type CreateOptions struct {
 	// UseCurrentBranch, when true, creates worktrees from the repo's current
 	// HEAD instead of the detected default branch. The BaseBranch field is
 	// still set to the default branch for diff/PR purposes.
+	//
+	// Acts as a global fallback when UseCurrentBranchPerRepo is nil or does
+	// not contain an entry for a given repo. UseCurrentBranchPerRepo wins
+	// when both are set.
 	UseCurrentBranch bool
-	Checkpoints      Checkpoints
-	Attachments      []string // temp attachment file paths
-	RiskLevel        RiskLevel
-	Pipeline         PipelineProfile
+	// UseCurrentBranchPerRepo overrides UseCurrentBranch on a per-repo basis.
+	// Keys are repo names; true means "start from current HEAD"; false means
+	// "start from default branch". Repos not in the map fall back to
+	// UseCurrentBranch.
+	UseCurrentBranchPerRepo map[string]bool
+	Checkpoints             Checkpoints
+	Attachments             []string // temp attachment file paths
+	RiskLevel               RiskLevel
+	Pipeline                PipelineProfile
 }
 
 // Re-entrancy / crash recovery:
@@ -210,7 +219,11 @@ func (m *Manager) Create(name, description string, repos []string, models config
 	if m.Worktrees != nil {
 		for i, fr := range featureRepos {
 			startPoint := fr.BaseBranch
-			if opt.UseCurrentBranch {
+			useCurrent := opt.UseCurrentBranch
+			if v, ok := opt.UseCurrentBranchPerRepo[fr.Name]; ok {
+				useCurrent = v
+			}
+			if useCurrent {
 				startPoint = "" // empty → HEAD in worktree.Create
 			}
 			wtPath, err := m.Worktrees.Create(fr.Path, slug, fr.Name, startPoint)

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -4211,11 +4211,12 @@ func (m AppModel) createFeatureCmd(result *WizardResult) tea.Cmd {
 		riskLevel := feature.RiskLevel(result.RiskLevel)
 		projection := result.Pipeline.ProjectGates(result.Checkpoints, true)
 		opts := feature.CreateOptions{
-			UseCurrentBranch: result.UseCurrentBranch,
-			Checkpoints:      projection.Checkpoints,
-			Attachments:      result.Attachments,
-			RiskLevel:        riskLevel,
-			Pipeline:         result.Pipeline,
+			UseCurrentBranch:        result.UseCurrentBranch,
+			UseCurrentBranchPerRepo: result.UseCurrentBranchPerRepo,
+			Checkpoints:             projection.Checkpoints,
+			Attachments:             result.Attachments,
+			RiskLevel:               riskLevel,
+			Pipeline:                result.Pipeline,
 		}
 
 		// Route creation through the orchestrator so its post-creation hook

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -8048,15 +8048,10 @@ func TestWizardBrowseOverlayStacking(t *testing.T) {
 	result, _ = app.Update(tea.KeyPressMsg{Code: tea.KeyEnter}) // description → Where
 	app = result.(AppModel)
 
-	// Navigate to browse item
-	repoCount := len(app.wizard.filteredRepos)
-	for i := 0; i < repoCount; i++ {
-		result, _ = app.Update(tea.KeyPressMsg{Code: tea.KeyDown})
-		app = result.(AppModel)
-	}
-
-	// Space to open picker (Space activates Browse/Root items on Where step)
-	result, _ = app.Update(tea.KeyPressMsg{Code: ' ', Text: " "})
+	// Tab to Browse focus, then Enter to open the picker.
+	result, _ = app.Update(tea.KeyPressMsg{Code: tea.KeyTab})
+	app = result.(AppModel)
+	result, _ = app.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
 	app = result.(AppModel)
 
 	if !app.wizard.IsPickerActive() {
@@ -8238,13 +8233,10 @@ func TestWizardBrowseNonKeyMessagesReachPicker(t *testing.T) {
 	result, _ = app.Update(tea.KeyPressMsg{Code: tea.KeyEnter}) // description → Where
 	app = result.(AppModel)
 
-	// Navigate to browse and open picker
-	repoCount := len(app.wizard.filteredRepos)
-	for i := 0; i < repoCount; i++ {
-		result, _ = app.Update(tea.KeyPressMsg{Code: tea.KeyDown})
-		app = result.(AppModel)
-	}
-	result, _ = app.Update(tea.KeyPressMsg{Code: ' ', Text: " "})
+	// Tab to Browse focus, then Enter to open the picker.
+	result, _ = app.Update(tea.KeyPressMsg{Code: tea.KeyTab})
+	app = result.(AppModel)
+	result, _ = app.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
 	app = result.(AppModel)
 
 	if !app.wizard.IsPickerActive() {

--- a/internal/tui/wizard.go
+++ b/internal/tui/wizard.go
@@ -1940,28 +1940,12 @@ func (m WizardModel) renderActionRow(label string, focused bool) string {
 	return " " + MutedStyle.Render(label)
 }
 
-// renderBranchSelectionScreen renders the dedicated branch-selection
-// screen shown when off-default branches are detected. The screen asks
-// about ONE repo at a time so the user only ever has two options on
-// screen and one action (Enter). After answering for one repo, Enter
-// moves to the next repo's screen; on the last, Enter advances to
-// Step 3. Esc backs up one screen, or dismisses the flow on the first.
-//
-// Layout (one screen per off-default repo):
-//
-//	<repo-name> is on a non-default branch.
-//
-//	  Current branch: <current>
-//	  Default branch: <default>
-//
-//	The orchestrator will create a fresh feature branch in a new
-//	worktree. Where should that worktree start from?
-//
-//	▸ ◉ Start from <default>      clean slate (recommended)
-//	  ○ Start from <current>      keep in-flight changes
-//
-//	Tip: pick "current branch" when you have uncommitted work in
-//	this repo that you want the orchestrator to build on.
+// renderBranchSelectionScreen renders the dedicated branch-selection screen
+// shown when off-default branches are detected. The screen asks about one repo
+// at a time so the user only ever has two choices and one action (Enter).
+// After answering for one repo, Enter moves to the next repo's screen; on the
+// last, Enter advances to Step 3. Esc backs up one screen, or dismisses the
+// flow on the first.
 //
 // The recommended option (default branch) is pre-selected.
 func (m WizardModel) renderBranchSelectionScreen(headingStyle lipgloss.Style, maxWidth int) string {
@@ -1979,7 +1963,6 @@ func (m WizardModel) renderBranchSelectionScreen(headingStyle lipgloss.Style, ma
 	bi := rows[idx]
 
 	var c strings.Builder
-	repoNameStyle := lipgloss.NewStyle().Foreground(colorSubtext).Bold(true)
 	bodyStyle := lipgloss.NewStyle().Foreground(colorSubtext)
 
 	// Header: which repo + how many are left.
@@ -1987,53 +1970,72 @@ func (m WizardModel) renderBranchSelectionScreen(headingStyle lipgloss.Style, ma
 	if len(rows) > 1 {
 		progress = MutedStyle.Render(fmt.Sprintf("   (%d of %d)", idx+1, len(rows)))
 	}
-	c.WriteString(headingStyle.Render(fmt.Sprintf("%s is on a non-default branch.", bi.Name)) + progress + "\n\n")
+	repoHeadingStyle := headingStyle.Bold(true)
+	c.WriteString(repoHeadingStyle.Render(bi.Name) + headingStyle.Render(" is on a non-default branch.") + progress + "\n\n")
 
-	// Branch facts.
-	c.WriteString("  " + repoNameStyle.Render("Current branch:") + " " + WarningStyle.Render(bi.CurrentBranch) + "\n")
-	c.WriteString("  " + repoNameStyle.Render("Default branch:") + " " + SuccessStyle.Render(bi.DefaultBranch) + "\n\n")
+	// Decision guidance before the choices. "Current branch" means current
+	// HEAD: committed branch history, not dirty working-tree changes.
+	guidanceStyle := bodyStyle.Width(maxWidth)
+	c.WriteString(guidanceStyle.Render("Start from "+SuccessStyle.Render(bi.DefaultBranch)+" for a clean feature branch.") + "\n")
+	c.WriteString(guidanceStyle.Render("Use "+WarningStyle.Render(bi.CurrentBranch)+" only if this feature depends on commits already there.") + "\n\n")
 
-	// Explanatory body: what's about to happen, what the choice means.
-	c.WriteString(bodyStyle.Render("  The orchestrator creates a fresh feature branch in a new worktree.") + "\n")
-	c.WriteString(bodyStyle.Render("  Where should that worktree start from?") + "\n\n")
-
-	// Two radio options. The cursor (`▸`) points at the focused option;
-	// the chosen option gets a filled radio (`◉`). With only two options,
-	// the cursor and the radio always land on the same row.
+	// Two full-width action buttons. The selected button uses the same active
+	// color treatment as the Step 2 Continue CTA, while the unselected button
+	// stays quiet so the screen reads as a branch-base decision rather than a
+	// warning form.
 	useCurrent := m.branchOptionCursor == 1
-	defaultRadio := "○"
-	currentRadio := "○"
-	if useCurrent {
-		currentRadio = SuccessStyle.Render("◉")
-	} else {
-		defaultRadio = SuccessStyle.Render("◉")
-	}
-	defaultLabel := fmt.Sprintf("%s Start from %s   %s",
-		defaultRadio, bi.DefaultBranch,
-		MutedStyle.Render("clean slate (recommended)"))
-	currentLabel := fmt.Sprintf("%s Start from %s   %s",
-		currentRadio, bi.CurrentBranch,
-		MutedStyle.Render("keep in-flight changes"))
-
-	writeOpt := func(label string, isChosen bool) {
-		if isChosen {
-			c.WriteString("  " + SelectedRowStyle.Render("▸ "+label))
-		} else {
-			c.WriteString("    " + label)
-		}
-		c.WriteString("\n")
-	}
-	writeOpt(defaultLabel, !useCurrent)
-	writeOpt(currentLabel, useCurrent)
-
-	// Tip: helps the user decide between the two options. Rendered with a
-	// width so lipgloss only wraps it when the terminal is too narrow to
-	// fit the full sentence on one line.
-	c.WriteString("\n")
-	tipStyle := MutedStyle.PaddingLeft(2).Width(maxWidth)
-	c.WriteString(tipStyle.Render(`Tip: pick "current branch" when you have uncommitted work in this repo that you want the orchestrator to build on.`) + "\n")
+	c.WriteString(renderBranchSourceButton(
+		fmt.Sprintf("Start from %s", bi.DefaultBranch),
+		"Recommended",
+		"Create the feature branch from the default codebase.",
+		!useCurrent,
+		maxWidth,
+	) + "\n\n")
+	c.WriteString(renderBranchSourceButton(
+		fmt.Sprintf("Start from %s", bi.CurrentBranch),
+		"Include current branch commits",
+		"Build on work that already exists on this branch.",
+		useCurrent,
+		maxWidth,
+	) + "\n")
 
 	return c.String()
+}
+
+func renderBranchSourceButton(title, primary, secondary string, selected bool, width int) string {
+	if width < 32 {
+		width = 32
+	}
+
+	borderColor := colorOverlay
+	border := lipgloss.RoundedBorder()
+	titleStyle := MutedStyle
+	primaryStyle := lipgloss.NewStyle().Bold(true).Foreground(colorSubtext)
+	secondaryStyle := MutedStyle
+	if selected {
+		borderColor = colorActive
+		border = lipgloss.ThickBorder()
+		titleStyle = lipgloss.NewStyle().Foreground(colorActive).Bold(true)
+		primaryStyle = lipgloss.NewStyle().Bold(true).Foreground(colorActive)
+		secondaryStyle = lipgloss.NewStyle().Foreground(colorSubtext)
+	}
+
+	prefix := "  "
+	if selected {
+		prefix = "› "
+	}
+	content := primaryStyle.Render(prefix+primary) + "\n" +
+		secondaryStyle.Render("  "+secondary)
+
+	box := lipgloss.NewStyle().
+		Border(border).
+		BorderForeground(borderColor).
+		Padding(0, 1).
+		Width(width).
+		Render(content)
+
+	title = truncateString(title, width-6)
+	return renderBorderTitle(box, title, titleStyle)
 }
 
 // renderContinueButton renders the primary Continue CTA. It is bright
@@ -2084,7 +2086,6 @@ func (m WizardModel) renderContinueButton(count int, maxWidth int) string {
 	}
 	return style.Render(label)
 }
-
 
 // RefreshRepos updates the wizard's repo list after a workspace root was added.
 // Preserves existing selections by stable path identity so that collision-induced
@@ -3147,7 +3148,7 @@ func (m WizardModel) wizardContent() (contentBox, footer string) {
 	// sub-screen rather than a new step.
 	stepTitle := titlePrefix + stepProgress
 	if m.step == wizardStepWhere && m.showBranchWarning {
-		stepTitle = titlePrefix + stepProgress + StepStyle.Render(" · Branch selection")
+		stepTitle = titlePrefix + stepProgress + StepStyle.Render(" · Branch base")
 	}
 	contentBox = panelStyle(true).
 		Width(panelWidth).
@@ -3159,7 +3160,7 @@ func (m WizardModel) wizardContent() (contentBox, footer string) {
 		footer = KeyHelpStyle.Render(" [tab] Switch field   [enter] Next   [esc] Cancel")
 	case wizardStepWhere:
 		if m.showBranchWarning {
-			footer = KeyHelpStyle.Render(" [↑↓/tab] Switch   [enter] Next   [esc] Back")
+			footer = KeyHelpStyle.Render(" [↑↓/tab] Switch   [enter] Choose   [esc] Back")
 		} else {
 			footer = KeyHelpStyle.Render(" [enter] Add   [backspace] Remove last   [tab] Cycle focus   [ctrl+d] Continue   [esc] Back")
 		}

--- a/internal/tui/wizard.go
+++ b/internal/tui/wizard.go
@@ -60,6 +60,18 @@ const (
 	wizardStepReview                     // Step 4: Summary + create
 )
 
+// whereFocus is the focus axis on the Where step (chip picker layout).
+// Tab cycles forward, Shift+Tab cycles backward. The list is the primary
+// axis; the others become reachable as the user moves through the picker.
+type whereFocus int
+
+const (
+	whereFocusList     whereFocus = iota // repo list (default; filter input is part of this focus)
+	whereFocusBrowse                     // "Browse for more..." action row
+	whereFocusCreate                     // "Create new repo..." action row (only when workspace roots exist)
+	whereFocusContinue                   // "Continue with N repos" CTA button
+)
+
 type summaryField int
 
 const (
@@ -87,18 +99,25 @@ type RepoBranchInfo struct {
 
 // WizardResult holds the collected data from the wizard.
 type WizardResult struct {
-	Name             string
-	Description      string
-	Images           []string // temp image paths
-	Attachments      []string // temp attachment file paths
-	Repos            []string
-	Models           config.ModelConfig
-	ExitCriteria     string
-	Inquireness      string
-	RiskLevel        string
-	Pipeline         feature.PipelineProfile
-	UseCurrentBranch bool // true if user chose to branch from current HEAD instead of default
-	Checkpoints      feature.Checkpoints
+	Name         string
+	Description  string
+	Images       []string // temp image paths
+	Attachments  []string // temp attachment file paths
+	Repos        []string
+	Models       config.ModelConfig
+	ExitCriteria string
+	Inquireness  string
+	RiskLevel    string
+	Pipeline     feature.PipelineProfile
+	// UseCurrentBranch is the "any repo branched off default" flag, retained
+	// for downstream callers that just need a yes/no signal. The per-repo
+	// truth lives in UseCurrentBranchPerRepo.
+	UseCurrentBranch bool
+	// UseCurrentBranchPerRepo carries each repo's branch-base choice: true
+	// means "start the worktree from current HEAD"; false (or missing) means
+	// "start from default branch". Only off-default repos appear in the map.
+	UseCurrentBranchPerRepo map[string]bool
+	Checkpoints             feature.Checkpoints
 }
 
 type WizardModel struct {
@@ -116,6 +135,7 @@ type WizardModel struct {
 	selectedRepos           map[string]bool
 	repoCursor              int
 	repoScrollOffset        int                          // scroll window start index for visible repos
+	whereFocus              whereFocus                   // focus axis on Step 2 (list / browse / create / continue)
 	repoError               string                       // validation error ("Select at least one repo")
 	repos                   map[string]config.RepoConfig // full repo configs for pipeline gate overrides
 	models                  config.ModelConfig
@@ -135,8 +155,10 @@ type WizardModel struct {
 	pipelineCursor          int
 	pipelineOptions         []string         // ["moonshot", "medium", "large"]
 	branchInfos             []RepoBranchInfo // populated when entering branch warning step
-	branchCursor            int              // 0=default branch (recommended), 1=current branch
-	showBranchWarning       bool             // true when inline branch warning is shown on Where step
+	branchScreenIndex       int              // which off-default repo's screen we're currently on (0..len(offDefaultRepos)-1)
+	branchOptionCursor      int              // 0 = start from default branch (recommended), 1 = start from current branch
+	branchChoices           map[string]bool  // repo name -> useCurrentBranch (true = start from current HEAD)
+	showBranchWarning       bool             // true when the dedicated branch-selection screen replaces the Where panel
 	checkpointsCursor       int              // which row is focused (0-4)
 	checkpoints             [5]bool          // toggle state for each checkpoint item
 	result                  *WizardResult
@@ -1066,37 +1088,68 @@ func (m WizardModel) Update(msg tea.Msg) (WizardModel, tea.Cmd) {
 			}
 		}
 
-		// When branch warning is showing on Where step, route keys to branch navigation
+		// When the dedicated branch-selection screen is showing, one repo is
+		// asked about at a time. The user toggles between two options
+		// (default branch / current branch), Enter saves the choice and
+		// advances to the next off-default repo; on the last screen it
+		// continues to Step 3. Esc backs up one screen (or dismisses the
+		// whole branch flow on the first screen).
 		if m.showBranchWarning && m.step == wizardStepWhere {
+			rows := m.offDefaultRepos()
 			switch {
 			case key.Matches(msg, key.NewBinding(key.WithKeys("ctrl+c"))):
 				m.cancelled = true
 				return m, nil
+
 			case key.Matches(msg, key.NewBinding(key.WithKeys("enter"))),
 				key.Matches(msg, key.NewBinding(key.WithKeys("ctrl+j"))):
+				// Save the choice for the current screen's repo.
+				if m.branchScreenIndex >= 0 && m.branchScreenIndex < len(rows) {
+					if m.branchChoices == nil {
+						m.branchChoices = make(map[string]bool)
+					}
+					m.branchChoices[rows[m.branchScreenIndex].Name] = m.branchOptionCursor == 1
+				}
+				// More repos to ask about? Advance to the next one.
+				if m.branchScreenIndex < len(rows)-1 {
+					m.branchScreenIndex++
+					// Pre-seed the option cursor from any previously-saved
+					// choice for this repo (lets back-and-forth navigation
+					// remember what was picked).
+					next := rows[m.branchScreenIndex].Name
+					if m.branchChoices[next] {
+						m.branchOptionCursor = 1
+					} else {
+						m.branchOptionCursor = 0
+					}
+					return m, nil
+				}
+				// Last repo: continue to Step 3.
 				return m.advance()
-			case key.Matches(msg, key.NewBinding(key.WithKeys("esc"))),
-				key.Matches(msg, key.NewBinding(key.WithKeys("shift+tab"))):
-				// Dismiss branch warning, return to repo selection
+
+			case key.Matches(msg, key.NewBinding(key.WithKeys("esc"))):
+				if m.branchScreenIndex > 0 {
+					m.branchScreenIndex--
+					prev := rows[m.branchScreenIndex].Name
+					if m.branchChoices[prev] {
+						m.branchOptionCursor = 1
+					} else {
+						m.branchOptionCursor = 0
+					}
+					return m, nil
+				}
+				// Already on the first screen: dismiss the branch flow.
 				m.showBranchWarning = false
+				m.whereFocus = whereFocusList
 				m.repoInput.Focus()
 				return m, textinput.Blink
-			case key.Matches(msg, key.NewBinding(key.WithKeys("tab"))):
-				m.branchCursor = 1 - m.branchCursor // toggle between 0 and 1
-				return m, nil
+
 			case key.Matches(msg, key.NewBinding(key.WithKeys("up"))),
-				key.Matches(msg, key.NewBinding(key.WithKeys("ctrl+p"))),
-				key.Matches(msg, key.NewBinding(key.WithKeys("k"))):
-				if m.branchCursor > 0 {
-					m.branchCursor--
-				}
-				return m, nil
-			case key.Matches(msg, key.NewBinding(key.WithKeys("down"))),
-				key.Matches(msg, key.NewBinding(key.WithKeys("ctrl+n"))),
-				key.Matches(msg, key.NewBinding(key.WithKeys("j"))):
-				if m.branchCursor < 1 {
-					m.branchCursor++
-				}
+				key.Matches(msg, key.NewBinding(key.WithKeys("down"))),
+				key.Matches(msg, key.NewBinding(key.WithKeys("tab"))):
+				// Two options, vertically stacked: ↑/↓/tab all flip between
+				// them. Minimal set - users don't need to memorize alternates.
+				m.branchOptionCursor = 1 - m.branchOptionCursor
 				return m, nil
 			}
 			// Block all other keys (typing into repo filter, etc.)
@@ -1111,6 +1164,15 @@ func (m WizardModel) Update(msg tea.Msg) (WizardModel, tea.Cmd) {
 		switch {
 		case key.Matches(msg, key.NewBinding(key.WithKeys("ctrl+c"))):
 			m.cancelled = true
+			return m, nil
+
+		case key.Matches(msg, key.NewBinding(key.WithKeys("ctrl+d"))):
+			// Ctrl+D = "I'm done" shortcut. On the Where step, jumps straight
+			// to advance (Continue) from anywhere - so users who get used to
+			// the chip picker can skip the Tab dance.
+			if m.step == wizardStepWhere && !m.showBranchWarning {
+				return m.advance()
+			}
 			return m, nil
 
 		case key.Matches(msg, key.NewBinding(key.WithKeys("esc"))):
@@ -1169,6 +1231,7 @@ func (m WizardModel) Update(msg tea.Msg) (WizardModel, tea.Cmd) {
 				case summaryFieldRepos:
 					m.showBranchWarning = false
 					m.step = wizardStepWhere
+					m.whereFocus = whereFocusList
 					m.repoInput.Focus()
 					return m, textinput.Blink
 				case summaryFieldRisk:
@@ -1212,7 +1275,20 @@ func (m WizardModel) Update(msg tea.Msg) (WizardModel, tea.Cmd) {
 				cmd := m.descInput.Focus()
 				return m, cmd
 			}
-			// On wizardStepWhat (description) and wizardStepWhere, enter advances
+			// Where step: Enter is contextual based on the focus axis.
+			if m.step == wizardStepWhere {
+				switch m.whereFocus {
+				case whereFocusList:
+					return m.addFocusedRepo()
+				case whereFocusBrowse:
+					return m.openBrowsePicker()
+				case whereFocusCreate:
+					return m.openRootPicker()
+				case whereFocusContinue:
+					return m.advance()
+				}
+			}
+			// wizardStepWhat (description) — advance to Where
 			return m.advance()
 
 		case key.Matches(msg, key.NewBinding(key.WithKeys("shift+tab"))):
@@ -1250,15 +1326,9 @@ func (m WizardModel) Update(msg tea.Msg) (WizardModel, tea.Cmd) {
 				return m, textinput.Blink
 			}
 			if m.step == wizardStepWhere {
-				// Tab jumps between the repo list and the + options section
-				if m.repoCursor < len(m.filteredRepos) {
-					// In repo list → jump to first + option (Browse)
-					m.repoCursor = len(m.filteredRepos)
-				} else {
-					// In + options → jump back to first repo
-					m.repoCursor = 0
-					m.repoScrollOffset = 0
-				}
+				// Tab cycles list -> Browse -> Create (if visible) -> Continue -> list.
+				m.whereFocus = m.cycleWhereFocusForward()
+				m.handleWhereFocusEntry()
 				return m, nil
 			}
 			if m.step == wizardStepReview && !m.summaryEditing {
@@ -1277,10 +1347,37 @@ func (m WizardModel) Update(msg tea.Msg) (WizardModel, tea.Cmd) {
 			if m.step == wizardStepWhat && m.whatFocus == 1 {
 				break
 			}
-			if m.step == wizardStepWhere && m.repoCursor > 0 {
-				m.repoCursor--
-				if m.repoCursor < m.repoScrollOffset {
-					m.repoScrollOffset = m.repoCursor
+			if m.step == wizardStepWhere {
+				avail := m.availableRepos()
+				switch m.whereFocus {
+				case whereFocusList:
+					if m.repoCursor > 0 {
+						m.repoCursor--
+						if m.repoCursor < m.repoScrollOffset {
+							m.repoScrollOffset = m.repoCursor
+						}
+					}
+				case whereFocusBrowse:
+					// Jump into the list at its last row.
+					if len(avail) > 0 {
+						m.whereFocus = whereFocusList
+						m.repoCursor = len(avail) - 1
+						const maxVisibleRepos = 12
+						if m.repoCursor >= m.repoScrollOffset+maxVisibleRepos {
+							m.repoScrollOffset = m.repoCursor - maxVisibleRepos + 1
+						}
+						m.handleWhereFocusEntry()
+					}
+				case whereFocusCreate:
+					m.whereFocus = whereFocusBrowse
+					m.handleWhereFocusEntry()
+				case whereFocusContinue:
+					if m.whereCreateVisible() {
+						m.whereFocus = whereFocusCreate
+					} else {
+						m.whereFocus = whereFocusBrowse
+					}
+					m.handleWhereFocusEntry()
 				}
 			}
 			if m.step == wizardStepPipeline && m.pipelineCursor > 0 {
@@ -1304,11 +1401,33 @@ func (m WizardModel) Update(msg tea.Msg) (WizardModel, tea.Cmd) {
 			if m.step == wizardStepWhat && m.whatFocus == 1 {
 				break
 			}
-			if m.step == wizardStepWhere && m.repoCursor < m.maxRepoCursor() {
-				m.repoCursor++
-				const maxVisibleRepos = 15
-				if m.repoCursor < len(m.filteredRepos) && m.repoCursor >= m.repoScrollOffset+maxVisibleRepos {
-					m.repoScrollOffset = m.repoCursor - maxVisibleRepos + 1
+			if m.step == wizardStepWhere {
+				avail := m.availableRepos()
+				switch m.whereFocus {
+				case whereFocusList:
+					if m.repoCursor < m.maxRepoCursor() {
+						m.repoCursor++
+						const maxVisibleRepos = 12
+						if m.repoCursor >= m.repoScrollOffset+maxVisibleRepos {
+							m.repoScrollOffset = m.repoCursor - maxVisibleRepos + 1
+						}
+					} else if len(avail) > 0 {
+						// At bottom of list - step into the action axis.
+						m.whereFocus = whereFocusBrowse
+						m.handleWhereFocusEntry()
+					}
+				case whereFocusBrowse:
+					if m.whereCreateVisible() {
+						m.whereFocus = whereFocusCreate
+					} else {
+						m.whereFocus = whereFocusContinue
+					}
+					m.handleWhereFocusEntry()
+				case whereFocusCreate:
+					m.whereFocus = whereFocusContinue
+					m.handleWhereFocusEntry()
+				case whereFocusContinue:
+					// Stay at the bottom.
 				}
 			}
 			if m.step == wizardStepPipeline && m.pipelineCursor < len(m.pipelineOptions)-1 {
@@ -1385,24 +1504,25 @@ func (m WizardModel) Update(msg tea.Msg) (WizardModel, tea.Cmd) {
 				}
 			}
 		case wizardStepWhere:
-			// Space toggles the highlighted repo instead of typing into filter
-			if key.Matches(msg, key.NewBinding(key.WithKeys("space"))) {
-				if m.repoCursor == len(m.filteredRepos) {
-					return m.openBrowsePicker()
-				}
-				if m.repoCursor == len(m.filteredRepos)+1 && len(m.workspaceRoots) > 0 {
-					return m.openRootPicker()
-				}
-				if len(m.filteredRepos) > 0 {
-					repo := m.filteredRepos[m.repoCursor]
-					m.selectedRepos[repo] = !m.selectedRepos[repo]
-					m.createRepoActive = false
-					m.createRepoParentPath = ""
-					m.createRepoPath = ""
-					m.createRepoNameInput.Reset()
-					m.recomputeProvisionalPublishability()
-					m.repoError = ""
-				}
+			// Space is kept as a synonym for Enter on the list axis (muscle-
+			// memory back-compat from the prior toggle-by-space UX).
+			if key.Matches(msg, key.NewBinding(key.WithKeys("space"))) && m.whereFocus == whereFocusList {
+				return m.addFocusedRepo()
+			}
+			// Backspace on an EMPTY filter input removes the last selected
+			// chip (matches the chip/pill picker convention from GitHub /
+			// Linear / Slack). When the filter input has text, fall through
+			// so Backspace edits the filter normally.
+			if key.Matches(msg, key.NewBinding(key.WithKeys("backspace"))) &&
+				m.whereFocus == whereFocusList &&
+				m.repoInput.Value() == "" &&
+				m.hasAnyRepoSelected() {
+				chips := m.selectedReposInOrder()
+				last := chips[len(chips)-1]
+				delete(m.selectedRepos, last)
+				m.recomputeProvisionalPublishability()
+				m.repoError = ""
+				m.handleWhereFocusEntry()
 				return m, nil
 			}
 			prevVal := m.repoInput.Value()
@@ -1656,15 +1776,315 @@ func (m *WizardModel) recomputeProvisionalPublishability() {
 	}
 }
 
-// maxRepoCursor returns the maximum valid repoCursor index.
-// When workspace roots are configured the "Create new repo..." row is present,
-// so the max is len(filteredRepos)+1; otherwise it is len(filteredRepos) (browse only).
+// maxRepoCursor returns the maximum valid repoCursor index within the
+// available-repo list. Chip-picker layout: only the in-list rows count
+// (Browse / Create / Continue live on their own focus axis).
 func (m WizardModel) maxRepoCursor() int {
-	if len(m.workspaceRoots) > 0 {
-		return len(m.filteredRepos) + 1
+	n := len(m.availableRepos())
+	if n == 0 {
+		return 0
 	}
-	return len(m.filteredRepos)
+	return n - 1
 }
+
+// availableRepos returns the filtered repos that are not yet selected.
+// Selected repos appear as chips at the top and are excluded from the
+// list so a repo cannot be "added" twice.
+func (m WizardModel) availableRepos() []string {
+	out := make([]string, 0, len(m.filteredRepos))
+	for _, r := range m.filteredRepos {
+		if !m.selectedRepos[r] {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+// selectedReposInOrder returns selected repos in availRepos order (stable
+// for chip rendering and undo-via-backspace).
+func (m WizardModel) selectedReposInOrder() []string {
+	out := make([]string, 0, len(m.selectedRepos))
+	for _, r := range m.availRepos {
+		if m.selectedRepos[r] {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+// hasAnyRepoSelected returns true when at least one repo is selected.
+func (m WizardModel) hasAnyRepoSelected() bool {
+	for _, v := range m.selectedRepos {
+		if v {
+			return true
+		}
+	}
+	return false
+}
+
+// whereCreateVisible returns true when the "Create new repo" action is
+// available (workspace roots are configured).
+func (m WizardModel) whereCreateVisible() bool {
+	return len(m.workspaceRoots) > 0
+}
+
+// cycleWhereFocusForward returns the next focus position for Tab on the
+// Where step. Cycle: list → browse → create (if visible) → continue → list.
+func (m WizardModel) cycleWhereFocusForward() whereFocus {
+	switch m.whereFocus {
+	case whereFocusList:
+		return whereFocusBrowse
+	case whereFocusBrowse:
+		if m.whereCreateVisible() {
+			return whereFocusCreate
+		}
+		return whereFocusContinue
+	case whereFocusCreate:
+		return whereFocusContinue
+	case whereFocusContinue:
+		return whereFocusList
+	}
+	return whereFocusList
+}
+
+// addFocusedRepo adds the repo at repoCursor (in availableRepos space) to
+// the selected set. Used by Enter / Space on the list axis. Acts as a
+// no-op when there is no repo to add at the cursor.
+func (m WizardModel) addFocusedRepo() (WizardModel, tea.Cmd) {
+	avail := m.availableRepos()
+	if len(avail) == 0 || m.repoCursor < 0 || m.repoCursor >= len(avail) {
+		return m, nil
+	}
+	repo := avail[m.repoCursor]
+	m.selectedRepos[repo] = true
+	m.createRepoActive = false
+	m.createRepoParentPath = ""
+	m.createRepoPath = ""
+	m.createRepoNameInput.Reset()
+	m.recomputeProvisionalPublishability()
+	m.repoError = ""
+	// After removing the picked repo from the list, the cursor naturally
+	// points at the next one. Clamp / scroll-adjust via the focus helper.
+	m.handleWhereFocusEntry()
+	return m, nil
+}
+
+// handleWhereFocusEntry runs side effects whenever m.whereFocus has just
+// changed: it focuses the filter input when the list axis is active and
+// blurs it otherwise, and clamps repoCursor to the current availableRepos
+// length so the cursor never points past the end.
+func (m *WizardModel) handleWhereFocusEntry() {
+	if m.whereFocus == whereFocusList {
+		m.repoInput.Focus()
+	} else {
+		m.repoInput.Blur()
+	}
+	availLen := len(m.availableRepos())
+	if availLen == 0 {
+		m.repoCursor = 0
+		m.repoScrollOffset = 0
+		return
+	}
+	if m.repoCursor > availLen-1 {
+		m.repoCursor = availLen - 1
+	}
+	const maxVisibleRepos = 12
+	if m.repoCursor < m.repoScrollOffset {
+		m.repoScrollOffset = m.repoCursor
+	}
+	if m.repoCursor >= m.repoScrollOffset+maxVisibleRepos {
+		m.repoScrollOffset = m.repoCursor - maxVisibleRepos + 1
+	}
+}
+
+// renderRepoChips lays out selected repos as removable pills. Wraps at the
+// available width; first chip is rendered with a bracket border. Style is
+// kept simple (no per-chip cursor) - chips are removed via Backspace on
+// an empty filter input, not by direct focus.
+func (m WizardModel) renderRepoChips(chips []string, maxWidth int) string {
+	chipStyle := lipgloss.NewStyle().
+		Foreground(colorActive).
+		Bold(true)
+	xStyle := MutedStyle
+	var lines []string
+	var current strings.Builder
+	currentWidth := 0
+	for _, name := range chips {
+		pill := chipStyle.Render("[ "+name+" ") + xStyle.Render("✕") + chipStyle.Render(" ]")
+		// 4 visual chars of overhead per pill (brackets + spaces) + name + x
+		pillWidth := len(name) + 6
+		if currentWidth > 0 && currentWidth+pillWidth+1 > maxWidth {
+			lines = append(lines, current.String())
+			current.Reset()
+			currentWidth = 0
+		}
+		if currentWidth > 0 {
+			current.WriteString(" ")
+			currentWidth++
+		}
+		current.WriteString(pill)
+		currentWidth += pillWidth
+	}
+	if current.Len() > 0 {
+		lines = append(lines, current.String())
+	}
+	return "  " + strings.Join(lines, "\n  ")
+}
+
+// renderActionRow renders one of the "+ Browse" / "+ Create" rows with
+// focus-sensitive styling.
+func (m WizardModel) renderActionRow(label string, focused bool) string {
+	if focused {
+		return SelectedRowStyle.Render("▸" + label)
+	}
+	return " " + MutedStyle.Render(label)
+}
+
+// renderBranchSelectionScreen renders the dedicated branch-selection
+// screen shown when off-default branches are detected. The screen asks
+// about ONE repo at a time so the user only ever has two options on
+// screen and one action (Enter). After answering for one repo, Enter
+// moves to the next repo's screen; on the last, Enter advances to
+// Step 3. Esc backs up one screen, or dismisses the flow on the first.
+//
+// Layout (one screen per off-default repo):
+//
+//	<repo-name> is on a non-default branch.
+//
+//	  Current branch: <current>
+//	  Default branch: <default>
+//
+//	The orchestrator will create a fresh feature branch in a new
+//	worktree. Where should that worktree start from?
+//
+//	▸ ◉ Start from <default>      clean slate (recommended)
+//	  ○ Start from <current>      keep in-flight changes
+//
+//	Tip: pick "current branch" when you have uncommitted work in
+//	this repo that you want the orchestrator to build on.
+//
+// The recommended option (default branch) is pre-selected.
+func (m WizardModel) renderBranchSelectionScreen(headingStyle lipgloss.Style, maxWidth int) string {
+	rows := m.offDefaultRepos()
+	if len(rows) == 0 {
+		return ""
+	}
+	idx := m.branchScreenIndex
+	if idx < 0 {
+		idx = 0
+	}
+	if idx >= len(rows) {
+		idx = len(rows) - 1
+	}
+	bi := rows[idx]
+
+	var c strings.Builder
+	repoNameStyle := lipgloss.NewStyle().Foreground(colorSubtext).Bold(true)
+	bodyStyle := lipgloss.NewStyle().Foreground(colorSubtext)
+
+	// Header: which repo + how many are left.
+	progress := ""
+	if len(rows) > 1 {
+		progress = MutedStyle.Render(fmt.Sprintf("   (%d of %d)", idx+1, len(rows)))
+	}
+	c.WriteString(headingStyle.Render(fmt.Sprintf("%s is on a non-default branch.", bi.Name)) + progress + "\n\n")
+
+	// Branch facts.
+	c.WriteString("  " + repoNameStyle.Render("Current branch:") + " " + WarningStyle.Render(bi.CurrentBranch) + "\n")
+	c.WriteString("  " + repoNameStyle.Render("Default branch:") + " " + SuccessStyle.Render(bi.DefaultBranch) + "\n\n")
+
+	// Explanatory body: what's about to happen, what the choice means.
+	c.WriteString(bodyStyle.Render("  The orchestrator creates a fresh feature branch in a new worktree.") + "\n")
+	c.WriteString(bodyStyle.Render("  Where should that worktree start from?") + "\n\n")
+
+	// Two radio options. The cursor (`▸`) points at the focused option;
+	// the chosen option gets a filled radio (`◉`). With only two options,
+	// the cursor and the radio always land on the same row.
+	useCurrent := m.branchOptionCursor == 1
+	defaultRadio := "○"
+	currentRadio := "○"
+	if useCurrent {
+		currentRadio = SuccessStyle.Render("◉")
+	} else {
+		defaultRadio = SuccessStyle.Render("◉")
+	}
+	defaultLabel := fmt.Sprintf("%s Start from %s   %s",
+		defaultRadio, bi.DefaultBranch,
+		MutedStyle.Render("clean slate (recommended)"))
+	currentLabel := fmt.Sprintf("%s Start from %s   %s",
+		currentRadio, bi.CurrentBranch,
+		MutedStyle.Render("keep in-flight changes"))
+
+	writeOpt := func(label string, isChosen bool) {
+		if isChosen {
+			c.WriteString("  " + SelectedRowStyle.Render("▸ "+label))
+		} else {
+			c.WriteString("    " + label)
+		}
+		c.WriteString("\n")
+	}
+	writeOpt(defaultLabel, !useCurrent)
+	writeOpt(currentLabel, useCurrent)
+
+	// Tip: helps the user decide between the two options. Rendered with a
+	// width so lipgloss only wraps it when the terminal is too narrow to
+	// fit the full sentence on one line.
+	c.WriteString("\n")
+	tipStyle := MutedStyle.PaddingLeft(2).Width(maxWidth)
+	c.WriteString(tipStyle.Render(`Tip: pick "current branch" when you have uncommitted work in this repo that you want the orchestrator to build on.`) + "\n")
+
+	return c.String()
+}
+
+// renderContinueButton renders the primary Continue CTA. It is bright
+// brand-colored and bordered when enabled, dim when no repos are selected.
+// The outer width matches the filter-input box (maxWidth) so the CTA lines
+// up with the input above it.
+func (m WizardModel) renderContinueButton(count int, maxWidth int) string {
+	enabled := count > 0
+	focused := m.whereFocus == whereFocusContinue
+	var label string
+	switch {
+	case count == 0:
+		label = "Continue (select a repo to enable)"
+	case count == 1:
+		label = "Continue with 1 repo →"
+	default:
+		label = fmt.Sprintf("Continue with %d repos →", count)
+	}
+
+	if maxWidth < 24 {
+		maxWidth = 24
+	}
+	// The style's Width is the OUTER width (lipgloss includes border+padding
+	// inside the given width when a border/padding is set), so passing
+	// maxWidth here makes the button align exactly with the filter input.
+	style := lipgloss.NewStyle().
+		Padding(0, 1).
+		Width(maxWidth).
+		Align(lipgloss.Center)
+
+	switch {
+	case !enabled:
+		style = style.Foreground(colorOverlay).
+			Border(lipgloss.RoundedBorder()).
+			BorderForeground(colorOverlay)
+	case focused:
+		// Focused state shifts to colorActive (teal) so it stands out clearly
+		// against the brand-purple unfocused state — matching how
+		// SelectedRowStyle teals the highlighted list/action rows.
+		style = style.Foreground(colorActive).
+			Bold(true).
+			Border(lipgloss.ThickBorder()).
+			BorderForeground(colorActive)
+	default:
+		style = style.Foreground(colorBrand).
+			Border(lipgloss.RoundedBorder()).
+			BorderForeground(colorBrand)
+	}
+	return style.Render(label)
+}
+
 
 // RefreshRepos updates the wizard's repo list after a workspace root was added.
 // Preserves existing selections by stable path identity so that collision-induced
@@ -1781,6 +2201,37 @@ func (m WizardModel) hasOffDefaultRepos() bool {
 	return false
 }
 
+// offDefaultRepos returns the branch info rows for repos that are NOT on
+// their default branch. Order matches the order of m.branchInfos (which
+// itself is derived from m.availRepos via detectBranches), so navigation
+// in the branch-selection screen is stable.
+func (m WizardModel) offDefaultRepos() []RepoBranchInfo {
+	out := make([]RepoBranchInfo, 0, len(m.branchInfos))
+	for _, bi := range m.branchInfos {
+		if bi.IsOffDefault {
+			out = append(out, bi)
+		}
+	}
+	return out
+}
+
+// useCurrentBranchPerRepo returns a copy of m.branchChoices restricted to
+// the repos currently known to be off-default. Default-branch repos are
+// not in the map (they always use the default base). Returns nil if no
+// off-default repos exist, so consumers can rely on the absence of the
+// map as a signal that no per-repo decision was made.
+func (m WizardModel) useCurrentBranchPerRepo() map[string]bool {
+	rows := m.offDefaultRepos()
+	if len(rows) == 0 {
+		return nil
+	}
+	out := make(map[string]bool, len(rows))
+	for _, bi := range rows {
+		out[bi.Name] = m.branchChoices[bi.Name]
+	}
+	return out
+}
+
 func (m WizardModel) goBack() (WizardModel, tea.Cmd) {
 	switch m.step {
 	case wizardStepWhat:
@@ -1802,6 +2253,7 @@ func (m WizardModel) goBack() (WizardModel, tea.Cmd) {
 	case wizardStepPipeline:
 		m.showBranchWarning = false
 		m.step = wizardStepWhere
+		m.whereFocus = whereFocusList
 		m.repoInput.Focus()
 		return m, textinput.Blink
 
@@ -1830,6 +2282,7 @@ func (m WizardModel) advance() (WizardModel, tea.Cmd) {
 
 		// Advance to Where
 		m.step = wizardStepWhere
+		m.whereFocus = whereFocusList
 		m.nameInput.Blur()
 		m.descInput.Blur()
 		m.repoInput.Focus()
@@ -1846,6 +2299,7 @@ func (m WizardModel) advance() (WizardModel, tea.Cmd) {
 		}
 		if !hasSelected && !m.createRepoActive {
 			m.repoError = "Select at least one repo"
+			m.whereFocus = whereFocusList
 			m.repoInput.Focus()
 			return m, textinput.Blink
 		}
@@ -1853,12 +2307,22 @@ func (m WizardModel) advance() (WizardModel, tea.Cmd) {
 		m.repoInput.Blur()
 
 		if !m.showBranchWarning {
-			// First Enter: detect branches for selected repos
+			// First Continue: detect branches for selected repos.
 			m.branchInfos = m.detectBranches()
 			if m.hasOffDefaultRepos() {
-				m.branchCursor = 0 // default to "use default branch"
+				// Initialize per-repo choices to "use default" (false).
+				m.branchChoices = make(map[string]bool)
+				for _, bi := range m.branchInfos {
+					if bi.IsOffDefault {
+						m.branchChoices[bi.Name] = false
+					}
+				}
+				// Start on the first off-default repo's screen with the
+				// recommended (default-branch) option selected.
+				m.branchScreenIndex = 0
+				m.branchOptionCursor = 0
 				m.showBranchWarning = true
-				return m, nil // stay on Where step, show inline warning
+				return m, nil // stay on Where step, show the dedicated branch screen
 			}
 		}
 
@@ -1888,19 +2352,28 @@ func (m WizardModel) advance() (WizardModel, tea.Cmd) {
 			}
 		}
 		projection := m.currentGateProjection()
+		perRepo := m.useCurrentBranchPerRepo()
+		anyCurrent := false
+		for _, v := range perRepo {
+			if v {
+				anyCurrent = true
+				break
+			}
+		}
 		m.result = &WizardResult{
-			Name:             strings.TrimSpace(m.nameInput.Value()),
-			Description:      strings.TrimSpace(m.descInput.Value()),
-			Images:           m.images,
-			Attachments:      m.attachments,
-			Repos:            repos,
-			Models:           m.models,
-			ExitCriteria:     m.exitCriteria,
-			Inquireness:      m.inquirenessOptions[m.inquirenessCursor],
-			RiskLevel:        m.riskOptions[m.riskCursor],
-			Pipeline:         pipelineProfileFromKey(m.pipelineOptions[m.pipelineCursor]),
-			UseCurrentBranch: m.branchCursor == 1 && m.hasOffDefaultRepos(),
-			Checkpoints:      projection.Checkpoints,
+			Name:                    strings.TrimSpace(m.nameInput.Value()),
+			Description:             strings.TrimSpace(m.descInput.Value()),
+			Images:                  m.images,
+			Attachments:             m.attachments,
+			Repos:                   repos,
+			Models:                  m.models,
+			ExitCriteria:            m.exitCriteria,
+			Inquireness:             m.inquirenessOptions[m.inquirenessCursor],
+			RiskLevel:               m.riskOptions[m.riskCursor],
+			Pipeline:                pipelineProfileFromKey(m.pipelineOptions[m.pipelineCursor]),
+			UseCurrentBranch:        anyCurrent,
+			UseCurrentBranchPerRepo: perRepo,
+			Checkpoints:             projection.Checkpoints,
 		}
 		return m, nil
 	}
@@ -2317,109 +2790,102 @@ func (m WizardModel) wizardContent() (contentBox, footer string) {
 			c.WriteString(m.filePicker.View() + "\n")
 		}
 	case wizardStepWhere:
-		c.WriteString(LabelStyle.Render("Repos") + MutedStyle.Render("  type to filter \u00b7 space to select") + "\n\n")
+		// LabelStyle has a hard Width(12) cap, so any heading or repo-name
+		// label that might exceed 12 characters has to use a plain inline
+		// style. Matches Step 3's heading pattern.
+		headingStyle := lipgloss.NewStyle().Foreground(colorSubtext)
 
-		// Render search input in a bordered box
+		// When off-default branches were detected and the user hit Continue,
+		// the picker is replaced entirely by a dedicated branch-selection
+		// screen — one decision per off-default repo, no competing CTAs.
+		if m.showBranchWarning {
+			c.WriteString(m.renderBranchSelectionScreen(headingStyle, inputBoxWidth))
+			break
+		}
+
+		// Chips: selected repos shown as removable pills at the top.
+		chips := m.selectedReposInOrder()
+		if len(chips) > 0 {
+			c.WriteString(headingStyle.Render("Building in") + "\n")
+			c.WriteString(m.renderRepoChips(chips, inputBoxWidth) + "\n\n")
+		} else {
+			c.WriteString(headingStyle.Render("Pick one or more repos") + "\n\n")
+		}
+
+		// Filter input. The border brightens when focus is on the list axis.
+		mutedBorder := compat.AdaptiveColor{Light: lipgloss.Color("#b5b9c8"), Dark: lipgloss.Color("#45475a")}
+		activeBorder := compat.AdaptiveColor(mutedBorder)
+		if m.whereFocus == whereFocusList {
+			activeBorder = colorOverlay
+		}
 		repoInputBox := lipgloss.NewStyle().
 			Border(lipgloss.RoundedBorder()).
-			BorderForeground(colorOverlay).
+			BorderForeground(activeBorder).
 			Padding(0, 1).
 			Width(inputBoxWidth).
 			Render(m.repoInput.View())
-		c.WriteString(repoInputBox + "\n\n")
+		c.WriteString(repoInputBox + "\n")
 
-		// Show match count when filtering
+		// Show match count when filtering.
+		avail := m.availableRepos()
 		if filter := m.repoInput.Value(); filter != "" {
-			c.WriteString(MutedStyle.Render(fmt.Sprintf("  %d of %d repos", len(m.filteredRepos), len(m.availRepos))) + "\n")
+			c.WriteString(MutedStyle.Render(fmt.Sprintf("  %d of %d available", len(avail), len(m.availRepos)-len(chips))) + "\n")
+		} else {
+			c.WriteString("\n")
 		}
 
-		// Render visible repos with scroll window (max 10 visible)
-		const maxVisibleRepos = 15
+		// Render visible repos with scroll window.
+		const maxVisibleRepos = 12
 		visibleStart := m.repoScrollOffset
 		visibleEnd := visibleStart + maxVisibleRepos
-		if visibleEnd > len(m.filteredRepos) {
-			visibleEnd = len(m.filteredRepos)
+		if visibleEnd > len(avail) {
+			visibleEnd = len(avail)
 		}
 
 		if visibleStart > 0 {
 			c.WriteString(MutedStyle.Render(fmt.Sprintf("  ↑ %d more", visibleStart)) + "\n")
 		}
+		listFocused := m.whereFocus == whereFocusList
 		for i := visibleStart; i < visibleEnd; i++ {
-			r := m.filteredRepos[i]
-			check := MutedStyle.Render("○") // ○
-			if m.selectedRepos[r] {
-				check = SuccessStyle.Render("●") // ●
-			}
-			label := fmt.Sprintf(" %s %s", check, r)
-			if i == m.repoCursor {
+			r := avail[i]
+			label := fmt.Sprintf(" %s", r)
+			if listFocused && i == m.repoCursor {
 				c.WriteString(SelectedRowStyle.Render("▸" + label))
 			} else {
 				c.WriteString(" " + label)
 			}
 			c.WriteString("\n")
 		}
-		if visibleEnd < len(m.filteredRepos) {
-			c.WriteString(MutedStyle.Render(fmt.Sprintf("  ↓ %d more", len(m.filteredRepos)-visibleEnd)) + "\n")
+		if visibleEnd < len(avail) {
+			c.WriteString(MutedStyle.Render(fmt.Sprintf("  ↓ %d more", len(avail)-visibleEnd)) + "\n")
 		}
-		if len(m.filteredRepos) == 0 && m.repoInput.Value() != "" {
-			c.WriteString(MutedStyle.Render("  No repos match filter.") + "\n")
-		}
-
-		// Visual separator between repo list and action items
-		c.WriteString("\n")
-
-		// Always render "Browse for more..." after the repo list
-		browseLabel := " + Browse for more..."
-		if m.repoCursor == len(m.filteredRepos) {
-			c.WriteString(SelectedRowStyle.Render("▸" + browseLabel))
-		} else {
-			c.WriteString(" " + MutedStyle.Render(browseLabel))
-		}
-		c.WriteString("\n")
-
-		// Render "Create new repo..." after "Browse for more..." (only when workspace roots exist)
-		if len(m.workspaceRoots) > 0 {
-			createLabel := " + Create new repo..."
-			if m.repoCursor == len(m.filteredRepos)+1 {
-				c.WriteString(SelectedRowStyle.Render("▸" + createLabel))
-			} else {
-				c.WriteString(" " + MutedStyle.Render(createLabel))
+		if len(avail) == 0 {
+			switch {
+			case m.repoInput.Value() != "" && len(m.filteredRepos) == 0:
+				c.WriteString(MutedStyle.Render("  No repos match filter.") + "\n")
+			case len(m.availRepos) > 0 && len(chips) == len(m.availRepos):
+				c.WriteString(MutedStyle.Render("  All repos added.") + "\n")
+			case len(m.availRepos) == 0:
+				c.WriteString(MutedStyle.Render("  No repos configured - browse or create one below.") + "\n")
+			default:
+				c.WriteString(MutedStyle.Render("  No repos to add.") + "\n")
 			}
-			c.WriteString("\n")
 		}
+
+		// Action rows: Browse, then Create (if workspace roots exist).
+		c.WriteString("\n")
+		c.WriteString(m.renderActionRow(" + Browse for more...", m.whereFocus == whereFocusBrowse) + "\n")
+		if m.whereCreateVisible() {
+			c.WriteString(m.renderActionRow(" + Create new repo...", m.whereFocus == whereFocusCreate) + "\n")
+		}
+
+		// Continue button - the explicit CTA.
+		c.WriteString("\n")
+		c.WriteString(m.renderContinueButton(len(chips), inputBoxWidth) + "\n")
 
 		// Validation error
 		if m.repoError != "" {
 			c.WriteString("\n" + WarningStyle.Render("  ✗ "+m.repoError) + "\n")
-		}
-
-		// Inline branch warning (shown after first Enter when off-default repos detected)
-		if m.showBranchWarning {
-			c.WriteString("\n")
-			c.WriteString(WarningStyle.Render("Branch Warning") + "\n\n")
-			for _, bi := range m.branchInfos {
-				if bi.IsOffDefault {
-					c.WriteString(fmt.Sprintf("  %s is on %s (default: %s)\n",
-						LabelStyle.Render(bi.Name),
-						WarningStyle.Render(bi.CurrentBranch),
-						SuccessStyle.Render(bi.DefaultBranch)))
-				}
-			}
-			c.WriteString("\n")
-			defBranch := m.defaultBranchName()
-			options := []struct{ label, desc string }{
-				{"Start from default branch", "recommended — clean slate from " + defBranch},
-				{"Start from current branch", "worktree will include in-flight changes"},
-			}
-			for i, opt := range options {
-				label := fmt.Sprintf("%s  %s", opt.label, MutedStyle.Render(opt.desc))
-				if i == m.branchCursor {
-					c.WriteString(SelectedRowStyle.Render("▸ " + label))
-				} else {
-					c.WriteString("  " + label)
-				}
-				c.WriteString("\n")
-			}
 		}
 
 	case wizardStepPipeline:
@@ -2560,9 +3026,25 @@ func (m WizardModel) wizardContent() (contentBox, footer string) {
 		}
 		renderRow(summaryFieldRepos, "Repos", strings.Join(repos, ", "), "")
 		if m.hasOffDefaultRepos() {
-			baseVal := SuccessStyle.Render("default branch")
-			if m.branchCursor == 1 {
+			countCurrent := 0
+			countOffDefault := 0
+			for _, bi := range m.branchInfos {
+				if !bi.IsOffDefault {
+					continue
+				}
+				countOffDefault++
+				if m.branchChoices[bi.Name] {
+					countCurrent++
+				}
+			}
+			var baseVal string
+			switch {
+			case countCurrent == 0:
+				baseVal = SuccessStyle.Render("default branch")
+			case countCurrent == countOffDefault:
 				baseVal = WarningStyle.Render("current branch")
+			default:
+				baseVal = WarningStyle.Render(fmt.Sprintf("mixed (%d of %d on current)", countCurrent, countOffDefault))
 			}
 			card.WriteString("  " + WizardLabelStyle.Render("Base") + baseVal + "\n")
 		}
@@ -2660,8 +3142,13 @@ func (m WizardModel) wizardContent() (contentBox, footer string) {
 		c.WriteString(gButton + " Create and start " + firstPhaseLabel)
 	}
 
-	// Wrap content in a main panel
+	// Wrap content in a main panel. The branch-selection screen lives inside
+	// Step 2; surface that in the title bar so users know they're in a
+	// sub-screen rather than a new step.
 	stepTitle := titlePrefix + stepProgress
+	if m.step == wizardStepWhere && m.showBranchWarning {
+		stepTitle = titlePrefix + stepProgress + StepStyle.Render(" · Branch selection")
+	}
 	contentBox = panelStyle(true).
 		Width(panelWidth).
 		Render(c.String())
@@ -2672,9 +3159,9 @@ func (m WizardModel) wizardContent() (contentBox, footer string) {
 		footer = KeyHelpStyle.Render(" [tab] Switch field   [enter] Next   [esc] Cancel")
 	case wizardStepWhere:
 		if m.showBranchWarning {
-			footer = KeyHelpStyle.Render(" [enter] Confirm   [↑↓] Select   [esc] Back")
+			footer = KeyHelpStyle.Render(" [↑↓/tab] Switch   [enter] Next   [esc] Back")
 		} else {
-			footer = KeyHelpStyle.Render(" [space] Select   [tab] More options   [enter] Next   [esc] Back")
+			footer = KeyHelpStyle.Render(" [enter] Add   [backspace] Remove last   [tab] Cycle focus   [ctrl+d] Continue   [esc] Back")
 		}
 	case wizardStepPipeline:
 		footer = KeyHelpStyle.Render(" [↑↓] Select   [enter] Next   [esc] Back")

--- a/internal/tui/wizard_test.go
+++ b/internal/tui/wizard_test.go
@@ -57,9 +57,9 @@ func TestWizardSteps(t *testing.T) {
 	if m.step != wizardStepWhere {
 		t.Errorf("expected step Where, got %d", m.step)
 	}
-	// Toggle first repo (Space toggles on Where step)
-	m, _ = m.Update(tea.KeyPressMsg{Code: ' ', Text: " "})
+	// Add first repo (Enter on list axis = add to chips), then Ctrl+D to advance
 	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	m, _ = m.Update(tea.KeyPressMsg{Code: 'd', Mod: tea.ModCtrl})
 
 	// Step 3 (Pipeline): Confirm selection
 	if m.step != wizardStepPipeline {
@@ -733,17 +733,18 @@ func TestWizardRepoFilter(t *testing.T) {
 		t.Errorf("repoCursor after filter = %d, want 0", m.repoCursor)
 	}
 
-	// Space to toggle first filtered repo (geo-intel)
-	m, _ = m.Update(tea.KeyPressMsg{Code: ' ', Text: " "})
+	// Enter to add first filtered repo (geo-intel). After adding, the picked
+	// repo is removed from the available list and the cursor naturally
+	// points at the next one (geo-proxy).
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
 	if !m.selectedRepos["geo-intel"] {
-		t.Error("expected geo-intel to be selected after Space")
+		t.Error("expected geo-intel to be selected after Enter")
 	}
 
-	// Navigate down and toggle second filtered repo (geo-proxy)
-	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
-	m, _ = m.Update(tea.KeyPressMsg{Code: ' ', Text: " "})
+	// Enter again to add the next available repo (geo-proxy)
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
 	if !m.selectedRepos["geo-proxy"] {
-		t.Error("expected geo-proxy to be selected after Space")
+		t.Error("expected geo-proxy to be selected after second Enter")
 	}
 
 	// Clear filter by sending backspace keys
@@ -782,12 +783,14 @@ func TestWizardCtrlNCtrlPNavigation(t *testing.T) {
 	if m.step != wizardStepWhere {
 		t.Fatalf("expected step Where, got %d", m.step)
 	}
-
+	if m.whereFocus != whereFocusList {
+		t.Fatalf("expected initial focus on the list, got %d", m.whereFocus)
+	}
 	if m.repoCursor != 0 {
 		t.Fatalf("expected repoCursor = 0, got %d", m.repoCursor)
 	}
 
-	// ctrl+n moves down
+	// ctrl+n moves down within the repo list
 	m, _ = m.Update(tea.KeyPressMsg{Code: 'n', Mod: tea.ModCtrl})
 	if m.repoCursor != 1 {
 		t.Errorf("expected repoCursor = 1 after ctrl+n, got %d", m.repoCursor)
@@ -809,42 +812,40 @@ func TestWizardCtrlNCtrlPNavigation(t *testing.T) {
 		t.Errorf("expected repoCursor = 0 after second ctrl+p, got %d", m.repoCursor)
 	}
 
-	// ctrl+p at top stays at 0
+	// ctrl+p at top of list stays at 0
 	m, _ = m.Update(tea.KeyPressMsg{Code: 'p', Mod: tea.ModCtrl})
 	if m.repoCursor != 0 {
 		t.Errorf("expected repoCursor to stay at 0, got %d", m.repoCursor)
 	}
 
-	// Navigate to bottom and verify ctrl+n bounds
-	m, _ = m.Update(tea.KeyPressMsg{Code: 'n', Mod: tea.ModCtrl})
-	m, _ = m.Update(tea.KeyPressMsg{Code: 'n', Mod: tea.ModCtrl})
-	m, _ = m.Update(tea.KeyPressMsg{Code: 'n', Mod: tea.ModCtrl})
-	if m.repoCursor != 3 {
-		t.Errorf("expected repoCursor = 3, got %d", m.repoCursor)
+	// ctrl+n past the bottom of the list steps into the action axis (Browse)
+	m, _ = m.Update(tea.KeyPressMsg{Code: 'n', Mod: tea.ModCtrl}) // 0 -> 1
+	m, _ = m.Update(tea.KeyPressMsg{Code: 'n', Mod: tea.ModCtrl}) // 1 -> 2
+	m, _ = m.Update(tea.KeyPressMsg{Code: 'n', Mod: tea.ModCtrl}) // 2 -> 3 (last list row)
+	if m.repoCursor != 3 || m.whereFocus != whereFocusList {
+		t.Fatalf("expected to be on last list row, got cursor=%d focus=%d", m.repoCursor, m.whereFocus)
+	}
+	m, _ = m.Update(tea.KeyPressMsg{Code: 'n', Mod: tea.ModCtrl}) // list -> Browse
+	if m.whereFocus != whereFocusBrowse {
+		t.Errorf("expected focus on Browse after stepping past last list row, got %d", m.whereFocus)
 	}
 
-	// Space to toggle at navigated position (delta is at index 3)
-	m, _ = m.Update(tea.KeyPressMsg{Code: ' ', Text: " "})
-	if !m.selectedRepos["delta"] {
-		t.Error("expected delta to be selected after Space at cursor 3")
+	// Browse -> Create
+	m, _ = m.Update(tea.KeyPressMsg{Code: 'n', Mod: tea.ModCtrl})
+	if m.whereFocus != whereFocusCreate {
+		t.Errorf("expected focus on Create after ctrl+n, got %d", m.whereFocus)
 	}
 
-	// ctrl+n goes to browse item (index 4)
+	// Create -> Continue
 	m, _ = m.Update(tea.KeyPressMsg{Code: 'n', Mod: tea.ModCtrl})
-	if m.repoCursor != 4 {
-		t.Errorf("expected repoCursor = 4 (browse item), got %d", m.repoCursor)
+	if m.whereFocus != whereFocusContinue {
+		t.Errorf("expected focus on Continue after ctrl+n, got %d", m.whereFocus)
 	}
 
-	// ctrl+n goes to create-new-repo item (index 5)
+	// ctrl+n on Continue stays there (bottom of the page)
 	m, _ = m.Update(tea.KeyPressMsg{Code: 'n', Mod: tea.ModCtrl})
-	if m.repoCursor != 5 {
-		t.Errorf("expected repoCursor = 5 (create-new-repo item), got %d", m.repoCursor)
-	}
-
-	// ctrl+n at create-new-repo item stays at max
-	m, _ = m.Update(tea.KeyPressMsg{Code: 'n', Mod: tea.ModCtrl})
-	if m.repoCursor != 5 {
-		t.Errorf("expected repoCursor to stay at 5, got %d", m.repoCursor)
+	if m.whereFocus != whereFocusContinue {
+		t.Errorf("expected focus to stay on Continue, got %d", m.whereFocus)
 	}
 }
 
@@ -1138,8 +1139,15 @@ func TestWizardBranchWarningShownOnOffDefault(t *testing.T) {
 	if len(m.branchInfos) == 0 {
 		t.Error("expected branchInfos to be populated")
 	}
-	if m.branchCursor != 0 {
-		t.Errorf("expected branchCursor 0, got %d", m.branchCursor)
+	if m.branchScreenIndex != 0 {
+		t.Errorf("expected branchScreenIndex 0, got %d", m.branchScreenIndex)
+	}
+	if m.branchOptionCursor != 0 {
+		t.Errorf("expected branchOptionCursor 0 (default-branch pre-selected), got %d", m.branchOptionCursor)
+	}
+	// Default choice for the single off-default repo should be "use default branch" (false)
+	if got, ok := m.branchChoices["repo-a"]; !ok || got {
+		t.Errorf("expected branchChoices[repo-a]=false, got value=%v present=%v", got, ok)
 	}
 }
 
@@ -1187,70 +1195,129 @@ func TestWizardNoBranchWarningNoRepoPaths(t *testing.T) {
 
 // --- Test Group: Branch Warning Navigation ---
 
-func TestWizardBranchWarningUpDown(t *testing.T) {
+func TestWizardBranchScreenOptionToggle(t *testing.T) {
+	// Within a single repo's screen, ↑/↓/tab all flip between the two
+	// options (default / current). Only two options, so toggle keys are
+	// symmetric - they don't care about direction.
 	defaults := config.DefaultsConfig{}
 	m := NewWizardModel(nil, nil, nil, defaults, "", nil, nil, nil, nil, nil, nil)
 	m.step = wizardStepWhere
 	m.showBranchWarning = true
 	m.branchInfos = []RepoBranchInfo{{Name: "repo-a", CurrentBranch: "feature/xyz", DefaultBranch: "main", IsOffDefault: true}}
-	m.branchCursor = 0
+	m.branchChoices = map[string]bool{"repo-a": false}
+	m.branchScreenIndex = 0
+	m.branchOptionCursor = 0
 
-	// Down moves to 1
+	// Down flips to "current branch"
 	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
-	if m.branchCursor != 1 {
-		t.Errorf("expected branchCursor 1 after down, got %d", m.branchCursor)
+	if m.branchOptionCursor != 1 {
+		t.Errorf("expected option cursor 1 after down, got %d", m.branchOptionCursor)
 	}
-	// Up moves back to 0
+	// Up flips back to "default branch"
 	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyUp})
-	if m.branchCursor != 0 {
-		t.Errorf("expected branchCursor 0 after up, got %d", m.branchCursor)
+	if m.branchOptionCursor != 0 {
+		t.Errorf("expected option cursor 0 after up, got %d", m.branchOptionCursor)
 	}
-	// Up again stays at 0 (no wrap)
-	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyUp})
-	if m.branchCursor != 0 {
-		t.Errorf("expected branchCursor 0 after second up, got %d", m.branchCursor)
-	}
-	// Down twice: should stop at 1
-	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
-	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
-	if m.branchCursor != 1 {
-		t.Errorf("expected branchCursor 1 after double down, got %d", m.branchCursor)
+	// Tab also toggles
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyTab})
+	if m.branchOptionCursor != 1 {
+		t.Errorf("expected option cursor 1 after tab, got %d", m.branchOptionCursor)
 	}
 }
 
-func TestWizardBranchWarningTab(t *testing.T) {
+func TestWizardBranchScreenEnterAdvancesPerRepo(t *testing.T) {
+	// With two off-default repos: Enter on the first repo saves its choice
+	// AND advances to the second repo's screen (not to Pipeline). Enter on
+	// the second one (the last) advances to Pipeline.
 	defaults := config.DefaultsConfig{}
-	m := NewWizardModel(nil, nil, nil, defaults, "", nil, nil, nil, nil, nil, nil)
+	repos := []string{"repo-a", "repo-b"}
+	m := NewWizardModel(repos, nil, nil, defaults, "", nil, nil, nil, nil, nil, nil)
 	m.step = wizardStepWhere
 	m.showBranchWarning = true
-	m.branchInfos = []RepoBranchInfo{{Name: "repo-a", CurrentBranch: "feature/xyz", DefaultBranch: "main", IsOffDefault: true}}
-	m.branchCursor = 0
-
-	// Tab toggles to 1
-	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyTab})
-	if m.branchCursor != 1 {
-		t.Errorf("expected branchCursor 1 after tab, got %d", m.branchCursor)
+	m.branchInfos = []RepoBranchInfo{
+		{Name: "repo-a", CurrentBranch: "feature/xyz", DefaultBranch: "main", IsOffDefault: true},
+		{Name: "repo-b", CurrentBranch: "bugfix/foo", DefaultBranch: "master", IsOffDefault: true},
 	}
-	// Tab again toggles back to 0
+	m.branchChoices = map[string]bool{"repo-a": false, "repo-b": false}
+	m.nameInput.SetValue("test-feature")
+	m.descInput.SetValue("test description")
+	m.selectedRepos["repo-a"] = true
+	m.selectedRepos["repo-b"] = true
+
+	// Pick "current branch" on repo-a (Tab to toggle), then Enter.
 	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyTab})
-	if m.branchCursor != 0 {
-		t.Errorf("expected branchCursor 0 after second tab, got %d", m.branchCursor)
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if m.step != wizardStepWhere {
+		t.Errorf("expected to still be on Where step (next repo screen), got %v", m.step)
+	}
+	if m.branchScreenIndex != 1 {
+		t.Errorf("expected to be on screen 1 (repo-b), got %d", m.branchScreenIndex)
+	}
+	if !m.branchChoices["repo-a"] {
+		t.Error("expected repo-a choice to be saved as true")
+	}
+	// repo-b's screen should start with the recommended (default) option
+	if m.branchOptionCursor != 0 {
+		t.Errorf("expected option cursor to reset to 0 (recommended) on new screen, got %d", m.branchOptionCursor)
+	}
+
+	// Enter on the last screen advances to Pipeline.
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if m.step != wizardStepPipeline {
+		t.Errorf("expected step wizardStepPipeline after last Enter, got %v", m.step)
+	}
+	if m.branchChoices["repo-b"] {
+		t.Error("expected repo-b choice to be saved as false (recommended)")
 	}
 }
 
-func TestWizardBranchWarningSecondEnterAdvances(t *testing.T) {
+func TestWizardBranchScreenEscBacksUpOneRepo(t *testing.T) {
+	// On screen 2 (second repo): Esc backs to screen 1 (first repo), NOT
+	// to the repo picker. Esc on screen 1 dismisses the branch flow.
+	defaults := config.DefaultsConfig{}
+	repos := []string{"repo-a", "repo-b"}
+	m := NewWizardModel(repos, nil, nil, defaults, "", nil, nil, nil, nil, nil, nil)
+	m.step = wizardStepWhere
+	m.showBranchWarning = true
+	m.branchInfos = []RepoBranchInfo{
+		{Name: "repo-a", CurrentBranch: "feature/xyz", DefaultBranch: "main", IsOffDefault: true},
+		{Name: "repo-b", CurrentBranch: "bugfix/foo", DefaultBranch: "master", IsOffDefault: true},
+	}
+	m.branchChoices = map[string]bool{"repo-a": true, "repo-b": false}
+	m.branchScreenIndex = 1
+
+	// Esc backs to screen 0 and remembers the previously-saved choice
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	if m.branchScreenIndex != 0 {
+		t.Errorf("expected to back up to screen 0, got %d", m.branchScreenIndex)
+	}
+	if !m.showBranchWarning {
+		t.Error("expected branch screen to still be active")
+	}
+	if m.branchOptionCursor != 1 {
+		t.Errorf("expected option cursor to reflect saved repo-a choice (true), got %d", m.branchOptionCursor)
+	}
+
+	// Esc on screen 0 dismisses the branch flow and returns to repo picker
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	if m.showBranchWarning {
+		t.Error("expected branch screen to be dismissed after esc on first screen")
+	}
+}
+
+func TestWizardBranchScreenSingleRepoEnterAdvances(t *testing.T) {
 	defaults := config.DefaultsConfig{}
 	repos := []string{"repo-a"}
 	m := NewWizardModel(repos, nil, nil, defaults, "", nil, nil, nil, nil, nil, nil)
 	m.step = wizardStepWhere
 	m.showBranchWarning = true
 	m.branchInfos = []RepoBranchInfo{{Name: "repo-a", CurrentBranch: "feature/xyz", DefaultBranch: "main", IsOffDefault: true}}
-	m.branchCursor = 0
+	m.branchChoices = map[string]bool{"repo-a": false}
 	m.nameInput.SetValue("test-feature")
 	m.descInput.SetValue("test description")
 	m.selectedRepos["repo-a"] = true
 
-	// Enter advances to Pipeline
+	// One off-default repo: Enter advances directly to Pipeline.
 	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
 	if m.step != wizardStepPipeline {
 		t.Errorf("expected step wizardStepPipeline, got %v", m.step)
@@ -1275,16 +1342,19 @@ func TestWizardBranchWarningBlocksRepoKeys(t *testing.T) {
 
 // --- Test Group: Branch Warning Back Navigation ---
 
-func TestWizardBranchWarningShiftTabDismisses(t *testing.T) {
+func TestWizardBranchScreenEscOnFirstDismisses(t *testing.T) {
+	// Esc on the first screen dismisses the branch flow entirely and
+	// returns to the repo picker. (Replaces the prior shift+tab dismiss
+	// path; shift+tab is no longer wired on the branch screen.)
 	defaults := config.DefaultsConfig{}
 	m := NewWizardModel(nil, nil, nil, defaults, "", nil, nil, nil, nil, nil, nil)
 	m.step = wizardStepWhere
 	m.showBranchWarning = true
 	m.branchInfos = []RepoBranchInfo{{Name: "repo-a", CurrentBranch: "feature/xyz", DefaultBranch: "main", IsOffDefault: true}}
 
-	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyTab, Mod: tea.ModShift})
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
 	if m.showBranchWarning {
-		t.Error("expected showBranchWarning to be false after shift+tab")
+		t.Error("expected showBranchWarning to be false after esc on first screen")
 	}
 	if m.step != wizardStepWhere {
 		t.Errorf("expected step wizardStepWhere (stays), got %v", m.step)
@@ -1329,19 +1399,22 @@ func TestWizardUseCurrentBranchTrue(t *testing.T) {
 	m.descInput.SetValue("test description")
 	m, _ = m.advance() // What -> Where
 	m.selectedRepos["repo-a"] = true
-	m, _ = m.advance() // First Enter -> shows warning
+	m, _ = m.advance() // First Continue -> shows branch screen
 	if !m.showBranchWarning {
-		t.Fatal("expected branch warning to be shown")
+		t.Fatal("expected branch screen to be shown")
 	}
-	// Move cursor down to select "current branch"
-	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
-	if m.branchCursor != 1 {
-		t.Fatalf("expected branchCursor 1, got %d", m.branchCursor)
+	// Tab toggles the option cursor to "use current branch"
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyTab})
+	if m.branchOptionCursor != 1 {
+		t.Fatalf("expected branchOptionCursor=1 after tab, got %d", m.branchOptionCursor)
 	}
-	// Second Enter -> advances to Pipeline
+	// Enter saves the choice and (last repo) advances to Pipeline
 	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
 	if m.step != wizardStepPipeline {
 		t.Fatalf("expected step wizardStepPipeline, got %v", m.step)
+	}
+	if !m.branchChoices["repo-a"] {
+		t.Fatalf("expected branchChoices[repo-a]=true after enter, got %v", m.branchChoices)
 	}
 	// Enter -> Review
 	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
@@ -1352,7 +1425,10 @@ func TestWizardUseCurrentBranchTrue(t *testing.T) {
 	}
 	result := m.Result()
 	if !result.UseCurrentBranch {
-		t.Error("expected UseCurrentBranch to be true")
+		t.Error("expected UseCurrentBranch (global fallback) to be true")
+	}
+	if v, ok := result.UseCurrentBranchPerRepo["repo-a"]; !ok || !v {
+		t.Errorf("expected UseCurrentBranchPerRepo[repo-a]=true, got value=%v present=%v", v, ok)
 	}
 }
 
@@ -1370,13 +1446,10 @@ func TestWizardUseCurrentBranchFalseDefault(t *testing.T) {
 	m.descInput.SetValue("test description")
 	m, _ = m.advance() // What -> Where
 	m.selectedRepos["repo-a"] = true
-	m, _ = m.advance() // First Enter -> shows warning
-	// Leave cursor at 0 (default branch)
-	// Second Enter -> Pipeline
-	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
-	// Enter -> Review
-	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
-	// Press G to create
+	m, _ = m.advance() // First Continue -> shows branch screen with default-branch pre-selected
+	// Don't toggle - leave the default choice in place
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEnter}) // Branch -> Pipeline
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEnter}) // Pipeline -> Review
 	m, _ = m.Update(tea.KeyPressMsg{Code: 'G', Text: "G"})
 	if !m.IsDone() {
 		t.Fatal("expected wizard to be done")
@@ -1384,6 +1457,68 @@ func TestWizardUseCurrentBranchFalseDefault(t *testing.T) {
 	result := m.Result()
 	if result.UseCurrentBranch {
 		t.Error("expected UseCurrentBranch to be false")
+	}
+	if v, ok := result.UseCurrentBranchPerRepo["repo-a"]; !ok || v {
+		t.Errorf("expected UseCurrentBranchPerRepo[repo-a]=false, got value=%v present=%v", v, ok)
+	}
+}
+
+// TestWizardUseCurrentBranchPerRepoMixed exercises the multi-repo case where
+// the user picks "default branch" for one repo and "current branch" for
+// another. The per-repo map must reflect each choice independently; the
+// global UseCurrentBranch boolean is true because ANY repo opted into
+// current branch.
+func TestWizardUseCurrentBranchPerRepoMixed(t *testing.T) {
+	repos := []string{"repo-a", "repo-b"}
+	defaults := config.DefaultsConfig{}
+	m := NewWizardModel(repos, nil, nil, defaults, "", nil, nil, nil, nil, nil, nil)
+	m.detectBranchesFn = func(WizardModel) []RepoBranchInfo {
+		return []RepoBranchInfo{
+			{Name: "repo-a", CurrentBranch: "feature/xyz", DefaultBranch: "main", IsOffDefault: true},
+			{Name: "repo-b", CurrentBranch: "bugfix/foo", DefaultBranch: "master", IsOffDefault: true},
+		}
+	}
+	m.nameInput.SetValue("test-feature")
+	m.descInput.SetValue("test description")
+	m, _ = m.advance() // What -> Where
+	m.selectedRepos["repo-a"] = true
+	m.selectedRepos["repo-b"] = true
+	m, _ = m.advance() // First Continue -> branch screen
+	if !m.showBranchWarning {
+		t.Fatal("expected branch screen to be shown")
+	}
+
+	// Screen 1 (repo-a): leave at default, Enter to save+advance to screen 2.
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if m.branchScreenIndex != 1 {
+		t.Fatalf("expected to advance to screen 1 (repo-b), got %d", m.branchScreenIndex)
+	}
+	if m.branchChoices["repo-a"] {
+		t.Error("expected repo-a choice to remain false")
+	}
+
+	// Screen 2 (repo-b): Tab flips to current branch, then Enter saves+advances.
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyTab})
+	if m.branchOptionCursor != 1 {
+		t.Fatalf("expected option cursor=1 after tab on repo-b, got %d", m.branchOptionCursor)
+	}
+
+	// Confirm and finish
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEnter}) // Branch -> Pipeline
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEnter}) // Pipeline -> Review
+	m, _ = m.Update(tea.KeyPressMsg{Code: 'G', Text: "G"})
+	if !m.IsDone() {
+		t.Fatal("expected wizard to be done")
+	}
+	result := m.Result()
+	if !result.UseCurrentBranch {
+		t.Error("expected UseCurrentBranch=true (any repo opted in)")
+	}
+	if v := result.UseCurrentBranchPerRepo["repo-a"]; v {
+		t.Errorf("expected repo-a=false in per-repo map, got %v", v)
+	}
+	if v := result.UseCurrentBranchPerRepo["repo-b"]; !v {
+		t.Errorf("expected repo-b=true in per-repo map, got %v", v)
 	}
 }
 
@@ -1396,19 +1531,19 @@ func TestWizardBranchWarningView(t *testing.T) {
 	m.step = wizardStepWhere
 	m.showBranchWarning = true
 	m.branchInfos = []RepoBranchInfo{{Name: "repo-a", CurrentBranch: "feature/xyz", DefaultBranch: "main", IsOffDefault: true}}
-	m.branchCursor = 0
+	m.branchChoices = map[string]bool{"repo-a": false}
 	m.width = 80
 	m.height = 24
 
 	view := m.View()
-	if !containsString(view, "Branch Warning") {
-		t.Error("expected view to contain 'Branch Warning'")
+	if !containsString(view, "Branch selection") {
+		t.Error("expected view title to contain 'Branch selection'")
 	}
-	if !containsString(view, "Start from default branch") {
-		t.Error("expected view to contain 'Start from default branch'")
+	if !containsString(view, "Start from main") {
+		t.Error("expected view to contain 'Start from main' (default-branch option)")
 	}
-	if !containsString(view, "Start from current branch") {
-		t.Error("expected view to contain 'Start from current branch'")
+	if !containsString(view, "Start from feature/xyz") {
+		t.Error("expected view to contain 'Start from feature/xyz' (current-branch option)")
 	}
 	if !containsString(view, "repo-a") {
 		t.Error("expected view to contain 'repo-a'")
@@ -1426,8 +1561,11 @@ func TestWizardBranchWarningFooter(t *testing.T) {
 	m.height = 24
 
 	view := m.View()
-	if !containsString(view, "Confirm") {
-		t.Error("expected footer to contain 'Confirm'")
+	if !containsString(view, "Next") {
+		t.Error("expected footer to contain 'Next' (enter action label)")
+	}
+	if !containsString(view, "Switch") {
+		t.Error("expected footer to contain 'Switch' (toggle action label)")
 	}
 }
 
@@ -1440,7 +1578,7 @@ func TestWizardReviewShowsBranchChoice(t *testing.T) {
 	m.selectedRepos["repo-a"] = true
 	m.step = wizardStepReview
 	m.branchInfos = []RepoBranchInfo{{Name: "repo-a", CurrentBranch: "feature/xyz", DefaultBranch: "main", IsOffDefault: true}}
-	m.branchCursor = 1
+	m.branchChoices = map[string]bool{"repo-a": true} // user picked current branch
 	m.width = 80
 	m.height = 24
 
@@ -1450,7 +1588,7 @@ func TestWizardReviewShowsBranchChoice(t *testing.T) {
 	}
 
 	// Switch to default branch
-	m.branchCursor = 0
+	m.branchChoices["repo-a"] = false
 	view = m.View()
 	if !containsString(view, "default branch") {
 		t.Error("expected review to show 'default branch'")
@@ -3414,30 +3552,35 @@ func TestWizardCursorCanReachBrowseItem(t *testing.T) {
 	m := NewWizardModel(repos, nil, nil, config.DefaultsConfig{}, "", nil, nil, nil, nil, nil, []string{"/tmp/roots"})
 	m = advanceWizardToWhereViaUI(m, "test")
 
-	// Move down twice to reach browse item (index 2, after repos 0 and 1)
-	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
-	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
-
-	if m.repoCursor != len(m.filteredRepos) {
-		t.Errorf("expected cursor at %d (browse item), got %d", len(m.filteredRepos), m.repoCursor)
+	// Tab cycles list -> Browse
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyTab})
+	if m.whereFocus != whereFocusBrowse {
+		t.Errorf("expected focus on Browse after Tab, got %d", m.whereFocus)
 	}
 
-	// Down again reaches create-new-repo item
-	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
-	if m.repoCursor != len(m.filteredRepos)+1 {
-		t.Errorf("expected cursor at %d (create item), got %d", len(m.filteredRepos)+1, m.repoCursor)
+	// Tab again reaches Create
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyTab})
+	if m.whereFocus != whereFocusCreate {
+		t.Errorf("expected focus on Create after second Tab, got %d", m.whereFocus)
 	}
 
-	// Down again should clamp at create item
-	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
-	if m.repoCursor != len(m.filteredRepos)+1 {
-		t.Errorf("cursor should clamp at create item, got %d", m.repoCursor)
+	// Tab again reaches Continue
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyTab})
+	if m.whereFocus != whereFocusContinue {
+		t.Errorf("expected focus on Continue after third Tab, got %d", m.whereFocus)
 	}
 
-	// Up should go back to browse item
+	// Tab again wraps back to the list
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyTab})
+	if m.whereFocus != whereFocusList {
+		t.Errorf("expected focus to wrap to list, got %d", m.whereFocus)
+	}
+
+	// Up from Continue with the create row visible should land on Create
+	m.whereFocus = whereFocusContinue
 	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyUp})
-	if m.repoCursor != len(m.filteredRepos) {
-		t.Errorf("expected cursor at %d (browse item) after up, got %d", len(m.filteredRepos), m.repoCursor)
+	if m.whereFocus != whereFocusCreate {
+		t.Errorf("expected Up from Continue to land on Create, got %d", m.whereFocus)
 	}
 }
 
@@ -3446,15 +3589,16 @@ func TestWizardTabOnBrowseOpensPicker(t *testing.T) {
 	m := NewWizardModel(repos, nil, nil, config.DefaultsConfig{}, "", nil, nil, nil, nil, nil, nil)
 	m = advanceWizardToWhereViaUI(m, "test")
 
-	// Move cursor to browse item
-	for i := 0; i < len(repos); i++ {
-		m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	// Tab cycles to Browse focus
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyTab})
+	if m.whereFocus != whereFocusBrowse {
+		t.Fatalf("expected focus on Browse after Tab, got %d", m.whereFocus)
 	}
 
-	// Space opens picker (Space activates Browse/Root items on Where step)
-	m, _ = m.Update(tea.KeyPressMsg{Code: ' ', Text: " "})
+	// Enter on Browse opens the picker
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
 	if !m.IsPickerActive() {
-		t.Error("expected picker to be active after space on browse item")
+		t.Error("expected picker to be active after Enter on Browse focus")
 	}
 	if m.ConsumeBrowseRoot() != "" {
 		t.Error("no root should be selected yet")
@@ -3466,9 +3610,9 @@ func TestWizardPickerCancelReturnToRepos(t *testing.T) {
 	m := NewWizardModel(repos, nil, nil, config.DefaultsConfig{}, "", nil, nil, nil, nil, nil, nil)
 	m = advanceWizardToWhereViaUI(m, "test")
 
-	// Move to browse and open
-	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
-	m, _ = m.Update(tea.KeyPressMsg{Code: ' ', Text: " "})
+	// Tab to Browse, then Enter to open picker
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyTab})
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
 	if !m.IsPickerActive() {
 		t.Fatal("precondition: picker should be active")
 	}
@@ -3586,9 +3730,9 @@ func TestWizardDirPickerDelegatesAllMessages(t *testing.T) {
 	m := NewWizardModel(repos, nil, nil, config.DefaultsConfig{}, "", nil, nil, nil, nil, nil, nil)
 	m = advanceWizardToWhereViaUI(m, "test")
 
-	// Open picker (Space activates Browse item on Where step)
-	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
-	m, _ = m.Update(tea.KeyPressMsg{Code: ' ', Text: " "})
+	// Tab to Browse, then Enter to open the picker.
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyTab})
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
 
 	// Send non-key message — should not panic
 	m, _ = m.Update(gitRepoScanMsg{dir: "/tmp", count: 0, repoDirs: map[string]bool{}})
@@ -3605,23 +3749,22 @@ func TestWizardMultipleBrowseRounds(t *testing.T) {
 	m := NewWizardModel([]string{"repo-a"}, nil, nil, config.DefaultsConfig{}, "", nil, nil, nil, nil, nil, nil)
 	m = advanceWizardToWhereViaUI(m, "test")
 
-	// Round 1: open picker, set root manually, consume
-	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
-	m, _ = m.Update(tea.KeyPressMsg{Code: ' ', Text: " "})
+	// Round 1: Tab to Browse, Enter to open, Esc to cancel.
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyTab})
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
 	if !m.IsPickerActive() {
 		t.Fatal("round 1: expected picker active")
 	}
-	// Cancel round 1
 	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
 	if m.IsPickerActive() {
 		t.Fatal("round 1: expected picker cancelled")
 	}
 
-	// Round 2: cursor should still be on browse item, reopen
-	if m.repoCursor != len(m.filteredRepos) {
-		t.Fatalf("cursor should be on browse item, got %d", m.repoCursor)
+	// Round 2: focus should still be on Browse, Enter reopens.
+	if m.whereFocus != whereFocusBrowse {
+		t.Fatalf("focus should remain on Browse, got %d", m.whereFocus)
 	}
-	m, _ = m.Update(tea.KeyPressMsg{Code: ' ', Text: " "})
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
 	if !m.IsPickerActive() {
 		t.Error("round 2: expected picker to reopen")
 	}
@@ -4108,20 +4251,20 @@ func TestWizardCreateNewRepoHiddenWithoutRoots(t *testing.T) {
 
 func TestWizardCursorClampsAtBrowseWithoutRoots(t *testing.T) {
 	repos := []string{"repo-a"}
-	// No workspace roots → cursor max should be len(repos) (browse item only)
+	// No workspace roots → action axis only has Browse and Continue (no Create row).
 	m := NewWizardModel(repos, nil, nil, config.DefaultsConfig{}, "", nil, nil, nil, nil, nil, nil)
 	m = advanceWizardToWhereViaUI(m, "test")
 
-	// Move down past repo to browse item
-	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
-	if m.repoCursor != len(m.filteredRepos) {
-		t.Errorf("expected cursor at %d (browse item), got %d", len(m.filteredRepos), m.repoCursor)
+	// Tab cycles list -> Browse (skips Create when no workspace roots)
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyTab})
+	if m.whereFocus != whereFocusBrowse {
+		t.Errorf("expected focus on Browse after Tab, got %d", m.whereFocus)
 	}
 
-	// Down again should clamp at browse (no create-repo row)
-	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
-	if m.repoCursor != len(m.filteredRepos) {
-		t.Errorf("cursor should clamp at browse item without roots, got %d", m.repoCursor)
+	// Tab again goes to Continue (NOT Create — Create is not visible)
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyTab})
+	if m.whereFocus != whereFocusContinue {
+		t.Errorf("expected focus to skip Create and land on Continue, got %d", m.whereFocus)
 	}
 }
 
@@ -4131,18 +4274,17 @@ func TestWizardCreateNewRepoRootPicker(t *testing.T) {
 	m := NewWizardModel(repos, nil, nil, config.DefaultsConfig{}, "", nil, nil, nil, nil, nil, roots)
 	m = advanceWizardToWhereViaUI(m, "test")
 
-	// Navigate to "Create new repo..." (index len(repos)+1 = 2)
-	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown}) // browse
-	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown}) // create
-
-	if m.repoCursor != len(m.filteredRepos)+1 {
-		t.Fatalf("expected cursor at create item, got %d", m.repoCursor)
+	// Tab twice to cycle list -> Browse -> Create
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyTab})
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyTab})
+	if m.whereFocus != whereFocusCreate {
+		t.Fatalf("expected focus on Create after two Tabs, got %d", m.whereFocus)
 	}
 
-	// Space opens root picker overlay (Space activates items on Where step)
-	m, _ = m.Update(tea.KeyPressMsg{Code: ' ', Text: " "})
+	// Enter opens root picker overlay
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
 	if !m.IsRootPickerActive() {
-		t.Fatal("expected root picker to be active after space on create item")
+		t.Fatal("expected root picker to be active after Enter on Create focus")
 	}
 	if m.rootPickerCursor != 0 {
 		t.Errorf("expected root picker cursor at 0, got %d", m.rootPickerCursor)
@@ -4189,10 +4331,10 @@ func TestWizardRootPickerEscCancels(t *testing.T) {
 	m := NewWizardModel(repos, nil, nil, config.DefaultsConfig{}, "", nil, nil, nil, nil, nil, roots)
 	m = advanceWizardToWhereViaUI(m, "test")
 
-	// Navigate to create item and open root picker (Space activates items on Where step)
-	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
-	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
-	m, _ = m.Update(tea.KeyPressMsg{Code: ' ', Text: " "})
+	// Tab to Create then Enter to open root picker
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyTab})
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyTab})
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
 
 	if !m.IsRootPickerActive() {
 		t.Fatal("expected root picker to be active")
@@ -4214,10 +4356,10 @@ func TestWizardRootPickerEscFromNameGoesBack(t *testing.T) {
 	m := NewWizardModel(repos, nil, nil, config.DefaultsConfig{}, "", nil, nil, nil, nil, nil, roots)
 	m = advanceWizardToWhereViaUI(m, "test")
 
-	// Open root picker and select a root (Space activates items on Where step)
-	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
-	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
-	m, _ = m.Update(tea.KeyPressMsg{Code: ' ', Text: " "})
+	// Tab twice to Create, Enter opens root picker, Enter again selects first root.
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyTab})
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyTab})
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
 	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEnter}) // select root → name input phase
 
 	if !m.createRepoActive {

--- a/internal/tui/wizard_test.go
+++ b/internal/tui/wizard_test.go
@@ -1536,14 +1536,20 @@ func TestWizardBranchWarningView(t *testing.T) {
 	m.height = 24
 
 	view := m.View()
-	if !containsString(view, "Branch selection") {
-		t.Error("expected view title to contain 'Branch selection'")
+	if !containsString(view, "Branch base") {
+		t.Error("expected view title to contain 'Branch base'")
 	}
 	if !containsString(view, "Start from main") {
 		t.Error("expected view to contain 'Start from main' (default-branch option)")
 	}
 	if !containsString(view, "Start from feature/xyz") {
 		t.Error("expected view to contain 'Start from feature/xyz' (current-branch option)")
+	}
+	if !containsString(view, "Recommended") {
+		t.Error("expected view to identify the default branch as recommended")
+	}
+	if !containsString(view, "Include current branch commits") {
+		t.Error("expected view to explain the current-branch option")
 	}
 	if !containsString(view, "repo-a") {
 		t.Error("expected view to contain 'repo-a'")
@@ -1561,8 +1567,8 @@ func TestWizardBranchWarningFooter(t *testing.T) {
 	m.height = 24
 
 	view := m.View()
-	if !containsString(view, "Next") {
-		t.Error("expected footer to contain 'Next' (enter action label)")
+	if !containsString(view, "Choose") {
+		t.Error("expected footer to contain 'Choose' (enter action label)")
 	}
 	if !containsString(view, "Switch") {
 		t.Error("expected footer to contain 'Switch' (toggle action label)")

--- a/test/e2e/tui_test.go
+++ b/test/e2e/tui_test.go
@@ -278,11 +278,11 @@ func TestMediumWizardGateProjectionSmoke(t *testing.T) {
 	)
 
 	tm.Send(tea.KeyPressMsg{Text: "medium wizard smoke"})
-	tm.Send(tea.KeyPressMsg{Code: tea.KeyEnter})
-	tm.Send(tea.KeyPressMsg{Code: tea.KeyEnter})
-	tm.Send(tea.KeyPressMsg{Code: ' ', Text: " "})
-	tm.Send(tea.KeyPressMsg{Code: tea.KeyEnter})
-	tm.Send(tea.KeyPressMsg{Code: tea.KeyUp})
+	tm.Send(tea.KeyPressMsg{Code: tea.KeyEnter})                  // name -> description
+	tm.Send(tea.KeyPressMsg{Code: tea.KeyEnter})                  // description -> Where
+	tm.Send(tea.KeyPressMsg{Code: tea.KeyEnter})                  // add focused repo to chips
+	tm.Send(tea.KeyPressMsg{Code: 'd', Mod: tea.ModCtrl})         // Ctrl+D advances Where -> Pipeline
+	tm.Send(tea.KeyPressMsg{Code: tea.KeyUp})                     // pipeline cursor up -> medium
 
 	teatest.WaitFor(t, tm.Output(),
 		func(bts []byte) bool {


### PR DESCRIPTION
## Summary

Reworks Step 2 of the new-feature wizard (repo selection) and the off-default branch warning, both of which suffered from the same problem: ambiguous role of Enter / Tab / Space, leaving users stuck or pressing keys that did the wrong thing.

### Step 2 — chip/pill picker
- Selected repos render as removable chips at the top; the list shows only unselected repos (so Enter on a list row unambiguously means "add this").
- Explicit `Continue with N repos →` CTA button replaces the old footer-only "Enter to advance" affordance — focused state uses `colorActive` (teal) for strong contrast against the unfocused brand-purple.
- Enter is contextual to the focused row: adds repos, opens Browse/Create, or activates Continue. Tab cycles list → Browse → Create → Continue (forward-only). Backspace on an empty filter removes the last chip. `Ctrl+D` is a global "I'm done" shortcut that advances from anywhere.

### Branch selection — dedicated per-repo screen
- The inline branch warning is replaced by a focused screen shown one repo at a time, with explanatory copy: which repo, current/default branch, what the orchestrator will do, why the choice matters, plus a tip on when to pick "current branch".
- Per-repo decision (previously a single global toggle was applied to *all* off-default repos). New `WizardResult.UseCurrentBranchPerRepo` map is plumbed through `feature.CreateOptions.UseCurrentBranchPerRepo`; `manager.go` worktree creation now consults the per-repo override before falling back to the global `UseCurrentBranch` bool — fixes a latent bug.
- Minimal bindings: `↑↓/tab` switch between the two options, `enter` saves and advances to the next repo (or Step 3 on the last), `esc` backs up one repo (or dismisses on the first).

### Polish bundled
- Fixed `LabelStyle.Width(12)` truncation/wrap that mangled long headings and repo names.
- Tip text rendered with `Width(maxWidth)` so lipgloss only wraps when terminal is too narrow.
- Step 2 heading switched to an inline `colorSubtext` style (matching Step 3's heading pattern).

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` clean across all packages
- [x] Updated wizard tests cover: new chip picker flow, Tab focus cycling, Backspace chip removal, Ctrl+D advance, per-repo branch choice, screen back/forward navigation in branch flow, mixed per-repo result propagation
- [x] Updated e2e smoke test for `TestMediumWizardGateProjectionSmoke` to use new add-then-Ctrl+D pattern
- [x] Manual: walk through the wizard with several repos, including ones on non-default branches, and confirm the new screens render and behave as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)