### PR TITLE
Add comment-hygiene directive to the three code-editing skills

### DIFF
--- a/skills/final-fix/SKILL.md
+++ b/skills/final-fix/SKILL.md
@@ -27,6 +27,7 @@ You are the fix agent for one final-review iteration. Your job is to address the
 - Keep access to every mounted feature repo; cross-repo fixes are valid when the reviewer feedback spans repos.
 - Do not write `progress.md` or `need-user-input.yaml`; this role's only required artifact is `verification-report.yaml`.
 - Do not create orchestration files at a repository worktree root.
+- Add comments only when they explain intent, rationale, invariants, or non-obvious tradeoffs. Keep required API/doc comments. Do not add comments that merely restate self-explanatory code.
 
 ## Manual Verification
 

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -25,6 +25,7 @@ You are the coordinator for the whole phase. Keep main context focused on readin
 - If a test is hard to write, treat that as design feedback: simplify the interface, introduce dependency injection, or narrow the behavior under test.
 - Use stubs only when the approved plan explicitly calls for them. Mark intentional stubs with `// STUB(Phase N): <what the real implementation will do>`.
 - Do not invent extra scope. New useful checks go in `verification-report.yaml` under `additional_checks:`, not in the contract `results:`.
+- Add comments only when they explain intent, rationale, invariants, or non-obvious tradeoffs. Keep required API/doc comments. Do not add comments that merely restate self-explanatory code.
 
 ## Workspace
 

--- a/skills/tweak-session/SKILL.md
+++ b/skills/tweak-session/SKILL.md
@@ -22,3 +22,4 @@ You are in an interactive tweak session for an existing feature. The session has
 - If a change seems risky or ambiguous, ask for clarification before proceeding.
 - Match the style and conventions of the existing codebase.
 - **Do not commit your changes.** Leave all modifications as unstaged working-tree changes in whichever of the repos you edited. The orchestrator handles committing and pushing automatically across every modified repo when the session ends.
+- Add comments only when they explain intent, rationale, invariants, or non-obvious tradeoffs. Keep required API/doc comments. Do not add comments that merely restate self-explanatory code.


### PR DESCRIPTION
## Summary

- Adds a single, identical comment-hygiene directive to the three embedded skill surfaces that produce implementation changes in AgenticO: the standard implementer (`skills/implement/SKILL.md`, in `Operating Rules`), the final-review fixer (`skills/final-fix/SKILL.md`, in `Boundaries`), and the interactive tweak session (`skills/tweak-session/SKILL.md`, in `Guidelines`).
- The directive biases generated code toward self-explanatory code over redundant comments — *"Add comments only when they explain intent, rationale, invariants, or non-obvious tradeoffs. Keep required API/doc comments. Do not add comments that merely restate self-explanatory code."* — which trims comment noise in generated PRs and avoids wasted tokens while preserving required API/doc comments and useful rationale.
- Prose-only change delivered through the existing skill reconciliation pipeline (`//go:embed` → user-state skill directories at startup). No role specs, prompt templates, planning/review roles, language guidelines, or rebase/review-comment plans were touched, and the wording is cross-language rather than Go-specific.

## Test plan

- Embedded-skill parser/reconciliation tests pass, confirming the updated SKILL.md assets remain valid embedded content and still reconcile to user-state skill directories on startup.
- Agent role/skill contract tests pass for the three roles backing the standard implementer, final-review fixer, and interactive tweak session (`Output Files` sections and implement-skill contract expectations intact).
- The documented fast suite passes; `go vet` and the standard build remain clean.
- No prompt golden snapshots were regenerated — any golden churn would indicate an unexpected template coupling and is treated as a failure signal to report rather than a regeneration to accept.
- The directive appears verbatim exactly once in each of the three intended skills and is not duplicated into any other skill, role spec, prompt template, or guideline.

---

*Generated with [Agentic](https://github.com/doordash-oss/agentic-orchestrator)*