### PR TITLE
Verify provider authentication at startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ On first launch, Agentic Orchestrator walks you through a welcome flow to select
 | **`gh` CLI** | Push-time PR creation and cross-repo PR body updates during Publish | [GitHub CLI docs](https://docs.github.com/en/github-cli/github-cli), then `gh auth login` |
 | **Node.js 18+ and npm** | Only needed when installing Claude Code or Codex through npm | [nodejs.org](https://nodejs.org/) |
 
-After installing provider CLIs, run `claude --version`, `codex --version`, and `gh auth status` before launching `agentico`.
+After installing provider CLIs, run `claude auth status`, `codex login status`, and `gh auth status` before launching `agentico`.
 
 ## How It Works
 

--- a/cmd/agentico/main.go
+++ b/cmd/agentico/main.go
@@ -193,23 +193,148 @@ When no explicit paths are passed, an existing ~/.agentic-workflow/
 runtime parent is used in place so legacy installs remain discoverable.`)
 }
 
-// checkRequiredProviders uses the registry to verify provider CLIs are available.
-// Returns (detected providers, warnings, error): errors when none are available.
-func checkRequiredProviders(registry *llm.Registry) ([]llm.LLMProvider, []string, error) {
-	detected := registry.DetectedProviders()
+const providerReadinessTimeout = 5 * time.Second
+const providerReadinessNoticeDelay = 3 * time.Second
+
+type providerReadinessIssue struct {
+	provider llm.LLMProvider
+	status   llm.ProviderReadiness
+}
+
+// checkRequiredProviders uses the registry to verify provider CLIs are
+// available and ready. Returns (ready providers, warnings, startup notices,
+// availabilityFiltered, error): errors when no provider is ready.
+func checkRequiredProviders(ctx context.Context, registry *llm.Registry) ([]llm.LLMProvider, []string, []string, bool, error) {
 	all := registry.All()
-	if len(detected) == 0 {
-		return nil, nil, fmt.Errorf("%s", agent.FormatNoCLIMessage(all))
-	}
 	var warnings []string
-	if len(detected) < len(all) {
-		for _, p := range all {
-			if !p.DetectCLI() {
-				warnings = append(warnings, fmt.Sprintf("Warning: %s CLI not found. Install with: %s", p.Name(), p.InstallHint()))
-			}
+	var missing []llm.LLMProvider
+	var detected []llm.LLMProvider
+	for _, p := range all {
+		if p.DetectCLI() {
+			detected = append(detected, p)
+			continue
+		}
+		missing = append(missing, p)
+	}
+	if len(detected) == 0 {
+		return nil, nil, nil, true, fmt.Errorf("%s", agent.FormatNoCLIMessage(all))
+	}
+
+	var ready []llm.LLMProvider
+	var unready []providerReadinessIssue
+	for _, p := range detected {
+		status := checkProviderReadiness(ctx, p)
+		if status.Ready {
+			ready = append(ready, p)
+			continue
+		}
+		unready = append(unready, providerReadinessIssue{provider: p, status: status})
+	}
+	if len(ready) == 0 {
+		return nil, nil, nil, true, fmt.Errorf("%s", formatNoReadyProviderMessage(all, unready))
+	}
+	startupNotices := formatProviderStartupNotices(ready, missing, unready)
+	registry.RestrictToProviders(ready)
+	return ready, warnings, startupNotices, len(ready) < len(all), nil
+}
+
+func checkProviderReadiness(ctx context.Context, p llm.LLMProvider) llm.ProviderReadiness {
+	checker, ok := p.(llm.ReadinessChecker)
+	if !ok {
+		return llm.ProviderReadiness{Ready: true}
+	}
+	checkCtx, cancel := context.WithTimeout(ctx, providerReadinessTimeout)
+	defer cancel()
+	status := checker.CheckReadiness(checkCtx)
+	if status.Detail == "" && !status.Ready {
+		status.Detail = "not ready"
+	}
+	return status
+}
+
+func formatReadinessProblem(status llm.ProviderReadiness) string {
+	detail := strings.TrimSpace(status.Detail)
+	if detail == "" {
+		detail = "not ready"
+	}
+	remedy := strings.TrimSpace(status.Remedy)
+	if remedy == "" {
+		return detail
+	}
+	return detail + ". " + remedy + "."
+}
+
+func formatProviderStartupNotices(ready []llm.LLMProvider, missing []llm.LLMProvider, unready []providerReadinessIssue) []string {
+	if len(ready) == 0 || (len(missing) == 0 && len(unready) == 0) {
+		return nil
+	}
+	readyText := formatProviderNameList(ready)
+	var notices []string
+	for _, p := range missing {
+		notices = append(notices, fmt.Sprintf(
+			"Provider %s CLI was not found. Install with: %s. Starting with %s only.",
+			p.Name(),
+			p.InstallHint(),
+			readyText,
+		))
+	}
+	for _, issue := range unready {
+		notices = append(notices, fmt.Sprintf(
+			"Provider %s is not configured: %s Starting with %s only.",
+			issue.provider.Name(),
+			formatReadinessProblem(issue.status),
+			readyText,
+		))
+	}
+	return notices
+}
+
+func formatProviderNameList(providers []llm.LLMProvider) string {
+	names := make([]string, 0, len(providers))
+	for _, p := range providers {
+		names = append(names, p.Name())
+	}
+	return strings.Join(names, ", ")
+}
+
+func showProviderStartupNotices(w io.Writer, notices []string, delay time.Duration) {
+	if len(notices) == 0 {
+		return
+	}
+	for _, notice := range notices {
+		fmt.Fprintln(w, notice)
+	}
+	if delay > 0 {
+		time.Sleep(delay)
+	}
+}
+
+func formatNoReadyProviderMessage(all []llm.LLMProvider, issues []providerReadinessIssue) string {
+	var b strings.Builder
+	b.WriteString("No ready AI coding assistant providers detected.\n\n")
+	b.WriteString("Agentic Orchestrator requires at least one provider CLI to be installed and authenticated.\n\n")
+	if len(issues) > 0 {
+		b.WriteString("Installed provider CLIs that need setup:\n\n")
+		for _, issue := range issues {
+			fmt.Fprintf(&b, "  %-8s %s\n", issue.provider.Name(), formatReadinessProblem(issue.status))
+		}
+		b.WriteString("\n")
+	}
+	var missing []llm.LLMProvider
+	for _, p := range all {
+		if !p.DetectCLI() {
+			missing = append(missing, p)
 		}
 	}
-	return detected, warnings, nil
+	if len(missing) > 0 {
+		b.WriteString("Missing provider CLIs:\n\n")
+		for _, p := range missing {
+			fmt.Fprintf(&b, "  %-8s %s\n", p.Name(), p.InstallHint())
+		}
+		b.WriteString("\n")
+	}
+	b.WriteString("Fix one provider and run 'agentico' again.")
+	return b.String()
 }
 
 func runTUI(configPath, stateDir string, dangerouslySkipPerms bool, enabledProviders []string) {
@@ -290,7 +415,7 @@ func runTUI(configPath, stateDir string, dangerouslySkipPerms bool, enabledProvi
 	}
 
 	// Check provider CLIs after fx initialization (registry is now populated)
-	detected, warnings, err := checkRequiredProviders(registry)
+	detected, warnings, startupNotices, availabilityFiltered, err := checkRequiredProviders(context.Background(), registry)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
@@ -364,9 +489,16 @@ func runTUI(configPath, stateDir string, dangerouslySkipPerms bool, enabledProvi
 	// don't persist provider-filtered defaults to the config file.
 	if enabledProviders != nil {
 		remapUnresolvableModels(cfg, registry)
+	} else if availabilityFiltered {
+		remapUnresolvableModels(cfg, registry)
+		if configIsNew && changed {
+			_ = config.Save(configPath, cfg)
+		}
 	} else if changed {
 		_ = config.Save(configPath, cfg)
 	}
+
+	showProviderStartupNotices(os.Stderr, startupNotices, providerReadinessNoticeDelay)
 
 	// Redirect stderr and Go's default logger to a file before the TUI takes
 	// over the terminal. Any write to stderr (from OTEL, gRPC, net/http, etc.)

--- a/cmd/agentico/main_test.go
+++ b/cmd/agentico/main_test.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -31,10 +32,12 @@ import (
 
 // stubProvider is a minimal LLMProvider for testing checkRequiredProviders.
 type stubProvider struct {
-	name        string
-	models      []string
-	hasCLI      bool
-	installHint string
+	name         string
+	models       []string
+	hasCLI       bool
+	installHint  string
+	readiness    llm.ProviderReadiness
+	hasReadiness bool
 }
 
 func (s *stubProvider) Name() string { return s.name }
@@ -51,6 +54,12 @@ func (s *stubProvider) InstallHint() string                         { return s.i
 func (s *stubProvider) VersionInfo() (string, error)                { return "1.0.0", nil }
 func (s *stubProvider) MinVersion() [3]int                          { return [3]int{0, 0, 0} }
 func (s *stubProvider) EnvVarsToExclude() []string                  { return nil }
+func (s *stubProvider) CheckReadiness(context.Context) llm.ProviderReadiness {
+	if s.hasReadiness {
+		return s.readiness
+	}
+	return llm.ProviderReadiness{Ready: true}
+}
 
 func TestRunArgsLaunchesTUIByDefault(t *testing.T) {
 	var stdout, stderr bytes.Buffer
@@ -221,9 +230,15 @@ func TestCheckRequiredProviders_AllDetected(t *testing.T) {
 	r.Register(&stubProvider{name: "claude", models: []string{"opus"}, hasCLI: true, installHint: "install claude"})
 	r.Register(&stubProvider{name: "codex", models: []string{"gpt-5.4"}, hasCLI: true, installHint: "install codex"})
 
-	detected, warnings, err := checkRequiredProviders(r)
+	detected, warnings, notices, filtered, err := checkRequiredProviders(context.Background(), r)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(notices) != 0 {
+		t.Fatalf("expected no startup notices, got %v", notices)
+	}
+	if filtered {
+		t.Fatal("filtered = true, want false")
 	}
 	if len(warnings) != 0 {
 		t.Errorf("expected no warnings, got %v", warnings)
@@ -238,12 +253,21 @@ func TestCheckRequiredProviders_OneDetected(t *testing.T) {
 	r.Register(&stubProvider{name: "claude", models: []string{"opus"}, hasCLI: true, installHint: "install claude"})
 	r.Register(&stubProvider{name: "codex", models: []string{"gpt-5.4"}, hasCLI: false, installHint: "install codex"})
 
-	detected, warnings, err := checkRequiredProviders(r)
+	detected, warnings, notices, filtered, err := checkRequiredProviders(context.Background(), r)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(warnings) != 1 {
-		t.Fatalf("expected 1 warning, got %d: %v", len(warnings), warnings)
+	if !filtered {
+		t.Fatal("filtered = false, want true when a registered provider is unavailable")
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("expected no immediate warnings, got %d: %v", len(warnings), warnings)
+	}
+	if len(notices) != 1 {
+		t.Fatalf("expected 1 startup notice, got %d: %v", len(notices), notices)
+	}
+	if !strings.Contains(notices[0], "Provider codex CLI was not found") || !strings.Contains(notices[0], "Starting with claude only") {
+		t.Fatalf("startup notice = %q, want missing codex/start claude", notices[0])
 	}
 	if len(detected) != 1 {
 		t.Errorf("expected 1 detected provider, got %d", len(detected))
@@ -336,9 +360,89 @@ func TestCheckRequiredProviders_NoneDetected(t *testing.T) {
 	r.Register(&stubProvider{name: "claude", models: []string{"opus"}, hasCLI: false, installHint: "install claude"})
 	r.Register(&stubProvider{name: "codex", models: []string{"gpt-5.4"}, hasCLI: false, installHint: "install codex"})
 
-	_, _, err := checkRequiredProviders(r)
+	_, _, _, _, err := checkRequiredProviders(context.Background(), r)
 	if err == nil {
 		t.Fatal("expected error when no providers detected")
+	}
+}
+
+func TestCheckRequiredProviders_UnreadyProviderWarnsAndFiltersRegistry(t *testing.T) {
+	r := llm.NewRegistry()
+	r.Register(&stubProvider{name: "claude", models: []string{"opus"}, hasCLI: true, installHint: "install claude", hasReadiness: true, readiness: llm.ProviderReadiness{Ready: true}})
+	r.Register(&stubProvider{name: "codex", models: []string{"gpt-5.4"}, hasCLI: true, installHint: "install codex", readiness: llm.ProviderReadiness{
+		Ready:  false,
+		Detail: "not logged in",
+		Remedy: "run 'codex login'",
+	}, hasReadiness: true})
+
+	detected, warnings, notices, filtered, err := checkRequiredProviders(context.Background(), r)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !filtered {
+		t.Fatal("filtered = false, want true")
+	}
+	if len(detected) != 1 || detected[0].Name() != "claude" {
+		t.Fatalf("detected = %v, want only claude", providerNames(detected))
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("warnings = %v, want no immediate warnings", warnings)
+	}
+	if len(notices) != 1 || !strings.Contains(notices[0], "Provider codex is not configured") || !strings.Contains(notices[0], "codex login") || !strings.Contains(notices[0], "Starting with claude only") {
+		t.Fatalf("notices = %v, want codex startup notice", notices)
+	}
+	if _, _, err := r.ResolveModel("codex:gpt-5.4"); err == nil {
+		t.Fatal("ResolveModel(codex:gpt-5.4) succeeded after codex was filtered")
+	}
+	if got := r.AvailableModels(); !slices.Equal(got, []string{"opus"}) {
+		t.Fatalf("AvailableModels() = %v, want [opus]", got)
+	}
+}
+
+func TestCheckRequiredProviders_NoneReadyReportsProviderSpecificFix(t *testing.T) {
+	r := llm.NewRegistry()
+	r.Register(&stubProvider{name: "claude", models: []string{"opus"}, hasCLI: true, installHint: "install claude", readiness: llm.ProviderReadiness{
+		Ready:  false,
+		Detail: "not authenticated",
+		Remedy: "run 'claude auth login'",
+	}, hasReadiness: true})
+	r.Register(&stubProvider{name: "codex", models: []string{"gpt-5.4"}, hasCLI: false, installHint: "install codex"})
+
+	_, _, _, filtered, err := checkRequiredProviders(context.Background(), r)
+	if err == nil {
+		t.Fatal("expected error when no providers are ready")
+	}
+	if !filtered {
+		t.Fatal("filtered = false, want true")
+	}
+	msg := err.Error()
+	for _, want := range []string{
+		"No ready AI coding assistant providers detected",
+		"claude",
+		"not authenticated",
+		"claude auth login",
+		"Missing provider CLIs",
+		"codex",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("error missing %q:\n%s", want, msg)
+		}
+	}
+}
+
+func providerNames(providers []llm.LLMProvider) []string {
+	names := make([]string, 0, len(providers))
+	for _, p := range providers {
+		names = append(names, p.Name())
+	}
+	return names
+}
+
+func TestShowProviderStartupNoticesWritesBeforeTUIWithoutForcedDelayInTests(t *testing.T) {
+	var out bytes.Buffer
+	showProviderStartupNotices(&out, []string{"Provider codex is not configured: not logged in. Starting with claude only."}, 0)
+	if got := out.String(); got != "Provider codex is not configured: not logged in. Starting with claude only.\n" {
+		t.Fatalf("startup notice output = %q", got)
 	}
 }
 

--- a/internal/llm/claude/provider.go
+++ b/internal/llm/claude/provider.go
@@ -16,6 +16,7 @@ package claude
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os/exec"
 	"strings"
@@ -156,6 +157,63 @@ func (p *Provider) VersionInfo() (string, error) {
 func (p *Provider) MinVersion() [3]int { return [3]int{2, 1, 81} }
 
 func (p *Provider) EnvVarsToExclude() []string { return []string{"CLAUDECODE"} }
+
+type authStatus struct {
+	LoggedIn     bool   `json:"loggedIn"`
+	AuthMethod   string `json:"authMethod"`
+	APIProvider  string `json:"apiProvider"`
+	Email        string `json:"email"`
+	APIKeySource string `json:"apiKeySource"`
+}
+
+func (p *Provider) CheckReadiness(ctx context.Context) llm.ProviderReadiness {
+	runner := p.runner
+	if runner == nil {
+		runner = clirun.DefaultRunner()
+	}
+	out, err := runner(ctx, "claude", []string{"auth", "status", "--json"}, nil)
+
+	var status authStatus
+	if parseErr := json.Unmarshal(out, &status); parseErr == nil {
+		if status.LoggedIn {
+			return llm.ProviderReadiness{
+				Ready:  true,
+				Detail: formatReadyAuthDetail(status),
+			}
+		}
+		return llm.ProviderReadiness{
+			Ready:  false,
+			Detail: "not authenticated",
+			Remedy: "Run 'claude auth login' or set ANTHROPIC_API_KEY",
+		}
+	}
+
+	if err != nil {
+		return llm.ProviderReadiness{
+			Ready:  false,
+			Detail: fmt.Sprintf("could not check authentication: %v", err),
+			Remedy: "Run 'claude auth status' to inspect Claude Code authentication",
+		}
+	}
+	return llm.ProviderReadiness{
+		Ready:  false,
+		Detail: fmt.Sprintf("could not parse 'claude auth status --json' output: %q", strings.TrimSpace(string(out))),
+		Remedy: "Run 'claude auth login'",
+	}
+}
+
+func formatReadyAuthDetail(status authStatus) string {
+	switch {
+	case status.AuthMethod == "api_key" && status.APIKeySource != "":
+		return "authenticated with API key from " + status.APIKeySource
+	case status.Email != "":
+		return "authenticated as " + status.Email
+	case status.AuthMethod != "":
+		return "authenticated with " + status.AuthMethod
+	default:
+		return "authenticated"
+	}
+}
 
 // PhaseDefaults returns Claude's recommended models per phase.
 // SetModelCatalog sets the discovered model catalog.

--- a/internal/llm/claude/provider_test.go
+++ b/internal/llm/claude/provider_test.go
@@ -15,7 +15,10 @@
 package claude
 
 import (
+	"context"
+	"errors"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/doordash-oss/agentic-orchestrator/internal/llm"
@@ -26,6 +29,68 @@ func TestClaudeProvider_EnvVarsToExclude(t *testing.T) {
 	got := p.EnvVarsToExclude()
 	if len(got) != 1 || got[0] != "CLAUDECODE" {
 		t.Errorf("EnvVarsToExclude() = %v, want [CLAUDECODE]", got)
+	}
+}
+
+func TestClaudeProvider_CheckReadinessAuthenticated(t *testing.T) {
+	p := &Provider{
+		runner: func(ctx context.Context, name string, args []string, env []string) ([]byte, error) {
+			assertCommand(t, name, args, "claude", []string{"auth", "status", "--json"})
+			return []byte(`{"loggedIn":true,"authMethod":"claude.ai","email":"user@example.com"}`), nil
+		},
+	}
+
+	status := p.CheckReadiness(context.Background())
+	if !status.Ready {
+		t.Fatalf("CheckReadiness().Ready = false, detail=%q remedy=%q", status.Detail, status.Remedy)
+	}
+	if !strings.Contains(status.Detail, "user@example.com") {
+		t.Fatalf("CheckReadiness().Detail = %q, want authenticated email", status.Detail)
+	}
+}
+
+func TestClaudeProvider_CheckReadinessNotAuthenticated(t *testing.T) {
+	p := &Provider{
+		runner: func(ctx context.Context, name string, args []string, env []string) ([]byte, error) {
+			return []byte(`{"loggedIn":false,"authMethod":"none","apiProvider":"firstParty"}`), errors.New("exit status 1")
+		},
+	}
+
+	status := p.CheckReadiness(context.Background())
+	if status.Ready {
+		t.Fatal("CheckReadiness().Ready = true, want false")
+	}
+	if !strings.Contains(status.Detail, "not authenticated") {
+		t.Fatalf("CheckReadiness().Detail = %q, want not authenticated", status.Detail)
+	}
+	if !strings.Contains(status.Remedy, "claude auth login") {
+		t.Fatalf("CheckReadiness().Remedy = %q, want claude auth login", status.Remedy)
+	}
+}
+
+func TestClaudeProvider_CheckReadinessAPIKey(t *testing.T) {
+	p := &Provider{
+		runner: func(ctx context.Context, name string, args []string, env []string) ([]byte, error) {
+			return []byte(`{"loggedIn":true,"authMethod":"api_key","apiKeySource":"ANTHROPIC_API_KEY"}`), nil
+		},
+	}
+
+	status := p.CheckReadiness(context.Background())
+	if !status.Ready {
+		t.Fatalf("CheckReadiness().Ready = false, detail=%q remedy=%q", status.Detail, status.Remedy)
+	}
+	if !strings.Contains(status.Detail, "ANTHROPIC_API_KEY") {
+		t.Fatalf("CheckReadiness().Detail = %q, want API key source", status.Detail)
+	}
+}
+
+func assertCommand(t *testing.T, gotName string, gotArgs []string, wantName string, wantArgs []string) {
+	t.Helper()
+	if gotName != wantName {
+		t.Fatalf("command name = %q, want %q", gotName, wantName)
+	}
+	if !slices.Equal(gotArgs, wantArgs) {
+		t.Fatalf("command args = %v, want %v", gotArgs, wantArgs)
 	}
 }
 

--- a/internal/llm/clirun/clirun.go
+++ b/internal/llm/clirun/clirun.go
@@ -42,6 +42,19 @@ func DefaultRunner() CommandRunner {
 	}
 }
 
+// CombinedRunner returns a CommandRunner that captures stdout and stderr
+// together. Use it for CLIs that report human-readable status (e.g. login
+// state) on stderr rather than stdout, where DefaultRunner would drop it.
+func CombinedRunner() CommandRunner {
+	return func(ctx context.Context, name string, args []string, env []string) ([]byte, error) {
+		cmd := exec.CommandContext(ctx, name, args...)
+		if len(env) > 0 {
+			cmd.Env = append(os.Environ(), env...)
+		}
+		return cmd.CombinedOutput()
+	}
+}
+
 var versionRe = regexp.MustCompile(`(\d+)\.(\d+)\.(\d+)`)
 
 // ParseVersionOutput extracts a semver string from CLI version output.

--- a/internal/llm/codex/provider.go
+++ b/internal/llm/codex/provider.go
@@ -202,6 +202,60 @@ func (p *Provider) MinVersion() [3]int { return [3]int{0, 116, 0} }
 
 func (p *Provider) EnvVarsToExclude() []string { return nil }
 
+func (p *Provider) CheckReadiness(ctx context.Context) llm.ProviderReadiness {
+	if _, err := p.ensureCodexHomeForStatus(); err != nil {
+		return llm.ProviderReadiness{
+			Ready:  false,
+			Detail: fmt.Sprintf("could not prepare Codex home: %v", err),
+			Remedy: "Fix CODEX_HOME or run 'codex login'",
+		}
+	}
+
+	runner := p.runner
+	if runner == nil {
+		// codex login status prints "Logged in using ..." to stderr, so
+		// capture combined output; DefaultRunner would drop it and make a
+		// logged-in account look like empty status.
+		runner = clirun.CombinedRunner()
+	}
+	out, err := runner(ctx, "codex", []string{"login", "status"}, nil)
+	text := strings.TrimSpace(string(out))
+	lower := strings.ToLower(text)
+
+	if err == nil && strings.Contains(lower, "logged in") && !strings.Contains(lower, "not logged in") {
+		return llm.ProviderReadiness{
+			Ready:  true,
+			Detail: text,
+		}
+	}
+	if strings.Contains(lower, "not logged in") {
+		return llm.ProviderReadiness{
+			Ready:  false,
+			Detail: "not logged in",
+			Remedy: "Run 'codex login'",
+		}
+	}
+	if err != nil {
+		detail := fmt.Sprintf("could not check login status: %v", err)
+		if text != "" {
+			detail = fmt.Sprintf("could not check login status: %s", text)
+		}
+		return llm.ProviderReadiness{
+			Ready:  false,
+			Detail: detail,
+			Remedy: "Run 'codex login status' to inspect Codex authentication",
+		}
+	}
+	if text == "" {
+		text = "<empty output>"
+	}
+	return llm.ProviderReadiness{
+		Ready:  false,
+		Detail: fmt.Sprintf("login status did not report a logged-in account: %s", text),
+		Remedy: "Run 'codex login'",
+	}
+}
+
 // SetModelCatalog sets the discovered model catalog.
 func (p *Provider) SetModelCatalog(models []llm.ModelInfo) {
 	p.mu.Lock()
@@ -329,6 +383,17 @@ func (p *Provider) prepareRealHome() error {
 		return err
 	}
 	return p.reconcileAgenticAgents(codexHome)
+}
+
+func (p *Provider) ensureCodexHomeForStatus() (string, error) {
+	codexHome, err := p.resolveCodexHome()
+	if err != nil {
+		return "", err
+	}
+	if err := os.MkdirAll(codexHome, 0o755); err != nil {
+		return "", fmt.Errorf("creating codex home: %w", err)
+	}
+	return codexHome, nil
 }
 
 func defaultCodexHome() string {

--- a/internal/llm/codex/provider_test.go
+++ b/internal/llm/codex/provider_test.go
@@ -17,9 +17,11 @@ package codex
 import (
 	"bytes"
 	"context"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -114,6 +116,16 @@ func assertConfigOverride(t *testing.T, cmd []string, want string) {
 	t.Fatalf("command %v missing -c %s", cmd, want)
 }
 
+func assertProviderCommand(t *testing.T, gotName string, gotArgs []string, wantName string, wantArgs []string) {
+	t.Helper()
+	if gotName != wantName {
+		t.Fatalf("command name = %q, want %q", gotName, wantName)
+	}
+	if !slices.Equal(gotArgs, wantArgs) {
+		t.Fatalf("command args = %v, want %v", gotArgs, wantArgs)
+	}
+}
+
 func snapshotAgentModTimes(t *testing.T, codexHome string) map[string]time.Time {
 	t.Helper()
 
@@ -163,6 +175,78 @@ func TestProviderResolveCodexHome_FallsBackToDefaultHome(t *testing.T) {
 	want := filepath.Join(homeDir, ".codex")
 	if got != want {
 		t.Fatalf("resolveCodexHome() = %q, want %q", got, want)
+	}
+}
+
+func TestProviderCheckReadinessLoggedIn(t *testing.T) {
+	homeDir := t.TempDir()
+	codexHome := filepath.Join(homeDir, "codex-home")
+	t.Setenv("HOME", homeDir)
+	t.Setenv("CODEX_HOME", codexHome)
+
+	p := &Provider{
+		runner: func(ctx context.Context, name string, args []string, env []string) ([]byte, error) {
+			assertProviderCommand(t, name, args, "codex", []string{"login", "status"})
+			return []byte("Logged in using ChatGPT\n"), nil
+		},
+	}
+
+	status := p.CheckReadiness(context.Background())
+	if !status.Ready {
+		t.Fatalf("CheckReadiness().Ready = false, detail=%q remedy=%q", status.Detail, status.Remedy)
+	}
+	if !strings.Contains(status.Detail, "Logged in") {
+		t.Fatalf("CheckReadiness().Detail = %q, want login status text", status.Detail)
+	}
+	if info, err := os.Stat(codexHome); err != nil || !info.IsDir() {
+		t.Fatalf("CheckReadiness() did not create CODEX_HOME: info=%v err=%v", info, err)
+	}
+}
+
+func TestProviderCheckReadinessNotLoggedIn(t *testing.T) {
+	homeDir := t.TempDir()
+	codexHome := filepath.Join(homeDir, "codex-home")
+	t.Setenv("HOME", homeDir)
+	t.Setenv("CODEX_HOME", codexHome)
+
+	p := &Provider{
+		runner: func(ctx context.Context, name string, args []string, env []string) ([]byte, error) {
+			return []byte("Not logged in\n"), errors.New("exit status 1")
+		},
+	}
+
+	status := p.CheckReadiness(context.Background())
+	if status.Ready {
+		t.Fatal("CheckReadiness().Ready = true, want false")
+	}
+	if !strings.Contains(status.Detail, "not logged in") {
+		t.Fatalf("CheckReadiness().Detail = %q, want not logged in", status.Detail)
+	}
+	if !strings.Contains(status.Remedy, "codex login") {
+		t.Fatalf("CheckReadiness().Remedy = %q, want codex login", status.Remedy)
+	}
+}
+
+func TestProviderCheckReadinessHomePreparationFailure(t *testing.T) {
+	blockingFile := filepath.Join(t.TempDir(), "not-a-directory")
+	if err := os.WriteFile(blockingFile, []byte("x"), 0o644); err != nil {
+		t.Fatalf("WriteFile(%s): %v", blockingFile, err)
+	}
+	t.Setenv("CODEX_HOME", blockingFile)
+
+	p := &Provider{
+		runner: func(ctx context.Context, name string, args []string, env []string) ([]byte, error) {
+			t.Fatal("runner should not be called when Codex home cannot be prepared")
+			return nil, nil
+		},
+	}
+
+	status := p.CheckReadiness(context.Background())
+	if status.Ready {
+		t.Fatal("CheckReadiness().Ready = true, want false")
+	}
+	if !strings.Contains(status.Detail, "could not prepare Codex home") {
+		t.Fatalf("CheckReadiness().Detail = %q, want home preparation failure", status.Detail)
 	}
 }
 

--- a/internal/llm/provider.go
+++ b/internal/llm/provider.go
@@ -62,6 +62,22 @@ type LLMProvider interface {
 	EnvVarsToExclude() []string
 }
 
+// ProviderReadiness reports whether an installed provider CLI is actually
+// usable for Agentic startup. This is deliberately separate from DetectCLI:
+// a binary can be present in PATH but still be unusable because the user has
+// not completed the provider's authentication flow.
+type ProviderReadiness struct {
+	Ready  bool
+	Detail string
+	Remedy string
+}
+
+// ReadinessChecker is implemented by providers that can run a provider-specific
+// non-interactive readiness probe.
+type ReadinessChecker interface {
+	CheckReadiness(ctx context.Context) ProviderReadiness
+}
+
 // PromptAdapter provides provider-specific prompt content.
 type PromptAdapter interface {
 	AskingQuestionsClause() string

--- a/internal/llm/registry.go
+++ b/internal/llm/registry.go
@@ -25,8 +25,9 @@ import (
 // Registry holds all registered LLM providers and routes model strings
 // to the appropriate provider.
 type Registry struct {
-	mu        sync.RWMutex
-	providers []LLMProvider
+	mu                   sync.RWMutex
+	providers            []LLMProvider
+	activeProviderFilter map[string]bool
 }
 
 // NewRegistry creates an empty provider registry.
@@ -42,12 +43,38 @@ func (r *Registry) Register(p LLMProvider) {
 	r.providers = append(r.providers, p)
 }
 
+// RestrictToProviders limits active model routing and detected-provider lists
+// to the supplied providers. Startup uses this after readiness checks so
+// installed-but-unauthenticated CLIs do not appear in defaults or model
+// selection.
+func (r *Registry) RestrictToProviders(providers []LLMProvider) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	filter := make(map[string]bool, len(providers))
+	for _, p := range providers {
+		if p != nil {
+			filter[p.Name()] = true
+		}
+	}
+	r.activeProviderFilter = filter
+}
+
+func (r *Registry) providerActiveLocked(p LLMProvider) bool {
+	if r.activeProviderFilter == nil {
+		return true
+	}
+	return r.activeProviderFilter[p.Name()]
+}
+
 // ForModel returns the provider that handles the given model string.
 // Returns an error if no provider matches.
 func (r *Registry) ForModel(model string) (LLMProvider, error) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	for _, p := range r.providers {
+		if !r.providerActiveLocked(p) {
+			continue
+		}
 		if p.MatchesModel(model) {
 			return p, nil
 		}
@@ -82,7 +109,7 @@ func (r *Registry) AvailableModels() []string {
 	defer r.mu.RUnlock()
 	var models []string
 	for _, p := range r.providers {
-		if p.DetectCLI() {
+		if p.DetectCLI() && r.providerActiveLocked(p) {
 			models = append(models, p.AvailableModels()...)
 		}
 	}
@@ -95,7 +122,7 @@ func (r *Registry) DetectedProviders() []LLMProvider {
 	defer r.mu.RUnlock()
 	var detected []LLMProvider
 	for _, p := range r.providers {
-		if p.DetectCLI() {
+		if p.DetectCLI() && r.providerActiveLocked(p) {
 			detected = append(detected, p)
 		}
 	}
@@ -147,6 +174,9 @@ func (r *Registry) ResolveModel(model string) (LLMProvider, string, error) {
 		bareModel := model[idx+1:]
 		for _, p := range r.providers {
 			if p.Name() == providerName {
+				if !r.providerActiveLocked(p) {
+					return nil, "", fmt.Errorf("provider %q is not available", providerName)
+				}
 				if bareModel == "" {
 					return p, "", nil
 				}
@@ -161,6 +191,9 @@ func (r *Registry) ResolveModel(model string) (LLMProvider, string, error) {
 
 	// Bare model name — search providers in registration order via MatchesModel
 	for _, p := range r.providers {
+		if !r.providerActiveLocked(p) {
+			continue
+		}
 		if canonical, ok := canonicalModelForProvider(p, model); ok {
 			return p, canonical, nil
 		}
@@ -262,7 +295,10 @@ func (r *Registry) AllModels() []ModelInfo {
 // Returns nil if the provider is not found or not detected.
 func (r *Registry) ModelsForProvider(name string) []ModelInfo {
 	p := r.ByName(name)
-	if p == nil || !p.DetectCLI() {
+	r.mu.RLock()
+	active := p != nil && r.providerActiveLocked(p)
+	r.mu.RUnlock()
+	if p == nil || !p.DetectCLI() || !active {
 		return nil
 	}
 	return catalogForProvider(p)

--- a/internal/llm/registry_test.go
+++ b/internal/llm/registry_test.go
@@ -121,6 +121,33 @@ func TestRegistry_AvailableModels(t *testing.T) {
 	}
 }
 
+func TestRegistry_RestrictToProvidersFiltersDetectedModelsAndRouting(t *testing.T) {
+	r := llm.NewRegistry()
+	claude := &stubProvider{name: "claude", models: []string{"opus"}, hasCLI: true}
+	codex := &stubProvider{name: "codex", models: []string{"gpt-5.4"}, hasCLI: true}
+	r.Register(claude)
+	r.Register(codex)
+
+	r.RestrictToProviders([]llm.LLMProvider{claude})
+
+	detected := r.DetectedProviders()
+	if len(detected) != 1 || detected[0].Name() != "claude" {
+		t.Fatalf("DetectedProviders() = %v, want only claude", detected)
+	}
+	if got := r.AvailableModels(); !slices.Equal(got, []string{"opus"}) {
+		t.Fatalf("AvailableModels() = %v, want [opus]", got)
+	}
+	if _, err := r.ForModel("gpt-5.4"); err == nil {
+		t.Fatal("ForModel(gpt-5.4) succeeded after codex was filtered")
+	}
+	if _, _, err := r.ResolveModel("codex:gpt-5.4"); err == nil || !strings.Contains(err.Error(), "not available") {
+		t.Fatalf("ResolveModel(codex:gpt-5.4) error = %v, want not available", err)
+	}
+	if got := r.ModelsForProvider("codex"); got != nil {
+		t.Fatalf("ModelsForProvider(codex) = %v, want nil", got)
+	}
+}
+
 func TestRegistry_ByName(t *testing.T) {
 	r := llm.NewRegistry()
 	r.Register(&stubProvider{name: "claude", models: []string{"opus"}})


### PR DESCRIPTION
## Summary

Detecting a provider CLI in PATH is not enough — a binary can be present but unusable because the user never completed its authentication flow. This PR adds a startup readiness probe so Agentic only offers providers that are actually usable.

- New `llm.ProviderReadiness` struct and `llm.ReadinessChecker` interface, distinct from `DetectCLI`.
- **Claude**: probes `claude auth status --json`, distinguishing logged-in, API-key, and unauthenticated states.
- **Codex**: probes `codex login status` (via a new `clirun.CombinedRunner` since codex reports status on stderr), and ensures `CODEX_HOME` exists first.
- `Registry.RestrictToProviders` filters unready/unauthenticated providers out of model routing, defaults, and model selection (`ForModel`, `ResolveModel`, `AvailableModels`, `DetectedProviders`, `ModelsForProvider`).
- Startup surfaces actionable notices when some — but not all — providers are unavailable, and fails with a provider-specific remedy only when *no* provider is ready.
- Readiness checks run with a 5s timeout; notices display briefly before the TUI takes over.
- README updated to reference `claude auth status` / `codex login status`.

## Test plan

- [x] `go build ./...`
- [x] `go test ./cmd/agentico/... ./internal/llm/...`
- New unit tests cover: authenticated/unauthenticated/API-key Claude states, logged-in/not-logged-in/home-prep-failure Codex states, registry restriction filtering, and startup-notice formatting & error messaging.
- [ ] Manual: launch `agentico` with one provider logged out → confirm it starts with the ready provider and shows a notice; with all providers logged out → confirm it exits with a provider-specific remedy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)