### PR TITLE
Handle final review terminal failures end-to-end

### DIFF
--- a/internal/agent/atomic_phase_stamp.go
+++ b/internal/agent/atomic_phase_stamp.go
@@ -120,11 +120,15 @@ func AtomicPhaseStamp(store ports.FeatureStore, in AtomicPhaseStampInput) error 
 			// feature for the harness to surface.
 			f.PendingNeedUserInputPath = in.GatePath
 		case PhaseOutcomeFinalReviewPassed:
-			// No per-repo state mutation on FR pass (feature-level Status
-			// carries the verdict). PR URL writes are mirrored when supplied.
+			// FR pass is feature-level, but stale per-repo errors from an
+			// earlier failed FR attempt must not keep rendering as repo
+			// failures after the feature has advanced.
 			for _, name := range repos {
+				ns := f.RepoStates[name]
+				if ns != nil {
+					ns.LastError = ""
+				}
 				if pr, ok := in.PRURLs[name]; ok && pr != "" {
-					ns := f.RepoStates[name]
 					if ns == nil {
 						ns = &feature.RepoState{}
 						f.RepoStates[name] = ns

--- a/internal/agent/atomic_phase_stamp_test.go
+++ b/internal/agent/atomic_phase_stamp_test.go
@@ -198,14 +198,14 @@ func TestAtomicPhaseStamp_PRURLsApplied(t *testing.T) {
 	}
 }
 
-// TestAtomicPhaseStamp_FinalReviewPassedNoStateMutation asserts the FR
-// success outcome leaves per-repo state untouched (feature-level Status
-// carries the verdict) but still mirrors PR URL writes when supplied.
-func TestAtomicPhaseStamp_FinalReviewPassedNoStateMutation(t *testing.T) {
+// TestAtomicPhaseStamp_FinalReviewPassedClearsStaleRepoErrors asserts the FR
+// success outcome clears stale per-repo error text left by earlier failed FR
+// attempts while preserving monotonic repo state and PR URL mirroring.
+func TestAtomicPhaseStamp_FinalReviewPassedClearsStaleRepoErrors(t *testing.T) {
 	repos := []feature.FeatureRepo{{Name: "api"}, {Name: "web"}}
 	prior := map[string]*feature.RepoState{
-		"api": {Touched: true},
-		"web": {Touched: true},
+		"api": {Touched: true, LastError: "protocol violation"},
+		"web": {Touched: true, LastError: "final review failed"},
 	}
 	store, id := newTestStoreWithFeature(t, repos, prior)
 
@@ -226,6 +226,9 @@ func TestAtomicPhaseStamp_FinalReviewPassedNoStateMutation(t *testing.T) {
 		// Touched flag must remain set (monotonic).
 		if !got.RepoStates[name].Touched {
 			t.Errorf("repo %s lost Touched=true after FR pass", name)
+		}
+		if got.RepoStates[name].LastError != "" {
+			t.Errorf("repo %s LastError = %q, want cleared after FR pass", name, got.RepoStates[name].LastError)
 		}
 	}
 	if got.RepoStates["api"].PRURL != "https://example.com/api/pr/1" {

--- a/internal/feature/feature.go
+++ b/internal/feature/feature.go
@@ -668,6 +668,7 @@ func (f *Feature) SetRun(r *Run) {
 	f.run = r
 	if r != nil {
 		f.syncRunToShadows()
+		f.reconcileTerminalRunFailure()
 	}
 }
 
@@ -752,6 +753,35 @@ func (f *Feature) syncRunToShadows() {
 	f.MaxPlanIterations = r.MaxPlanIterations
 	f.PendingNeedUserInputPath = r.PendingNeedUserInputPath
 	f.CurrentPhaseStatus = r.CurrentPhaseStatus
+}
+
+// HasTerminalFailure reports whether the active run carries terminal failure
+// context. These fields are run-scoped shadows, so a feature in a successful
+// terminal status with either value set is inconsistent and should be treated
+// as failed by status projections and recovery paths.
+func (f *Feature) HasTerminalFailure() bool {
+	if f == nil {
+		return false
+	}
+	return strings.TrimSpace(f.FailureType) != "" || strings.TrimSpace(f.LastError) != ""
+}
+
+func (f *Feature) reconcileTerminalRunFailure() {
+	if !f.HasTerminalFailure() {
+		return
+	}
+	switch f.Status {
+	case StatusCodeReady, StatusPublished, StatusDone:
+		f.Status = StatusFailed
+		if f.CurrentPhase == PhasePublish && looksLikeFinalReviewFailure(f.LastError) {
+			f.CurrentPhase = PhaseFinalReview
+		}
+	}
+}
+
+func looksLikeFinalReviewFailure(msg string) bool {
+	msg = strings.ToLower(msg)
+	return strings.Contains(msg, "final_review") || strings.Contains(msg, "final review")
 }
 
 func normalizeLegacyArtifactAliases(artifacts map[string]string) {

--- a/internal/feature/manager.go
+++ b/internal/feature/manager.go
@@ -592,6 +592,9 @@ func (m *Manager) CompleteImplementation(featureID string) error {
 // MarkCodeReady transitions a feature to CodeReady and sets CurrentPhase to Publish.
 func (m *Manager) MarkCodeReady(featureID string) error {
 	return m.Store.Modify(featureID, func(f *Feature) error {
+		if f.Status == StatusFailed || f.HasTerminalFailure() {
+			return fmt.Errorf("cannot mark code ready for feature %s with terminal failure", featureID)
+		}
 		if err := f.Transition(StatusCodeReady); err != nil {
 			return err
 		}

--- a/internal/feature/manager_test.go
+++ b/internal/feature/manager_test.go
@@ -465,6 +465,43 @@ func TestManagerMarkFailed(t *testing.T) {
 	}
 }
 
+func TestManagerMarkCodeReadyRefusesTerminalFailure(t *testing.T) {
+	t.Parallel()
+	// parallel-candidate: per-test temp dirs and mocks isolate filesystem and collaborator state.
+	mgr := newTestManager(t)
+	f, err := mgr.Create("Failed Final Review", "test", []string{"test-repo"}, mgr.Config.Defaults.Models, "", "", nil)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	if err := mgr.Store.Modify(f.ID, func(ff *feature.Feature) error {
+		ff.Status = feature.StatusFailed
+		ff.CurrentPhase = feature.PhaseFinalReview
+		ff.LastError = "protocol violation: final_review_reviewer @ /tmp/iter: invalid report"
+		ff.FailureType = feature.FailureProtocolViolation
+		return nil
+	}); err != nil {
+		t.Fatalf("seed failed final review: %v", err)
+	}
+
+	if err := mgr.MarkCodeReady(f.ID); err == nil {
+		t.Fatal("MarkCodeReady succeeded, want terminal failure guard")
+	}
+	got, err := mgr.Get(f.ID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Status != feature.StatusFailed {
+		t.Fatalf("Status = %s, want Failed", got.Status)
+	}
+	if got.CurrentPhase != feature.PhaseFinalReview {
+		t.Fatalf("CurrentPhase = %s, want FinalReview", got.CurrentPhase)
+	}
+	if got.FailureType != feature.FailureProtocolViolation {
+		t.Fatalf("FailureType = %q, want %q", got.FailureType, feature.FailureProtocolViolation)
+	}
+}
+
 func TestManagerCreateWithImages(t *testing.T) {
 	t.Parallel()
 	// parallel-candidate: per-test temp dirs and mocks isolate filesystem and collaborator state.

--- a/internal/feature/store.go
+++ b/internal/feature/store.go
@@ -242,8 +242,7 @@ func (s *Store) loadUnlocked(id string) (*Feature, error) {
 	if err != nil {
 		return nil, fmt.Errorf("loading active run for feature %s: %w", id, err)
 	}
-	f.run = run
-	f.syncRunToShadows()
+	f.SetRun(run)
 	return &f, nil
 }
 

--- a/internal/feature/store_test.go
+++ b/internal/feature/store_test.go
@@ -260,6 +260,41 @@ func TestStoreFailureFieldsPersistence(t *testing.T) {
 	}
 }
 
+func TestStoreLoadReconcilesSuccessfulStatusWithTerminalFinalReviewFailure(t *testing.T) {
+	t.Parallel()
+	// parallel-candidate: per-test temp dirs and mocks isolate filesystem and collaborator state.
+	dir := t.TempDir()
+	store := NewStore(dir)
+
+	f := &Feature{
+		ID:            "corrupt-fr-001",
+		Name:          "Corrupt Final Review",
+		Slug:          "corrupt-final-review",
+		Status:        StatusCodeReady,
+		CurrentPhase:  PhasePublish,
+		LastError:     "protocol violation: final_review_reviewer @ /tmp/iter: verification-report.yaml is malformed",
+		FailureType:   FailureProtocolViolation,
+		SchemaVersion: SchemaVersionCurrent,
+	}
+	if err := store.Save(f); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	loaded, err := store.Load("corrupt-fr-001")
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if loaded.Status != StatusFailed {
+		t.Fatalf("Status = %s, want Failed", loaded.Status)
+	}
+	if loaded.CurrentPhase != PhaseFinalReview {
+		t.Fatalf("CurrentPhase = %s, want FinalReview", loaded.CurrentPhase)
+	}
+	if loaded.FailureType != FailureProtocolViolation {
+		t.Fatalf("FailureType = %q, want %q", loaded.FailureType, FailureProtocolViolation)
+	}
+}
+
 func TestStoreMuteInputNotificationsPersistence(t *testing.T) {
 	t.Parallel()
 	// parallel-candidate: per-test temp dirs and mocks isolate filesystem and collaborator state.

--- a/internal/orchestrator/completion.go
+++ b/internal/orchestrator/completion.go
@@ -1097,6 +1097,13 @@ func (o *Orchestrator) advanceAfterFinalReview(featureID string) error {
 	if err != nil {
 		return fmt.Errorf("reload after final review: %w", err)
 	}
+	if f.Status == feature.StatusFailed || f.HasTerminalFailure() {
+		errMsg := strings.TrimSpace(f.LastError)
+		if errMsg == "" {
+			errMsg = "final review did not complete successfully"
+		}
+		return fmt.Errorf("final review did not complete successfully: %s", errMsg)
+	}
 
 	if !f.IsPublishable() || !f.Checkpoints.AutoPublish() {
 		if err := o.deps.Lifecycle.MarkCodeReady(featureID); err != nil {
@@ -1337,19 +1344,19 @@ func (o *Orchestrator) runDeferredFinalReview(featureID string) error {
 	if runFn == nil {
 		errMsg := "runMultiRepoFinalReviewFn not configured"
 		o.emitPhaseCompleted(featureID, feature.PhaseFinalReview, errors.New(errMsg))
-		return o.markFailedWithEvent(featureID, feature.FailureInfrastructure, errMsg)
+		return o.markFinalReviewFailedWithEvent(featureID, feature.FailureInfrastructure, errMsg)
 	}
 	resultCh, err := runFn(f, o.computeKBInfos(f)...)
 	if err != nil {
 		errMsg := fmt.Sprintf("dispatch final review: %v", err)
 		o.emitPhaseCompleted(featureID, feature.PhaseFinalReview, errors.New(errMsg))
-		return o.markFailedWithEvent(featureID, feature.FailureInfrastructure, errMsg)
+		return o.markFinalReviewFailedWithEvent(featureID, feature.FailureInfrastructure, errMsg)
 	}
 	res, ok := <-resultCh
 	if !ok || res == nil {
 		errMsg := "final review returned no result"
 		o.emitPhaseCompleted(featureID, feature.PhaseFinalReview, errors.New(errMsg))
-		return o.markFailedWithEvent(featureID, feature.FailureInfrastructure, errMsg)
+		return o.markFinalReviewFailedWithEvent(featureID, feature.FailureInfrastructure, errMsg)
 	}
 	switch res.FinalStatus {
 	case "all_passed":
@@ -1401,10 +1408,17 @@ func (o *Orchestrator) runDeferredFinalReview(featureID string) error {
 			}
 		}
 		o.emitPhaseCompleted(featureID, feature.PhaseFinalReview, errors.New(errMsg))
-		return o.markFailedWithEvent(featureID, failureType, errMsg)
+		return o.markFinalReviewFailedWithEvent(featureID, failureType, errMsg)
 	default:
 		errMsg := fmt.Sprintf("unknown final review FinalStatus %q", res.FinalStatus)
 		o.emitPhaseCompleted(featureID, feature.PhaseFinalReview, errors.New(errMsg))
-		return o.markFailedWithEvent(featureID, feature.FailureInfrastructure, errMsg)
+		return o.markFinalReviewFailedWithEvent(featureID, feature.FailureInfrastructure, errMsg)
 	}
+}
+
+func (o *Orchestrator) markFinalReviewFailedWithEvent(featureID, failureType, errMsg string) error {
+	if err := o.markFailedWithEvent(featureID, failureType, errMsg); err != nil {
+		return err
+	}
+	return errors.New(errMsg)
 }

--- a/internal/orchestrator/completion_unified_fr_test.go
+++ b/internal/orchestrator/completion_unified_fr_test.go
@@ -950,7 +950,18 @@ func TestOrchestrator_FeatureFinalReview_FailedProtocolViolationPreserved(t *tes
 	}
 	lc := lifecycleForFeature(f)
 	lc.CompleteImplementationFn = func(id string) error { f.Status = feature.StatusReviewPassed; return nil }
-	lc.MarkFinalReviewReadyFn = func(id string) error { f.Status = feature.StatusFinalReviewing; return nil }
+	lc.MarkFinalReviewReadyFn = func(id string) error {
+		f.Status = feature.StatusFinalReviewing
+		f.CurrentPhase = feature.PhaseFinalReview
+		return nil
+	}
+	var markCodeReadyCalled int
+	lc.MarkCodeReadyFn = func(id string) error {
+		markCodeReadyCalled++
+		f.Status = feature.StatusCodeReady
+		f.CurrentPhase = feature.PhasePublish
+		return nil
+	}
 	var gotFailureType string
 	var gotLastError string
 	lc.MarkFailedFn = func(id, failureType, lastError string) error {
@@ -976,11 +987,15 @@ func TestOrchestrator_FeatureFinalReview_FailedProtocolViolationPreserved(t *tes
 		return ch, nil
 	})
 
-	if err := o.HandlePhaseCompletion("feat-fr-protocol", orchestrator.PhaseCompletionInput{
+	err := o.HandlePhaseCompletion("feat-fr-protocol", orchestrator.PhaseCompletionInput{
 		Phase:           feature.PhaseImplement,
 		MultiRepoResult: &agent.OrchestratorResult{FinalStatus: "awaiting_final_review"},
-	}); err != nil {
-		t.Fatalf("HandlePhaseCompletion() error = %v", err)
+	})
+	if err == nil {
+		t.Fatal("HandlePhaseCompletion() error = nil, want final review failure")
+	}
+	if !strings.Contains(err.Error(), "final_review_fixer") {
+		t.Fatalf("HandlePhaseCompletion() error = %v, want final_review_fixer context", err)
 	}
 
 	if gotFailureType != feature.FailureProtocolViolation {
@@ -988,5 +1003,14 @@ func TestOrchestrator_FeatureFinalReview_FailedProtocolViolationPreserved(t *tes
 	}
 	if !strings.Contains(gotLastError, "final_review_fixer") {
 		t.Fatalf("last error = %q, want final_review_fixer context", gotLastError)
+	}
+	if markCodeReadyCalled != 0 {
+		t.Fatalf("MarkCodeReady called %d times, want 0 after final review failure", markCodeReadyCalled)
+	}
+	if f.Status != feature.StatusFailed {
+		t.Fatalf("Status = %s, want Failed", f.Status)
+	}
+	if f.CurrentPhase != feature.PhaseFinalReview {
+		t.Fatalf("CurrentPhase = %s, want FinalReview", f.CurrentPhase)
 	}
 }

--- a/internal/orchestrator/lifecycle_delegates.go
+++ b/internal/orchestrator/lifecycle_delegates.go
@@ -1133,6 +1133,11 @@ func (o *Orchestrator) RestartPhase(featureID string, maxIterationsDelta, maxPla
 			if err := o.TransitionTo(featureID, feature.StatusImplementReady); err != nil {
 				return RestartOutcome{}, err
 			}
+		case feature.PhaseReview, feature.PhaseFinalReview:
+			if err := o.resetFailedFinalReviewForRestart(featureID); err != nil {
+				return RestartOutcome{}, err
+			}
+			phase = feature.PhaseFinalReview
 		case feature.PhasePublish:
 			if err := o.TransitionTo(featureID, feature.StatusCodeReady); err != nil {
 				return RestartOutcome{}, err
@@ -1158,6 +1163,25 @@ func (o *Orchestrator) RestartPhase(featureID string, maxIterationsDelta, maxPla
 	}
 
 	return RestartOutcome{Action: RestartDispatchPhase, Phase: phase}, nil
+}
+
+func (o *Orchestrator) resetFailedFinalReviewForRestart(featureID string) error {
+	return o.deps.Store.Modify(featureID, func(f *feature.Feature) error {
+		f.Status = feature.StatusReviewPassed
+		f.CurrentPhase = feature.PhaseFinalReview
+		f.LastError = ""
+		f.FailureType = ""
+		f.CurrentPhaseStatus = ""
+		f.ReviewFixing = false
+		f.ReviewingGate = false
+		for _, r := range f.Repos {
+			if st := f.RepoStates[r.Name]; st != nil {
+				st.LastError = ""
+			}
+		}
+		clearPendingFeatureAttention(f)
+		return nil
+	})
 }
 
 func isArtifactReviewSession(s ports.SessionView) bool {

--- a/internal/orchestrator/lifecycle_delegates_test.go
+++ b/internal/orchestrator/lifecycle_delegates_test.go
@@ -485,6 +485,53 @@ func TestOrchestrator_RestartPhase_FailedPlan_ExtendsBudgetAndDispatches(t *test
 	}
 }
 
+func TestOrchestrator_RestartPhase_FailedFinalReview_DispatchesFinalReview(t *testing.T) {
+	f := &feature.Feature{
+		ID:           "feat-fr",
+		Status:       feature.StatusFailed,
+		CurrentPhase: feature.PhaseFinalReview,
+		FailureType:  feature.FailureProtocolViolation,
+		LastError:    "protocol violation: final_review_reviewer @ /tmp/iter: invalid report",
+		Repos:        []feature.FeatureRepo{{Name: "agentic"}},
+		RepoStates: map[string]*feature.RepoState{
+			"agentic": {
+				Touched:   true,
+				LastError: "protocol violation: final_review_reviewer @ /tmp/iter: invalid report",
+			},
+		},
+	}
+	lc := lifecycleForFeature(f)
+	fs := newFeatureStore(f)
+
+	o := orchestrator.New(orchestrator.Deps{
+		Lifecycle: lc,
+		Store:     fs,
+	}, orchestrator.Hooks{})
+
+	outcome, err := o.RestartPhase("feat-fr", 10, 2)
+	if err != nil {
+		t.Fatalf("RestartPhase: %v", err)
+	}
+	if outcome.Action != orchestrator.RestartDispatchPhase {
+		t.Fatalf("Action = %v, want RestartDispatchPhase", outcome.Action)
+	}
+	if outcome.Phase != feature.PhaseFinalReview {
+		t.Fatalf("Phase = %v, want PhaseFinalReview", outcome.Phase)
+	}
+	if f.Status != feature.StatusReviewPassed {
+		t.Fatalf("Status = %v, want ReviewPassed so startFinalReview can re-enter", f.Status)
+	}
+	if f.CurrentPhase != feature.PhaseFinalReview {
+		t.Fatalf("CurrentPhase = %v, want PhaseFinalReview", f.CurrentPhase)
+	}
+	if f.LastError != "" || f.FailureType != "" {
+		t.Fatalf("failure fields should be cleared: LastError=%q FailureType=%q", f.LastError, f.FailureType)
+	}
+	if st := f.RepoStates["agentic"]; st == nil || st.LastError != "" {
+		t.Fatalf("RepoStates[agentic] = %+v, want LastError cleared", st)
+	}
+}
+
 // TestOrchestrator_RestartPhase_PublishedWithRepoCycles_ReturnsRestartList
 // ---------------------------------------------------------------------------
 // For a Published feature with RepoCycles, RestartPhase clears the cycles

--- a/internal/orchestrator/multirepo.go
+++ b/internal/orchestrator/multirepo.go
@@ -142,6 +142,10 @@ func (o *Orchestrator) surfaceDispatchCompletionError(featureID string, cause er
 		// the TUI owns routing that into the rebase-resolution cycle.
 		return
 	}
+	if f, err := o.deps.Lifecycle.Get(featureID); err == nil &&
+		f.Status == feature.StatusFailed && f.HasTerminalFailure() {
+		return
+	}
 	errMsg := fmt.Sprintf("handle phase completion: %v", cause)
 	if markErr := o.markFailedWithEvent(featureID, feature.FailureInfrastructure, errMsg); markErr != nil {
 		o.emitEventBlocking(ports.Event{

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -4451,40 +4451,17 @@ func (m AppModel) resumeAllCmd() tea.Cmd {
 			return RefreshFeaturesMsg{}
 		}
 
+		maxIterationsDelta, maxPlanIterationsDelta := m.restartBudgetDeltas()
 		for _, f := range features {
 			if f.Status != feature.StatusInterrupted && f.Status != feature.StatusFailed {
 				continue
 			}
-			fID := f.ID
-			phase := f.CurrentPhase
 
-			sessions := m.sessionManager.ActiveSessions()
-			for _, s := range sessions {
-				if s.FeatureID() == fID {
-					_ = m.sessionManager.StopSession(s.ID())
-				}
+			outcome, err := m.orchestrator.RestartPhase(f.ID, maxIterationsDelta, maxPlanIterationsDelta)
+			if err != nil {
+				continue
 			}
-
-			if f.Status == feature.StatusFailed {
-				switch phase {
-				case feature.PhaseKnowledgeBase, feature.PhaseInquire, feature.PhaseResearch:
-					_ = m.orchestrator.TransitionTo(fID, feature.StatusCreated)
-				case feature.PhaseDesign:
-					// Route Failed→DesignReady so StartDesign can proceed
-					_ = m.orchestrator.SetDesignReady(fID)
-				case feature.PhasePlan:
-					_ = m.orchestrator.TransitionTo(fID, feature.StatusResearching)
-					_ = m.orchestrator.TransitionTo(fID, feature.StatusPlanReady)
-				case feature.PhaseImplement:
-					_ = m.orchestrator.TransitionTo(fID, feature.StatusImplementReady)
-				default:
-					continue
-				}
-			}
-
-			if m.programRef != nil && m.programRef.P != nil {
-				m.programRef.P.Send(StartPhaseMsg{FeatureID: fID, Phase: phase})
-			}
+			m.sendRestartOutcome(f.ID, outcome)
 		}
 
 		return RefreshFeaturesMsg{}
@@ -5624,6 +5601,50 @@ func (m AppModel) buildChatContext() string {
 	return b.String()
 }
 
+func (m AppModel) restartBudgetDeltas() (int, int) {
+	// Config defaults drive the iteration budget bump for failed phases. The
+	// orchestrator's ports.FeatureLifecycle surface does not carry config, so
+	// the TUI reads Defaults and passes them through.
+	maxIterationsDelta := 10
+	maxPlanIterationsDelta := 2
+	if cfg := m.featureManager.Config; cfg != nil {
+		if cfg.Defaults.MaxIterations > 0 {
+			maxIterationsDelta = cfg.Defaults.MaxIterations
+		}
+		if cfg.Defaults.MaxPhasePlanIterations > 0 {
+			maxPlanIterationsDelta = cfg.Defaults.MaxPhasePlanIterations
+		}
+	}
+	return maxIterationsDelta, maxPlanIterationsDelta
+}
+
+func (m AppModel) sendRestartOutcome(featureID string, outcome orchestrator.RestartOutcome) {
+	if m.programRef == nil || m.programRef.P == nil {
+		return
+	}
+
+	switch outcome.Action {
+	case orchestrator.RestartDispatchPhase:
+		m.programRef.P.Send(StartPhaseMsg{FeatureID: featureID, Phase: outcome.Phase})
+	case orchestrator.RestartDispatchRepoCycles:
+		for _, r := range outcome.RepoCycleRestarts {
+			m.programRef.P.Send(restartRepoCycleMsg{
+				FeatureID:   featureID,
+				RepoName:    r.RepoName,
+				CycleType:   r.CycleType,
+				PlanContent: r.PlanContent,
+			})
+		}
+		if outcome.RefactorRestart != nil {
+			m.programRef.P.Send(restartRefactorCycleMsg{
+				FeatureID: featureID,
+				RepoName:  outcome.RefactorRestart.RepoName,
+				Prompt:    outcome.RefactorRestart.Prompt,
+			})
+		}
+	}
+}
+
 // restartPhaseCmd is a thin delegate over orchestrator.RestartPhase. The
 // orchestrator owns the full restart decision tree: session-stop, tweak-cycle
 // reset, failed-phase budget extension, Published + repo-cycles fan-out, and
@@ -5632,19 +5653,7 @@ func (m AppModel) buildChatContext() string {
 // to the program event loop.
 func (m AppModel) restartPhaseCmd(featureID string) tea.Cmd {
 	return func() tea.Msg {
-		// Config defaults drive the iteration budget bump for failed phases.
-		// The orchestrator's ports.FeatureLifecycle surface does not carry
-		// config, so the TUI reads Defaults and passes them through.
-		maxIterationsDelta := 10
-		maxPlanIterationsDelta := 2
-		if cfg := m.featureManager.Config; cfg != nil {
-			if cfg.Defaults.MaxIterations > 0 {
-				maxIterationsDelta = cfg.Defaults.MaxIterations
-			}
-			if cfg.Defaults.MaxPhasePlanIterations > 0 {
-				maxPlanIterationsDelta = cfg.Defaults.MaxPhasePlanIterations
-			}
-		}
+		maxIterationsDelta, maxPlanIterationsDelta := m.restartBudgetDeltas()
 
 		outcome, err := m.orchestrator.RestartPhase(featureID, maxIterationsDelta, maxPlanIterationsDelta)
 		if err != nil {
@@ -5655,29 +5664,7 @@ func (m AppModel) restartPhaseCmd(featureID string) tea.Cmd {
 		}
 
 		// Dispatch the follow-up work the orchestrator asked for.
-		if m.programRef != nil && m.programRef.P != nil {
-			switch outcome.Action {
-			case orchestrator.RestartDispatchPhase:
-				m.programRef.P.Send(StartPhaseMsg{FeatureID: featureID, Phase: outcome.Phase})
-			case orchestrator.RestartDispatchRepoCycles:
-				for _, r := range outcome.RepoCycleRestarts {
-					m.programRef.P.Send(restartRepoCycleMsg{
-						FeatureID:   featureID,
-						RepoName:    r.RepoName,
-						CycleType:   r.CycleType,
-						PlanContent: r.PlanContent,
-					})
-				}
-				if outcome.RefactorRestart != nil {
-					m.programRef.P.Send(restartRefactorCycleMsg{
-						FeatureID: featureID,
-						RepoName:  outcome.RefactorRestart.RepoName,
-						Prompt:    outcome.RefactorRestart.Prompt,
-					})
-				}
-			}
-		}
-
+		m.sendRestartOutcome(featureID, outcome)
 		return RefreshFeaturesMsg{}
 	}
 }

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -1285,6 +1285,43 @@ func TestRestartFromFailedPlanPhase(t *testing.T) {
 	}
 }
 
+func TestResumeAllRestartsFailedFinalReviewProtocolViolation(t *testing.T) {
+	app, fm := newTestAppModel(t)
+
+	f, err := fm.Create("Failed Final Review", "desc", []string{"test-repo"}, fm.Config.Defaults.Models, "", "", nil)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if err := fm.Store.Modify(f.ID, func(ff *feature.Feature) error {
+		ff.Status = feature.StatusFailed
+		ff.CurrentPhase = feature.PhaseFinalReview
+		ff.LastError = "protocol violation"
+		ff.FailureType = feature.FailureProtocolViolation
+		return nil
+	}); err != nil {
+		t.Fatalf("modify feature: %v", err)
+	}
+
+	msg := app.resumeAllCmd()()
+	if _, ok := msg.(RefreshFeaturesMsg); !ok {
+		t.Fatalf("expected RefreshFeaturesMsg, got %T", msg)
+	}
+
+	f, err = fm.Get(f.ID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if f.Status != feature.StatusReviewPassed {
+		t.Errorf("feature status = %v, want StatusReviewPassed after resume-all final review restart", f.Status)
+	}
+	if f.CurrentPhase != feature.PhaseFinalReview {
+		t.Errorf("current phase = %v, want PhaseFinalReview", f.CurrentPhase)
+	}
+	if f.LastError != "" || f.FailureType != "" {
+		t.Errorf("failure context = (%q, %q), want cleared", f.LastError, f.FailureType)
+	}
+}
+
 func TestRestartFromFailedClearsFailureContext(t *testing.T) {
 	app, fm := newTestAppModel(t)
 

--- a/internal/tui/detail.go
+++ b/internal/tui/detail.go
@@ -131,6 +131,29 @@ func featureHasFailedRepos(f *feature.Feature) bool {
 	return false
 }
 
+func featureHasDisplayFailure(f *feature.Feature) bool {
+	return f != nil && f.HasTerminalFailure()
+}
+
+func effectiveCurrentPhaseForDisplay(f *feature.Feature) feature.Phase {
+	if f == nil {
+		return 0
+	}
+	if featureHasDisplayFailure(f) && f.CurrentPhase == feature.PhasePublish && looksLikeFinalReviewFailureForDisplay(f.LastError) {
+		return feature.PhaseFinalReview
+	}
+	return f.CurrentPhase
+}
+
+func looksLikeFinalReviewFailureForDisplay(msg string) bool {
+	msg = strings.ToLower(msg)
+	return strings.Contains(msg, "final_review") || strings.Contains(msg, "final review")
+}
+
+func phaseMatchesCurrentForDisplay(row, current feature.Phase) bool {
+	return row == current || (row == feature.PhaseReview && current == feature.PhaseFinalReview)
+}
+
 func (m DetailModel) View() string {
 	if m.feature == nil {
 		return "No feature selected\n"
@@ -197,8 +220,8 @@ func (m DetailModel) View() string {
 	phaseBox = renderBorderTitle(phaseBox, "Phase Progress", MutedStyle)
 	b.WriteString(" " + phaseBox + "\n")
 
-	// Failure info box (only for failed features)
-	if f.Status == feature.StatusFailed && (f.LastError != "" || f.FailureType != "") {
+	// Failure info box.
+	if featureHasDisplayFailure(f) {
 		failureContent := m.renderFailureInfo(f)
 		failureBox := panelStyle(false).
 			BorderForeground(colorError).
@@ -255,7 +278,7 @@ func (m DetailModel) View() string {
 		actionParts = append(actionParts, "[r] Restart")
 	}
 	actionParts = append(actionParts, "[ctrl+r] Rewind")
-	if f.Status == feature.StatusFailed || f.Status == feature.StatusInterrupted {
+	if f.Status == feature.StatusFailed || f.Status == feature.StatusInterrupted || featureHasDisplayFailure(f) {
 		actionParts = append(actionParts, "[l] Logs")
 	}
 	if f.Status == feature.StatusCodeReady && len(f.Repos) > 0 && f.Repos[0].WorktreePath != "" {
@@ -546,22 +569,30 @@ func (m DetailModel) renderPhaseProgressFull(f *feature.Feature) string {
 		}
 	}
 
+	currentPhase := effectiveCurrentPhaseForDisplay(f)
 	for i, p := range phases {
-		done := p.phase.LogicalOrder() < f.CurrentPhase.LogicalOrder()
+		done := p.phase.LogicalOrder() < currentPhase.LogicalOrder()
 		// PhaseReview and PhaseFinalReview share logical order 6 — the row is
 		// labelled "Final Review" with phase enum PhaseReview, but f.CurrentPhase
 		// becomes PhaseFinalReview when the deferred end-of-feature FR pass is
 		// active. Treat them as equivalent here so the row highlights correctly.
-		current := p.phase == f.CurrentPhase ||
-			(p.phase == feature.PhaseReview && f.CurrentPhase == feature.PhaseFinalReview)
+		current := phaseMatchesCurrentForDisplay(p.phase, currentPhase)
+		failed := current && featureHasDisplayFailure(f)
+		if failed {
+			done = false
+		}
 
 		icon := phaseIcon(done, current)
 		if current && isRunningStatus(f.Status) {
 			icon = m.activeProgressIcon()
+		} else if failed {
+			icon = ErrorStyle.Render("✗")
 		}
 
 		status := MutedStyle.Render("pending")
-		if done {
+		if failed {
+			status = ErrorStyle.Render("failed")
+		} else if done {
 			status = SuccessStyle.Render("complete")
 		} else if current {
 			status = formatPhaseStatus(f)
@@ -728,8 +759,8 @@ func (m DetailModel) ViewCompact(width int) string {
 	b.WriteString(phaseBox)
 	b.WriteString("\n")
 
-	// Failure info box (only for failed features)
-	if f.Status == feature.StatusFailed && (f.LastError != "" || f.FailureType != "") {
+	// Failure info box.
+	if featureHasDisplayFailure(f) {
 		failureContent := m.renderFailureInfo(f)
 		failureBox := panelStyle(false).
 			BorderForeground(colorError).
@@ -849,22 +880,30 @@ func (m DetailModel) renderPhaseProgress(f *feature.Feature) string {
 		}
 	}
 
+	currentPhase := effectiveCurrentPhaseForDisplay(f)
 	for i, p := range phases {
-		done := p.phase.LogicalOrder() < f.CurrentPhase.LogicalOrder()
+		done := p.phase.LogicalOrder() < currentPhase.LogicalOrder()
 		// PhaseReview and PhaseFinalReview share logical order 6 — the row is
 		// labelled "Final Review" with phase enum PhaseReview, but f.CurrentPhase
 		// becomes PhaseFinalReview when the deferred end-of-feature FR pass is
 		// active. Treat them as equivalent here so the row highlights correctly.
-		current := p.phase == f.CurrentPhase ||
-			(p.phase == feature.PhaseReview && f.CurrentPhase == feature.PhaseFinalReview)
+		current := phaseMatchesCurrentForDisplay(p.phase, currentPhase)
+		failed := current && featureHasDisplayFailure(f)
+		if failed {
+			done = false
+		}
 
 		icon := phaseIcon(done, current)
 		if current && isRunningStatus(f.Status) {
 			icon = m.activeProgressIcon()
+		} else if failed {
+			icon = ErrorStyle.Render("✗")
 		}
 
 		status := MutedStyle.Render("pending")
-		if done {
+		if failed {
+			status = ErrorStyle.Render("failed")
+		} else if done {
 			status = SuccessStyle.Render("complete")
 		} else if current {
 			status = formatPhaseStatus(f)
@@ -1222,6 +1261,13 @@ func finalReviewStatusText(f *feature.Feature) string {
 }
 
 func formatDetailStatus(f *feature.Feature) string {
+	if featureHasDisplayFailure(f) && f.Status != feature.StatusFailed && !isRunningStatus(f.Status) {
+		msg := "Failed"
+		if f.FailureType != "" {
+			msg = "Failed (" + formatFailureType(f.FailureType) + ")"
+		}
+		return ErrorStyle.Render(msg + " — press [r] to restart, [l] logs")
+	}
 	switch f.Status {
 	case feature.StatusImplementing:
 		var label string

--- a/internal/tui/detail_test.go
+++ b/internal/tui/detail_test.go
@@ -806,6 +806,46 @@ func TestDetailViewFinalReviewShowsSubphaseAndIteration(t *testing.T) {
 	}
 }
 
+func TestDetailViewTerminalFinalReviewFailureOverridesCodeReadyProjection(t *testing.T) {
+	t.Parallel()
+	f := &feature.Feature{
+		ID:           "feat-fr-corrupt",
+		Slug:         "fr-corrupt",
+		Status:       feature.StatusCodeReady,
+		CurrentPhase: feature.PhasePublish,
+		FailureType:  feature.FailureProtocolViolation,
+		LastError:    "protocol violation: final_review_reviewer @ /tmp/iter: invalid report",
+		Models:       config.ModelConfig{Research: "opus", Planning: "opus", Implementation: "opus", Review: "opus"},
+	}
+	m := NewDetailModel(f, "")
+	m.width = 100
+	m.height = 40
+
+	view := stripANSI(m.View())
+	if !strings.Contains(view, "Failed (protocol violation) — press [r] to restart") {
+		t.Fatalf("View() = %q, want failed restart status", view)
+	}
+	frLine := ""
+	for _, line := range strings.Split(view, "\n") {
+		if strings.Contains(line, "Final Review") && !strings.Contains(line, "Status") {
+			frLine = line
+			break
+		}
+	}
+	if frLine == "" {
+		t.Fatalf("could not locate Final Review line in view:\n%s", view)
+	}
+	if !strings.Contains(frLine, "failed") {
+		t.Fatalf("Final Review line = %q, want failed", frLine)
+	}
+	if strings.Contains(frLine, "complete") {
+		t.Fatalf("Final Review line = %q, must not render complete", frLine)
+	}
+	if !strings.Contains(view, "[r] Restart") || !strings.Contains(view, "[l] Logs") {
+		t.Fatalf("View() = %q, want restart and logs actions", view)
+	}
+}
+
 func TestDetailViewContextPercentage(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/skills/final-fix/SKILL.md
+++ b/skills/final-fix/SKILL.md
@@ -21,6 +21,21 @@ You are the fix agent for one final-review iteration. Your job is to address the
 5. Update `verification-report.yaml` with structured pass/fail/blocked evidence for the checks you ran and for any contract rows the reviewer explicitly called out.
 6. Create the `phase_complete` marker named by the system prompt as the last action.
 
+## Verification Report Contract
+
+When `verification-report.yaml` has a non-empty `contract_path`, read the bound testing contract before updating the report. The report's `results:` rows are contract-backed: each `item_id` must already exist in that testing contract.
+
+- Do not rename item IDs or add rows under `results:`.
+- Put extra checks you run during the fix under `additional_checks:`, not `results:`.
+- Preserve every pre-seeded contract row, updating only its status and evidence.
+- Use YAML block scalars for evidence text that includes command output, file locations, colons, or multiple sentences:
+
+```yaml
+evidence:
+  summary: |-
+    git diff --check main failed with path/to/file.go:11: trailing whitespace.
+```
+
 ## Boundaries
 
 - Address only the requested final-review changes and directly necessary mechanical follow-ons.

--- a/skills/final-review/SKILL.md
+++ b/skills/final-review/SKILL.md
@@ -35,6 +35,22 @@ You are read-only on repository worktrees. The only writes allowed for this role
 
 Final Review runs **review first, then fix** in the same iterDir (inverted vs phase implement, where the implementer runs first). So the current iteration's fix artifacts are empty when you run; look one iteration back (`iteration-(N-1)/`) for prior fix output. N=1 has no prior — absent artifacts are expected.
 
+## Verification Report Contract
+
+The iteration-local `verification-report.yaml` is pre-seeded from the final-review testing contract. When its `contract_path` field is non-empty, read that testing contract before updating the report. The report's `results:` rows are contract-backed: each `item_id` must already exist in the bound testing contract.
+
+- Do not rename item IDs or add rows under `results:`.
+- Do not add visual or behavioral rows to the final-review PlanLess testing contract.
+- Put reviewer-authored spot checks and extra verification under `additional_checks:`, not `results:`.
+- Preserve every pre-seeded contract row, updating only its status and evidence.
+- Use YAML block scalars for evidence text that includes command output, file locations, colons, or multiple sentences:
+
+```yaml
+evidence:
+  summary: |-
+    git diff --check main failed with path/to/file.go:11: trailing whitespace.
+```
+
 ## Scope Guidance
 
 - One verdict gates the whole feature — APPROVED ships every repo together (atomic transition to `RepoImplReviewPassed`), CHANGES_REQUESTED keeps every repo at `RepoImplAwaitingFinalReview` for the fix iteration.


### PR DESCRIPTION
## Summary

Features can end up with terminal failure context (`FailureType` / `LastError`) attached to their active run while `Status` drifts to a success terminal state (`CodeReady` / `Published` / `Done`). The TUI then renders them as healthy and orchestrator paths happily advance past Final Review even though FR failed. This PR makes the failure state authoritative across the orchestrator, the TUI, and the FR contract surface.

- **`feature.Feature`**: add `HasTerminalFailure()` and an idempotent `reconcileTerminalRunFailure` that flips drifted success statuses back to `Failed` on `SetRun` / `Store.loadUnlocked`. `MarkCodeReady` refuses to advance a feature with terminal failure.
- **Orchestrator FR path**: new `markFinalReviewFailedWithEvent` propagates the original error instead of swallowing it; `advanceAfterFinalReview` bails when terminal failure is present; `surfaceDispatchCompletionError` skips re-marking features already in terminal failure.
- **Stale per-repo errors**: `AtomicPhaseStamp` clears `RepoState.LastError` on `PhaseOutcomeFinalReviewPassed`, and `resetFailedFinalReviewForRestart` clears it on restart, so prior-attempt repo errors stop bleeding into the next run.
- **TUI**: "Resume All" now delegates to `Orchestrator.RestartPhase` with config-driven `MaxIterations` / `MaxPhasePlanIterations` deltas instead of inline status massaging. Detail view renders the failure box, `✗` icon, "failed" phase status, and `[l] Logs` hint whenever `HasTerminalFailure()` is true, and routes the failed row to Final Review when the error message names it.
- **Skills**: `final-fix` and `final-review` now document the verification-report contract — `results:` rows are contract-backed (no renames / no additions), extras go under `additional_checks:`, and evidence uses YAML block scalars when it contains command output, paths, or multiple sentences.

## Test plan

- [ ] `go test ./internal/feature/... ./internal/orchestrator/... ./internal/tui/... ./internal/agent/...`
- [ ] Drive a feature to a Final Review failure and confirm Detail view shows the failure box, `✗` row, "failed" phase status, and `[l] Logs` action — even if `Status` is stuck at `CodeReady` / `Published`.
- [ ] Press `[r]` on a failed feature and confirm stale per-repo `LastError` entries clear, and the iteration / plan-iteration budgets bump by the configured defaults.
- [ ] Restart a feature that had an FR pass after a prior failed FR attempt — confirm no lingering repo-level errors render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)