### PR TITLE
agentico update

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,17 @@ Flags:
   --version, -v                    Show version
 ```
 
+### Updating
+
+```text
+agentico update [--check|-n]
+```
+
+Run `agentico update` to upgrade to the latest stable release. Use
+`agentico update --check` (alias `-n`) to report the current and latest
+available versions without installing anything; it exits `0` and prints an
+already-up-to-date message when you are on the newest release.
+
 ## Development
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -25,32 +25,33 @@ The design follows patterns described in Anthropic's [Building Effective Agents]
 
 ## Quick Start
 
-The fastest way to install is to download a prebuilt binary from the [latest release](https://github.com/doordash-oss/agentic-orchestrator/releases/latest) — no Go toolchain required. Prebuilt binaries are published for macOS and Linux on both amd64 and arm64.
+Use Homebrew if you have it; otherwise grab the prebuilt binary. Build from source only if you're working on agentico itself.
+
+**Homebrew** (recommended — macOS/Linux):
 
 ```bash
-# Install the latest prebuilt binary into ~/.local/bin (no sudo, macOS/Linux, amd64/arm64)
+brew install doordash-oss/agentic-orchestrator/agentico
+```
+
+**Prebuilt binary** — no Homebrew or Go (macOS/Linux, amd64/arm64):
+
+```bash
 OS=$(uname -s | tr '[:upper:]' '[:lower:]')
 ARCH=$(uname -m | sed 's/x86_64/amd64/; s/aarch64/arm64/')
 TAG=$(curl -fsSLI -o /dev/null -w '%{url_effective}' https://github.com/doordash-oss/agentic-orchestrator/releases/latest | sed 's@.*/@@')
 mkdir -p ~/.local/bin
 curl -fsSL "https://github.com/doordash-oss/agentic-orchestrator/releases/download/${TAG}/agentic-orchestrator_${TAG#v}_${OS}_${ARCH}.tar.gz" | tar -xz -C ~/.local/bin agentico
-
-# Launch (add ~/.local/bin to your PATH first if it isn't already)
-~/.local/bin/agentico
+# ensure ~/.local/bin is on your PATH
 ```
 
-<details>
-<summary>Build from source (requires Go 1.25+)</summary>
+**From source** — for contributing to agentico (Go 1.25+):
 
 ```bash
 go install github.com/doordash-oss/agentic-orchestrator/cmd/agentico@latest
-
-# Or clone and build
-git clone https://github.com/doordash-oss/agentic-orchestrator.git
-cd agentic-orchestrator && make install
+# or: git clone https://github.com/doordash-oss/agentic-orchestrator.git && cd agentic-orchestrator && make install
 ```
 
-</details>
+Then run `agentico`. Update any time with `agentico update` — it uses the right method for how you installed.
 
 On first launch, Agentic Orchestrator walks you through a welcome flow to select your workspace directories. After that, you're on the dashboard.
 

--- a/cmd/agentico/docs_contract_test.go
+++ b/cmd/agentico/docs_contract_test.go
@@ -84,6 +84,10 @@ func TestUserFacingDocsDescribeTUIOnlyLaunchSurface(t *testing.T) {
 			"--dangerously-skip-permissions",
 			"--help",
 			"--version",
+			// Phase 1 update surface: docs must advertise the new subcommand
+			// and its check-only flag alongside the retained launch flags.
+			"agentico update",
+			"--check",
 		} {
 			if !strings.Contains(text, want) {
 				t.Fatalf("%s missing retained launch guidance %q", rel, want)

--- a/cmd/agentico/installmethod.go
+++ b/cmd/agentico/installmethod.go
@@ -1,0 +1,244 @@
+// Copyright 2026 DoorDash, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime/debug"
+	"strings"
+
+	"github.com/doordash-oss/agentic-orchestrator/internal/tui"
+)
+
+// installMethod is how the running binary was installed, which decides the
+// update action the command would take.
+type installMethod int
+
+const (
+	// installMethodGoInstall: installed via `go install` (a real module version
+	// in build info) or `make install` (lands under the Go bin dir).
+	installMethodGoInstall installMethod = iota
+	// installMethodTarball: a released binary distributed as a tarball, carrying
+	// a clean injected release version.
+	installMethodTarball
+	// installMethodDevBuild: built from source; not safe to auto-update, so the
+	// command refuses and points the user back at their build.
+	installMethodDevBuild
+)
+
+// errResolveHome is returned by the home-dir resolver injected into
+// resolveGoBinDir when the user home directory cannot be determined.
+var errResolveHome = errors.New("home directory unavailable")
+
+// classifyInstallMethod is the pure decision function at the heart of the
+// update command. Given four already-resolved signals — the build-info module
+// version, the raw injected ldflags version, the binary's containing directory,
+// and the Go bin directory — it returns the install method. It performs no
+// filesystem, network, or environment access of its own; symlink resolution and
+// path normalization happen in the caller, so this stays hermetic and
+// table-testable.
+//
+// Precedence (see the phase plan's Overview block):
+//
+//  1. go-install  if build info is a real module version, OR the binary sits in
+//     the Go bin dir (which also captures `make install`).
+//  2. tarball     else if the injected version is a clean MAJOR.MINOR.PATCH.
+//  3. dev-refuse  otherwise.
+func classifyInstallMethod(buildInfoVersion, injectedVersion, binaryDir, goBinDir string) installMethod {
+	if isRealModuleVersion(buildInfoVersion) || sameDir(binaryDir, goBinDir) {
+		return installMethodGoInstall
+	}
+	if isReleaseVersion(injectedVersion) {
+		return installMethodTarball
+	}
+	return installMethodDevBuild
+}
+
+// isRealModuleVersion reports whether a build-info Main.Version is a genuine
+// module version. The Go toolchain only sets Main.Version to a tag or a
+// pseudo-version when the binary was installed from the module proxy; local
+// builds report "(devel)" (and tests/older toolchains may report ""). Trusting
+// the toolchain here means commit-pinned `go install` (a pseudo-version) is
+// correctly treated as go-install.
+func isRealModuleVersion(v string) bool {
+	return v != "" && v != "(devel)"
+}
+
+// isReleaseVersion reports whether v is a clean MAJOR.MINOR.PATCH release
+// version after trimming surrounding whitespace and a single leading "v". It is
+// hand-rolled — no new module dependency — and deliberately conservative: any
+// git-describe suffix (v1.2.3-5-gabc1234), -dirty marker, bare SHA, "dev", or
+// empty string is NOT a release, so the classifier refuses rather than risk a
+// wrong swap.
+func isReleaseVersion(v string) bool {
+	v = strings.TrimPrefix(strings.TrimSpace(v), "v")
+	parts := strings.Split(v, ".")
+	if len(parts) != 3 {
+		return false
+	}
+	for _, p := range parts {
+		if !isAllDigits(p) {
+			return false
+		}
+	}
+	return true
+}
+
+// isAllDigits reports whether s is a non-empty run of ASCII digits.
+func isAllDigits(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		if s[i] < '0' || s[i] > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+// sameDir reports whether two directories refer to the same location after
+// path normalization. It is pure (filepath.Clean does no I/O); any symlink
+// resolution must already have happened in the caller. An empty goBinDir never
+// matches, so a binary with no resolvable directory is not mistaken for a
+// go-install.
+func sameDir(binaryDir, goBinDir string) bool {
+	if binaryDir == "" || goBinDir == "" {
+		return false
+	}
+	return filepath.Clean(binaryDir) == filepath.Clean(goBinDir)
+}
+
+// installInputs are the four signals classifyInstallMethod consumes for the
+// running binary.
+type installInputs struct {
+	buildInfoVersion string
+	injectedVersion  string
+	binaryDir        string
+	goBinDir         string
+}
+
+// gatherInstallInputs resolves the classifier inputs for the running binary
+// from real sources: the symlink-resolved executable directory, the build-info
+// Main.Version, the raw injected ldflags version (read separately from the
+// collapsed GetVersion accessor), and the env-resolved Go bin directory. It
+// never invokes the `go` toolchain — release users typically have no Go
+// installed.
+func gatherInstallInputs() installInputs {
+	return installInputs{
+		buildInfoVersion: buildInfoMainVersion(),
+		injectedVersion:  tui.InjectedVersion(),
+		binaryDir:        normalizeDir(resolveBinaryDir()),
+		goBinDir:         normalizeDir(resolveGoBinDir(os.Getenv, os.UserHomeDir)),
+	}
+}
+
+// gatherInstallMethod resolves and classifies the running binary's install
+// method. It is the production detector wired behind the updater seam.
+func gatherInstallMethod() installMethod {
+	in := gatherInstallInputs()
+	return classifyInstallMethod(in.buildInfoVersion, in.injectedVersion, in.binaryDir, in.goBinDir)
+}
+
+// buildInfoMainVersion returns the build-info Main.Version, or "" when build
+// info is unavailable.
+func buildInfoMainVersion() string {
+	if info, ok := debug.ReadBuildInfo(); ok {
+		return info.Main.Version
+	}
+	return ""
+}
+
+// resolveBinaryDir returns the directory containing the running executable,
+// resolving symlinks first so a binary reached through a symlink is compared on
+// its real location. It returns "" when the executable path cannot be resolved.
+func resolveBinaryDir() string {
+	exe, err := os.Executable()
+	if err != nil {
+		return ""
+	}
+	if resolved, err := filepath.EvalSymlinks(exe); err == nil {
+		exe = resolved
+	}
+	return filepath.Dir(exe)
+}
+
+// resolveGoBinDir resolves the Go bin directory from the environment without
+// invoking the `go` toolchain: GOBIN if set, else the first GOPATH entry +
+// "/bin", else ~/go/bin. The getenv and home-dir lookups are injected so the
+// precedence is unit-testable. It returns "" only when none of the three are
+// resolvable.
+func resolveGoBinDir(getenv func(string) string, homeDir func() (string, error)) string {
+	if gobin := strings.TrimSpace(getenv("GOBIN")); gobin != "" {
+		return gobin
+	}
+	if gopath := strings.TrimSpace(getenv("GOPATH")); gopath != "" {
+		if parts := filepath.SplitList(gopath); len(parts) > 0 {
+			if first := strings.TrimSpace(parts[0]); first != "" {
+				return filepath.Join(first, "bin")
+			}
+		}
+	}
+	if home, err := homeDir(); err == nil && home != "" {
+		return filepath.Join(home, "go", "bin")
+	}
+	return ""
+}
+
+// normalizeDir best-effort resolves symlinks and normalizes a directory path so
+// the classifier's pure comparison sees canonical forms. When the path does not
+// exist (EvalSymlinks fails — common for a Go bin dir on a release machine), it
+// falls back to filepath.Clean. An empty input stays empty.
+func normalizeDir(dir string) string {
+	if dir == "" {
+		return ""
+	}
+	if resolved, err := filepath.EvalSymlinks(dir); err == nil {
+		return resolved
+	}
+	return filepath.Clean(dir)
+}
+
+// label returns the human-facing name of the install method for --check output
+// and the bare-update "not yet implemented" message.
+func (m installMethod) label() string {
+	switch m {
+	case installMethodGoInstall:
+		return "go install"
+	case installMethodTarball:
+		return "release tarball"
+	case installMethodDevBuild:
+		return "development build (built from source)"
+	default:
+		return "unknown"
+	}
+}
+
+// wouldDoAction returns the action `agentico update --check` reports it would
+// take for this install method.
+func (m installMethod) wouldDoAction() string {
+	switch m {
+	case installMethodGoInstall:
+		return "Would update by re-running the Go install of the latest version."
+	case installMethodTarball:
+		return "Would update by downloading the latest release and replacing the binary in place."
+	case installMethodDevBuild:
+		return "Would update from source (development builds are not updated automatically)."
+	default:
+		return ""
+	}
+}

--- a/cmd/agentico/installmethod.go
+++ b/cmd/agentico/installmethod.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime/debug"
+	"strconv"
 	"strings"
 
 	"github.com/doordash-oss/agentic-orchestrator/internal/tui"
@@ -83,19 +84,59 @@ func isRealModuleVersion(v string) bool {
 // hand-rolled — no new module dependency — and deliberately conservative: any
 // git-describe suffix (v1.2.3-5-gabc1234), -dirty marker, bare SHA, "dev", or
 // empty string is NOT a release, so the classifier refuses rather than risk a
-// wrong swap.
+// wrong swap. It delegates to parseReleaseVersion so the acceptance set and the
+// downgrade-guard's ordering share one definition of "clean release version".
 func isReleaseVersion(v string) bool {
+	_, ok := parseReleaseVersion(v)
+	return ok
+}
+
+// parseReleaseVersion parses a clean MAJOR.MINOR.PATCH version into its three
+// numeric components after trimming surrounding whitespace and a single leading
+// "v". ok is false for anything that is not exactly three all-digit fields (a
+// git-describe suffix, -dirty marker, bare SHA, "dev", go-install pseudo-version,
+// or empty string) and for a field too large to fit an int, so callers never
+// attempt to order versions they cannot reason about.
+func parseReleaseVersion(v string) (parts [3]int, ok bool) {
 	v = strings.TrimPrefix(strings.TrimSpace(v), "v")
-	parts := strings.Split(v, ".")
-	if len(parts) != 3 {
-		return false
+	fields := strings.Split(v, ".")
+	if len(fields) != 3 {
+		return parts, false
 	}
-	for _, p := range parts {
-		if !isAllDigits(p) {
-			return false
+	for i, f := range fields {
+		if !isAllDigits(f) {
+			return parts, false
+		}
+		n, err := strconv.Atoi(f)
+		if err != nil {
+			return parts, false
+		}
+		parts[i] = n
+	}
+	return parts, true
+}
+
+// compareReleaseVersions orders two release versions numerically. cmp is -1, 0,
+// or 1 for a<b, a==b, a>b, and ordered is true only when BOTH parse as clean
+// MAJOR.MINOR.PATCH versions. When either side is not a clean release version (a
+// go-install pseudo-version, a dev build, an empty string), ordered is false and
+// the caller falls back to plain inequality rather than guessing an order — so
+// the downgrade guard engages only where the comparison is trustworthy.
+func compareReleaseVersions(a, b string) (cmp int, ordered bool) {
+	pa, oka := parseReleaseVersion(a)
+	pb, okb := parseReleaseVersion(b)
+	if !oka || !okb {
+		return 0, false
+	}
+	for i := range 3 {
+		switch {
+		case pa[i] < pb[i]:
+			return -1, true
+		case pa[i] > pb[i]:
+			return 1, true
 		}
 	}
-	return true
+	return 0, true
 }
 
 // isAllDigits reports whether s is a non-empty run of ASCII digits.

--- a/cmd/agentico/installmethod.go
+++ b/cmd/agentico/installmethod.go
@@ -36,6 +36,9 @@ const (
 	// installMethodTarball: a released binary distributed as a tarball, carrying
 	// a clean injected release version.
 	installMethodTarball
+	// installMethodHomebrew: installed via the Homebrew tap; updates delegate to
+	// `brew upgrade` rather than swapping the brew-managed binary in place.
+	installMethodHomebrew
 	// installMethodDevBuild: built from source; not safe to auto-update, so the
 	// command refuses and points the user back at their build.
 	installMethodDevBuild
@@ -46,22 +49,30 @@ const (
 var errResolveHome = errors.New("home directory unavailable")
 
 // classifyInstallMethod is the pure decision function at the heart of the
-// update command. Given four already-resolved signals — the build-info module
+// update command. Given five already-resolved signals — the build-info module
 // version, the raw injected ldflags version, the binary's containing directory,
-// and the Go bin directory — it returns the install method. It performs no
-// filesystem, network, or environment access of its own; symlink resolution and
-// path normalization happen in the caller, so this stays hermetic and
+// the Go bin directory, and whether the resolved binary lives inside a Homebrew
+// Cellar — it returns the install method. It performs no filesystem, network, or
+// environment access of its own; symlink resolution, path normalization, and the
+// Homebrew-path check all happen in the caller, so this stays hermetic and
 // table-testable.
 //
-// Precedence (see the phase plan's Overview block):
+// Precedence:
 //
 //  1. go-install  if build info is a real module version, OR the binary sits in
 //     the Go bin dir (which also captures `make install`).
-//  2. tarball     else if the injected version is a clean MAJOR.MINOR.PATCH.
-//  3. dev-refuse  otherwise.
-func classifyInstallMethod(buildInfoVersion, injectedVersion, binaryDir, goBinDir string) installMethod {
+//  2. homebrew    else if the resolved binary lives inside a Homebrew Cellar.
+//     Ordered before tarball because a Homebrew-installed binary also carries a
+//     clean injected release version; without this it would misclassify as a
+//     tarball and the in-place swap would desync Homebrew's bookkeeping.
+//  3. tarball     else if the injected version is a clean MAJOR.MINOR.PATCH.
+//  4. dev-refuse  otherwise.
+func classifyInstallMethod(buildInfoVersion, injectedVersion, binaryDir, goBinDir string, homebrew bool) installMethod {
 	if isRealModuleVersion(buildInfoVersion) || sameDir(binaryDir, goBinDir) {
 		return installMethodGoInstall
+	}
+	if homebrew {
+		return installMethodHomebrew
 	}
 	if isReleaseVersion(injectedVersion) {
 		return installMethodTarball
@@ -164,13 +175,26 @@ func sameDir(binaryDir, goBinDir string) bool {
 	return filepath.Clean(binaryDir) == filepath.Clean(goBinDir)
 }
 
-// installInputs are the four signals classifyInstallMethod consumes for the
+// isHomebrewBinary reports whether the symlink-resolved binary path sits inside a
+// Homebrew Cellar (<prefix>/Cellar/...). The "/Cellar/" segment is prefix-agnostic,
+// covering /opt/homebrew, /usr/local, and Linuxbrew. Symlink resolution happens in
+// the caller, so this stays pure and table-testable.
+func isHomebrewBinary(resolvedBinaryPath string) bool {
+	if resolvedBinaryPath == "" {
+		return false
+	}
+	sep := string(os.PathSeparator)
+	return strings.Contains(resolvedBinaryPath, sep+"Cellar"+sep)
+}
+
+// installInputs are the five signals classifyInstallMethod consumes for the
 // running binary.
 type installInputs struct {
 	buildInfoVersion string
 	injectedVersion  string
 	binaryDir        string
 	goBinDir         string
+	homebrew         bool
 }
 
 // gatherInstallInputs resolves the classifier inputs for the running binary
@@ -185,6 +209,7 @@ func gatherInstallInputs() installInputs {
 		injectedVersion:  tui.InjectedVersion(),
 		binaryDir:        normalizeDir(resolveBinaryDir()),
 		goBinDir:         normalizeDir(resolveGoBinDir(os.Getenv, os.UserHomeDir)),
+		homebrew:         isHomebrewBinary(resolveBinaryPath()),
 	}
 }
 
@@ -192,7 +217,7 @@ func gatherInstallInputs() installInputs {
 // method. It is the production detector wired behind the updater seam.
 func gatherInstallMethod() installMethod {
 	in := gatherInstallInputs()
-	return classifyInstallMethod(in.buildInfoVersion, in.injectedVersion, in.binaryDir, in.goBinDir)
+	return classifyInstallMethod(in.buildInfoVersion, in.injectedVersion, in.binaryDir, in.goBinDir, in.homebrew)
 }
 
 // buildInfoMainVersion returns the build-info Main.Version, or "" when build
@@ -273,6 +298,8 @@ func (m installMethod) label() string {
 		return "go install"
 	case installMethodTarball:
 		return "release tarball"
+	case installMethodHomebrew:
+		return "homebrew"
 	case installMethodDevBuild:
 		return "development build (built from source)"
 	default:
@@ -288,6 +315,8 @@ func (m installMethod) wouldDoAction() string {
 		return "Would update by re-running the Go install of the latest version."
 	case installMethodTarball:
 		return "Would update by downloading the latest release and replacing the binary in place."
+	case installMethodHomebrew:
+		return "Would update via Homebrew by running `brew upgrade agentico`."
 	case installMethodDevBuild:
 		return "Would update from source (development builds are not updated automatically)."
 	default:

--- a/cmd/agentico/installmethod.go
+++ b/cmd/agentico/installmethod.go
@@ -163,18 +163,29 @@ func buildInfoMainVersion() string {
 	return ""
 }
 
-// resolveBinaryDir returns the directory containing the running executable,
-// resolving symlinks first so a binary reached through a symlink is compared on
-// its real location. It returns "" when the executable path cannot be resolved.
-func resolveBinaryDir() string {
+// resolveBinaryPath returns the symlink-resolved path of the running
+// executable — the file the tarball swap replaces in place. It returns "" when
+// the executable path cannot be resolved, which the caller surfaces as a clear
+// error that leaves the binary untouched.
+func resolveBinaryPath() string {
 	exe, err := os.Executable()
 	if err != nil {
 		return ""
 	}
 	if resolved, err := filepath.EvalSymlinks(exe); err == nil {
-		exe = resolved
+		return resolved
 	}
-	return filepath.Dir(exe)
+	return exe
+}
+
+// resolveBinaryDir returns the directory containing the running executable,
+// resolving symlinks first so a binary reached through a symlink is compared on
+// its real location. It returns "" when the executable path cannot be resolved.
+func resolveBinaryDir() string {
+	if p := resolveBinaryPath(); p != "" {
+		return filepath.Dir(p)
+	}
+	return ""
 }
 
 // resolveGoBinDir resolves the Go bin directory from the environment without

--- a/cmd/agentico/installmethod_test.go
+++ b/cmd/agentico/installmethod_test.go
@@ -1,0 +1,293 @@
+// Copyright 2026 DoorDash, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/doordash-oss/agentic-orchestrator/internal/tui"
+)
+
+// --- Task 1: hand-rolled release-version predicate -------------------------
+
+func TestIsReleaseVersion(t *testing.T) {
+	tests := []struct {
+		in   string
+		want bool
+	}{
+		// Clean MAJOR.MINOR.PATCH, with and without the optional leading v.
+		{"1.2.3", true},
+		{"v1.2.3", true},
+		{" v1.2.3 ", true},
+		{"0.0.0", true},
+		{"v10.20.30", true},
+		// Not three clean numeric components.
+		{"1.2", false},
+		{"v1.2", false},
+		{"1.2.3.4", false},
+		{"1.2.x", false},
+		// git-describe / dirty / SHA / dev / empty all fall through to refuse.
+		{"v1.2.3-5-gabc1234", false},
+		{"1.2.3-5-gabc1234", false},
+		{"1.2.3-dirty", false},
+		{"abc1234", false},
+		{"dev", false},
+		{"", false},
+		{"   ", false},
+	}
+	for _, tt := range tests {
+		if got := isReleaseVersion(tt.in); got != tt.want {
+			t.Errorf("isReleaseVersion(%q) = %v, want %v", tt.in, got, tt.want)
+		}
+	}
+}
+
+// --- Task 1: build-info "real module version" predicate --------------------
+
+func TestIsRealModuleVersion(t *testing.T) {
+	tests := []struct {
+		in   string
+		want bool
+	}{
+		{"", false},
+		{"(devel)", false},
+		{"v1.2.3", true},
+		{"v0.0.0-20230101000000-abcdef123456", true}, // commit-pinned pseudo-version
+	}
+	for _, tt := range tests {
+		if got := isRealModuleVersion(tt.in); got != tt.want {
+			t.Errorf("isRealModuleVersion(%q) = %v, want %v", tt.in, got, tt.want)
+		}
+	}
+}
+
+// --- Task 1: the pure classifier, every branch -----------------------------
+
+func TestClassifyInstallMethod(t *testing.T) {
+	const goBin = "/home/user/go/bin"
+	tests := []struct {
+		name             string
+		buildInfoVersion string
+		injectedVersion  string
+		binaryDir        string
+		goBinDir         string
+		want             installMethod
+	}{
+		{
+			name:             "go install @vX.Y.Z (build-info semver)",
+			buildInfoVersion: "v1.2.3",
+			injectedVersion:  "",
+			binaryDir:        goBin,
+			goBinDir:         goBin,
+			want:             installMethodGoInstall,
+		},
+		{
+			name:             "go install commit-pinned pseudo-version",
+			buildInfoVersion: "v0.0.0-20230101000000-abcdef123456",
+			injectedVersion:  "",
+			binaryDir:        "/usr/local/bin",
+			goBinDir:         goBin,
+			want:             installMethodGoInstall,
+		},
+		{
+			name:             "make install: (devel) build-info, dirty injected, binary under go bin dir",
+			buildInfoVersion: "(devel)",
+			injectedVersion:  "v1.2.3-5-gabc1234-dirty",
+			binaryDir:        goBin,
+			goBinDir:         goBin,
+			want:             installMethodGoInstall,
+		},
+		{
+			name:             "make install: (devel) build-info, empty injected, binary under go bin dir",
+			buildInfoVersion: "(devel)",
+			injectedVersion:  "",
+			binaryDir:        goBin,
+			goBinDir:         goBin,
+			want:             installMethodGoInstall,
+		},
+		{
+			name:             "go bin dir match survives trailing-slash / unclean paths",
+			buildInfoVersion: "(devel)",
+			injectedVersion:  "",
+			binaryDir:        goBin + "/",
+			goBinDir:         "/home/user/go/bin/../bin",
+			want:             installMethodGoInstall,
+		},
+		{
+			name:             "clean tag outside go bin dir -> tarball",
+			buildInfoVersion: "(devel)",
+			injectedVersion:  "1.2.3",
+			binaryDir:        "/usr/local/bin",
+			goBinDir:         goBin,
+			want:             installMethodTarball,
+		},
+		{
+			name:             "clean tag with leading v outside go bin dir -> tarball",
+			buildInfoVersion: "",
+			injectedVersion:  "v2.0.1",
+			binaryDir:        "/opt/agentico/bin",
+			goBinDir:         goBin,
+			want:             installMethodTarball,
+		},
+		{
+			name:             "refuse: dev injected, no build-info, outside go bin dir",
+			buildInfoVersion: "(devel)",
+			injectedVersion:  "dev",
+			binaryDir:        "/tmp/build",
+			goBinDir:         goBin,
+			want:             installMethodDevBuild,
+		},
+		{
+			name:             "refuse: bare SHA injected",
+			buildInfoVersion: "",
+			injectedVersion:  "abc1234",
+			binaryDir:        "/tmp/build",
+			goBinDir:         goBin,
+			want:             installMethodDevBuild,
+		},
+		{
+			name:             "refuse: -dirty injected",
+			buildInfoVersion: "(devel)",
+			injectedVersion:  "1.2.3-dirty",
+			binaryDir:        "/tmp/build",
+			goBinDir:         goBin,
+			want:             installMethodDevBuild,
+		},
+		{
+			name:             "refuse: git-describe suffix injected",
+			buildInfoVersion: "(devel)",
+			injectedVersion:  "v1.2.3-5-gabc1234",
+			binaryDir:        "/tmp/build",
+			goBinDir:         goBin,
+			want:             installMethodDevBuild,
+		},
+		{
+			name:             "refuse: everything empty",
+			buildInfoVersion: "",
+			injectedVersion:  "",
+			binaryDir:        "/tmp/build",
+			goBinDir:         goBin,
+			want:             installMethodDevBuild,
+		},
+		{
+			name:             "empty dirs never falsely match as go-install",
+			buildInfoVersion: "(devel)",
+			injectedVersion:  "",
+			binaryDir:        "",
+			goBinDir:         "",
+			want:             installMethodDevBuild,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := classifyInstallMethod(tt.buildInfoVersion, tt.injectedVersion, tt.binaryDir, tt.goBinDir)
+			if got != tt.want {
+				t.Errorf("classifyInstallMethod(%q, %q, %q, %q) = %v, want %v",
+					tt.buildInfoVersion, tt.injectedVersion, tt.binaryDir, tt.goBinDir, got, tt.want)
+			}
+		})
+	}
+}
+
+// --- Task 2: env-resolved Go bin dir (no `go` toolchain invocation) --------
+
+func TestResolveGoBinDir(t *testing.T) {
+	const home = "/home/user"
+	homeOK := func() (string, error) { return home, nil }
+
+	multi := "/first/gopath" + string(filepath.ListSeparator) + "/second/gopath"
+
+	tests := []struct {
+		name string
+		env  map[string]string
+		home func() (string, error)
+		want string
+	}{
+		{
+			name: "GOBIN wins when set",
+			env:  map[string]string{"GOBIN": "/explicit/gobin", "GOPATH": "/ignored"},
+			home: homeOK,
+			want: "/explicit/gobin",
+		},
+		{
+			name: "first GOPATH entry + /bin when GOBIN unset",
+			env:  map[string]string{"GOPATH": "/single/gopath"},
+			home: homeOK,
+			want: filepath.Join("/single/gopath", "bin"),
+		},
+		{
+			name: "first of a multi-entry GOPATH",
+			env:  map[string]string{"GOPATH": multi},
+			home: homeOK,
+			want: filepath.Join("/first/gopath", "bin"),
+		},
+		{
+			name: "~/go/bin fallback when GOBIN and GOPATH unset",
+			env:  map[string]string{},
+			home: homeOK,
+			want: filepath.Join(home, "go", "bin"),
+		},
+		{
+			name: "empty when nothing resolvable",
+			env:  map[string]string{},
+			home: func() (string, error) { return "", errResolveHome },
+			want: "",
+		},
+		{
+			name: "whitespace-only GOBIN/GOPATH ignored, falls to home",
+			env:  map[string]string{"GOBIN": "  ", "GOPATH": "   "},
+			home: homeOK,
+			want: filepath.Join(home, "go", "bin"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			getenv := func(k string) string { return tt.env[k] }
+			if got := resolveGoBinDir(getenv, tt.home); got != tt.want {
+				t.Errorf("resolveGoBinDir() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// --- Task 2: production gatherer drives the classifier on real inputs -------
+
+// The `go test` binary is inherently a development build: build info reports
+// "(devel)", no release version is injected via ldflags, and it lives in a temp
+// build dir rather than the Go bin dir. So the real-input gatherer chain must
+// classify it as a dev build, proving detection wires real signals into the
+// Task 1 classifier without simulation.
+func TestGatherInstallMethodClassifiesTestBinaryAsDevBuild(t *testing.T) {
+	if got := gatherInstallMethod(); got != installMethodDevBuild {
+		t.Fatalf("gatherInstallMethod() = %v, want installMethodDevBuild for the test binary", got)
+	}
+}
+
+// gatherInstallInputs must read real signals: a non-empty binary directory (the
+// executable always resolves under test) and the raw injected version straight
+// from the tui accessor, kept separate from the collapsed GetVersion.
+func TestGatherInstallInputsReadsRealSignals(t *testing.T) {
+	in := gatherInstallInputs()
+	if in.binaryDir == "" {
+		t.Error("gatherInstallInputs() binaryDir is empty; expected a resolved executable directory")
+	}
+	if in.injectedVersion != tui.InjectedVersion() {
+		t.Errorf("injectedVersion = %q, want raw tui.InjectedVersion() %q", in.injectedVersion, tui.InjectedVersion())
+	}
+	if in.buildInfoVersion != "(devel)" {
+		t.Errorf("buildInfoVersion = %q, want %q for the test binary", in.buildInfoVersion, "(devel)")
+	}
+}

--- a/cmd/agentico/installmethod_test.go
+++ b/cmd/agentico/installmethod_test.go
@@ -55,6 +55,62 @@ func TestIsReleaseVersion(t *testing.T) {
 	}
 }
 
+// --- downgrade guard: release-version parsing and ordering -----------------
+
+func TestParseReleaseVersion(t *testing.T) {
+	tests := []struct {
+		in        string
+		wantParts [3]int
+		wantOK    bool
+	}{
+		{"1.2.3", [3]int{1, 2, 3}, true},
+		{"v1.2.3", [3]int{1, 2, 3}, true},
+		{" v10.20.30 ", [3]int{10, 20, 30}, true},
+		{"0.0.0", [3]int{0, 0, 0}, true},
+		{"02.0.0", [3]int{2, 0, 0}, true}, // leading zeros parse numerically
+		// Anything not exactly three numeric fields is unparseable.
+		{"1.2", [3]int{}, false},
+		{"1.2.3.4", [3]int{}, false},
+		{"1.2.x", [3]int{}, false},
+		{"v1.2.3-5-gabc1234", [3]int{}, false},
+		{"dev", [3]int{}, false},
+		{"", [3]int{}, false},
+		{"99999999999999999999.0.0", [3]int{}, false}, // overflows int
+	}
+	for _, tt := range tests {
+		parts, ok := parseReleaseVersion(tt.in)
+		if ok != tt.wantOK || (ok && parts != tt.wantParts) {
+			t.Errorf("parseReleaseVersion(%q) = %v,%v want %v,%v", tt.in, parts, ok, tt.wantParts, tt.wantOK)
+		}
+	}
+}
+
+func TestCompareReleaseVersions(t *testing.T) {
+	tests := []struct {
+		a, b        string
+		wantCmp     int
+		wantOrdered bool
+	}{
+		{"1.0.0", "2.0.0", -1, true},
+		{"2.0.0", "1.0.0", 1, true},
+		{"2.0.0", "2.0.0", 0, true},
+		{"v2.0.0", "2.0.0", 0, true}, // leading-v normalized
+		{"1.2.3", "1.3.0", -1, true},
+		{"1.2.3", "1.2.4", -1, true},
+		{"1.10.0", "1.9.0", 1, true}, // numeric, not lexical
+		// Unorderable when either side is not a clean release version.
+		{"dev", "1.0.0", 0, false},
+		{"v0.0.0-20230101000000-abcdef123456", "1.0.0", 0, false},
+		{"1.0.0", "", 0, false},
+	}
+	for _, tt := range tests {
+		cmp, ordered := compareReleaseVersions(tt.a, tt.b)
+		if ordered != tt.wantOrdered || (ordered && cmp != tt.wantCmp) {
+			t.Errorf("compareReleaseVersions(%q,%q) = %d,%v want %d,%v", tt.a, tt.b, cmp, ordered, tt.wantCmp, tt.wantOrdered)
+		}
+	}
+}
+
 // --- Task 1: build-info "real module version" predicate --------------------
 
 func TestIsRealModuleVersion(t *testing.T) {

--- a/cmd/agentico/installmethod_test.go
+++ b/cmd/agentico/installmethod_test.go
@@ -140,6 +140,7 @@ func TestClassifyInstallMethod(t *testing.T) {
 		injectedVersion  string
 		binaryDir        string
 		goBinDir         string
+		homebrew         bool
 		want             installMethod
 	}{
 		{
@@ -246,15 +247,77 @@ func TestClassifyInstallMethod(t *testing.T) {
 			goBinDir:         "",
 			want:             installMethodDevBuild,
 		},
+		{
+			name:             "homebrew: clean injected, resolved into Cellar, outside go bin dir",
+			buildInfoVersion: "(devel)",
+			injectedVersion:  "0.141.0",
+			binaryDir:        "/opt/homebrew/Cellar/agentico/0.141.0/bin",
+			goBinDir:         goBin,
+			homebrew:         true,
+			want:             installMethodHomebrew,
+		},
+		{
+			name:             "homebrew signal classifies even with an empty injected version",
+			buildInfoVersion: "(devel)",
+			injectedVersion:  "",
+			binaryDir:        "/usr/local/Cellar/agentico/0.141.0/bin",
+			goBinDir:         goBin,
+			homebrew:         true,
+			want:             installMethodHomebrew,
+		},
+		{
+			name:             "go-install precedence: a real module version wins over the homebrew signal",
+			buildInfoVersion: "v1.2.3",
+			injectedVersion:  "1.2.3",
+			binaryDir:        "/opt/homebrew/Cellar/agentico/1.2.3/bin",
+			goBinDir:         goBin,
+			homebrew:         true,
+			want:             installMethodGoInstall,
+		},
+		{
+			name:             "go-install precedence: a binary in the go bin dir wins over the homebrew signal",
+			buildInfoVersion: "(devel)",
+			injectedVersion:  "1.2.3",
+			binaryDir:        goBin,
+			goBinDir:         goBin,
+			homebrew:         true,
+			want:             installMethodGoInstall,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := classifyInstallMethod(tt.buildInfoVersion, tt.injectedVersion, tt.binaryDir, tt.goBinDir)
+			got := classifyInstallMethod(tt.buildInfoVersion, tt.injectedVersion, tt.binaryDir, tt.goBinDir, tt.homebrew)
 			if got != tt.want {
-				t.Errorf("classifyInstallMethod(%q, %q, %q, %q) = %v, want %v",
-					tt.buildInfoVersion, tt.injectedVersion, tt.binaryDir, tt.goBinDir, got, tt.want)
+				t.Errorf("classifyInstallMethod(%q, %q, %q, %q, homebrew=%v) = %v, want %v",
+					tt.buildInfoVersion, tt.injectedVersion, tt.binaryDir, tt.goBinDir, tt.homebrew, got, tt.want)
 			}
 		})
+	}
+}
+
+// --- Homebrew detection: resolved binary inside a Cellar -------------------
+
+func TestIsHomebrewBinary(t *testing.T) {
+	tests := []struct {
+		in   string
+		want bool
+	}{
+		// Resolved Cellar paths across the common Homebrew prefixes.
+		{"/opt/homebrew/Cellar/agentico/0.141.0/bin/agentico", true},            // Apple Silicon
+		{"/usr/local/Cellar/agentico/1.2.3/bin/agentico", true},                 // Intel
+		{"/home/linuxbrew/.linuxbrew/Cellar/agentico/1.0.0/bin/agentico", true}, // Linuxbrew
+		// Non-Homebrew locations.
+		{"/Users/me/.local/bin/agentico", false},
+		{"/usr/local/bin/agentico", false}, // a brew bin symlink dir, not the resolved Cellar target
+		{"/opt/homebrew/bin/agentico", false},
+		{"/home/user/go/bin/agentico", false},
+		{"/CellarSomething/agentico", false}, // substring without the surrounding separators must not match
+		{"", false},
+	}
+	for _, tt := range tests {
+		if got := isHomebrewBinary(tt.in); got != tt.want {
+			t.Errorf("isHomebrewBinary(%q) = %v, want %v", tt.in, got, tt.want)
+		}
 	}
 }
 
@@ -345,5 +408,8 @@ func TestGatherInstallInputsReadsRealSignals(t *testing.T) {
 	}
 	if in.buildInfoVersion != "(devel)" {
 		t.Errorf("buildInfoVersion = %q, want %q for the test binary", in.buildInfoVersion, "(devel)")
+	}
+	if in.homebrew {
+		t.Error("gatherInstallInputs() homebrew = true; the test binary is not a Homebrew install")
 	}
 }

--- a/cmd/agentico/main.go
+++ b/cmd/agentico/main.go
@@ -70,6 +70,7 @@ const (
 	launchModeTUI launchMode = iota
 	launchModeHelp
 	launchModeVersion
+	launchModeUpdate
 )
 
 type launchOptions struct {
@@ -78,9 +79,18 @@ type launchOptions struct {
 	dangerouslySkipPerms bool
 	enabledProviders     []string
 	mode                 launchMode
+	// updateCheck is set when update mode was selected with --check / -n,
+	// requesting a check-only run that never attempts to install.
+	updateCheck bool
 }
 
 type tuiLauncher func(configPath, stateDir string, dangerouslySkipPerms bool, enabledProviders []string)
+
+// updater is the injectable update seam. It mirrors tuiLauncher: production
+// wiring passes the real updater, tests pass a fake. It returns the process
+// exit code the router propagates verbatim. The update path deliberately never
+// acquires the instance lock, starts the fx container, or reconciles assets.
+type updater func(checkOnly bool, stdout, stderr io.Writer) int
 
 func defaultLaunchOptions() launchOptions {
 	parent := pickRuntimeParent(os.Stat)
@@ -108,10 +118,10 @@ func pickRuntimeParent(stat func(string) (os.FileInfo, error)) string {
 }
 
 func run() {
-	os.Exit(runArgs(os.Args[1:], os.Stdout, os.Stderr, runTUI))
+	os.Exit(runArgs(os.Args[1:], os.Stdout, os.Stderr, runTUI, runUpdate))
 }
 
-func runArgs(args []string, stdout, stderr io.Writer, launch tuiLauncher) int {
+func runArgs(args []string, stdout, stderr io.Writer, launch tuiLauncher, update updater) int {
 	opts, err := parseLaunchArgs(args)
 	if err != nil {
 		fmt.Fprintln(stderr, err)
@@ -124,6 +134,12 @@ func runArgs(args []string, stdout, stderr io.Writer, launch tuiLauncher) int {
 	case launchModeVersion:
 		fmt.Fprintf(stdout, "agentico v%s\n", tui.GetVersion())
 		return 0
+	case launchModeUpdate:
+		// Dispatch through the updater seam ahead of the TUI branch, early
+		// returning its exit code — exactly as help/version early-return.
+		// The update path never reaches the TUI launcher below, so it takes
+		// no instance lock, builds no fx container, and reconciles no assets.
+		return update(opts.updateCheck, stdout, stderr)
 	default:
 		launch(opts.configPath, opts.stateDir, opts.dangerouslySkipPerms, opts.enabledProviders)
 		return 0
@@ -132,6 +148,14 @@ func runArgs(args []string, stdout, stderr io.Writer, launch tuiLauncher) int {
 
 func parseLaunchArgs(args []string) (launchOptions, error) {
 	opts := defaultLaunchOptions()
+	// `update` is a standalone subcommand recognized only as the first
+	// argument. Its sub-flags (--check / -n) are valid only in this context;
+	// elsewhere they fall through to the launch-flag loop and reject as
+	// unknown flags, and every other bare word still rejects as an unknown
+	// command.
+	if len(args) > 0 && args[0] == "update" {
+		return parseUpdateArgs(opts, args[1:])
+	}
 	for i := 0; i < len(args); i++ {
 		arg := args[i]
 		switch arg {
@@ -177,8 +201,11 @@ func printUsage(w io.Writer) {
 	fmt.Fprintln(w, `Agentic Orchestrator
 
 Usage: agentico [flags]
+       agentico update [--check|-n]
 
 Launches the Bubble Tea TUI dashboard.
+Run 'agentico update' to upgrade the binary, or 'agentico update --check'
+(alias -n) to report the latest available release without installing.
 
 Flags:
   --config <path>                  Config file path (default: ~/.agentic-orchestrator/config.yaml)
@@ -186,6 +213,7 @@ Flags:
   --providers <list>               Comma-separated provider list (default: all)
                                    Available: claude, codex
   --dangerously-skip-permissions   Skip all permission prompts (use with caution)
+  --check, -n                      With 'update': check for a newer release without installing
   --help, -h                       Show this help
   --version, -v                    Show version
 

--- a/cmd/agentico/main_test.go
+++ b/cmd/agentico/main_test.go
@@ -79,7 +79,7 @@ func TestRunArgsLaunchesTUIByDefault(t *testing.T) {
 		if enabledProviders != nil {
 			t.Errorf("enabledProviders = %v, want nil", enabledProviders)
 		}
-	})
+	}, failingUpdater(t))
 	if code != 0 {
 		t.Errorf("runArgs() code = %d, want 0", code)
 	}
@@ -106,6 +106,7 @@ func TestRunArgsPassesRetainedLaunchFlags(t *testing.T) {
 			gotDangerouslySkipPerms = dangerouslySkipPerms
 			gotProviders = enabledProviders
 		},
+		failingUpdater(t),
 	)
 	if code != 0 {
 		t.Errorf("runArgs() code = %d, want 0", code)

--- a/cmd/agentico/swap_owner_other.go
+++ b/cmd/agentico/swap_owner_other.go
@@ -1,0 +1,26 @@
+// Copyright 2026 DoorDash, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !unix
+
+package main
+
+import "io/fs"
+
+// fileOwnerIDs reports no ownership information on non-unix platforms, where the
+// binary swap falls back to default ownership. The release matrix is unix-only;
+// this keeps the package buildable for any GOOS without a Windows-specific path.
+func fileOwnerIDs(_ fs.FileInfo) (uid, gid int, ok bool) {
+	return 0, 0, false
+}

--- a/cmd/agentico/swap_owner_unix.go
+++ b/cmd/agentico/swap_owner_unix.go
@@ -1,0 +1,33 @@
+// Copyright 2026 DoorDash, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build unix
+
+package main
+
+import (
+	"io/fs"
+	"syscall"
+)
+
+// fileOwnerIDs returns the numeric uid and gid owning info on unix systems
+// (darwin and linux, the release targets) so the binary swap can preserve
+// ownership. ok is false when the platform-specific stat data is unavailable.
+func fileOwnerIDs(info fs.FileInfo) (uid, gid int, ok bool) {
+	st, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return 0, 0, false
+	}
+	return int(st.Uid), int(st.Gid), true
+}

--- a/cmd/agentico/swap_owner_unix_test.go
+++ b/cmd/agentico/swap_owner_unix_test.go
@@ -1,0 +1,50 @@
+// Copyright 2026 DoorDash, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build unix
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// On unix, fileOwnerIDs reports the uid/gid that own a freshly created file —
+// the invoking user — so the swap can preserve ownership.
+func TestFileOwnerIDsUnix(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "f")
+	if err := os.WriteFile(path, []byte("x"), 0o644); err != nil {
+		t.Fatalf("writing file: %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	uid, gid, ok := fileOwnerIDs(info)
+	if !ok {
+		t.Fatal("fileOwnerIDs must report ok on unix")
+	}
+	// A file you create is owned by your uid. The gid is intentionally not pinned
+	// to os.Getgid(): BSD/macOS assigns a new file the *parent directory's* group
+	// rather than the process group, so we only assert it is read as a valid
+	// non-negative id.
+	if uid != os.Getuid() {
+		t.Errorf("fileOwnerIDs uid = %d, want %d", uid, os.Getuid())
+	}
+	if gid < 0 {
+		t.Errorf("fileOwnerIDs gid = %d, want a valid gid", gid)
+	}
+}

--- a/cmd/agentico/testdata/scripts/launch_contract.txtar
+++ b/cmd/agentico/testdata/scripts/launch_contract.txtar
@@ -12,6 +12,8 @@ stdout '--dangerously-skip-permissions'
 stdout '--version, -v'
 stdout '~/.agentic-orchestrator/config.yaml'
 stdout '~/.agentic-orchestrator/features'
+stdout 'agentico update \[--check\|-n\]'
+stdout '--check'
 ! stdout 'Commands:'
 ! stdout 'feature list'
 ! stdout 'feature create'
@@ -22,6 +24,25 @@ stdout '~/.agentic-orchestrator/features'
 exec agentico --version
 stdout 'agentico v'
 ! stderr .
+
+# Malformed `update` invocations reject at parse time (no network seam runs).
+! exec agentico update --bogus
+stderr 'unknown flag: --bogus'
+! stdout .
+
+! exec agentico update extra
+stderr 'unexpected argument: extra'
+! stdout .
+
+# --check is recognized only after `update`; bare it is an unknown flag.
+! exec agentico --check
+stderr 'unknown flag: --check'
+! stdout .
+
+# Every other bare word still rejects as an unknown command.
+! exec agentico feature
+stderr 'unknown command: feature'
+! stdout .
 
 ! exec agentico --config $WORK/config.yaml --state-dir $WORK/features --dangerously-skip-permissions --providers not-a-provider
 stderr 'unknown provider "not-a-provider"'

--- a/cmd/agentico/testdata/scripts/update_dev_refusal.txtar
+++ b/cmd/agentico/testdata/scripts/update_dev_refusal.txtar
@@ -1,0 +1,32 @@
+# Development-build update contract.
+#
+# The testscript binary is compiled by `go test`, so it is inherently a
+# development build: build info reports "(devel)", no release version is
+# injected, and it does not live in the Go bin dir. Every assertion below is
+# therefore network-free — the command classifies the install method offline
+# and never reaches the GitHub release lookup.
+
+# Bare `agentico update` on a dev build refuses with update-from-source
+# guidance on stderr, writes nothing to stdout, and exits non-zero. The binary
+# is never touched.
+! exec agentico update
+stderr 'built from source'
+stderr 'Update from source'
+! stdout .
+
+# `agentico update --check` on the same dev build is a non-destructive report:
+# it prints the current version, the detected method, and the would-do action
+# to stdout, writes nothing to stderr, and exits 0.
+exec agentico update --check
+stdout 'Current version:'
+stdout 'Install method:'
+stdout 'development build'
+stdout 'Would update from source'
+! stderr .
+
+# The dev-build path must never print the network "Checking for updates" line
+# in either mode — classification happens before any GitHub call.
+! exec agentico update
+! stdout 'Checking for updates'
+exec agentico update --check
+! stdout 'Checking for updates'

--- a/cmd/agentico/update.go
+++ b/cmd/agentico/update.go
@@ -1,0 +1,228 @@
+// Copyright 2026 DoorDash, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"runtime/debug"
+	"strings"
+	"time"
+
+	"github.com/doordash-oss/agentic-orchestrator/internal/tui"
+)
+
+const (
+	// githubAPIBaseURL is the GitHub REST API root for the unauthenticated
+	// release lookup. The default transport honors standard proxy env vars.
+	githubAPIBaseURL = "https://api.github.com"
+	// updateCheckTimeout bounds the single outbound GitHub call.
+	updateCheckTimeout = 15 * time.Second
+
+	// User-facing narrative strings. The placeholder action line is a Phase 1
+	// stand-in; real install-method classification lands in Phase 2.
+	updateCheckingNarrative = "Checking for updates…"
+	updatePlaceholderAction = "Install method: not yet detected — automatic install is coming in a future release. Re-run your original install command to upgrade for now."
+	updateNotImplementedMsg = "Update execution is not yet implemented."
+)
+
+// errNoStableRelease signals that a repository has no published non-draft,
+// non-pre-release release to update to. Callers map it to a clean message and
+// a non-zero exit rather than a hard failure.
+var errNoStableRelease = errors.New("no stable release found")
+
+// parseUpdateArgs parses the arguments that follow the `update` subcommand.
+// Only --check / -n are accepted; any other flag or extra positional token is
+// rejected so the surface stays minimal and unambiguous.
+func parseUpdateArgs(opts launchOptions, rest []string) (launchOptions, error) {
+	opts.mode = launchModeUpdate
+	for _, arg := range rest {
+		switch arg {
+		case "--check", "-n":
+			opts.updateCheck = true
+		default:
+			if strings.HasPrefix(arg, "-") {
+				return opts, fmt.Errorf("unknown flag: %s", arg)
+			}
+			return opts, fmt.Errorf("unexpected argument: %s", arg)
+		}
+	}
+	return opts, nil
+}
+
+// updateDeps bundles the injectable dependencies of the update flow so the
+// resolution logic can be exercised hermetically: tests supply a controllable
+// slug and an httptest-backed (or canned) latest-release fetcher.
+type updateDeps struct {
+	currentVersion string
+	slug           func() (string, error)
+	fetchLatest    func(ctx context.Context, slug string) (string, error)
+}
+
+// runUpdate is the production updater seam wired into the router. It resolves
+// the current version via the existing accessor and the latest stable release
+// via the first outbound GitHub call, then prints the result.
+func runUpdate(checkOnly bool, stdout, stderr io.Writer) int {
+	ctx, cancel := context.WithTimeout(context.Background(), updateCheckTimeout)
+	defer cancel()
+	return runUpdateWith(ctx, checkOnly, stdout, stderr, updateDeps{
+		currentVersion: tui.GetVersion(),
+		slug:           moduleSlug,
+		fetchLatest:    githubFetchLatestStableTag(http.DefaultClient, githubBaseURL()),
+	})
+}
+
+// githubBaseURL returns the GitHub REST API root, honoring the standard
+// GITHUB_API_URL environment variable (set by GitHub Actions and used to point
+// at GitHub Enterprise) and falling back to the public API. The value is still
+// reached over the default transport, which honors standard proxy env vars.
+func githubBaseURL() string {
+	if v := strings.TrimSpace(os.Getenv("GITHUB_API_URL")); v != "" {
+		return v
+	}
+	return githubAPIBaseURL
+}
+
+// runUpdateWith implements the --check / bare-update behavior against injected
+// dependencies and returns the process exit code.
+func runUpdateWith(ctx context.Context, checkOnly bool, stdout, stderr io.Writer, deps updateDeps) int {
+	fmt.Fprintln(stdout, updateCheckingNarrative)
+
+	slug, err := deps.slug()
+	if err != nil {
+		fmt.Fprintf(stderr, "Error: could not determine the release repository: %v\n", err)
+		return 1
+	}
+
+	latest, err := deps.fetchLatest(ctx, slug)
+	if err != nil {
+		if errors.Is(err, errNoStableRelease) {
+			fmt.Fprintln(stderr, "Error: no published stable release is available to update to.")
+			return 1
+		}
+		fmt.Fprintf(stderr, "Error: could not check for the latest release: %v\n", err)
+		return 1
+	}
+
+	current := deps.currentVersion
+	if sameVersion(current, latest) {
+		fmt.Fprintf(stdout, "agentico is already up to date (version %s).\n", normalizeVersion(current))
+		return 0
+	}
+
+	if checkOnly {
+		fmt.Fprintf(stdout, "Current version: %s\n", normalizeVersion(current))
+		fmt.Fprintf(stdout, "Latest version:  %s\n", normalizeVersion(latest))
+		fmt.Fprintln(stdout, updatePlaceholderAction)
+		return 0
+	}
+
+	// Bare `update` with an update available: print the conventional old → new
+	// skeleton to stdout, then report that execution is not yet wired on
+	// stderr and exit non-zero (real execution lands in Phases 2-4).
+	fmt.Fprintf(stdout, "Update available: %s → %s\n", normalizeVersion(current), normalizeVersion(latest))
+	fmt.Fprintln(stderr, updateNotImplementedMsg)
+	return 1
+}
+
+// normalizeVersion trims surrounding whitespace and a single leading "v" so
+// ldflags/build-info versions and GitHub tags compare on equal footing.
+func normalizeVersion(v string) string {
+	return strings.TrimPrefix(strings.TrimSpace(v), "v")
+}
+
+// sameVersion reports whether two version strings are equal after
+// normalization. A "dev" current never equals a release tag.
+func sameVersion(a, b string) bool {
+	return normalizeVersion(a) == normalizeVersion(b)
+}
+
+// moduleSlug derives the owner/repo GitHub slug from the binary's module path
+// at runtime (e.g. github.com/doordash-oss/agentic-orchestrator →
+// doordash-oss/agentic-orchestrator) rather than hardcoding it.
+func moduleSlug() (string, error) {
+	info, ok := debug.ReadBuildInfo()
+	if !ok || info.Main.Path == "" {
+		return "", errors.New("build info unavailable; cannot determine module path")
+	}
+	return slugFromModulePath(info.Main.Path)
+}
+
+// slugFromModulePath extracts the owner/repo slug from a github.com module
+// path, ignoring any sub-package suffix.
+func slugFromModulePath(path string) (string, error) {
+	const host = "github.com/"
+	if !strings.HasPrefix(path, host) {
+		return "", fmt.Errorf("module path %q is not a github.com repository", path)
+	}
+	parts := strings.Split(strings.TrimPrefix(path, host), "/")
+	if len(parts) < 2 || parts[0] == "" || parts[1] == "" {
+		return "", fmt.Errorf("module path %q has no owner/repo slug", path)
+	}
+	return parts[0] + "/" + parts[1], nil
+}
+
+// githubRelease is the subset of the GitHub release object this phase reads.
+type githubRelease struct {
+	TagName    string `json:"tag_name"`
+	Draft      bool   `json:"draft"`
+	Prerelease bool   `json:"prerelease"`
+}
+
+// githubFetchLatestStableTag returns a fetcher that lists a repository's
+// releases and yields the tag of the most recent non-draft, non-pre-release
+// entry. The base URL and HTTP client are injected so the resolution logic can
+// be unit-tested against an in-process httptest server. The call is
+// unauthenticated; GITHUB_TOKEN consumption is deferred to a later phase.
+func githubFetchLatestStableTag(client *http.Client, baseURL string) func(ctx context.Context, slug string) (string, error) {
+	return func(ctx context.Context, slug string) (string, error) {
+		url := fmt.Sprintf("%s/repos/%s/releases", strings.TrimRight(baseURL, "/"), slug)
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+		if err != nil {
+			return "", fmt.Errorf("building release request: %w", err)
+		}
+		req.Header.Set("Accept", "application/vnd.github+json")
+
+		resp, err := client.Do(req)
+		if err != nil {
+			return "", fmt.Errorf("requesting latest release: %w", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			return "", fmt.Errorf("github returned status %s", resp.Status)
+		}
+
+		var releases []githubRelease
+		if err := json.NewDecoder(resp.Body).Decode(&releases); err != nil {
+			return "", fmt.Errorf("decoding releases: %w", err)
+		}
+
+		for _, rel := range releases {
+			if rel.Draft || rel.Prerelease {
+				continue
+			}
+			if tag := strings.TrimSpace(rel.TagName); tag != "" {
+				return tag, nil
+			}
+		}
+		return "", errNoStableRelease
+	}
+}

--- a/cmd/agentico/update.go
+++ b/cmd/agentico/update.go
@@ -15,7 +15,13 @@
 package main
 
 import (
+	"archive/tar"
+	"bufio"
+	"bytes"
+	"compress/gzip"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -23,6 +29,8 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"runtime"
 	"runtime/debug"
 	"strings"
 	"time"
@@ -42,10 +50,22 @@ const (
 	// stalled install cannot hang forever. It is rooted at a fresh context, not
 	// derived from the 15s check context, so the install gets its full budget.
 	updateInstallTimeout = 5 * time.Minute
+	// updateDownloadTimeout bounds the tarball download → verify → extract → swap
+	// flow. Like the install timeout it is rooted at a fresh context, not derived
+	// from the 15s check context, so a release-archive download has room to
+	// complete while a stalled transfer still cannot hang forever.
+	updateDownloadTimeout = 5 * time.Minute
 
 	// User-facing narrative strings.
 	updateCheckingNarrative = "Checking for updates…"
-	updateNotImplementedMsg = "Update execution is not yet implemented."
+
+	// checksumsAssetName is the goreleaser-published manifest of per-asset
+	// SHA-256 digests the tarball branch verifies the archive against.
+	checksumsAssetName = "checksums.txt"
+	// innerBinaryName is the executable packaged inside the release archive. The
+	// archive carries the project name while the binary inside is agentico, so
+	// the two are matched separately.
+	innerBinaryName = "agentico"
 
 	// updateGoToolchainMissingMsg is printed to stderr when the go-install
 	// branch cannot find the Go toolchain on PATH. The existing binary is left
@@ -90,6 +110,15 @@ func parseUpdateArgs(opts launchOptions, rest []string) (launchOptions, error) {
 // `go install` ever runs in the unit suite.
 type commandRunner func(ctx context.Context, name string, args, env []string) ([]byte, error)
 
+// tarballUpdater performs the verified, non-destructive in-place tarball swap
+// for a resolved release. It is the injectable seam for the tarball branch,
+// mirroring runInstall: production wires an implementation closing over an HTTP
+// client, the GitHub base URL, the running binary's path, and the target
+// GOOS/GOARCH (see newTarballUpdater); tests inject one backed by an httptest
+// server and a real temp target. It returns nil only after the swap succeeds;
+// any error leaves the existing binary untouched.
+type tarballUpdater func(ctx context.Context, slug, version string) error
+
 // updateDeps bundles the injectable dependencies of the update flow so the
 // resolution logic can be exercised hermetically: tests supply a controllable
 // install-method detector, slug, an httptest-backed (or canned) latest-release
@@ -112,6 +141,9 @@ type updateDeps struct {
 	// runInstall is the injectable command-runner seam for the `go install`
 	// subprocess.
 	runInstall commandRunner
+	// runTarball is the injectable seam for the release-tarball branch: it
+	// downloads, verifies, extracts, and atomically swaps the binary in place.
+	runTarball tarballUpdater
 }
 
 // runUpdate is the production updater seam wired into the router. It resolves
@@ -128,6 +160,7 @@ func runUpdate(checkOnly bool, stdout, stderr io.Writer) int {
 		mainPackage:    mainPackagePath,
 		binaryDir:      resolveBinaryDir,
 		runInstall:     execGoInstall,
+		runTarball:     newTarballUpdater(http.DefaultClient, githubBaseURL(), resolveBinaryPath(), runtime.GOOS, runtime.GOARCH),
 	})
 }
 
@@ -185,17 +218,18 @@ func runUpdateWith(ctx context.Context, checkOnly bool, stdout, stderr io.Writer
 	}
 
 	// Bare `update` with an update available: dispatch on the detected install
-	// method. The go-install branch performs a real in-place re-install; the
-	// tarball branch is still the not-yet-implemented placeholder (Phase 4).
-	if method == installMethodGoInstall {
+	// method. Each branch performs a real in-place update for its method; the
+	// dev-build case was already handled (and refused) above.
+	switch method {
+	case installMethodGoInstall:
 		return performGoInstall(stdout, stderr, deps, current, latest)
+	case installMethodTarball:
+		return performTarballUpdate(stdout, stderr, deps, slug, current, latest)
 	}
 
-	// Print the conventional old → new skeleton to stdout, then report that
-	// execution for the detected method is not yet wired on stderr and exit
-	// non-zero. Naming the method proves the classifier ran on this branch.
-	fmt.Fprintf(stdout, "Update available: %s → %s\n", normalizeVersion(current), normalizeVersion(latest))
-	fmt.Fprintf(stderr, "%s (detected install method: %s)\n", updateNotImplementedMsg, method.label())
+	// No execution branch is wired for this method; report and exit non-zero
+	// without touching the binary.
+	fmt.Fprintf(stderr, "Error: automatic update is not supported for the %s install method.\n", method.label())
 	return 1
 }
 
@@ -230,6 +264,31 @@ func performGoInstall(stdout, stderr io.Writer, deps updateDeps, current, latest
 	out, err := deps.runInstall(ctx, "go", args, goInstallEnv(deps.binaryDir))
 	if err != nil {
 		return reportGoInstallFailure(ctx, stderr, err, out)
+	}
+
+	fmt.Fprintf(stdout, "Updated agentico %s → %s\n", normalizeVersion(current), normalizeVersion(latest))
+	return 0
+}
+
+// performTarballUpdate runs the verified, non-destructive in-place tarball swap
+// for the resolved release through the injectable runTarball seam. It is reached
+// only in bare (non --check) mode when the detected install method is a release
+// tarball and an update is available.
+//
+// The download → verify → extract → swap runs under its own generous, bounded
+// context (distinct from the 15s check timeout) so a release archive has room
+// to download but a stalled transfer cannot hang forever. On success it prints
+// the old → new transition to stdout and returns 0. Every failure — a failed or
+// partial download, a checksum mismatch, a missing per-OS/arch asset, or an
+// extraction failure — is surfaced to stderr with a non-zero exit and no success
+// transition, leaving the existing binary untouched.
+func performTarballUpdate(stdout, stderr io.Writer, deps updateDeps, slug, current, latest string) int {
+	ctx, cancel := context.WithTimeout(context.Background(), updateDownloadTimeout)
+	defer cancel()
+
+	if err := deps.runTarball(ctx, slug, latest); err != nil {
+		fmt.Fprintf(stderr, "Error: could not update from the release tarball: %v\n", err)
+		return 1
 	}
 
 	fmt.Fprintf(stdout, "Updated agentico %s → %s\n", normalizeVersion(current), normalizeVersion(latest))
@@ -361,42 +420,68 @@ func slugFromModulePath(path string) (string, error) {
 	return parts[0] + "/" + parts[1], nil
 }
 
-// githubRelease is the subset of the GitHub release object this phase reads.
+// githubRelease is the subset of the GitHub release object this command reads.
+// The published asset list (also carried by the /releases response) lets the
+// tarball branch resolve the per-platform archive and the checksums manifest.
 type githubRelease struct {
-	TagName    string `json:"tag_name"`
-	Draft      bool   `json:"draft"`
-	Prerelease bool   `json:"prerelease"`
+	TagName    string        `json:"tag_name"`
+	Draft      bool          `json:"draft"`
+	Prerelease bool          `json:"prerelease"`
+	Assets     []githubAsset `json:"assets"`
+}
+
+// githubAsset is the subset of a release asset this command reads: its name (to
+// match the per-platform archive and checksums.txt) and its download URL.
+type githubAsset struct {
+	Name               string `json:"name"`
+	BrowserDownloadURL string `json:"browser_download_url"`
+}
+
+// listReleases lists a repository's releases — including each release's
+// published assets — over the injected client and base URL. The base URL and
+// HTTP client are injected so the resolution logic can be unit-tested against an
+// in-process httptest server. When authenticated is true and GITHUB_TOKEN is
+// set, the request carries an Authorization header; the check-mode caller passes
+// false to stay unauthenticated, while the tarball download flow passes true.
+func listReleases(ctx context.Context, client *http.Client, baseURL, slug string, authenticated bool) ([]githubRelease, error) {
+	url := fmt.Sprintf("%s/repos/%s/releases", strings.TrimRight(baseURL, "/"), slug)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("building release request: %w", err)
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	if authenticated {
+		authorizeGitHub(req)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("requesting releases: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("github returned status %s", resp.Status)
+	}
+
+	var releases []githubRelease
+	if err := json.NewDecoder(resp.Body).Decode(&releases); err != nil {
+		return nil, fmt.Errorf("decoding releases: %w", err)
+	}
+	return releases, nil
 }
 
 // githubFetchLatestStableTag returns a fetcher that lists a repository's
 // releases and yields the tag of the most recent non-draft, non-pre-release
-// entry. The base URL and HTTP client are injected so the resolution logic can
-// be unit-tested against an in-process httptest server. The call is
-// unauthenticated; GITHUB_TOKEN consumption is deferred to a later phase.
+// entry. The call is unauthenticated by design — it is the lightweight check
+// that runs under the 15s timeout; the GITHUB_TOKEN-consuming requests live in
+// the tarball download flow.
 func githubFetchLatestStableTag(client *http.Client, baseURL string) func(ctx context.Context, slug string) (string, error) {
 	return func(ctx context.Context, slug string) (string, error) {
-		url := fmt.Sprintf("%s/repos/%s/releases", strings.TrimRight(baseURL, "/"), slug)
-		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+		releases, err := listReleases(ctx, client, baseURL, slug, false)
 		if err != nil {
-			return "", fmt.Errorf("building release request: %w", err)
+			return "", err
 		}
-		req.Header.Set("Accept", "application/vnd.github+json")
-
-		resp, err := client.Do(req)
-		if err != nil {
-			return "", fmt.Errorf("requesting latest release: %w", err)
-		}
-		defer resp.Body.Close()
-
-		if resp.StatusCode != http.StatusOK {
-			return "", fmt.Errorf("github returned status %s", resp.Status)
-		}
-
-		var releases []githubRelease
-		if err := json.NewDecoder(resp.Body).Decode(&releases); err != nil {
-			return "", fmt.Errorf("decoding releases: %w", err)
-		}
-
 		for _, rel := range releases {
 			if rel.Draft || rel.Prerelease {
 				continue
@@ -407,4 +492,237 @@ func githubFetchLatestStableTag(client *http.Client, baseURL string) func(ctx co
 		}
 		return "", errNoStableRelease
 	}
+}
+
+// githubToken returns the GITHUB_TOKEN environment value, trimmed, or "".
+func githubToken() string {
+	return strings.TrimSpace(os.Getenv("GITHUB_TOKEN"))
+}
+
+// authorizeGitHub adds an Authorization: Bearer header when a GITHUB_TOKEN is
+// set so the tarball flow can reach private-repo assets and lift rate limits; an
+// unset token leaves the request unauthenticated.
+func authorizeGitHub(req *http.Request) {
+	if tok := githubToken(); tok != "" {
+		req.Header.Set("Authorization", "Bearer "+tok)
+	}
+}
+
+// newTarballUpdater builds the production tarball-update seam. It closes over an
+// HTTP client, the GitHub base URL, the resolved target binary path, and the
+// running GOOS/GOARCH so the whole download → verify → extract → swap chain is
+// exercised hermetically in tests against an httptest server and a temp target.
+// All GitHub requests it issues consume GITHUB_TOKEN when set.
+func newTarballUpdater(client *http.Client, baseURL, targetPath, goos, goarch string) tarballUpdater {
+	return func(ctx context.Context, slug, version string) error {
+		if targetPath == "" {
+			return errors.New("could not resolve the running binary's path")
+		}
+
+		archiveAsset, checksumsAsset, err := resolveTarballAssets(ctx, client, baseURL, slug, version, goos, goarch)
+		if err != nil {
+			return err
+		}
+
+		archive, err := downloadAsset(ctx, client, archiveAsset.BrowserDownloadURL)
+		if err != nil {
+			return fmt.Errorf("downloading %s: %w", archiveAsset.Name, err)
+		}
+		checksums, err := downloadAsset(ctx, client, checksumsAsset.BrowserDownloadURL)
+		if err != nil {
+			return fmt.Errorf("downloading %s: %w", checksumsAsset.Name, err)
+		}
+
+		if err := verifyChecksum(archive, checksums, archiveAsset.Name); err != nil {
+			return err
+		}
+
+		binary, err := extractAgenticoBinary(archive)
+		if err != nil {
+			return err
+		}
+
+		return swapBinary(targetPath, binary)
+	}
+}
+
+// resolveTarballAssets lists the chosen release's published assets and selects
+// the per-platform archive (matched by the project-name prefix and the
+// _<GOOS>_<GOARCH>.tar.gz suffix) and the checksums.txt manifest. A missing
+// archive for the running platform is a clear, non-destructive error.
+func resolveTarballAssets(ctx context.Context, client *http.Client, baseURL, slug, version, goos, goarch string) (archive, checksums githubAsset, err error) {
+	releases, err := listReleases(ctx, client, baseURL, slug, true)
+	if err != nil {
+		return githubAsset{}, githubAsset{}, err
+	}
+
+	rel, ok := findReleaseByTag(releases, version)
+	if !ok {
+		return githubAsset{}, githubAsset{}, fmt.Errorf("release %s not found among the published releases", version)
+	}
+
+	prefix := projectNameFromSlug(slug) + "_"
+	suffix := fmt.Sprintf("_%s_%s.tar.gz", goos, goarch)
+	var haveArchive, haveChecksums bool
+	for _, a := range rel.Assets {
+		switch {
+		case a.Name == checksumsAssetName:
+			checksums, haveChecksums = a, true
+		case strings.HasPrefix(a.Name, prefix) && strings.HasSuffix(a.Name, suffix):
+			archive, haveArchive = a, true
+		}
+	}
+	if !haveArchive {
+		return githubAsset{}, githubAsset{}, fmt.Errorf("no release archive for %s/%s in release %s", goos, goarch, version)
+	}
+	if !haveChecksums {
+		return githubAsset{}, githubAsset{}, fmt.Errorf("%s not found in release %s", checksumsAssetName, version)
+	}
+	return archive, checksums, nil
+}
+
+// findReleaseByTag returns the release whose tag matches version (compared after
+// version normalization, so "v2.0.0" and "2.0.0" are equal).
+func findReleaseByTag(releases []githubRelease, version string) (githubRelease, bool) {
+	for _, rel := range releases {
+		if sameVersion(rel.TagName, version) {
+			return rel, true
+		}
+	}
+	return githubRelease{}, false
+}
+
+// projectNameFromSlug returns the repository name from an owner/repo slug, which
+// is the goreleaser project name and therefore the release archive's name
+// prefix (the archive carries the project name; the binary inside is agentico).
+func projectNameFromSlug(slug string) string {
+	if i := strings.LastIndex(slug, "/"); i >= 0 {
+		return slug[i+1:]
+	}
+	return slug
+}
+
+// downloadAsset fetches an asset's bytes over the injected client, consuming
+// GITHUB_TOKEN when set. A non-200 response is an error so a partial or failed
+// download never reaches verification.
+func downloadAsset(ctx context.Context, client *http.Client, url string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("building download request: %w", err)
+	}
+	authorizeGitHub(req)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("github returned status %s", resp.Status)
+	}
+	return io.ReadAll(resp.Body)
+}
+
+// verifyChecksum computes the archive's SHA-256 and compares it to the entry for
+// archiveName in a sha256sum-style checksums manifest. Any mismatch — or a
+// missing entry — is an error, so verification fails closed before anything
+// touches the binary.
+func verifyChecksum(archive, checksums []byte, archiveName string) error {
+	want, ok := checksumFor(checksums, archiveName)
+	if !ok {
+		return fmt.Errorf("no checksum entry for %s in %s", archiveName, checksumsAssetName)
+	}
+	sum := sha256.Sum256(archive)
+	got := hex.EncodeToString(sum[:])
+	if !strings.EqualFold(got, want) {
+		return fmt.Errorf("checksum mismatch for %s: computed %s, expected %s", archiveName, got, want)
+	}
+	return nil
+}
+
+// checksumFor parses sha256sum-style "DIGEST␠␠FILENAME" lines and returns the
+// digest whose filename matches name. goreleaser writes the bare asset name, so
+// the comparison is on the entry's base name.
+func checksumFor(checksums []byte, name string) (string, bool) {
+	sc := bufio.NewScanner(bytes.NewReader(checksums))
+	for sc.Scan() {
+		fields := strings.Fields(sc.Text())
+		if len(fields) != 2 {
+			continue
+		}
+		if filepath.Base(fields[1]) == name {
+			return fields[0], true
+		}
+	}
+	return "", false
+}
+
+// extractAgenticoBinary reads the inner agentico executable out of a gzip-
+// compressed tar archive. It returns an error when the archive is unreadable or
+// carries no agentico entry, so a malformed archive never reaches the swap.
+func extractAgenticoBinary(archive []byte) ([]byte, error) {
+	gz, err := gzip.NewReader(bytes.NewReader(archive))
+	if err != nil {
+		return nil, fmt.Errorf("opening gzip archive: %w", err)
+	}
+	defer gz.Close()
+
+	tr := tar.NewReader(gz)
+	for {
+		hdr, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("reading archive: %w", err)
+		}
+		if hdr.Typeflag == tar.TypeReg && filepath.Base(hdr.Name) == innerBinaryName {
+			data, err := io.ReadAll(tr)
+			if err != nil {
+				return nil, fmt.Errorf("extracting %s: %w", innerBinaryName, err)
+			}
+			return data, nil
+		}
+	}
+	return nil, fmt.Errorf("archive does not contain an %q binary", innerBinaryName)
+}
+
+// swapBinary performs the atomic, non-destructive in-place swap: it writes the
+// new binary to a temp file in the target's own directory, sets the executable
+// mode, then renames it over the target. Writing into the target directory keeps
+// the rename on one filesystem so it is atomic, and the rename gives the path a
+// new inode while the running process keeps executing the original — a partial
+// or failed write can never replace the live binary. On any error before the
+// rename the temp file is removed and the target is left untouched.
+func swapBinary(targetPath string, binary []byte) error {
+	dir := filepath.Dir(targetPath)
+	tmp, err := os.CreateTemp(dir, ".agentico-update-*")
+	if err != nil {
+		return fmt.Errorf("creating temp file in %s: %w", dir, err)
+	}
+	tmpName := tmp.Name()
+
+	renamed := false
+	defer func() {
+		if !renamed {
+			_ = os.Remove(tmpName)
+		}
+	}()
+
+	if _, err := tmp.Write(binary); err != nil {
+		tmp.Close()
+		return fmt.Errorf("writing new binary: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("closing new binary: %w", err)
+	}
+	if err := os.Chmod(tmpName, 0o755); err != nil {
+		return fmt.Errorf("setting executable mode: %w", err)
+	}
+	if err := os.Rename(tmpName, targetPath); err != nil {
+		return fmt.Errorf("replacing %s: %w", targetPath, err)
+	}
+	renamed = true
+	return nil
 }

--- a/cmd/agentico/update.go
+++ b/cmd/agentico/update.go
@@ -32,6 +32,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"runtime/debug"
+	"strconv"
 	"strings"
 	"time"
 
@@ -564,9 +565,10 @@ type githubAsset struct {
 // listReleases lists a repository's releases — including each release's
 // published assets — over the injected client and base URL. The base URL and
 // HTTP client are injected so the resolution logic can be unit-tested against an
-// in-process httptest server. When authenticated is true and GITHUB_TOKEN is
-// set, the request carries an Authorization header; the check-mode caller passes
-// false to stay unauthenticated, while the tarball download flow passes true.
+// in-process httptest server. When authenticated is true the request carries an
+// Authorization header if GITHUB_TOKEN is set (and is a no-op otherwise); both
+// the check and the tarball download flow pass true so a token, when present,
+// lifts the 60/hour unauthenticated rate limit on every request.
 func listReleases(ctx context.Context, client *http.Client, baseURL, slug string, authenticated bool) ([]githubRelease, error) {
 	url := fmt.Sprintf("%s/repos/%s/releases", strings.TrimRight(baseURL, "/"), slug)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
@@ -585,6 +587,9 @@ func listReleases(ctx context.Context, client *http.Client, baseURL, slug string
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
+		if msg := rateLimitMessage(resp, githubToken() != ""); msg != "" {
+			return nil, errors.New(msg)
+		}
 		return nil, fmt.Errorf("github returned status %s", resp.Status)
 	}
 
@@ -595,14 +600,41 @@ func listReleases(ctx context.Context, client *http.Client, baseURL, slug string
 	return releases, nil
 }
 
+// rateLimitMessage returns a clear, actionable error message when resp is a
+// GitHub primary rate-limit rejection — a 403/429 carrying X-RateLimit-Remaining: 0
+// — or "" when resp is some other failure. The unauthenticated limit is only
+// 60/hour per IP (easily exhausted behind a shared NAT egress), so the message
+// points an unauthenticated caller at GITHUB_TOKEN, names the authenticated
+// limit, and includes the reset time when the header is parseable.
+func rateLimitMessage(resp *http.Response, tokenSet bool) string {
+	if resp.StatusCode != http.StatusForbidden && resp.StatusCode != http.StatusTooManyRequests {
+		return ""
+	}
+	if resp.Header.Get("X-RateLimit-Remaining") != "0" {
+		return ""
+	}
+	var when string
+	if reset := resp.Header.Get("X-RateLimit-Reset"); reset != "" {
+		if secs, err := strconv.ParseInt(reset, 10, 64); err == nil {
+			when = fmt.Sprintf(" Try again after %s.", time.Unix(secs, 0).Format("15:04 MST"))
+		}
+	}
+	if tokenSet {
+		return "GitHub API rate limit exceeded for the authenticated token." + when
+	}
+	return "GitHub API rate limit exceeded (unauthenticated requests are capped at 60/hour per IP). " +
+		"Set GITHUB_TOKEN to a personal access token to raise the limit to 5000/hour." + when
+}
+
 // githubFetchLatestStableTag returns a fetcher that lists a repository's
 // releases and yields the tag of the most recent non-draft, non-pre-release
-// entry. The call is unauthenticated by design — it is the lightweight check
-// that runs under the 15s timeout; the GITHUB_TOKEN-consuming requests live in
-// the tarball download flow.
+// entry. It consumes GITHUB_TOKEN when one is set (and stays unauthenticated
+// otherwise), so a caller behind a shared egress IP can lift the 60/hour
+// unauthenticated rate limit on the check — the same token the tarball download
+// flow already uses — and so private/Enterprise repositories can be checked.
 func githubFetchLatestStableTag(client *http.Client, baseURL string) func(ctx context.Context, slug string) (string, error) {
 	return func(ctx context.Context, slug string) (string, error) {
-		releases, err := listReleases(ctx, client, baseURL, slug, false)
+		releases, err := listReleases(ctx, client, baseURL, slug, true)
 		if err != nil {
 			return "", err
 		}

--- a/cmd/agentico/update.go
+++ b/cmd/agentico/update.go
@@ -36,11 +36,15 @@ const (
 	// updateCheckTimeout bounds the single outbound GitHub call.
 	updateCheckTimeout = 15 * time.Second
 
-	// User-facing narrative strings. The placeholder action line is a Phase 1
-	// stand-in; real install-method classification lands in Phase 2.
+	// User-facing narrative strings.
 	updateCheckingNarrative = "Checking for updates…"
-	updatePlaceholderAction = "Install method: not yet detected — automatic install is coming in a future release. Re-run your original install command to upgrade for now."
 	updateNotImplementedMsg = "Update execution is not yet implemented."
+
+	// updateFromSourceGuidance is printed to stderr when a development build
+	// refuses to self-update. It points the user back at their source checkout
+	// rather than touching the binary or the network.
+	updateFromSourceGuidance = "agentico was built from source; development builds are not updated automatically.\n" +
+		"Update from source instead: pull the latest changes and rebuild (for example, `git pull` then `make install`)."
 )
 
 // errNoStableRelease signals that a repository has no published non-draft,
@@ -69,11 +73,15 @@ func parseUpdateArgs(opts launchOptions, rest []string) (launchOptions, error) {
 
 // updateDeps bundles the injectable dependencies of the update flow so the
 // resolution logic can be exercised hermetically: tests supply a controllable
-// slug and an httptest-backed (or canned) latest-release fetcher.
+// install-method detector, slug, and an httptest-backed (or canned)
+// latest-release fetcher.
 type updateDeps struct {
 	currentVersion string
-	slug           func() (string, error)
-	fetchLatest    func(ctx context.Context, slug string) (string, error)
+	// method detects how the running binary was installed. It is consulted
+	// before any network call so a development build can be refused offline.
+	method      func() installMethod
+	slug        func() (string, error)
+	fetchLatest func(ctx context.Context, slug string) (string, error)
 }
 
 // runUpdate is the production updater seam wired into the router. It resolves
@@ -84,6 +92,7 @@ func runUpdate(checkOnly bool, stdout, stderr io.Writer) int {
 	defer cancel()
 	return runUpdateWith(ctx, checkOnly, stdout, stderr, updateDeps{
 		currentVersion: tui.GetVersion(),
+		method:         gatherInstallMethod,
 		slug:           moduleSlug,
 		fetchLatest:    githubFetchLatestStableTag(http.DefaultClient, githubBaseURL()),
 	})
@@ -103,6 +112,13 @@ func githubBaseURL() string {
 // runUpdateWith implements the --check / bare-update behavior against injected
 // dependencies and returns the process exit code.
 func runUpdateWith(ctx context.Context, checkOnly bool, stdout, stderr io.Writer, deps updateDeps) int {
+	// Classify the install method before any network call. A development build
+	// is refused entirely offline — no GitHub request, no binary touched.
+	method := deps.method()
+	if method == installMethodDevBuild {
+		return reportDevBuild(checkOnly, stdout, stderr, deps.currentVersion)
+	}
+
 	fmt.Fprintln(stdout, updateCheckingNarrative)
 
 	slug, err := deps.slug()
@@ -130,15 +146,34 @@ func runUpdateWith(ctx context.Context, checkOnly bool, stdout, stderr io.Writer
 	if checkOnly {
 		fmt.Fprintf(stdout, "Current version: %s\n", normalizeVersion(current))
 		fmt.Fprintf(stdout, "Latest version:  %s\n", normalizeVersion(latest))
-		fmt.Fprintln(stdout, updatePlaceholderAction)
+		fmt.Fprintf(stdout, "Install method:  %s\n", method.label())
+		fmt.Fprintln(stdout, method.wouldDoAction())
 		return 0
 	}
 
 	// Bare `update` with an update available: print the conventional old → new
-	// skeleton to stdout, then report that execution is not yet wired on
-	// stderr and exit non-zero (real execution lands in Phases 2-4).
+	// skeleton to stdout, then report that execution for the detected method is
+	// not yet wired on stderr and exit non-zero (real execution lands in
+	// Phases 3-4). Naming the method proves the classifier ran on this branch.
 	fmt.Fprintf(stdout, "Update available: %s → %s\n", normalizeVersion(current), normalizeVersion(latest))
-	fmt.Fprintln(stderr, updateNotImplementedMsg)
+	fmt.Fprintf(stderr, "%s (detected install method: %s)\n", updateNotImplementedMsg, method.label())
+	return 1
+}
+
+// reportDevBuild handles the development-build case for both modes without any
+// network call or binary mutation. In --check mode it reports the current
+// version, the detected method, and the would-do action to stdout and exits 0
+// (a non-destructive report). In bare mode it prints update-from-source
+// guidance to stderr and exits non-zero (the refusal — the first real action
+// the update command takes).
+func reportDevBuild(checkOnly bool, stdout, stderr io.Writer, current string) int {
+	if checkOnly {
+		fmt.Fprintf(stdout, "Current version: %s\n", normalizeVersion(current))
+		fmt.Fprintf(stdout, "Install method:  %s\n", installMethodDevBuild.label())
+		fmt.Fprintln(stdout, installMethodDevBuild.wouldDoAction())
+		return 0
+	}
+	fmt.Fprintln(stderr, updateFromSourceGuidance)
 	return 1
 }
 

--- a/cmd/agentico/update.go
+++ b/cmd/agentico/update.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"os/exec"
 	"runtime/debug"
 	"strings"
 	"time"
@@ -35,10 +36,22 @@ const (
 	githubAPIBaseURL = "https://api.github.com"
 	// updateCheckTimeout bounds the single outbound GitHub call.
 	updateCheckTimeout = 15 * time.Second
+	// updateInstallTimeout bounds the `go install` subprocess. It is far more
+	// generous than the check timeout because a cold module cache must download
+	// and compile the whole dependency graph, but it is still bounded so a
+	// stalled install cannot hang forever. It is rooted at a fresh context, not
+	// derived from the 15s check context, so the install gets its full budget.
+	updateInstallTimeout = 5 * time.Minute
 
 	// User-facing narrative strings.
 	updateCheckingNarrative = "Checking for updates…"
 	updateNotImplementedMsg = "Update execution is not yet implemented."
+
+	// updateGoToolchainMissingMsg is printed to stderr when the go-install
+	// branch cannot find the Go toolchain on PATH. The existing binary is left
+	// untouched.
+	updateGoToolchainMissingMsg = "Error: the Go toolchain was not found on PATH. " +
+		"Install Go or add it to PATH, then run `agentico update` again."
 
 	// updateFromSourceGuidance is printed to stderr when a development build
 	// refuses to self-update. It points the user back at their source checkout
@@ -71,10 +84,17 @@ func parseUpdateArgs(opts launchOptions, rest []string) (launchOptions, error) {
 	return opts, nil
 }
 
+// commandRunner runs an external command and returns its combined stdout+stderr
+// output. It is a function value mirroring the repo's CommandRunner convention,
+// injected so the go-install subprocess is faked in unit tests and no real
+// `go install` ever runs in the unit suite.
+type commandRunner func(ctx context.Context, name string, args, env []string) ([]byte, error)
+
 // updateDeps bundles the injectable dependencies of the update flow so the
 // resolution logic can be exercised hermetically: tests supply a controllable
-// install-method detector, slug, and an httptest-backed (or canned)
-// latest-release fetcher.
+// install-method detector, slug, an httptest-backed (or canned) latest-release
+// fetcher, and — for the go-install execution branch — a main-package resolver,
+// a running-binary-directory resolver, and a command runner.
 type updateDeps struct {
 	currentVersion string
 	// method detects how the running binary was installed. It is consulted
@@ -82,6 +102,16 @@ type updateDeps struct {
 	method      func() installMethod
 	slug        func() (string, error)
 	fetchLatest func(ctx context.Context, slug string) (string, error)
+
+	// mainPackage derives the command's own main-package import path from build
+	// info at runtime (the package to `go install`, not the bare module path).
+	mainPackage func() (string, error)
+	// binaryDir resolves the symlink-resolved directory of the running binary so
+	// the re-install can force GOBIN there and replace the binary in place.
+	binaryDir func() string
+	// runInstall is the injectable command-runner seam for the `go install`
+	// subprocess.
+	runInstall commandRunner
 }
 
 // runUpdate is the production updater seam wired into the router. It resolves
@@ -95,6 +125,9 @@ func runUpdate(checkOnly bool, stdout, stderr io.Writer) int {
 		method:         gatherInstallMethod,
 		slug:           moduleSlug,
 		fetchLatest:    githubFetchLatestStableTag(http.DefaultClient, githubBaseURL()),
+		mainPackage:    mainPackagePath,
+		binaryDir:      resolveBinaryDir,
+		runInstall:     execGoInstall,
 	})
 }
 
@@ -151,13 +184,127 @@ func runUpdateWith(ctx context.Context, checkOnly bool, stdout, stderr io.Writer
 		return 0
 	}
 
-	// Bare `update` with an update available: print the conventional old → new
-	// skeleton to stdout, then report that execution for the detected method is
-	// not yet wired on stderr and exit non-zero (real execution lands in
-	// Phases 3-4). Naming the method proves the classifier ran on this branch.
+	// Bare `update` with an update available: dispatch on the detected install
+	// method. The go-install branch performs a real in-place re-install; the
+	// tarball branch is still the not-yet-implemented placeholder (Phase 4).
+	if method == installMethodGoInstall {
+		return performGoInstall(stdout, stderr, deps, current, latest)
+	}
+
+	// Print the conventional old → new skeleton to stdout, then report that
+	// execution for the detected method is not yet wired on stderr and exit
+	// non-zero. Naming the method proves the classifier ran on this branch.
 	fmt.Fprintf(stdout, "Update available: %s → %s\n", normalizeVersion(current), normalizeVersion(latest))
 	fmt.Fprintf(stderr, "%s (detected install method: %s)\n", updateNotImplementedMsg, method.label())
 	return 1
+}
+
+// performGoInstall re-runs the Go toolchain install of the command's own main
+// package, pinned to the resolved latest stable tag, so the toolchain-managed
+// binary is replaced in place. It is reached only in bare (non --check) mode
+// when the detected install method is go-install and an update is available.
+//
+// The subprocess runs under its own generous, bounded context (distinct from
+// the 15s check timeout) through the injectable runner seam, with an
+// inherited-plus-augmented environment that forces GOBIN to the running
+// binary's resolved directory so the binary that is actually running is the one
+// replaced — no stray second copy in the default Go bin dir. On success it
+// prints the old → new transition to stdout and returns 0. Every failure is
+// surfaced to stderr with a non-zero exit and no success transition; a failed
+// or partial `go install` does not replace the running binary.
+func performGoInstall(stdout, stderr io.Writer, deps updateDeps, current, latest string) int {
+	pkg, err := deps.mainPackage()
+	if err != nil {
+		fmt.Fprintf(stderr, "Error: could not determine the package to install: %v\n", err)
+		return 1
+	}
+
+	// Pin to the exact resolved tag (not @latest): the report is truthful by
+	// construction and the install fails loudly if the proxy has not indexed the
+	// tag rather than silently installing an older version.
+	args := []string{"install", pkg + "@" + latest}
+
+	ctx, cancel := context.WithTimeout(context.Background(), updateInstallTimeout)
+	defer cancel()
+
+	out, err := deps.runInstall(ctx, "go", args, goInstallEnv(deps.binaryDir))
+	if err != nil {
+		return reportGoInstallFailure(ctx, stderr, err, out)
+	}
+
+	fmt.Fprintf(stdout, "Updated agentico %s → %s\n", normalizeVersion(current), normalizeVersion(latest))
+	return 0
+}
+
+// goInstallEnv returns the environment for the `go install` subprocess: the
+// inherited process environment augmented so GOBIN points at the running
+// binary's resolved directory, guaranteeing the re-install replaces the binary
+// in place. os/exec honors the last value for a duplicated key, so appending
+// overrides any inherited GOBIN. When the binary's directory cannot be resolved
+// (resolver nil or empty), GOBIN is left untouched and the toolchain default
+// applies.
+func goInstallEnv(binaryDir func() string) []string {
+	env := os.Environ()
+	if binaryDir == nil {
+		return env
+	}
+	if dir := binaryDir(); dir != "" {
+		env = append(env, "GOBIN="+dir)
+	}
+	return env
+}
+
+// reportGoInstallFailure maps a failed `go install` to a clear stderr message
+// and a non-zero exit, distinguishing a missing toolchain, a timeout, and a
+// generic install error. The captured combined output is included for the
+// timeout and generic cases so the user sees what the toolchain reported.
+func reportGoInstallFailure(ctx context.Context, stderr io.Writer, err error, out []byte) int {
+	switch {
+	case errors.Is(err, exec.ErrNotFound):
+		fmt.Fprintln(stderr, updateGoToolchainMissingMsg)
+	case errors.Is(err, context.DeadlineExceeded) || ctx.Err() == context.DeadlineExceeded:
+		fmt.Fprintf(stderr, "Error: the Go install timed out after %s and was aborted; the existing binary is unchanged.\n", updateInstallTimeout)
+		writeCapturedOutput(stderr, out)
+	default:
+		fmt.Fprintf(stderr, "Error: `go install` failed: %v\n", err)
+		writeCapturedOutput(stderr, out)
+	}
+	return 1
+}
+
+// writeCapturedOutput appends the trimmed combined output of the subprocess to
+// stderr under a label, when there is any.
+func writeCapturedOutput(stderr io.Writer, out []byte) {
+	if trimmed := strings.TrimSpace(string(out)); trimmed != "" {
+		fmt.Fprintf(stderr, "go install output:\n%s\n", trimmed)
+	}
+}
+
+// execGoInstall is the production command-runner seam: it runs the command
+// under ctx with the augmented environment and returns the combined
+// stdout+stderr output. Tests swap in a fake so no real install runs.
+func execGoInstall(ctx context.Context, name string, args, env []string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Env = env
+	return cmd.CombinedOutput()
+}
+
+// mainPackagePath derives the command's own main-package import path from the
+// binary's build info at runtime — the package path (module path plus the
+// command subdirectory, e.g.
+// github.com/doordash-oss/agentic-orchestrator/cmd/agentico), not the bare
+// module path, which has no main package and so cannot be `go install`ed. It
+// mirrors moduleSlug's runtime derivation.
+func mainPackagePath() (string, error) {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return "", errors.New("build info unavailable; cannot determine the package to install")
+	}
+	path := strings.TrimSpace(info.Path)
+	if path == "" || path == "command-line-arguments" {
+		return "", errors.New("build info has no main package path; cannot determine the package to install")
+	}
+	return path, nil
 }
 
 // reportDevBuild handles the development-build case for both modes without any

--- a/cmd/agentico/update.go
+++ b/cmd/agentico/update.go
@@ -95,6 +95,16 @@ const (
 	updateResignWarning = "Warning: agentico was updated but could not be ad-hoc re-signed (%[1]v); " +
 		"on Apple Silicon it may fail to launch (\"killed: 9\").\n" +
 		"If so, sign it manually: codesign -s - %[2]s"
+
+	// homebrewFormulaName matches the goreleaser brews block `name:`.
+	homebrewFormulaName = "agentico"
+
+	// updateBrewTimeout bounds the `brew upgrade` subprocess (generous: brew may
+	// refresh taps and download), rooted at a fresh context like the other timeouts.
+	updateBrewTimeout = 10 * time.Minute
+
+	updateBrewMissingMsg = "Error: Homebrew (brew) was not found on PATH. " +
+		"Install it from https://brew.sh, or update manually: brew upgrade " + homebrewFormulaName
 )
 
 // errNoStableRelease signals that a repository has no published non-draft,
@@ -181,6 +191,9 @@ type updateDeps struct {
 	// re-sign subprocess — the same commandRunner kind the go-install branch uses,
 	// so no real codesign runs in the unit suite.
 	runCodesign commandRunner
+	// runBrew is the injectable seam for the `brew upgrade` subprocess; nil makes
+	// the branch print the command as guidance instead of running it.
+	runBrew commandRunner
 }
 
 // runUpdate is the production updater seam wired into the router. It resolves
@@ -205,6 +218,7 @@ func runUpdate(checkOnly bool, stdout, stderr io.Writer) int {
 		goos:           runtime.GOOS,
 		checkWritable:  checkDirWritable,
 		runCodesign:    execCommand,
+		runBrew:        execCommand,
 	})
 }
 
@@ -295,6 +309,8 @@ func runUpdateWith(ctx context.Context, checkOnly bool, stdout, stderr io.Writer
 		return performGoInstall(stdout, stderr, deps, current, latest)
 	case installMethodTarball:
 		return performTarballUpdate(stdout, stderr, deps, slug, current, latest)
+	case installMethodHomebrew:
+		return performHomebrewUpdate(stdout, stderr, deps, latest)
 	}
 
 	// No execution branch is wired for this method; report and exit non-zero
@@ -371,6 +387,54 @@ func performTarballUpdate(stdout, stderr io.Writer, deps updateDeps, slug, curre
 
 	fmt.Fprintf(stdout, "Updated agentico %s → %s\n", normalizeVersion(current), normalizeVersion(latest))
 	return 0
+}
+
+// performHomebrewUpdate delegates to `brew upgrade` rather than swapping a
+// brew-managed binary in place (which would desync Homebrew). It prints the
+// command, runs it through the runBrew seam, surfaces brew's output, and maps
+// failures to a non-zero exit. Reached only in bare mode once the check confirms a
+// newer release; a nil runBrew prints the command as guidance instead.
+func performHomebrewUpdate(stdout, stderr io.Writer, deps updateDeps, latest string) int {
+	cmdline := "brew upgrade " + homebrewFormulaName
+	fmt.Fprintf(stdout, "agentico was installed via Homebrew. Updating with: %s\n", cmdline)
+
+	if deps.runBrew == nil {
+		fmt.Fprintf(stdout, "Run `%s` to update.\n", cmdline)
+		return 0
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), updateBrewTimeout)
+	defer cancel()
+
+	fmt.Fprintln(stdout, "(this can take a minute while Homebrew refreshes its taps)")
+	out, err := deps.runBrew(ctx, "brew", []string{"upgrade", homebrewFormulaName}, nil)
+	writeBrewOutput(stdout, out)
+	if err != nil {
+		return reportBrewFailure(ctx, stderr, err)
+	}
+	fmt.Fprintf(stdout, "agentico updated via Homebrew (latest release is %s). Run `agentico --version` to confirm.\n", normalizeVersion(latest))
+	return 0
+}
+
+// writeBrewOutput prints brew's combined output to stdout when non-empty.
+func writeBrewOutput(stdout io.Writer, out []byte) {
+	if trimmed := strings.TrimSpace(string(out)); trimmed != "" {
+		fmt.Fprintln(stdout, trimmed)
+	}
+}
+
+// reportBrewFailure maps a failed `brew upgrade` (missing brew, timeout, or a
+// generic error) to a stderr message and a non-zero exit.
+func reportBrewFailure(ctx context.Context, stderr io.Writer, err error) int {
+	switch {
+	case errors.Is(err, exec.ErrNotFound):
+		fmt.Fprintln(stderr, updateBrewMissingMsg)
+	case errors.Is(err, context.DeadlineExceeded) || ctx.Err() == context.DeadlineExceeded:
+		fmt.Fprintf(stderr, "Error: `brew upgrade %s` timed out after %s and was aborted; the existing binary is unchanged.\n", homebrewFormulaName, updateBrewTimeout)
+	default:
+		fmt.Fprintf(stderr, "Error: `brew upgrade %s` failed: %v\n", homebrewFormulaName, err)
+	}
+	return 1
 }
 
 // preflightTarballWritable verifies the swap's target directory — the directory

--- a/cmd/agentico/update.go
+++ b/cmd/agentico/update.go
@@ -78,6 +78,22 @@ const (
 	// rather than touching the binary or the network.
 	updateFromSourceGuidance = "agentico was built from source; development builds are not updated automatically.\n" +
 		"Update from source instead: pull the latest changes and rebuild (for example, `git pull` then `make install`)."
+
+	// updateNotWritableMsg is printed to stderr when the tarball pre-flight finds
+	// the swap's target directory unwritable. It names the directory and points
+	// the user at re-running with elevated privileges. It is intentionally
+	// distinct from the generic tarball-failure error so the remedy is
+	// unambiguous, and the command never self-escalates — it only instructs.
+	updateNotWritableMsg = "Error: cannot update agentico because the install directory %[1]s is not writable.\n" +
+		"Re-run with elevated privileges, for example: sudo agentico update"
+
+	// updateResignWarning is printed to stderr when the best-effort macOS ad-hoc
+	// re-sign of the freshly swapped binary fails (codesign missing or a signing
+	// error). The update has already succeeded and is not rolled back; the warning
+	// tells the user how to recover if the binary will not launch.
+	updateResignWarning = "Warning: agentico was updated but could not be ad-hoc re-signed (%[1]v); " +
+		"on Apple Silicon it may fail to launch (\"killed: 9\").\n" +
+		"If so, sign it manually: codesign -s - %[2]s"
 )
 
 // errNoStableRelease signals that a repository has no published non-draft,
@@ -144,6 +160,26 @@ type updateDeps struct {
 	// runTarball is the injectable seam for the release-tarball branch: it
 	// downloads, verifies, extracts, and atomically swaps the binary in place.
 	runTarball tarballUpdater
+
+	// binaryPath is the symlink-resolved path of the running binary — the swap's
+	// target. The tarball pre-flight derives the directory to probe from it, and
+	// the darwin re-sign step signs exactly this path. Empty when the executable
+	// path could not be resolved.
+	binaryPath string
+	// goos is the target operating system for OS-gated post-swap steps
+	// (production: runtime.GOOS). It is a field rather than a direct runtime.GOOS
+	// read so the darwin re-sign gate is deterministically testable on any host.
+	goos string
+	// checkWritable reports whether the swap's target directory admits the
+	// temp-create + rename the swap performs. It is injected so the pre-flight is
+	// deterministic regardless of the test process's uid (a root process bypasses
+	// real permission bits). Nil disables the pre-flight on unit paths that do not
+	// exercise it.
+	checkWritable func(dir string) error
+	// runCodesign is the injectable command-runner seam for the macOS ad-hoc
+	// re-sign subprocess — the same commandRunner kind the go-install branch uses,
+	// so no real codesign runs in the unit suite.
+	runCodesign commandRunner
 }
 
 // runUpdate is the production updater seam wired into the router. It resolves
@@ -152,6 +188,9 @@ type updateDeps struct {
 func runUpdate(checkOnly bool, stdout, stderr io.Writer) int {
 	ctx, cancel := context.WithTimeout(context.Background(), updateCheckTimeout)
 	defer cancel()
+	// Resolve the running binary's path once so the tarball swap, the pre-flight
+	// writability probe, and the darwin re-sign all target the same path.
+	binPath := resolveBinaryPath()
 	return runUpdateWith(ctx, checkOnly, stdout, stderr, updateDeps{
 		currentVersion: tui.GetVersion(),
 		method:         gatherInstallMethod,
@@ -159,8 +198,12 @@ func runUpdate(checkOnly bool, stdout, stderr io.Writer) int {
 		fetchLatest:    githubFetchLatestStableTag(http.DefaultClient, githubBaseURL()),
 		mainPackage:    mainPackagePath,
 		binaryDir:      resolveBinaryDir,
-		runInstall:     execGoInstall,
-		runTarball:     newTarballUpdater(http.DefaultClient, githubBaseURL(), resolveBinaryPath(), runtime.GOOS, runtime.GOARCH),
+		runInstall:     execCommand,
+		runTarball:     newTarballUpdater(http.DefaultClient, githubBaseURL(), binPath, runtime.GOOS, runtime.GOARCH),
+		binaryPath:     binPath,
+		goos:           runtime.GOOS,
+		checkWritable:  checkDirWritable,
+		runCodesign:    execCommand,
 	})
 }
 
@@ -183,6 +226,19 @@ func runUpdateWith(ctx context.Context, checkOnly bool, stdout, stderr io.Writer
 	method := deps.method()
 	if method == installMethodDevBuild {
 		return reportDevBuild(checkOnly, stdout, stderr, deps.currentVersion)
+	}
+
+	// Pre-flight the swap's target directory on the one path that will actually
+	// mutate the binary: a bare (non --check) tarball update. It sits ahead of
+	// every network request — the latest-release lookup below and the tarball
+	// download/swap seam — so an unwritable, root-owned install aborts here with
+	// elevated-privilege guidance and no GitHub request or binary change occurs.
+	// --check, the go-install branch, and the dev-build refusal never reach this
+	// gate, so their behavior is unchanged.
+	if !checkOnly && method == installMethodTarball {
+		if !preflightTarballWritable(stderr, deps) {
+			return 1
+		}
 	}
 
 	fmt.Fprintln(stdout, updateCheckingNarrative)
@@ -283,6 +339,9 @@ func performGoInstall(stdout, stderr io.Writer, deps updateDeps, current, latest
 // extraction failure — is surfaced to stderr with a non-zero exit and no success
 // transition, leaving the existing binary untouched.
 func performTarballUpdate(stdout, stderr io.Writer, deps updateDeps, slug, current, latest string) int {
+	// The swap's target directory was already verified writable by the pre-flight
+	// in runUpdateWith, ahead of the latest-release fetch — so this branch is
+	// reached only once the directory admits the temp-create + rename swap.
 	ctx, cancel := context.WithTimeout(context.Background(), updateDownloadTimeout)
 	defer cancel()
 
@@ -291,8 +350,59 @@ func performTarballUpdate(stdout, stderr io.Writer, deps updateDeps, slug, curre
 		return 1
 	}
 
+	// Best-effort macOS ad-hoc re-sign of the freshly swapped binary. It is
+	// strictly non-fatal: the swap has already succeeded, so any failure is
+	// downgraded to a warning and the update still reports success.
+	resignDarwinBinary(ctx, stderr, deps)
+
 	fmt.Fprintf(stdout, "Updated agentico %s → %s\n", normalizeVersion(current), normalizeVersion(latest))
 	return 0
+}
+
+// preflightTarballWritable verifies the swap's target directory — the directory
+// containing the resolved running binary — is writable before any network
+// request. It returns true to proceed and false to abort; on a failed check it
+// prints directory-naming, elevated-privilege guidance to stderr. It never
+// self-escalates: it only instructs. The check is skipped (proceed) when no seam
+// is wired, mirroring goInstallEnv's nil handling for unit paths that do not
+// exercise the pre-flight.
+func preflightTarballWritable(stderr io.Writer, deps updateDeps) bool {
+	if deps.checkWritable == nil {
+		return true
+	}
+	dir := tarballSwapDir(deps.binaryPath)
+	if err := deps.checkWritable(dir); err != nil {
+		fmt.Fprintf(stderr, updateNotWritableMsg+"\n", dir)
+		return false
+	}
+	return true
+}
+
+// tarballSwapDir returns the directory the swap writes into — the directory
+// containing the resolved running binary — or "" when the binary path is
+// unresolved (which checkDirWritable then reports as an error).
+func tarballSwapDir(binaryPath string) string {
+	if strings.TrimSpace(binaryPath) == "" {
+		return ""
+	}
+	return filepath.Dir(binaryPath)
+}
+
+// resignDarwinBinary ad-hoc re-signs the freshly swapped binary on macOS,
+// mirroring the system-install step (codesign -s -). It is gated to darwin (a
+// literal no-op elsewhere, on both Apple Silicon and Intel) and strictly
+// non-fatal: a missing codesign tool or a signing failure is downgraded to a
+// stderr warning while the update still reports success — the swap has already
+// happened and is not rolled back. The subprocess runs through the injected
+// command-runner seam under the caller's update context, so no real codesign
+// runs in the unit suite; a nil runner is likewise a no-op.
+func resignDarwinBinary(ctx context.Context, stderr io.Writer, deps updateDeps) {
+	if deps.goos != "darwin" || deps.runCodesign == nil {
+		return
+	}
+	if _, err := deps.runCodesign(ctx, "codesign", []string{"-s", "-", deps.binaryPath}, nil); err != nil {
+		fmt.Fprintf(stderr, updateResignWarning+"\n", err, deps.binaryPath)
+	}
 }
 
 // goInstallEnv returns the environment for the `go install` subprocess: the
@@ -339,10 +449,11 @@ func writeCapturedOutput(stderr io.Writer, out []byte) {
 	}
 }
 
-// execGoInstall is the production command-runner seam: it runs the command
-// under ctx with the augmented environment and returns the combined
-// stdout+stderr output. Tests swap in a fake so no real install runs.
-func execGoInstall(ctx context.Context, name string, args, env []string) ([]byte, error) {
+// execCommand is the production command-runner seam shared by the go-install
+// re-install and the macOS ad-hoc re-sign: it runs the command under ctx with
+// the given environment and returns the combined stdout+stderr output. Tests
+// swap in a fake so neither a real `go install` nor a real `codesign` runs.
+func execCommand(ctx context.Context, name string, args, env []string) ([]byte, error) {
 	cmd := exec.CommandContext(ctx, name, args...)
 	cmd.Env = env
 	return cmd.CombinedOutput()
@@ -686,6 +797,27 @@ func extractAgenticoBinary(archive []byte) ([]byte, error) {
 		}
 	}
 	return nil, fmt.Errorf("archive does not contain an %q binary", innerBinaryName)
+}
+
+// checkDirWritable reports whether dir admits the tarball swap's temp-create +
+// rename by performing that same first step: it creates, then immediately
+// removes, a temp entry in dir. Modeling the swap's real operation — rather than
+// inspecting permission bits, which misjudge root and ACLs — means a read-only or
+// root-owned directory fails here exactly as the later rename would. An empty
+// dir (the running binary's directory could not be resolved) is reported as an
+// error so the caller aborts cleanly rather than probing the process's temp dir.
+func checkDirWritable(dir string) error {
+	if strings.TrimSpace(dir) == "" {
+		return errors.New("the running binary's directory could not be resolved")
+	}
+	f, err := os.CreateTemp(dir, ".agentico-preflight-*")
+	if err != nil {
+		return err
+	}
+	name := f.Name()
+	_ = f.Close()
+	_ = os.Remove(name)
+	return nil
 }
 
 // swapBinary performs the atomic, non-destructive in-place swap: it writes the

--- a/cmd/agentico/update.go
+++ b/cmd/agentico/update.go
@@ -228,19 +228,6 @@ func runUpdateWith(ctx context.Context, checkOnly bool, stdout, stderr io.Writer
 		return reportDevBuild(checkOnly, stdout, stderr, deps.currentVersion)
 	}
 
-	// Pre-flight the swap's target directory on the one path that will actually
-	// mutate the binary: a bare (non --check) tarball update. It sits ahead of
-	// every network request — the latest-release lookup below and the tarball
-	// download/swap seam — so an unwritable, root-owned install aborts here with
-	// elevated-privilege guidance and no GitHub request or binary change occurs.
-	// --check, the go-install branch, and the dev-build refusal never reach this
-	// gate, so their behavior is unchanged.
-	if !checkOnly && method == installMethodTarball {
-		if !preflightTarballWritable(stderr, deps) {
-			return 1
-		}
-	}
-
 	fmt.Fprintln(stdout, updateCheckingNarrative)
 
 	slug, err := deps.slug()
@@ -260,8 +247,20 @@ func runUpdateWith(ctx context.Context, checkOnly bool, stdout, stderr io.Writer
 	}
 
 	current := deps.currentVersion
-	if sameVersion(current, latest) {
-		fmt.Fprintf(stdout, "agentico is already up to date (version %s).\n", normalizeVersion(current))
+	// Decide whether an update is actually warranted. Equal versions are up to
+	// date; and when both sides are clean release versions, a current that is
+	// newer than the latest published release is also "up to date" — the command
+	// never downgrades. Only when neither rule applies (the versions differ and
+	// at least one is not a clean release version, e.g. a go-install
+	// pseudo-version) does it fall through to the install-method branches, which
+	// preserves the prior string-inequality behavior for the go-install path.
+	if cmp, ordered := compareReleaseVersions(current, latest); sameVersion(current, latest) || (ordered && cmp >= 0) {
+		if ordered && cmp > 0 {
+			fmt.Fprintf(stdout, "agentico is already up to date (version %s is newer than the latest release %s).\n",
+				normalizeVersion(current), normalizeVersion(latest))
+		} else {
+			fmt.Fprintf(stdout, "agentico is already up to date (version %s).\n", normalizeVersion(current))
+		}
 		return 0
 	}
 
@@ -271,6 +270,20 @@ func runUpdateWith(ctx context.Context, checkOnly bool, stdout, stderr io.Writer
 		fmt.Fprintf(stdout, "Install method:  %s\n", method.label())
 		fmt.Fprintln(stdout, method.wouldDoAction())
 		return 0
+	}
+
+	// An update is warranted and this is a real (non --check) run. Pre-flight the
+	// swap's target directory on the one path that mutates the binary — a tarball
+	// update — so an unwritable, root-owned install aborts here with
+	// elevated-privilege guidance and no download or binary change occurs. This
+	// gate sits after the version check on purpose: a binary already up to date or
+	// ahead of the latest release must report that (exit 0), not a spurious "not
+	// writable, use sudo" error. --check (returned above) and the go-install branch
+	// never reach it, so their behavior is unchanged.
+	if method == installMethodTarball {
+		if !preflightTarballWritable(stderr, deps) {
+			return 1
+		}
 	}
 
 	// Bare `update` with an update available: dispatch on the detected install
@@ -340,8 +353,8 @@ func performGoInstall(stdout, stderr io.Writer, deps updateDeps, current, latest
 // transition, leaving the existing binary untouched.
 func performTarballUpdate(stdout, stderr io.Writer, deps updateDeps, slug, current, latest string) int {
 	// The swap's target directory was already verified writable by the pre-flight
-	// in runUpdateWith, ahead of the latest-release fetch — so this branch is
-	// reached only once the directory admits the temp-create + rename swap.
+	// in runUpdateWith (which runs once an update is confirmed warranted) — so this
+	// branch is reached only once the directory admits the temp-create + rename swap.
 	ctx, cancel := context.WithTimeout(context.Background(), updateDownloadTimeout)
 	defer cancel()
 
@@ -658,9 +671,9 @@ func newTarballUpdater(client *http.Client, baseURL, targetPath, goos, goarch st
 }
 
 // resolveTarballAssets lists the chosen release's published assets and selects
-// the per-platform archive (matched by the project-name prefix and the
-// _<GOOS>_<GOARCH>.tar.gz suffix) and the checksums.txt manifest. A missing
-// archive for the running platform is a clear, non-destructive error.
+// the per-platform archive (matched tolerantly by matchArchiveAsset) and the
+// checksums.txt manifest. A missing archive for the running platform or a
+// missing manifest is a clear, non-destructive error.
 func resolveTarballAssets(ctx context.Context, client *http.Client, baseURL, slug, version, goos, goarch string) (archive, checksums githubAsset, err error) {
 	releases, err := listReleases(ctx, client, baseURL, slug, true)
 	if err != nil {
@@ -672,14 +685,13 @@ func resolveTarballAssets(ctx context.Context, client *http.Client, baseURL, slu
 		return githubAsset{}, githubAsset{}, fmt.Errorf("release %s not found among the published releases", version)
 	}
 
-	prefix := projectNameFromSlug(slug) + "_"
-	suffix := fmt.Sprintf("_%s_%s.tar.gz", goos, goarch)
+	project := projectNameFromSlug(slug)
 	var haveArchive, haveChecksums bool
 	for _, a := range rel.Assets {
 		switch {
 		case a.Name == checksumsAssetName:
 			checksums, haveChecksums = a, true
-		case strings.HasPrefix(a.Name, prefix) && strings.HasSuffix(a.Name, suffix):
+		case matchArchiveAsset(a.Name, project, goos, goarch):
 			archive, haveArchive = a, true
 		}
 	}
@@ -711,6 +723,73 @@ func projectNameFromSlug(slug string) string {
 		return slug[i+1:]
 	}
 	return slug
+}
+
+// matchArchiveAsset reports whether assetName is the release archive for the
+// running platform. It is deliberately tolerant of release-naming drift: the
+// match is anchored by the project-name prefix and a .tar.gz/.tgz extension, and
+// a trailing _<os>_<arch> is matched case-insensitively against a small alias
+// set, so x86_64 matches amd64, aarch64 matches arm64, and macos/osx match
+// darwin even if the naming convention changes. The version field between the
+// prefix and the OS token is not inspected. A suffix match (rather than
+// splitting on "_") is used so an arch token that itself contains an underscore,
+// e.g. x86_64, is handled correctly.
+func matchArchiveAsset(assetName, project, goos, goarch string) bool {
+	lower := strings.ToLower(assetName)
+	prefix := strings.ToLower(project) + "_"
+	if !strings.HasPrefix(lower, prefix) {
+		return false
+	}
+	stem := lower[len(prefix):]
+	switch {
+	case strings.HasSuffix(stem, ".tar.gz"):
+		stem = strings.TrimSuffix(stem, ".tar.gz")
+	case strings.HasSuffix(stem, ".tgz"):
+		stem = strings.TrimSuffix(stem, ".tgz")
+	default:
+		return false
+	}
+	for _, osName := range osAliases(goos) {
+		for _, arch := range archAliases(goarch) {
+			// The leading "_" guarantees the OS token is preceded by the version
+			// (or another field), so a name lacking the version field does not
+			// spuriously match.
+			if strings.HasSuffix(stem, "_"+osName+"_"+arch) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// osAliases returns the lowercase OS tokens that may name a release archive for
+// goos, tolerating common goreleaser naming variations. Unknown values map to
+// themselves so the match stays exact rather than failing closed.
+func osAliases(goos string) []string {
+	switch goos {
+	case "darwin":
+		return []string{"darwin", "macos", "osx", "mac"}
+	case "linux":
+		return []string{"linux"}
+	default:
+		return []string{goos}
+	}
+}
+
+// archAliases returns the lowercase architecture tokens that may name a release
+// archive for goarch (amd64↔x86_64↔x64, arm64↔aarch64). Unknown values map to
+// themselves.
+func archAliases(goarch string) []string {
+	switch goarch {
+	case "amd64":
+		return []string{"amd64", "x86_64", "x64"}
+	case "arm64":
+		return []string{"arm64", "aarch64"}
+	case "386":
+		return []string{"386", "i386", "x86"}
+	default:
+		return []string{goarch}
+	}
 }
 
 // downloadAsset fetches an asset's bytes over the injected client, consuming
@@ -821,14 +900,31 @@ func checkDirWritable(dir string) error {
 }
 
 // swapBinary performs the atomic, non-destructive in-place swap: it writes the
-// new binary to a temp file in the target's own directory, sets the executable
-// mode, then renames it over the target. Writing into the target directory keeps
-// the rename on one filesystem so it is atomic, and the rename gives the path a
-// new inode while the running process keeps executing the original — a partial
-// or failed write can never replace the live binary. On any error before the
-// rename the temp file is removed and the target is left untouched.
+// new binary to a temp file in the target's own directory, restores the existing
+// binary's permission bits and ownership, then renames it over the target.
+// Writing into the target directory keeps the rename on one filesystem so it is
+// atomic, and the rename gives the path a new inode while the running process
+// keeps executing the original — a partial or failed write can never replace the
+// live binary. On any error before the rename the temp file is removed and the
+// target is left untouched, so the rollback on failure is inherent.
 func swapBinary(targetPath string, binary []byte) error {
 	dir := filepath.Dir(targetPath)
+
+	// Preserve the existing binary's permission bits and ownership across the
+	// swap rather than imposing a fixed mode/owner. When the target cannot be
+	// stat'd, fall back to a sane executable default.
+	mode := os.FileMode(0o755)
+	var ownerUID, ownerGID int
+	var haveOwner bool
+	if info, err := os.Stat(targetPath); err == nil {
+		// Keep the original perms but guarantee the result is executable by its
+		// owner — a binary that is not runnable would be worse than a mode change.
+		mode = info.Mode().Perm() | 0o100
+		if uid, gid, ok := fileOwnerIDs(info); ok {
+			ownerUID, ownerGID, haveOwner = uid, gid, true
+		}
+	}
+
 	tmp, err := os.CreateTemp(dir, ".agentico-update-*")
 	if err != nil {
 		return fmt.Errorf("creating temp file in %s: %w", dir, err)
@@ -849,8 +945,16 @@ func swapBinary(targetPath string, binary []byte) error {
 	if err := tmp.Close(); err != nil {
 		return fmt.Errorf("closing new binary: %w", err)
 	}
-	if err := os.Chmod(tmpName, 0o755); err != nil {
-		return fmt.Errorf("setting executable mode: %w", err)
+	if err := os.Chmod(tmpName, mode); err != nil {
+		return fmt.Errorf("setting file mode: %w", err)
+	}
+	// Best-effort ownership preservation: chown only succeeds when the process
+	// may assign the target owner (typically root replacing a root-owned binary).
+	// A non-root updater keeps the file owned by the invoking user, exactly as
+	// before, so a chown failure is intentionally ignored rather than aborting a
+	// swap that is otherwise complete.
+	if haveOwner {
+		_ = os.Chown(tmpName, ownerUID, ownerGID)
 	}
 	if err := os.Rename(tmpName, targetPath); err != nil {
 		return fmt.Errorf("replacing %s: %w", targetPath, err)

--- a/cmd/agentico/update_test.go
+++ b/cmd/agentico/update_test.go
@@ -1,0 +1,510 @@
+// Copyright 2026 DoorDash, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// failingUpdater returns an updater seam that fails the test if invoked. Use
+// it in launch-path tests that must never reach the update seam.
+func failingUpdater(t *testing.T) updater {
+	t.Helper()
+	return func(bool, io.Writer, io.Writer) int {
+		t.Fatal("update seam invoked on a non-update launch path")
+		return 1
+	}
+}
+
+// --- Task 1: parser surface for `update` ------------------------------------
+
+func TestParseLaunchArgsUpdateSurface(t *testing.T) {
+	tests := []struct {
+		name      string
+		args      []string
+		wantMode  launchMode
+		wantCheck bool
+		wantErr   string // empty means no error expected
+	}{
+		{name: "bare update", args: []string{"update"}, wantMode: launchModeUpdate, wantCheck: false},
+		{name: "update --check", args: []string{"update", "--check"}, wantMode: launchModeUpdate, wantCheck: true},
+		{name: "update -n", args: []string{"update", "-n"}, wantMode: launchModeUpdate, wantCheck: true},
+		{name: "update --bogus", args: []string{"update", "--bogus"}, wantErr: "unknown flag: --bogus"},
+		{name: "update with retained launch flag --config", args: []string{"update", "--config", "/tmp/x"}, wantErr: "unknown flag: --config"},
+		{name: "update with --state-dir", args: []string{"update", "--state-dir", "/tmp/x"}, wantErr: "unknown flag: --state-dir"},
+		{name: "update with --providers", args: []string{"update", "--providers", "claude"}, wantErr: "unknown flag: --providers"},
+		{name: "update with --dangerously-skip-permissions", args: []string{"update", "--dangerously-skip-permissions"}, wantErr: "unknown flag: --dangerously-skip-permissions"},
+		{name: "update with extra positional", args: []string{"update", "extra"}, wantErr: "unexpected argument: extra"},
+		{name: "update --check then extra positional", args: []string{"update", "--check", "extra"}, wantErr: "unexpected argument: extra"},
+		{name: "update not first arg", args: []string{"--config", "/tmp/x", "update"}, wantErr: "unknown command: update"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts, err := parseLaunchArgs(tt.args)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("parseLaunchArgs(%v) error = nil, want %q", tt.args, tt.wantErr)
+				}
+				if err.Error() != tt.wantErr {
+					t.Fatalf("parseLaunchArgs(%v) error = %q, want %q", tt.args, err.Error(), tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseLaunchArgs(%v) unexpected error: %v", tt.args, err)
+			}
+			if opts.mode != tt.wantMode {
+				t.Errorf("mode = %v, want %v", opts.mode, tt.wantMode)
+			}
+			if opts.updateCheck != tt.wantCheck {
+				t.Errorf("updateCheck = %v, want %v", opts.updateCheck, tt.wantCheck)
+			}
+		})
+	}
+}
+
+// --check / -n outside update context must still reject as an unknown flag.
+func TestParseLaunchArgsCheckFlagOutsideUpdateRejects(t *testing.T) {
+	for _, arg := range []string{"--check", "-n"} {
+		t.Run(arg, func(t *testing.T) {
+			_, err := parseLaunchArgs([]string{arg})
+			if err == nil || err.Error() != "unknown flag: "+arg {
+				t.Fatalf("parseLaunchArgs([%q]) error = %v, want unknown flag", arg, err)
+			}
+		})
+	}
+}
+
+// --- Task 1: router dispatch through the injectable seam --------------------
+
+func TestRunArgsDispatchesUpdateToSeam(t *testing.T) {
+	tests := []struct {
+		name      string
+		args      []string
+		wantCheck bool
+	}{
+		{name: "bare update", args: []string{"update"}, wantCheck: false},
+		{name: "update --check", args: []string{"update", "--check"}, wantCheck: true},
+		{name: "update -n", args: []string{"update", "-n"}, wantCheck: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			var gotCheck, updateCalled, launchCalled bool
+			code := runArgs(tt.args, &stdout, &stderr,
+				func(string, string, bool, []string) { launchCalled = true },
+				func(checkOnly bool, _, _ io.Writer) int {
+					updateCalled = true
+					gotCheck = checkOnly
+					return 7 // arbitrary known exit code the router must propagate verbatim
+				},
+			)
+			if !updateCalled {
+				t.Fatal("update seam was not invoked")
+			}
+			if launchCalled {
+				t.Fatal("TUI launcher was invoked on the update path; it must not be")
+			}
+			if gotCheck != tt.wantCheck {
+				t.Errorf("checkOnly = %v, want %v", gotCheck, tt.wantCheck)
+			}
+			if code != 7 {
+				t.Errorf("runArgs returned %d, want the seam's exit code 7", code)
+			}
+		})
+	}
+}
+
+func TestRunArgsDefaultStillLaunchesTUINotUpdate(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	var launchCalled, updateCalled bool
+	code := runArgs(nil, &stdout, &stderr,
+		func(string, string, bool, []string) { launchCalled = true },
+		func(bool, io.Writer, io.Writer) int { updateCalled = true; return 1 },
+	)
+	if !launchCalled {
+		t.Fatal("default mode must launch the TUI")
+	}
+	if updateCalled {
+		t.Fatal("default mode must not invoke the update seam")
+	}
+	if code != 0 {
+		t.Errorf("code = %d, want 0", code)
+	}
+}
+
+func TestGithubBaseURL(t *testing.T) {
+	t.Run("defaults to public api", func(t *testing.T) {
+		t.Setenv("GITHUB_API_URL", "")
+		if got := githubBaseURL(); got != githubAPIBaseURL {
+			t.Errorf("githubBaseURL() = %q, want %q", got, githubAPIBaseURL)
+		}
+	})
+	t.Run("honors GITHUB_API_URL override", func(t *testing.T) {
+		t.Setenv("GITHUB_API_URL", "https://ghe.example.com/api/v3")
+		if got := githubBaseURL(); got != "https://ghe.example.com/api/v3" {
+			t.Errorf("githubBaseURL() = %q, want override", got)
+		}
+	})
+	t.Run("trims surrounding whitespace", func(t *testing.T) {
+		t.Setenv("GITHUB_API_URL", "  https://ghe.example.com/api/v3  ")
+		if got := githubBaseURL(); got != "https://ghe.example.com/api/v3" {
+			t.Errorf("githubBaseURL() = %q, want trimmed override", got)
+		}
+	})
+}
+
+// --- Task 2: version normalization & slug derivation ------------------------
+
+func TestNormalizeVersion(t *testing.T) {
+	cases := map[string]string{
+		"v1.2.3":   "1.2.3",
+		" v1.2.3 ": "1.2.3",
+		"1.2.3":    "1.2.3",
+		"dev":      "dev",
+		"  dev  ":  "dev",
+		"v0.0.0":   "0.0.0",
+	}
+	for in, want := range cases {
+		if got := normalizeVersion(in); got != want {
+			t.Errorf("normalizeVersion(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestSameVersion(t *testing.T) {
+	if !sameVersion("1.2.3", "v1.2.3") {
+		t.Error("1.2.3 and v1.2.3 should be equal after normalization")
+	}
+	if sameVersion("dev", "v1.2.3") {
+		t.Error("dev must never equal a release tag")
+	}
+	if sameVersion("1.2.3", "v1.2.4") {
+		t.Error("different versions must not be equal")
+	}
+}
+
+func TestSlugFromModulePath(t *testing.T) {
+	tests := []struct {
+		path    string
+		want    string
+		wantErr bool
+	}{
+		{path: "github.com/doordash-oss/agentic-orchestrator", want: "doordash-oss/agentic-orchestrator"},
+		{path: "github.com/doordash-oss/agentic-orchestrator/cmd/agentico", want: "doordash-oss/agentic-orchestrator"},
+		{path: "example.com/foo/bar", wantErr: true},
+		{path: "github.com/onlyowner", wantErr: true},
+		{path: "", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			got, err := slugFromModulePath(tt.path)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("slugFromModulePath(%q) error = nil, want error", tt.path)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("slugFromModulePath(%q) unexpected error: %v", tt.path, err)
+			}
+			if got != tt.want {
+				t.Errorf("slugFromModulePath(%q) = %q, want %q", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+// --- Task 2: real GitHub fetch logic against an in-process httptest server ---
+
+// releasesServer returns an httptest server serving the GitHub releases list
+// endpoint for the given slug with the supplied release payload.
+func releasesServer(t *testing.T, wantSlug string, status int, releases []map[string]any) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		wantPath := "/repos/" + wantSlug + "/releases"
+		if r.URL.Path != wantPath {
+			t.Errorf("request path = %q, want %q", r.URL.Path, wantPath)
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		if status != http.StatusOK {
+			w.WriteHeader(status)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(releases)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestGithubFetchLatestStableTag(t *testing.T) {
+	const slug = "doordash-oss/agentic-orchestrator"
+
+	t.Run("returns latest stable tag", func(t *testing.T) {
+		srv := releasesServer(t, slug, http.StatusOK, []map[string]any{
+			{"tag_name": "v2.0.0"},
+			{"tag_name": "v1.0.0"},
+		})
+		fetch := githubFetchLatestStableTag(srv.Client(), srv.URL)
+		got, err := fetch(context.Background(), slug)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "v2.0.0" {
+			t.Errorf("tag = %q, want v2.0.0", got)
+		}
+	})
+
+	t.Run("skips drafts and pre-releases", func(t *testing.T) {
+		srv := releasesServer(t, slug, http.StatusOK, []map[string]any{
+			{"tag_name": "v3.0.0-rc1", "prerelease": true},
+			{"tag_name": "v2.5.0", "draft": true},
+			{"tag_name": "v2.0.0"},
+		})
+		fetch := githubFetchLatestStableTag(srv.Client(), srv.URL)
+		got, err := fetch(context.Background(), slug)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "v2.0.0" {
+			t.Errorf("tag = %q, want v2.0.0 (drafts/pre-releases skipped)", got)
+		}
+	})
+
+	t.Run("no stable release", func(t *testing.T) {
+		srv := releasesServer(t, slug, http.StatusOK, []map[string]any{
+			{"tag_name": "v3.0.0-rc1", "prerelease": true},
+		})
+		fetch := githubFetchLatestStableTag(srv.Client(), srv.URL)
+		_, err := fetch(context.Background(), slug)
+		if !errors.Is(err, errNoStableRelease) {
+			t.Fatalf("error = %v, want errNoStableRelease", err)
+		}
+	})
+
+	t.Run("empty release list", func(t *testing.T) {
+		srv := releasesServer(t, slug, http.StatusOK, []map[string]any{})
+		fetch := githubFetchLatestStableTag(srv.Client(), srv.URL)
+		_, err := fetch(context.Background(), slug)
+		if !errors.Is(err, errNoStableRelease) {
+			t.Fatalf("error = %v, want errNoStableRelease", err)
+		}
+	})
+
+	t.Run("non-200 response", func(t *testing.T) {
+		srv := releasesServer(t, slug, http.StatusInternalServerError, nil)
+		fetch := githubFetchLatestStableTag(srv.Client(), srv.URL)
+		_, err := fetch(context.Background(), slug)
+		if err == nil {
+			t.Fatal("expected error on non-200 response")
+		}
+	})
+
+	t.Run("network failure", func(t *testing.T) {
+		// Point at a closed server to force a transport error.
+		srv := httptest.NewServer(http.NotFoundHandler())
+		url := srv.URL
+		srv.Close()
+		fetch := githubFetchLatestStableTag(http.DefaultClient, url)
+		_, err := fetch(context.Background(), slug)
+		if err == nil {
+			t.Fatal("expected error on network failure")
+		}
+	})
+}
+
+// --- Task 2: end-to-end --check / bare update behavior (hermetic) -----------
+
+// fakeFetch returns a fetchLatest function that always yields tag/err.
+func fakeFetch(tag string, err error) func(context.Context, string) (string, error) {
+	return func(context.Context, string) (string, error) { return tag, err }
+}
+
+func okSlug() (string, error) { return "doordash-oss/agentic-orchestrator", nil }
+
+func TestRunUpdateWith(t *testing.T) {
+	t.Run("check prints versions and placeholder, exits 0", func(t *testing.T) {
+		var stdout, stderr bytes.Buffer
+		code := runUpdateWith(context.Background(), true, &stdout, &stderr, updateDeps{
+			currentVersion: "1.2.3",
+			slug:           okSlug,
+			fetchLatest:    fakeFetch("v2.0.0", nil),
+		})
+		if code != 0 {
+			t.Fatalf("code = %d, want 0\nstderr: %s", code, stderr.String())
+		}
+		out := stdout.String()
+		for _, want := range []string{"Checking for updates", "1.2.3", "2.0.0", updatePlaceholderAction} {
+			if !strings.Contains(out, want) {
+				t.Errorf("stdout missing %q\nfull:\n%s", want, out)
+			}
+		}
+		if stderr.Len() != 0 {
+			t.Errorf("stderr = %q, want empty", stderr.String())
+		}
+	})
+
+	t.Run("already up to date short-circuits, exits 0", func(t *testing.T) {
+		for _, checkOnly := range []bool{true, false} {
+			var stdout, stderr bytes.Buffer
+			code := runUpdateWith(context.Background(), checkOnly, &stdout, &stderr, updateDeps{
+				currentVersion: "2.0.0",
+				slug:           okSlug,
+				fetchLatest:    fakeFetch("v2.0.0", nil),
+			})
+			if code != 0 {
+				t.Fatalf("checkOnly=%v code = %d, want 0", checkOnly, code)
+			}
+			out := stdout.String()
+			if !strings.Contains(out, "up to date") {
+				t.Errorf("checkOnly=%v stdout missing up-to-date message\nfull:\n%s", checkOnly, out)
+			}
+			if strings.Contains(out, updatePlaceholderAction) {
+				t.Errorf("checkOnly=%v up-to-date path must not print placeholder action", checkOnly)
+			}
+		}
+	})
+
+	t.Run("dev current never claims up to date, check exits 0", func(t *testing.T) {
+		var stdout, stderr bytes.Buffer
+		code := runUpdateWith(context.Background(), true, &stdout, &stderr, updateDeps{
+			currentVersion: "dev",
+			slug:           okSlug,
+			fetchLatest:    fakeFetch("v2.0.0", nil),
+		})
+		if code != 0 {
+			t.Fatalf("code = %d, want 0", code)
+		}
+		out := stdout.String()
+		if strings.Contains(out, "up to date") {
+			t.Errorf("dev must never claim up to date\nfull:\n%s", out)
+		}
+		if !strings.Contains(out, "2.0.0") {
+			t.Errorf("dev --check must still print latest\nfull:\n%s", out)
+		}
+	})
+
+	t.Run("bare update available prints skeleton + stderr stub, exits 1", func(t *testing.T) {
+		var stdout, stderr bytes.Buffer
+		code := runUpdateWith(context.Background(), false, &stdout, &stderr, updateDeps{
+			currentVersion: "1.2.3",
+			slug:           okSlug,
+			fetchLatest:    fakeFetch("v2.0.0", nil),
+		})
+		if code != 1 {
+			t.Fatalf("code = %d, want 1", code)
+		}
+		if !strings.Contains(stdout.String(), "→") {
+			t.Errorf("stdout missing old → new skeleton\nfull:\n%s", stdout.String())
+		}
+		if !strings.Contains(stderr.String(), updateNotImplementedMsg) {
+			t.Errorf("stderr missing not-yet-wired stub\nfull:\n%s", stderr.String())
+		}
+	})
+
+	t.Run("fetch error exits 1 with stderr message", func(t *testing.T) {
+		var stdout, stderr bytes.Buffer
+		code := runUpdateWith(context.Background(), true, &stdout, &stderr, updateDeps{
+			currentVersion: "1.2.3",
+			slug:           okSlug,
+			fetchLatest:    fakeFetch("", errors.New("boom")),
+		})
+		if code != 1 {
+			t.Fatalf("code = %d, want 1", code)
+		}
+		if stderr.Len() == 0 {
+			t.Error("expected an error message on stderr")
+		}
+	})
+
+	t.Run("no stable release exits 1 with clean message", func(t *testing.T) {
+		var stdout, stderr bytes.Buffer
+		code := runUpdateWith(context.Background(), true, &stdout, &stderr, updateDeps{
+			currentVersion: "1.2.3",
+			slug:           okSlug,
+			fetchLatest:    fakeFetch("", errNoStableRelease),
+		})
+		if code != 1 {
+			t.Fatalf("code = %d, want 1", code)
+		}
+		if stderr.Len() == 0 {
+			t.Error("expected a no-release message on stderr")
+		}
+	})
+
+	t.Run("underivable slug exits 1", func(t *testing.T) {
+		var stdout, stderr bytes.Buffer
+		fetchCalled := false
+		code := runUpdateWith(context.Background(), true, &stdout, &stderr, updateDeps{
+			currentVersion: "1.2.3",
+			slug:           func() (string, error) { return "", errors.New("no module path") },
+			fetchLatest: func(context.Context, string) (string, error) {
+				fetchCalled = true
+				return "", nil
+			},
+		})
+		if code != 1 {
+			t.Fatalf("code = %d, want 1", code)
+		}
+		if fetchCalled {
+			t.Error("fetch must not run when the slug cannot be derived")
+		}
+		if stderr.Len() == 0 {
+			t.Error("expected a slug error on stderr")
+		}
+	})
+}
+
+// Exercises the real fetch path end-to-end through runUpdateWith and httptest,
+// confirming the whole resolution chain stays hermetic.
+func TestRunUpdateWithRealFetchHermetic(t *testing.T) {
+	const slug = "doordash-oss/agentic-orchestrator"
+	srv := releasesServer(t, slug, http.StatusOK, []map[string]any{{"tag_name": "v9.9.9"}})
+	var stdout, stderr bytes.Buffer
+	code := runUpdateWith(context.Background(), true, &stdout, &stderr, updateDeps{
+		currentVersion: "1.0.0",
+		slug:           func() (string, error) { return slug, nil },
+		fetchLatest:    githubFetchLatestStableTag(srv.Client(), srv.URL),
+	})
+	if code != 0 {
+		t.Fatalf("code = %d, want 0\nstderr: %s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "9.9.9") {
+		t.Errorf("stdout missing resolved latest tag\nfull:\n%s", stdout.String())
+	}
+}
+
+// Guards that the default production wiring resolves an owner/repo slug from
+// the test binary's own module path (github.com/doordash-oss/...), proving the
+// slug is derived at runtime rather than hardcoded.
+func TestModuleSlugDerivedFromBuildInfo(t *testing.T) {
+	slug, err := moduleSlug()
+	if err != nil {
+		t.Fatalf("moduleSlug() error: %v", err)
+	}
+	if slug != "doordash-oss/agentic-orchestrator" {
+		t.Errorf("moduleSlug() = %q, want doordash-oss/agentic-orchestrator", slug)
+	}
+}

--- a/cmd/agentico/update_test.go
+++ b/cmd/agentico/update_test.go
@@ -1292,3 +1292,273 @@ func TestSwapBinaryFailsClosedOnBadDir(t *testing.T) {
 		t.Errorf("target must not exist after a failed swap; stat err = %v", err)
 	}
 }
+
+// --- Phase 5: tarball robustness — pre-flight writability + macOS re-sign ----
+
+// failingTarball returns a tarballUpdater that fails the test if invoked. It
+// guards the pre-flight: an unwritable target must abort before the download
+// seam (which issues the GitHub requests and mutates the binary) is ever
+// reached.
+func failingTarball(t *testing.T) tarballUpdater {
+	t.Helper()
+	return func(context.Context, string, string) error {
+		t.Fatal("tarball download seam invoked after a pre-flight that must have aborted")
+		return nil
+	}
+}
+
+// newTarballSuccessDeps wires a hermetic release server, a writable temp target
+// binary, and the base updateDeps for a successful tarball swap through
+// runUpdateWith (current 1.0.0 → latest 2.0.0). Callers set the Phase-5 seams
+// (goos, binaryPath, runCodesign, checkWritable) on the returned deps before
+// invoking runUpdateWith. The returned target is the swapped-in-place path.
+func newTarballSuccessDeps(t *testing.T) (updateDeps, string) {
+	t.Helper()
+	const slug = "doordash-oss/agentic-orchestrator"
+	archiveName := fmt.Sprintf("agentic-orchestrator_2.0.0_%s_%s.tar.gz", testTarballGOOS, testTarballGOARCH)
+	archive := makeTarGz(t, map[string]string{"agentico": "NEW-AGENTICO-BINARY-BYTES"})
+	checksums := fmt.Appendf(nil, "%s  %s\n", sha256Hex(archive), archiveName)
+	srv := newTarballServer(t, slug, "v2.0.0", archiveName, archive, checksums)
+	target, _ := writeTargetBinary(t, "OLD-AGENTICO-BINARY")
+	deps := updateDeps{
+		currentVersion: "1.0.0",
+		method:         fixedMethod(installMethodTarball),
+		slug:           func() (string, error) { return slug, nil },
+		fetchLatest:    fakeFetch("v2.0.0", nil),
+		runTarball:     newTarballUpdater(srv.srv.Client(), srv.srv.URL, target, testTarballGOOS, testTarballGOARCH),
+	}
+	return deps, target
+}
+
+// --- Task 1: pre-flight writability check -----------------------------------
+
+// checkDirWritable performs the swap's own temp-create + rename probe: a
+// writable directory succeeds, a nonexistent one fails, and an empty path (the
+// binary directory could not be resolved) is reported as an error — all
+// independent of the test process's uid.
+func TestCheckDirWritable(t *testing.T) {
+	t.Run("writable directory", func(t *testing.T) {
+		dir := t.TempDir()
+		if err := checkDirWritable(dir); err != nil {
+			t.Errorf("checkDirWritable(writable temp dir) = %v, want nil", err)
+		}
+		// Inspect the same directory that was probed: the temp-create + remove
+		// must leave nothing behind.
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			t.Fatalf("reading probed dir: %v", err)
+		}
+		if len(entries) != 0 {
+			t.Errorf("probe must leave no temp entry behind; found %d", len(entries))
+		}
+	})
+	t.Run("nonexistent directory", func(t *testing.T) {
+		dir := filepath.Join(t.TempDir(), "no-such-subdir")
+		if err := checkDirWritable(dir); err == nil {
+			t.Error("checkDirWritable(nonexistent dir) = nil, want error")
+		}
+	})
+	t.Run("empty path", func(t *testing.T) {
+		if err := checkDirWritable(""); err == nil {
+			t.Error("checkDirWritable(\"\") = nil, want error")
+		}
+	})
+}
+
+// On the real tarball update path, an unwritable target directory aborts before
+// any download: the command exits non-zero, prints stderr guidance naming the
+// directory and pointing at elevated privileges (sudo), prints no old → new
+// line, and never reaches the download seam. The verdict is driven by an
+// injected check, so it is deterministic regardless of the test process's uid.
+func TestRunUpdateWithTarballPreflightUnwritableAborts(t *testing.T) {
+	const dir = "/usr/local/bin"
+	var checkedDir string
+	var fetchCalled bool
+	deps := updateDeps{
+		currentVersion: "1.0.0",
+		method:         fixedMethod(installMethodTarball),
+		slug:           okSlug,
+		// The latest-release lookup is the first GitHub request. An unwritable
+		// target must abort the pre-flight ahead of it, so this must never run.
+		fetchLatest: func(context.Context, string) (string, error) {
+			fetchCalled = true
+			t.Error("latest-release fetch must not run when the pre-flight aborts an unwritable tarball update")
+			return "v2.0.0", nil
+		},
+		binaryPath: dir + "/agentico",
+		checkWritable: func(d string) error {
+			checkedDir = d
+			return errors.New("permission denied")
+		},
+		runTarball: failingTarball(t), // the download/swap seam must never be reached
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := runUpdateWith(context.Background(), false, &stdout, &stderr, deps)
+
+	t.Logf("exit=%d fetchCalled=%v\nstdout:\n%s\nstderr:\n%s", code, fetchCalled, stdout.String(), stderr.String())
+	if code == 0 {
+		t.Fatalf("unwritable target must exit non-zero, got %d", code)
+	}
+	if fetchCalled {
+		t.Error("the pre-flight must abort before the latest-release GitHub fetch (no network request occurs)")
+	}
+	if checkedDir != dir {
+		t.Errorf("pre-flight probed %q, want the binary's directory %q", checkedDir, dir)
+	}
+	errOut := stderr.String()
+	if !strings.Contains(errOut, dir) {
+		t.Errorf("stderr must name the unwritable directory %q\nfull:\n%s", dir, errOut)
+	}
+	if !strings.Contains(strings.ToLower(errOut), "sudo") {
+		t.Errorf("stderr must point the user at elevated privileges (sudo)\nfull:\n%s", errOut)
+	}
+	if strings.Contains(errOut, "could not update from the release tarball") {
+		t.Errorf("the pre-flight message must be distinct from the generic tarball-failure error\nfull:\n%s", errOut)
+	}
+	if strings.Contains(stdout.String(), "→") {
+		t.Errorf("no old → new line may print when the pre-flight aborts\nfull:\n%s", stdout.String())
+	}
+}
+
+// A writable target directory lets the flow proceed unchanged into the existing
+// fetch → verify → swap path: the swap happens, the old → new line prints, and
+// the command exits 0.
+func TestRunUpdateWithTarballPreflightWritableProceeds(t *testing.T) {
+	deps, target := newTarballSuccessDeps(t)
+	var checked bool
+	deps.binaryPath = target
+	deps.checkWritable = func(string) error { checked = true; return nil }
+
+	var stdout, stderr bytes.Buffer
+	code := runUpdateWith(context.Background(), false, &stdout, &stderr, deps)
+
+	if code != 0 {
+		t.Fatalf("code = %d, want 0\nstderr: %s", code, stderr.String())
+	}
+	if !checked {
+		t.Error("the pre-flight writability check must run on the tarball path")
+	}
+	if !strings.Contains(stdout.String(), "1.0.0 → 2.0.0") {
+		t.Errorf("a writable target must proceed to the swap and print the transition\nfull:\n%s", stdout.String())
+	}
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("reading swapped target: %v", err)
+	}
+	if string(got) != "NEW-AGENTICO-BINARY-BYTES" {
+		t.Errorf("target content = %q, want the swapped-in bytes", got)
+	}
+}
+
+// --- Task 2: best-effort macOS ad-hoc re-sign -------------------------------
+
+// After a successful darwin swap, codesign -s - is invoked against the resolved
+// binary path through the runner seam, mirroring the system-install step; the
+// success line still prints, no warning is emitted, and the command exits 0.
+func TestRunUpdateWithTarballResignsDarwin(t *testing.T) {
+	deps, target := newTarballSuccessDeps(t)
+	var rec recordedInstall
+	deps.goos = "darwin"
+	deps.binaryPath = target
+	deps.runCodesign = fakeRunner(&rec, nil, nil)
+
+	var stdout, stderr bytes.Buffer
+	code := runUpdateWith(context.Background(), false, &stdout, &stderr, deps)
+
+	t.Logf("exit=%d codesign=%v %v\nstdout:\n%s\nstderr:\n%s", code, rec.name, rec.args, stdout.String(), stderr.String())
+	if code != 0 {
+		t.Fatalf("code = %d, want 0\nstderr: %s", code, stderr.String())
+	}
+	if !rec.called {
+		t.Fatal("codesign runner was not invoked after a darwin swap")
+	}
+	if rec.name != "codesign" {
+		t.Errorf("command name = %q, want %q", rec.name, "codesign")
+	}
+	wantArgs := []string{"-s", "-", target}
+	if !slices.Equal(rec.args, wantArgs) {
+		t.Errorf("codesign args = %v, want %v (mirroring the system-install step)", rec.args, wantArgs)
+	}
+	if !strings.Contains(stdout.String(), "1.0.0 → 2.0.0") {
+		t.Errorf("stdout missing old → new transition\nfull:\n%s", stdout.String())
+	}
+	if stderr.Len() != 0 {
+		t.Errorf("a successful re-sign must emit no warning; stderr = %q", stderr.String())
+	}
+}
+
+// A missing codesign tool is non-fatal: a stderr warning is printed, the old →
+// new success line still prints on stdout, and the command exits 0 (the swap is
+// not undone).
+func TestRunUpdateWithTarballResignMissingToolNonFatal(t *testing.T) {
+	deps, target := newTarballSuccessDeps(t)
+	var rec recordedInstall
+	deps.goos = "darwin"
+	deps.binaryPath = target
+	deps.runCodesign = fakeRunner(&rec, nil, &exec.Error{Name: "codesign", Err: exec.ErrNotFound})
+
+	var stdout, stderr bytes.Buffer
+	code := runUpdateWith(context.Background(), false, &stdout, &stderr, deps)
+
+	t.Logf("exit=%d\nstdout:\n%s\nstderr:\n%s", code, stdout.String(), stderr.String())
+	if code != 0 {
+		t.Fatalf("a missing codesign tool must stay non-fatal (exit 0), got %d\nstderr: %s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "1.0.0 → 2.0.0") {
+		t.Errorf("the success line must still print when re-sign is skipped\nfull:\n%s", stdout.String())
+	}
+	if !strings.Contains(strings.ToLower(stderr.String()), "warning") {
+		t.Errorf("a missing codesign tool must emit a non-fatal warning\nfull:\n%s", stderr.String())
+	}
+}
+
+// A codesign invocation failure (non-zero exit) is non-fatal: a stderr warning
+// is printed, the success line still prints, and the command exits 0 — the swap
+// is not rolled back.
+func TestRunUpdateWithTarballResignFailureNonFatal(t *testing.T) {
+	deps, target := newTarballSuccessDeps(t)
+	var rec recordedInstall
+	deps.goos = "darwin"
+	deps.binaryPath = target
+	deps.runCodesign = fakeRunner(&rec, []byte("codesign: some signing error"), errors.New("exit status 1"))
+
+	var stdout, stderr bytes.Buffer
+	code := runUpdateWith(context.Background(), false, &stdout, &stderr, deps)
+
+	t.Logf("exit=%d\nstdout:\n%s\nstderr:\n%s", code, stdout.String(), stderr.String())
+	if code != 0 {
+		t.Fatalf("a codesign failure must stay non-fatal (exit 0), got %d\nstderr: %s", code, stderr.String())
+	}
+	if !rec.called {
+		t.Fatal("codesign runner was not invoked")
+	}
+	if !strings.Contains(stdout.String(), "1.0.0 → 2.0.0") {
+		t.Errorf("the success line must still print on a re-sign failure\nfull:\n%s", stdout.String())
+	}
+	if !strings.Contains(strings.ToLower(stderr.String()), "warning") {
+		t.Errorf("a codesign failure must emit a non-fatal warning\nfull:\n%s", stderr.String())
+	}
+}
+
+// Off darwin the re-sign is a literal no-op: the runner is never invoked, no
+// warning prints, the success line prints, and the command exits 0.
+func TestRunUpdateWithTarballNoResignOffDarwin(t *testing.T) {
+	deps, target := newTarballSuccessDeps(t)
+	deps.goos = "linux"
+	deps.binaryPath = target
+	deps.runCodesign = failingRunner(t) // must never be invoked off darwin
+
+	var stdout, stderr bytes.Buffer
+	code := runUpdateWith(context.Background(), false, &stdout, &stderr, deps)
+
+	if code != 0 {
+		t.Fatalf("code = %d, want 0\nstderr: %s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "1.0.0 → 2.0.0") {
+		t.Errorf("stdout missing old → new transition\nfull:\n%s", stdout.String())
+	}
+	if stderr.Len() != 0 {
+		t.Errorf("off-darwin must emit no re-sign warning; stderr = %q", stderr.String())
+	}
+}

--- a/cmd/agentico/update_test.go
+++ b/cmd/agentico/update_test.go
@@ -1793,3 +1793,91 @@ func TestRunUpdateWithCheckModeSkipsPreflight(t *testing.T) {
 		t.Errorf("--check must report the would-do action, got:\n%s", stdout.String())
 	}
 }
+
+// --- rate-limit handling on the check path ----------------------------------
+
+func TestRateLimitMessage(t *testing.T) {
+	resp := func(status int, remaining, reset string) *http.Response {
+		h := http.Header{}
+		if remaining != "" {
+			h.Set("X-RateLimit-Remaining", remaining)
+		}
+		if reset != "" {
+			h.Set("X-RateLimit-Reset", reset)
+		}
+		return &http.Response{StatusCode: status, Header: h}
+	}
+
+	t.Run("unauthenticated 403 points at GITHUB_TOKEN and the reset time", func(t *testing.T) {
+		msg := rateLimitMessage(resp(http.StatusForbidden, "0", "1780506343"), false)
+		if !strings.Contains(msg, "GITHUB_TOKEN") || !strings.Contains(msg, "60/hour") {
+			t.Errorf("message must name GITHUB_TOKEN and the 60/hour limit, got %q", msg)
+		}
+		if !strings.Contains(msg, "Try again after") {
+			t.Errorf("message must include the reset time, got %q", msg)
+		}
+	})
+	t.Run("429 is also treated as rate limiting", func(t *testing.T) {
+		if rateLimitMessage(resp(http.StatusTooManyRequests, "0", ""), false) == "" {
+			t.Error("429 with remaining 0 must be reported as rate limiting")
+		}
+	})
+	t.Run("authenticated token gets a token-specific message, no GITHUB_TOKEN hint", func(t *testing.T) {
+		msg := rateLimitMessage(resp(http.StatusForbidden, "0", ""), true)
+		if msg == "" || strings.Contains(msg, "GITHUB_TOKEN") {
+			t.Errorf("an authenticated rate-limit must not suggest setting GITHUB_TOKEN, got %q", msg)
+		}
+	})
+	t.Run("403 with remaining left is not a rate limit", func(t *testing.T) {
+		if got := rateLimitMessage(resp(http.StatusForbidden, "12", ""), false); got != "" {
+			t.Errorf("a 403 with quota remaining is some other error, got %q", got)
+		}
+	})
+	t.Run("non-error status is not a rate limit", func(t *testing.T) {
+		if got := rateLimitMessage(resp(http.StatusOK, "0", ""), false); got != "" {
+			t.Errorf("a 200 is never a rate limit, got %q", got)
+		}
+	})
+	t.Run("missing reset header omits the retry hint", func(t *testing.T) {
+		if got := rateLimitMessage(resp(http.StatusForbidden, "0", ""), false); strings.Contains(got, "Try again") {
+			t.Errorf("no reset header means no retry hint, got %q", got)
+		}
+	})
+}
+
+// The latest-release check honors GITHUB_TOKEN: it sends an Authorization
+// header when the token is set (lifting the unauthenticated rate limit) and
+// none when it is unset.
+func TestGithubFetchLatestStableTagUsesGithubToken(t *testing.T) {
+	const slug = "doordash-oss/agentic-orchestrator"
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode([]map[string]any{{"tag_name": "v1.0.0"}})
+	}))
+	t.Cleanup(srv.Close)
+
+	t.Run("sends Bearer token when GITHUB_TOKEN is set", func(t *testing.T) {
+		t.Setenv("GITHUB_TOKEN", "secret-token")
+		gotAuth = "unset"
+		fetch := githubFetchLatestStableTag(srv.Client(), srv.URL)
+		if _, err := fetch(context.Background(), slug); err != nil {
+			t.Fatalf("fetch: %v", err)
+		}
+		if gotAuth != "Bearer secret-token" {
+			t.Errorf("Authorization = %q, want %q", gotAuth, "Bearer secret-token")
+		}
+	})
+	t.Run("no Authorization header without GITHUB_TOKEN", func(t *testing.T) {
+		t.Setenv("GITHUB_TOKEN", "")
+		gotAuth = "unset"
+		fetch := githubFetchLatestStableTag(srv.Client(), srv.URL)
+		if _, err := fetch(context.Background(), slug); err != nil {
+			t.Fatalf("fetch: %v", err)
+		}
+		if gotAuth != "" {
+			t.Errorf("Authorization = %q, want empty without GITHUB_TOKEN", gotAuth)
+		}
+	})
+}

--- a/cmd/agentico/update_test.go
+++ b/cmd/agentico/update_test.go
@@ -15,15 +15,22 @@
 package main
 
 import (
+	"archive/tar"
 	"bytes"
+	"compress/gzip"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"os/exec"
+	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -569,34 +576,6 @@ func TestRunUpdateWithCheckReportsMethodAndAction(t *testing.T) {
 	}
 }
 
-// The tarball method is still the not-yet-implemented placeholder (Phase 4):
-// bare update prints the old → new skeleton to stdout and the not-yet-wired
-// stub naming the detected method to stderr, then exits non-zero. (The
-// go-install method is now wired to a real re-install; see the GoInstall tests
-// below.)
-func TestRunUpdateWithBareTarballNamesDetectedMethod(t *testing.T) {
-	var stdout, stderr bytes.Buffer
-	code := runUpdateWith(context.Background(), false, &stdout, &stderr, updateDeps{
-		currentVersion: "1.2.3",
-		method:         fixedMethod(installMethodTarball),
-		slug:           okSlug,
-		fetchLatest:    fakeFetch("v2.0.0", nil),
-	})
-	if code != 1 {
-		t.Fatalf("code = %d, want 1", code)
-	}
-	if !strings.Contains(stdout.String(), "→") {
-		t.Errorf("stdout missing old → new skeleton\nfull:\n%s", stdout.String())
-	}
-	errOut := stderr.String()
-	if !strings.Contains(errOut, updateNotImplementedMsg) {
-		t.Errorf("stderr missing not-yet-wired stub\nfull:\n%s", errOut)
-	}
-	if !strings.Contains(errOut, "release tarball") {
-		t.Errorf("stderr must name the detected tarball method\nfull:\n%s", errOut)
-	}
-}
-
 // Exercises the real fetch path end-to-end through runUpdateWith and httptest,
 // confirming the whole resolution chain stays hermetic.
 func TestRunUpdateWithRealFetchHermetic(t *testing.T) {
@@ -860,5 +839,456 @@ func TestRunUpdateWithGoInstallTimeout(t *testing.T) {
 	}
 	if strings.Contains(stdout.String(), "→") {
 		t.Errorf("no old → new success line may be printed on timeout\nfull:\n%s", stdout.String())
+	}
+}
+
+// --- Phase 4: tarball update — fetch, verify, extract, atomic swap ----------
+
+// makeTarGz builds an in-memory .tar.gz containing the given name→content files
+// as regular 0755 entries, fabricating a goreleaser-style release archive
+// (typically with an inner "agentico" binary alongside LICENSE/README).
+func makeTarGz(t *testing.T, files map[string]string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	for name, content := range files {
+		hdr := &tar.Header{Name: name, Mode: 0o755, Size: int64(len(content)), Typeflag: tar.TypeReg}
+		if err := tw.WriteHeader(hdr); err != nil {
+			t.Fatalf("writing tar header for %q: %v", name, err)
+		}
+		if _, err := tw.Write([]byte(content)); err != nil {
+			t.Fatalf("writing tar body for %q: %v", name, err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("closing tar writer: %v", err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatalf("closing gzip writer: %v", err)
+	}
+	return buf.Bytes()
+}
+
+// sha256Hex returns the lowercase hex SHA-256 of b, matching checksums.txt.
+func sha256Hex(b []byte) string {
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}
+
+// tarballServer is an httptest server that serves a single release's listing
+// (with assets whose download URLs point back at itself) plus the asset bytes,
+// recording the Authorization header seen on every request so a test can assert
+// the unauthenticated default and the GITHUB_TOKEN-authenticated behavior.
+type tarballServer struct {
+	srv         *httptest.Server
+	authHeaders []string
+}
+
+// newTarballServer wires a hermetic release+asset server. slug/tag identify the
+// release; archiveName is the archive asset's name; archive and checksums are
+// the served asset bytes. A checksums.txt asset is always advertised.
+func newTarballServer(t *testing.T, slug, tag, archiveName string, archive, checksums []byte) *tarballServer {
+	t.Helper()
+	ts := &tarballServer{}
+	releasesPath := "/repos/" + slug + "/releases"
+	const archivePath = "/dl/archive"
+	const checksumsPath = "/dl/checksums.txt"
+	ts.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ts.authHeaders = append(ts.authHeaders, r.Header.Get("Authorization"))
+		base := "http://" + r.Host
+		switch r.URL.Path {
+		case releasesPath:
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode([]map[string]any{
+				{
+					"tag_name": tag,
+					"assets": []map[string]any{
+						{"name": archiveName, "browser_download_url": base + archivePath},
+						{"name": "checksums.txt", "browser_download_url": base + checksumsPath},
+					},
+				},
+			})
+		case archivePath:
+			_, _ = w.Write(archive)
+		case checksumsPath:
+			_, _ = w.Write(checksums)
+		default:
+			t.Errorf("unexpected request path %q", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(ts.srv.Close)
+	return ts
+}
+
+// sawAuthHeader reports whether any recorded request carried the given exact
+// Authorization header value.
+func (ts *tarballServer) sawAuthHeader(value string) bool {
+	return slices.Contains(ts.authHeaders, value)
+}
+
+// sawAnyAuthHeader reports whether any recorded request carried a non-empty
+// Authorization header.
+func (ts *tarballServer) sawAnyAuthHeader() bool {
+	for _, h := range ts.authHeaders {
+		if h != "" {
+			return true
+		}
+	}
+	return false
+}
+
+const (
+	testTarballGOOS   = "linux"
+	testTarballGOARCH = "amd64"
+)
+
+// writeTargetBinary creates a stand-in installed binary under a fresh temp dir
+// with the given content and returns its path and pre-swap FileInfo.
+func writeTargetBinary(t *testing.T, content string) (string, os.FileInfo) {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "agentico")
+	if err := os.WriteFile(path, []byte(content), 0o755); err != nil {
+		t.Fatalf("writing target binary: %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat target binary: %v", err)
+	}
+	return path, info
+}
+
+// Success path through runUpdateWith: the matching archive and checksums.txt
+// assets are resolved from the release, downloaded, the archive SHA-256 is
+// verified, the inner agentico binary is extracted and atomically swapped into
+// the target, the old → new transition is printed, and the process exits 0. The
+// target is replaced via rename (a new file identity), preserving any open
+// handle to the original — the non-destructive swap guarantee.
+func TestRunUpdateWithTarballSuccess(t *testing.T) {
+	const slug = "doordash-oss/agentic-orchestrator"
+	const newContent = "NEW-AGENTICO-BINARY-BYTES"
+	archiveName := fmt.Sprintf("agentic-orchestrator_2.0.0_%s_%s.tar.gz", testTarballGOOS, testTarballGOARCH)
+	archive := makeTarGz(t, map[string]string{"agentico": newContent, "LICENSE": "Apache-2.0"})
+	checksums := fmt.Appendf(nil, "%s  %s\n%s  some-other-asset.tar.gz\n", sha256Hex(archive), archiveName, sha256Hex([]byte("other")))
+
+	srv := newTarballServer(t, slug, "v2.0.0", archiveName, archive, checksums)
+	target, origInfo := writeTargetBinary(t, "OLD-AGENTICO-BINARY")
+
+	var stdout, stderr bytes.Buffer
+	code := runUpdateWith(context.Background(), false, &stdout, &stderr, updateDeps{
+		currentVersion: "1.0.0",
+		method:         fixedMethod(installMethodTarball),
+		slug:           func() (string, error) { return slug, nil },
+		fetchLatest:    fakeFetch("v2.0.0", nil),
+		runTarball:     newTarballUpdater(srv.srv.Client(), srv.srv.URL, target, testTarballGOOS, testTarballGOARCH),
+	})
+
+	t.Logf("exit=%d\nstdout:\n%s\nstderr:\n%s", code, stdout.String(), stderr.String())
+	if code != 0 {
+		t.Fatalf("code = %d, want 0\nstderr: %s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "1.0.0 → 2.0.0") {
+		t.Errorf("stdout missing old → new transition\nfull:\n%s", stdout.String())
+	}
+	if stderr.Len() != 0 {
+		t.Errorf("stderr = %q, want empty on success", stderr.String())
+	}
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("reading swapped target: %v", err)
+	}
+	if string(got) != newContent {
+		t.Errorf("target content = %q, want %q", got, newContent)
+	}
+	newInfo, err := os.Stat(target)
+	if err != nil {
+		t.Fatalf("stat swapped target: %v", err)
+	}
+	if os.SameFile(origInfo, newInfo) {
+		t.Error("swap must replace the target via rename (new file identity), preserving the original inode for any process holding it open")
+	}
+	if newInfo.Mode().Perm()&0o100 == 0 {
+		t.Errorf("swapped target is not executable: mode %v", newInfo.Mode())
+	}
+}
+
+// Checksum mismatch is non-destructive: the swap aborts before touching the
+// binary, a clear error reaches stderr, the process exits non-zero, no old → new
+// line is printed, and the original binary is byte-for-byte unchanged.
+func TestRunUpdateWithTarballChecksumMismatch(t *testing.T) {
+	const slug = "doordash-oss/agentic-orchestrator"
+	archiveName := fmt.Sprintf("agentic-orchestrator_2.0.0_%s_%s.tar.gz", testTarballGOOS, testTarballGOARCH)
+	archive := makeTarGz(t, map[string]string{"agentico": "NEW"})
+	// A digest that does not match the archive bytes.
+	checksums := fmt.Appendf(nil, "%s  %s\n", sha256Hex([]byte("WRONG")), archiveName)
+
+	srv := newTarballServer(t, slug, "v2.0.0", archiveName, archive, checksums)
+	const original = "ORIGINAL-UNTOUCHED"
+	target, origInfo := writeTargetBinary(t, original)
+
+	var stdout, stderr bytes.Buffer
+	code := runUpdateWith(context.Background(), false, &stdout, &stderr, updateDeps{
+		currentVersion: "1.0.0",
+		method:         fixedMethod(installMethodTarball),
+		slug:           func() (string, error) { return slug, nil },
+		fetchLatest:    fakeFetch("v2.0.0", nil),
+		runTarball:     newTarballUpdater(srv.srv.Client(), srv.srv.URL, target, testTarballGOOS, testTarballGOARCH),
+	})
+
+	t.Logf("exit=%d\nstdout:\n%s\nstderr:\n%s", code, stdout.String(), stderr.String())
+	if code == 0 {
+		t.Fatal("checksum mismatch must exit non-zero")
+	}
+	if strings.Contains(stdout.String(), "→") {
+		t.Errorf("no old → new line may print on checksum mismatch\nfull:\n%s", stdout.String())
+	}
+	if stderr.Len() == 0 {
+		t.Error("expected a clear checksum error on stderr")
+	}
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("reading target: %v", err)
+	}
+	if string(got) != original {
+		t.Errorf("target content = %q, want it left untouched as %q", got, original)
+	}
+	newInfo, err := os.Stat(target)
+	if err != nil {
+		t.Fatalf("stat target: %v", err)
+	}
+	if !os.SameFile(origInfo, newInfo) {
+		t.Error("the original binary file must be left untouched (same identity) on a failed swap")
+	}
+}
+
+// Missing per-OS/arch asset is non-destructive: when the release carries no
+// archive matching the running platform, the update errors clearly, exits
+// non-zero, prints no transition, and leaves the binary unchanged.
+func TestRunUpdateWithTarballMissingAsset(t *testing.T) {
+	const slug = "doordash-oss/agentic-orchestrator"
+	// The only published archive targets darwin/arm64, not the linux/amd64 we ask for.
+	archiveName := "agentic-orchestrator_2.0.0_darwin_arm64.tar.gz"
+	archive := makeTarGz(t, map[string]string{"agentico": "NEW"})
+	checksums := fmt.Appendf(nil, "%s  %s\n", sha256Hex(archive), archiveName)
+
+	srv := newTarballServer(t, slug, "v2.0.0", archiveName, archive, checksums)
+	const original = "ORIGINAL-UNTOUCHED"
+	target, origInfo := writeTargetBinary(t, original)
+
+	var stdout, stderr bytes.Buffer
+	code := runUpdateWith(context.Background(), false, &stdout, &stderr, updateDeps{
+		currentVersion: "1.0.0",
+		method:         fixedMethod(installMethodTarball),
+		slug:           func() (string, error) { return slug, nil },
+		fetchLatest:    fakeFetch("v2.0.0", nil),
+		runTarball:     newTarballUpdater(srv.srv.Client(), srv.srv.URL, target, testTarballGOOS, testTarballGOARCH),
+	})
+
+	if code == 0 {
+		t.Fatal("missing per-platform asset must exit non-zero")
+	}
+	if strings.Contains(stdout.String(), "→") {
+		t.Errorf("no old → new line may print when the asset is missing\nfull:\n%s", stdout.String())
+	}
+	if stderr.Len() == 0 {
+		t.Error("expected a clear missing-asset error on stderr")
+	}
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("reading target: %v", err)
+	}
+	if string(got) != original {
+		t.Errorf("target content = %q, want it left untouched as %q", got, original)
+	}
+	newInfo, err := os.Stat(target)
+	if err != nil {
+		t.Fatalf("stat target: %v", err)
+	}
+	if !os.SameFile(origInfo, newInfo) {
+		t.Error("the original binary file must be left untouched on a missing-asset error")
+	}
+}
+
+// The tarball flow is unauthenticated by default and adds an Authorization:
+// Bearer header to every GitHub request only when GITHUB_TOKEN is set.
+func TestTarballUpdaterGithubTokenAuth(t *testing.T) {
+	const slug = "doordash-oss/agentic-orchestrator"
+	archiveName := fmt.Sprintf("agentic-orchestrator_2.0.0_%s_%s.tar.gz", testTarballGOOS, testTarballGOARCH)
+	archive := makeTarGz(t, map[string]string{"agentico": "NEW"})
+	checksums := fmt.Appendf(nil, "%s  %s\n", sha256Hex(archive), archiveName)
+
+	runOnce := func(t *testing.T) *tarballServer {
+		t.Helper()
+		srv := newTarballServer(t, slug, "v2.0.0", archiveName, archive, checksums)
+		target, _ := writeTargetBinary(t, "OLD")
+		update := newTarballUpdater(srv.srv.Client(), srv.srv.URL, target, testTarballGOOS, testTarballGOARCH)
+		if err := update(context.Background(), slug, "v2.0.0"); err != nil {
+			t.Fatalf("tarball update failed: %v", err)
+		}
+		return srv
+	}
+
+	t.Run("unauthenticated by default", func(t *testing.T) {
+		t.Setenv("GITHUB_TOKEN", "")
+		srv := runOnce(t)
+		if srv.sawAnyAuthHeader() {
+			t.Errorf("no Authorization header expected without GITHUB_TOKEN; saw %v", srv.authHeaders)
+		}
+	})
+
+	t.Run("adds Bearer token when GITHUB_TOKEN set", func(t *testing.T) {
+		t.Setenv("GITHUB_TOKEN", "secret-token")
+		srv := runOnce(t)
+		if !srv.sawAuthHeader("Bearer secret-token") {
+			t.Errorf("expected Bearer token on requests; saw %v", srv.authHeaders)
+		}
+	})
+}
+
+// --- Phase 4: tarball update helper units -----------------------------------
+
+func TestProjectNameFromSlug(t *testing.T) {
+	cases := map[string]string{
+		"doordash-oss/agentic-orchestrator": "agentic-orchestrator",
+		"owner/repo":                        "repo",
+		"single":                            "single",
+	}
+	for in, want := range cases {
+		if got := projectNameFromSlug(in); got != want {
+			t.Errorf("projectNameFromSlug(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestChecksumFor(t *testing.T) {
+	checksums := []byte("aaa  first.tar.gz\nbbb  second.tar.gz\n\nccc  dist/third.tar.gz\n")
+	t.Run("exact name match", func(t *testing.T) {
+		got, ok := checksumFor(checksums, "second.tar.gz")
+		if !ok || got != "bbb" {
+			t.Errorf("checksumFor(second) = %q,%v want bbb,true", got, ok)
+		}
+	})
+	t.Run("matches on base name", func(t *testing.T) {
+		got, ok := checksumFor(checksums, "third.tar.gz")
+		if !ok || got != "ccc" {
+			t.Errorf("checksumFor(third) = %q,%v want ccc,true", got, ok)
+		}
+	})
+	t.Run("missing entry", func(t *testing.T) {
+		if _, ok := checksumFor(checksums, "absent.tar.gz"); ok {
+			t.Error("checksumFor(absent) ok = true, want false")
+		}
+	})
+}
+
+func TestVerifyChecksum(t *testing.T) {
+	archive := []byte("the-archive-bytes")
+	name := "agentic.tar.gz"
+	good := fmt.Appendf(nil, "%s  %s\n", sha256Hex(archive), name)
+	t.Run("match", func(t *testing.T) {
+		if err := verifyChecksum(archive, good, name); err != nil {
+			t.Errorf("verifyChecksum match error: %v", err)
+		}
+	})
+	t.Run("case-insensitive digest", func(t *testing.T) {
+		upper := fmt.Appendf(nil, "%s  %s\n", strings.ToUpper(sha256Hex(archive)), name)
+		if err := verifyChecksum(archive, upper, name); err != nil {
+			t.Errorf("verifyChecksum should accept upper-case digest: %v", err)
+		}
+	})
+	t.Run("mismatch", func(t *testing.T) {
+		bad := fmt.Appendf(nil, "%s  %s\n", sha256Hex([]byte("other")), name)
+		if err := verifyChecksum(archive, bad, name); err == nil {
+			t.Error("verifyChecksum mismatch error = nil, want error")
+		}
+	})
+	t.Run("no entry for archive", func(t *testing.T) {
+		if err := verifyChecksum(archive, []byte("zzz  unrelated.tar.gz\n"), name); err == nil {
+			t.Error("verifyChecksum with no matching entry error = nil, want error")
+		}
+	})
+}
+
+func TestExtractAgenticoBinary(t *testing.T) {
+	t.Run("extracts inner agentico binary", func(t *testing.T) {
+		const want = "BINARY-CONTENT"
+		archive := makeTarGz(t, map[string]string{"LICENSE": "x", "agentico": want, "README.md": "y"})
+		got, err := extractAgenticoBinary(archive)
+		if err != nil {
+			t.Fatalf("extractAgenticoBinary error: %v", err)
+		}
+		if string(got) != want {
+			t.Errorf("extracted content = %q, want %q", got, want)
+		}
+	})
+	t.Run("errors when agentico entry absent", func(t *testing.T) {
+		archive := makeTarGz(t, map[string]string{"LICENSE": "x", "README.md": "y"})
+		if _, err := extractAgenticoBinary(archive); err == nil {
+			t.Error("expected error when archive lacks an agentico entry")
+		}
+	})
+	t.Run("errors on non-gzip input", func(t *testing.T) {
+		if _, err := extractAgenticoBinary([]byte("not a gzip stream")); err == nil {
+			t.Error("expected error on a corrupt archive")
+		}
+	})
+}
+
+// swapBinary writes a temp file in the target directory and renames it over the
+// target: the swapped target has new content, an executable mode, and a new
+// file identity (rename), so the original inode survives for any open handle.
+func TestSwapBinaryAtomicRename(t *testing.T) {
+	const newContent = "REPLACEMENT"
+	target, origInfo := writeTargetBinary(t, "ORIGINAL")
+
+	// Hold the original file open to model the running process; reading from the
+	// handle after the swap must still return the original bytes.
+	orig, err := os.Open(target)
+	if err != nil {
+		t.Fatalf("opening original: %v", err)
+	}
+	defer orig.Close()
+
+	if err := swapBinary(target, []byte(newContent)); err != nil {
+		t.Fatalf("swapBinary error: %v", err)
+	}
+
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("reading swapped target: %v", err)
+	}
+	if string(got) != newContent {
+		t.Errorf("target content = %q, want %q", got, newContent)
+	}
+	newInfo, err := os.Stat(target)
+	if err != nil {
+		t.Fatalf("stat swapped target: %v", err)
+	}
+	if os.SameFile(origInfo, newInfo) {
+		t.Error("swapBinary must rename a fresh file over the target (new identity)")
+	}
+	if newInfo.Mode().Perm()&0o100 == 0 {
+		t.Errorf("swapped target not executable: %v", newInfo.Mode())
+	}
+	fromHandle, err := io.ReadAll(orig)
+	if err != nil {
+		t.Fatalf("reading original handle: %v", err)
+	}
+	if string(fromHandle) != "ORIGINAL" {
+		t.Errorf("original handle content = %q, want it preserved as %q", fromHandle, "ORIGINAL")
+	}
+}
+
+// swapBinary leaves nothing behind when the target directory is unwritable: the
+// temp-file creation fails and the (absent) target is not created.
+func TestSwapBinaryFailsClosedOnBadDir(t *testing.T) {
+	target := filepath.Join(t.TempDir(), "no-such-subdir", "agentico")
+	if err := swapBinary(target, []byte("X")); err == nil {
+		t.Fatal("swapBinary into a nonexistent directory must error")
+	}
+	if _, err := os.Stat(target); !os.IsNotExist(err) {
+		t.Errorf("target must not exist after a failed swap; stat err = %v", err)
 	}
 }

--- a/cmd/agentico/update_test.go
+++ b/cmd/agentico/update_test.go
@@ -344,33 +344,38 @@ func fakeFetch(tag string, err error) func(context.Context, string) (string, err
 
 func okSlug() (string, error) { return "doordash-oss/agentic-orchestrator", nil }
 
-func TestRunUpdateWith(t *testing.T) {
-	t.Run("check prints versions and placeholder, exits 0", func(t *testing.T) {
-		var stdout, stderr bytes.Buffer
-		code := runUpdateWith(context.Background(), true, &stdout, &stderr, updateDeps{
-			currentVersion: "1.2.3",
-			slug:           okSlug,
-			fetchLatest:    fakeFetch("v2.0.0", nil),
-		})
-		if code != 0 {
-			t.Fatalf("code = %d, want 0\nstderr: %s", code, stderr.String())
-		}
-		out := stdout.String()
-		for _, want := range []string{"Checking for updates", "1.2.3", "2.0.0", updatePlaceholderAction} {
-			if !strings.Contains(out, want) {
-				t.Errorf("stdout missing %q\nfull:\n%s", want, out)
-			}
-		}
-		if stderr.Len() != 0 {
-			t.Errorf("stderr = %q, want empty", stderr.String())
-		}
-	})
+// fixedMethod returns a detector that always reports m. The non-dev branches of
+// runUpdateWith reach the network, so most tests pin a concrete non-dev method.
+func fixedMethod(m installMethod) func() installMethod {
+	return func() installMethod { return m }
+}
 
+// failingSlugFn / failingFetchFn fail the test if invoked. They guard the
+// classify-first control flow: a dev build must never reach the slug resolver
+// or the latest-release fetcher.
+func failingSlugFn(t *testing.T) func() (string, error) {
+	t.Helper()
+	return func() (string, error) {
+		t.Fatal("slug resolver called on a network-free (dev-build) path")
+		return "", nil
+	}
+}
+
+func failingFetchFn(t *testing.T) func(context.Context, string) (string, error) {
+	t.Helper()
+	return func(context.Context, string) (string, error) {
+		t.Fatal("fetchLatest called on a network-free (dev-build) path")
+		return "", nil
+	}
+}
+
+func TestRunUpdateWith(t *testing.T) {
 	t.Run("already up to date short-circuits, exits 0", func(t *testing.T) {
 		for _, checkOnly := range []bool{true, false} {
 			var stdout, stderr bytes.Buffer
 			code := runUpdateWith(context.Background(), checkOnly, &stdout, &stderr, updateDeps{
 				currentVersion: "2.0.0",
+				method:         fixedMethod(installMethodTarball),
 				slug:           okSlug,
 				fetchLatest:    fakeFetch("v2.0.0", nil),
 			})
@@ -381,16 +386,20 @@ func TestRunUpdateWith(t *testing.T) {
 			if !strings.Contains(out, "up to date") {
 				t.Errorf("checkOnly=%v stdout missing up-to-date message\nfull:\n%s", checkOnly, out)
 			}
-			if strings.Contains(out, updatePlaceholderAction) {
-				t.Errorf("checkOnly=%v up-to-date path must not print placeholder action", checkOnly)
+			if strings.Contains(out, "Would update") {
+				t.Errorf("checkOnly=%v up-to-date path must not print a would-do action", checkOnly)
 			}
 		}
 	})
 
-	t.Run("dev current never claims up to date, check exits 0", func(t *testing.T) {
+	t.Run("dev version string with non-dev method still prints latest, check exits 0", func(t *testing.T) {
+		// The injected method decides the branch; the version string only
+		// decides up-to-date. A "dev" version on a go-install method must not
+		// claim up to date and must still resolve the latest release.
 		var stdout, stderr bytes.Buffer
 		code := runUpdateWith(context.Background(), true, &stdout, &stderr, updateDeps{
 			currentVersion: "dev",
+			method:         fixedMethod(installMethodGoInstall),
 			slug:           okSlug,
 			fetchLatest:    fakeFetch("v2.0.0", nil),
 		})
@@ -406,28 +415,11 @@ func TestRunUpdateWith(t *testing.T) {
 		}
 	})
 
-	t.Run("bare update available prints skeleton + stderr stub, exits 1", func(t *testing.T) {
-		var stdout, stderr bytes.Buffer
-		code := runUpdateWith(context.Background(), false, &stdout, &stderr, updateDeps{
-			currentVersion: "1.2.3",
-			slug:           okSlug,
-			fetchLatest:    fakeFetch("v2.0.0", nil),
-		})
-		if code != 1 {
-			t.Fatalf("code = %d, want 1", code)
-		}
-		if !strings.Contains(stdout.String(), "→") {
-			t.Errorf("stdout missing old → new skeleton\nfull:\n%s", stdout.String())
-		}
-		if !strings.Contains(stderr.String(), updateNotImplementedMsg) {
-			t.Errorf("stderr missing not-yet-wired stub\nfull:\n%s", stderr.String())
-		}
-	})
-
 	t.Run("fetch error exits 1 with stderr message", func(t *testing.T) {
 		var stdout, stderr bytes.Buffer
 		code := runUpdateWith(context.Background(), true, &stdout, &stderr, updateDeps{
 			currentVersion: "1.2.3",
+			method:         fixedMethod(installMethodTarball),
 			slug:           okSlug,
 			fetchLatest:    fakeFetch("", errors.New("boom")),
 		})
@@ -443,6 +435,7 @@ func TestRunUpdateWith(t *testing.T) {
 		var stdout, stderr bytes.Buffer
 		code := runUpdateWith(context.Background(), true, &stdout, &stderr, updateDeps{
 			currentVersion: "1.2.3",
+			method:         fixedMethod(installMethodTarball),
 			slug:           okSlug,
 			fetchLatest:    fakeFetch("", errNoStableRelease),
 		})
@@ -459,6 +452,7 @@ func TestRunUpdateWith(t *testing.T) {
 		fetchCalled := false
 		code := runUpdateWith(context.Background(), true, &stdout, &stderr, updateDeps{
 			currentVersion: "1.2.3",
+			method:         fixedMethod(installMethodTarball),
 			slug:           func() (string, error) { return "", errors.New("no module path") },
 			fetchLatest: func(context.Context, string) (string, error) {
 				fetchCalled = true
@@ -477,6 +471,136 @@ func TestRunUpdateWith(t *testing.T) {
 	})
 }
 
+// --- Task 2: dev-build refusal (network-free) -------------------------------
+
+func TestRunUpdateWithDevBuildBareRefuses(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := runUpdateWith(context.Background(), false, &stdout, &stderr, updateDeps{
+		currentVersion: "dev",
+		method:         fixedMethod(installMethodDevBuild),
+		slug:           failingSlugFn(t),  // must not be reached
+		fetchLatest:    failingFetchFn(t), // must not be reached
+	})
+	if code == 0 {
+		t.Fatalf("bare dev-build update must exit non-zero, got %d", code)
+	}
+	if stdout.Len() != 0 {
+		t.Errorf("bare dev-build refusal must keep stdout empty, got %q", stdout.String())
+	}
+	errOut := stderr.String()
+	for _, want := range []string{"built from source", "Update from source"} {
+		if !strings.Contains(errOut, want) {
+			t.Errorf("stderr missing guidance %q\nfull:\n%s", want, errOut)
+		}
+	}
+}
+
+func TestRunUpdateWithDevBuildCheckReports(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := runUpdateWith(context.Background(), true, &stdout, &stderr, updateDeps{
+		currentVersion: "dev",
+		method:         fixedMethod(installMethodDevBuild),
+		slug:           failingSlugFn(t),  // must not be reached
+		fetchLatest:    failingFetchFn(t), // must not be reached
+	})
+	if code != 0 {
+		t.Fatalf("dev-build --check must exit 0 (non-destructive report), got %d\nstderr: %s", code, stderr.String())
+	}
+	out := stdout.String()
+	for _, want := range []string{"Current version", "dev", installMethodDevBuild.label(), installMethodDevBuild.wouldDoAction()} {
+		if !strings.Contains(out, want) {
+			t.Errorf("stdout missing %q\nfull:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "Latest version") {
+		t.Errorf("dev-build --check must not print a latest version (no network)\nfull:\n%s", out)
+	}
+	if stderr.Len() != 0 {
+		t.Errorf("dev-build --check stderr = %q, want empty", stderr.String())
+	}
+}
+
+// --- Task 3: real method + would-do-action reporting for non-dev branches ---
+
+func TestRunUpdateWithCheckReportsMethodAndAction(t *testing.T) {
+	tests := []struct {
+		name       string
+		method     installMethod
+		wantLabel  string
+		wantAction string
+	}{
+		{
+			name:       "go-install",
+			method:     installMethodGoInstall,
+			wantLabel:  "go install",
+			wantAction: "re-running the Go install",
+		},
+		{
+			name:       "tarball",
+			method:     installMethodTarball,
+			wantLabel:  "release tarball",
+			wantAction: "downloading the latest release and replacing the binary",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			code := runUpdateWith(context.Background(), true, &stdout, &stderr, updateDeps{
+				currentVersion: "1.2.3",
+				method:         fixedMethod(tt.method),
+				slug:           okSlug,
+				fetchLatest:    fakeFetch("v2.0.0", nil),
+			})
+			if code != 0 {
+				t.Fatalf("code = %d, want 0\nstderr: %s", code, stderr.String())
+			}
+			out := stdout.String()
+			for _, want := range []string{"Current version", "1.2.3", "Latest version", "2.0.0", tt.wantLabel, tt.wantAction} {
+				if !strings.Contains(out, want) {
+					t.Errorf("stdout missing %q\nfull:\n%s", want, out)
+				}
+			}
+			if stderr.Len() != 0 {
+				t.Errorf("stderr = %q, want empty", stderr.String())
+			}
+		})
+	}
+}
+
+func TestRunUpdateWithBareNamesDetectedMethod(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		method    installMethod
+		wantLabel string
+	}{
+		{name: "go-install", method: installMethodGoInstall, wantLabel: "go install"},
+		{name: "tarball", method: installMethodTarball, wantLabel: "release tarball"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			code := runUpdateWith(context.Background(), false, &stdout, &stderr, updateDeps{
+				currentVersion: "1.2.3",
+				method:         fixedMethod(tt.method),
+				slug:           okSlug,
+				fetchLatest:    fakeFetch("v2.0.0", nil),
+			})
+			if code != 1 {
+				t.Fatalf("code = %d, want 1", code)
+			}
+			if !strings.Contains(stdout.String(), "→") {
+				t.Errorf("stdout missing old → new skeleton\nfull:\n%s", stdout.String())
+			}
+			errOut := stderr.String()
+			if !strings.Contains(errOut, updateNotImplementedMsg) {
+				t.Errorf("stderr missing not-yet-wired stub\nfull:\n%s", errOut)
+			}
+			if !strings.Contains(errOut, tt.wantLabel) {
+				t.Errorf("stderr must name the detected method %q\nfull:\n%s", tt.wantLabel, errOut)
+			}
+		})
+	}
+}
+
 // Exercises the real fetch path end-to-end through runUpdateWith and httptest,
 // confirming the whole resolution chain stays hermetic.
 func TestRunUpdateWithRealFetchHermetic(t *testing.T) {
@@ -485,6 +609,7 @@ func TestRunUpdateWithRealFetchHermetic(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	code := runUpdateWith(context.Background(), true, &stdout, &stderr, updateDeps{
 		currentVersion: "1.0.0",
+		method:         fixedMethod(installMethodTarball),
 		slug:           func() (string, error) { return slug, nil },
 		fetchLatest:    githubFetchLatestStableTag(srv.Client(), srv.URL),
 	})

--- a/cmd/agentico/update_test.go
+++ b/cmd/agentico/update_test.go
@@ -1047,6 +1047,9 @@ func TestRunUpdateWithTarballChecksumMismatch(t *testing.T) {
 	if stderr.Len() == 0 {
 		t.Error("expected a clear checksum error on stderr")
 	}
+	if !strings.Contains(strings.ToLower(stderr.String()), "checksum") {
+		t.Errorf("the error must name the checksum so the user can diagnose it\nfull:\n%s", stderr.String())
+	}
 	got, err := os.ReadFile(target)
 	if err != nil {
 		t.Fatalf("reading target: %v", err)
@@ -1365,11 +1368,13 @@ func TestCheckDirWritable(t *testing.T) {
 	})
 }
 
-// On the real tarball update path, an unwritable target directory aborts before
-// any download: the command exits non-zero, prints stderr guidance naming the
-// directory and pointing at elevated privileges (sudo), prints no old → new
-// line, and never reaches the download seam. The verdict is driven by an
-// injected check, so it is deterministic regardless of the test process's uid.
+// On the real tarball update path, when an update IS warranted but the target
+// directory is unwritable, the command aborts before any download: it exits
+// non-zero, prints stderr guidance naming the directory and pointing at elevated
+// privileges (sudo), prints no old → new line, and never reaches the download
+// seam. The pre-flight runs only after the version check confirms an update is
+// needed, so the fetch does run here. The verdict is driven by an injected
+// check, so it is deterministic regardless of the test process's uid.
 func TestRunUpdateWithTarballPreflightUnwritableAborts(t *testing.T) {
 	const dir = "/usr/local/bin"
 	var checkedDir string
@@ -1378,11 +1383,10 @@ func TestRunUpdateWithTarballPreflightUnwritableAborts(t *testing.T) {
 		currentVersion: "1.0.0",
 		method:         fixedMethod(installMethodTarball),
 		slug:           okSlug,
-		// The latest-release lookup is the first GitHub request. An unwritable
-		// target must abort the pre-flight ahead of it, so this must never run.
+		// An update is available (2.0.0 > 1.0.0), so the version check falls
+		// through to the pre-flight, which then aborts on the unwritable dir.
 		fetchLatest: func(context.Context, string) (string, error) {
 			fetchCalled = true
-			t.Error("latest-release fetch must not run when the pre-flight aborts an unwritable tarball update")
 			return "v2.0.0", nil
 		},
 		binaryPath: dir + "/agentico",
@@ -1400,8 +1404,8 @@ func TestRunUpdateWithTarballPreflightUnwritableAborts(t *testing.T) {
 	if code == 0 {
 		t.Fatalf("unwritable target must exit non-zero, got %d", code)
 	}
-	if fetchCalled {
-		t.Error("the pre-flight must abort before the latest-release GitHub fetch (no network request occurs)")
+	if !fetchCalled {
+		t.Error("the version check (and its fetch) must run before the pre-flight, so an up-to-date binary is not nagged about writability")
 	}
 	if checkedDir != dir {
 		t.Errorf("pre-flight probed %q, want the binary's directory %q", checkedDir, dir)
@@ -1560,5 +1564,232 @@ func TestRunUpdateWithTarballNoResignOffDarwin(t *testing.T) {
 	}
 	if stderr.Len() != 0 {
 		t.Errorf("off-darwin must emit no re-sign warning; stderr = %q", stderr.String())
+	}
+}
+
+// --- downgrade guard --------------------------------------------------------
+
+// When the running version is newer than the latest published release, a bare
+// tarball update must NOT downgrade: it reports "already up to date" (noting the
+// running version is ahead), exits 0, and never reaches the download/swap seam.
+func TestRunUpdateWithTarballDoesNotDowngrade(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := runUpdateWith(context.Background(), false, &stdout, &stderr, updateDeps{
+		currentVersion: "2.0.0",
+		method:         fixedMethod(installMethodTarball),
+		slug:           okSlug,
+		fetchLatest:    fakeFetch("v1.0.0", nil),
+		runTarball:     failingTarball(t), // the swap must never run when no update is warranted
+	})
+
+	t.Logf("exit=%d\nstdout:\n%s\nstderr:\n%s", code, stdout.String(), stderr.String())
+	if code != 0 {
+		t.Fatalf("a current version newer than latest must exit 0 (no downgrade), got %d", code)
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "already up to date") || !strings.Contains(out, "newer than") {
+		t.Errorf("expected an up-to-date/ahead message, got:\n%s", out)
+	}
+	if strings.Contains(out, "→") {
+		t.Errorf("no old → new transition may print when no update is warranted\n%s", out)
+	}
+}
+
+// Numerically-equal versions that differ only in formatting (leading v) are
+// treated as up to date — the swap does not run.
+func TestRunUpdateWithTarballEqualVersionNoUpdate(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := runUpdateWith(context.Background(), false, &stdout, &stderr, updateDeps{
+		currentVersion: "v2.0.0",
+		method:         fixedMethod(installMethodTarball),
+		slug:           okSlug,
+		fetchLatest:    fakeFetch("2.0.0", nil),
+		runTarball:     failingTarball(t),
+	})
+	if code != 0 {
+		t.Fatalf("equal versions must exit 0, got %d\nstderr:%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "already up to date") {
+		t.Errorf("expected already-up-to-date message, got:\n%s", stdout.String())
+	}
+}
+
+// --- forgiving asset matching -----------------------------------------------
+
+func TestMatchArchiveAsset(t *testing.T) {
+	const project = "agentic-orchestrator"
+	tests := []struct {
+		name         string
+		goos, goarch string
+		want         bool
+	}{
+		{"agentic-orchestrator_2.0.0_linux_amd64.tar.gz", "linux", "amd64", true},
+		{"agentic-orchestrator_2.0.0_linux_x86_64.tar.gz", "linux", "amd64", true},    // arch alias
+		{"agentic-orchestrator_2.0.0_darwin_aarch64.tar.gz", "darwin", "arm64", true}, // arch alias
+		{"agentic-orchestrator_2.0.0_macos_arm64.tar.gz", "darwin", "arm64", true},    // os alias
+		{"AGENTIC-ORCHESTRATOR_2.0.0_LINUX_AMD64.TAR.GZ", "linux", "amd64", true},     // case-insensitive
+		{"agentic-orchestrator_2.0.0_linux_amd64.tgz", "linux", "amd64", true},        // .tgz
+		{"agentic-orchestrator_2.0.0_linux_arm64.tar.gz", "linux", "amd64", false},    // arch mismatch
+		{"agentic-orchestrator_2.0.0_windows_amd64.tar.gz", "linux", "amd64", false},  // os mismatch
+		{"agentic-orchestrator_2.0.0_linux_amd64.zip", "linux", "amd64", false},       // zip not matched
+		{"other-project_2.0.0_linux_amd64.tar.gz", "linux", "amd64", false},           // wrong project
+		{"checksums.txt", "linux", "amd64", false},                                    // no prefix
+		{"agentic-orchestrator_linux_amd64.tar.gz", "linux", "amd64", false},          // too few fields
+	}
+	for _, tt := range tests {
+		if got := matchArchiveAsset(tt.name, project, tt.goos, tt.goarch); got != tt.want {
+			t.Errorf("matchArchiveAsset(%q, %s/%s) = %v, want %v", tt.name, tt.goos, tt.goarch, got, tt.want)
+		}
+	}
+}
+
+// End-to-end: an archive named with an arch alias (x86_64 for amd64) still
+// resolves and swaps successfully.
+func TestRunUpdateWithTarballMatchesAliasArchive(t *testing.T) {
+	const slug = "doordash-oss/agentic-orchestrator"
+	const newContent = "NEW-AGENTICO-ALIAS"
+	// linux/amd64 binary published under the x86_64 alias name.
+	archiveName := "agentic-orchestrator_2.0.0_linux_x86_64.tar.gz"
+	archive := makeTarGz(t, map[string]string{"agentico": newContent})
+	checksums := fmt.Appendf(nil, "%s  %s\n", sha256Hex(archive), archiveName)
+
+	srv := newTarballServer(t, slug, "v2.0.0", archiveName, archive, checksums)
+	target, _ := writeTargetBinary(t, "OLD")
+
+	var stdout, stderr bytes.Buffer
+	code := runUpdateWith(context.Background(), false, &stdout, &stderr, updateDeps{
+		currentVersion: "1.0.0",
+		method:         fixedMethod(installMethodTarball),
+		slug:           func() (string, error) { return slug, nil },
+		fetchLatest:    fakeFetch("v2.0.0", nil),
+		runTarball:     newTarballUpdater(srv.srv.Client(), srv.srv.URL, target, "linux", "amd64"),
+	})
+
+	if code != 0 {
+		t.Fatalf("alias-named archive must resolve and swap, got %d\nstderr:%s", code, stderr.String())
+	}
+	if got, _ := os.ReadFile(target); string(got) != newContent {
+		t.Errorf("target content = %q, want %q", got, newContent)
+	}
+}
+
+// --- mode preservation ------------------------------------------------------
+
+// swapBinary preserves the existing binary's permission bits across the swap,
+// guaranteeing the result stays executable by its owner.
+func TestSwapBinaryPreservesMode(t *testing.T) {
+	tests := []struct {
+		orig os.FileMode
+		want os.FileMode
+	}{
+		{0o755, 0o755},
+		{0o750, 0o750},
+		{0o640, 0o740}, // no owner-exec bit -> swap guarantees 0o100
+	}
+	for _, tt := range tests {
+		dir := t.TempDir()
+		target := filepath.Join(dir, "agentico")
+		if err := os.WriteFile(target, []byte("OLD"), tt.orig); err != nil {
+			t.Fatalf("writing target: %v", err)
+		}
+		// WriteFile is subject to umask; normalize the starting mode explicitly.
+		if err := os.Chmod(target, tt.orig); err != nil {
+			t.Fatalf("chmod target: %v", err)
+		}
+		if err := swapBinary(target, []byte("NEW")); err != nil {
+			t.Fatalf("swapBinary: %v", err)
+		}
+		info, err := os.Stat(target)
+		if err != nil {
+			t.Fatalf("stat: %v", err)
+		}
+		if info.Mode().Perm() != tt.want {
+			t.Errorf("orig %v -> swapped %v, want %v", tt.orig, info.Mode().Perm(), tt.want)
+		}
+		if got, _ := os.ReadFile(target); string(got) != "NEW" {
+			t.Errorf("content = %q, want NEW", got)
+		}
+	}
+}
+
+// --- pre-flight ordering relative to the version check ----------------------
+
+// Regression guard for the reorder: a binary AHEAD of the latest release in an
+// unwritable directory must report "already up to date" and exit 0 — the
+// version check runs before the pre-flight, so no spurious "use sudo" error and
+// no swap. (Before the reorder, the pre-flight fired first and produced a
+// misleading non-zero sudo error.)
+func TestRunUpdateWithTarballAheadInUnwritableDirReportsUpToDate(t *testing.T) {
+	var checkWritableCalled bool
+	var stdout, stderr bytes.Buffer
+	code := runUpdateWith(context.Background(), false, &stdout, &stderr, updateDeps{
+		currentVersion: "2.0.0",
+		method:         fixedMethod(installMethodTarball),
+		slug:           okSlug,
+		fetchLatest:    fakeFetch("v1.0.0", nil), // latest is OLDER than current
+		binaryPath:     "/usr/local/bin/agentico",
+		checkWritable:  func(string) error { checkWritableCalled = true; return errors.New("permission denied") },
+		runTarball:     failingTarball(t),
+	})
+
+	t.Logf("exit=%d checkWritableCalled=%v\nstdout:\n%s\nstderr:\n%s", code, checkWritableCalled, stdout.String(), stderr.String())
+	if code != 0 {
+		t.Fatalf("an ahead binary must exit 0 even in an unwritable dir, got %d\nstderr:%s", code, stderr.String())
+	}
+	if checkWritableCalled {
+		t.Error("the writability pre-flight must NOT run when no update is warranted (no spurious sudo error)")
+	}
+	if !strings.Contains(stdout.String(), "already up to date") {
+		t.Errorf("expected an up-to-date report, got:\n%s", stdout.String())
+	}
+	if strings.Contains(strings.ToLower(stderr.String()), "sudo") {
+		t.Errorf("no sudo/writability error may print when no update is warranted\nstderr:\n%s", stderr.String())
+	}
+}
+
+// In --check mode the downgrade guard still fires: a binary newer than the
+// latest release reports up-to-date and exits 0 without printing "Would update".
+func TestRunUpdateWithDoesNotDowngradeCheckMode(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := runUpdateWith(context.Background(), true /*checkOnly*/, &stdout, &stderr, updateDeps{
+		currentVersion: "2.0.0",
+		method:         fixedMethod(installMethodTarball),
+		slug:           okSlug,
+		fetchLatest:    fakeFetch("v1.0.0", nil),
+		runTarball:     failingTarball(t),
+	})
+	if code != 0 {
+		t.Fatalf("check mode with an ahead version must exit 0, got %d", code)
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "already up to date") || !strings.Contains(out, "newer than") {
+		t.Errorf("check mode must report up-to-date/ahead, got:\n%s", out)
+	}
+	if strings.Contains(out, "Would update") {
+		t.Errorf("check mode must not claim an update is available for an ahead binary\n%s", out)
+	}
+}
+
+// --check mode never triggers the writability pre-flight, even on a tarball
+// install in an unwritable directory: it reports the would-do action and exits 0.
+func TestRunUpdateWithCheckModeSkipsPreflight(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := runUpdateWith(context.Background(), true /*checkOnly*/, &stdout, &stderr, updateDeps{
+		currentVersion: "1.0.0",
+		method:         fixedMethod(installMethodTarball),
+		slug:           okSlug,
+		fetchLatest:    fakeFetch("v2.0.0", nil), // an update IS available
+		binaryPath:     "/usr/local/bin/agentico",
+		checkWritable: func(string) error {
+			t.Error("pre-flight must not run in --check mode")
+			return errors.New("permission denied")
+		},
+		runTarball: failingTarball(t),
+	})
+	if code != 0 {
+		t.Fatalf("--check must exit 0 regardless of writability, got %d\nstderr:%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Would update") {
+		t.Errorf("--check must report the would-do action, got:\n%s", stdout.String())
 	}
 }

--- a/cmd/agentico/update_test.go
+++ b/cmd/agentico/update_test.go
@@ -19,9 +19,11 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os/exec"
 	"strings"
 	"testing"
 )
@@ -567,37 +569,31 @@ func TestRunUpdateWithCheckReportsMethodAndAction(t *testing.T) {
 	}
 }
 
-func TestRunUpdateWithBareNamesDetectedMethod(t *testing.T) {
-	for _, tt := range []struct {
-		name      string
-		method    installMethod
-		wantLabel string
-	}{
-		{name: "go-install", method: installMethodGoInstall, wantLabel: "go install"},
-		{name: "tarball", method: installMethodTarball, wantLabel: "release tarball"},
-	} {
-		t.Run(tt.name, func(t *testing.T) {
-			var stdout, stderr bytes.Buffer
-			code := runUpdateWith(context.Background(), false, &stdout, &stderr, updateDeps{
-				currentVersion: "1.2.3",
-				method:         fixedMethod(tt.method),
-				slug:           okSlug,
-				fetchLatest:    fakeFetch("v2.0.0", nil),
-			})
-			if code != 1 {
-				t.Fatalf("code = %d, want 1", code)
-			}
-			if !strings.Contains(stdout.String(), "→") {
-				t.Errorf("stdout missing old → new skeleton\nfull:\n%s", stdout.String())
-			}
-			errOut := stderr.String()
-			if !strings.Contains(errOut, updateNotImplementedMsg) {
-				t.Errorf("stderr missing not-yet-wired stub\nfull:\n%s", errOut)
-			}
-			if !strings.Contains(errOut, tt.wantLabel) {
-				t.Errorf("stderr must name the detected method %q\nfull:\n%s", tt.wantLabel, errOut)
-			}
-		})
+// The tarball method is still the not-yet-implemented placeholder (Phase 4):
+// bare update prints the old → new skeleton to stdout and the not-yet-wired
+// stub naming the detected method to stderr, then exits non-zero. (The
+// go-install method is now wired to a real re-install; see the GoInstall tests
+// below.)
+func TestRunUpdateWithBareTarballNamesDetectedMethod(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := runUpdateWith(context.Background(), false, &stdout, &stderr, updateDeps{
+		currentVersion: "1.2.3",
+		method:         fixedMethod(installMethodTarball),
+		slug:           okSlug,
+		fetchLatest:    fakeFetch("v2.0.0", nil),
+	})
+	if code != 1 {
+		t.Fatalf("code = %d, want 1", code)
+	}
+	if !strings.Contains(stdout.String(), "→") {
+		t.Errorf("stdout missing old → new skeleton\nfull:\n%s", stdout.String())
+	}
+	errOut := stderr.String()
+	if !strings.Contains(errOut, updateNotImplementedMsg) {
+		t.Errorf("stderr missing not-yet-wired stub\nfull:\n%s", errOut)
+	}
+	if !strings.Contains(errOut, "release tarball") {
+		t.Errorf("stderr must name the detected tarball method\nfull:\n%s", errOut)
 	}
 }
 
@@ -631,5 +627,238 @@ func TestModuleSlugDerivedFromBuildInfo(t *testing.T) {
 	}
 	if slug != "doordash-oss/agentic-orchestrator" {
 		t.Errorf("moduleSlug() = %q, want doordash-oss/agentic-orchestrator", slug)
+	}
+}
+
+// --- Phase 3: real go-install re-install behind the runner seam -------------
+
+const testMainPkg = "github.com/doordash-oss/agentic-orchestrator/cmd/agentico"
+
+// recordedInstall captures the single invocation a fake runner saw so a test can
+// assert the command name, argument slice, and the GOBIN-augmented environment.
+type recordedInstall struct {
+	called bool
+	name   string
+	args   []string
+	env    []string
+}
+
+// fakeRunner returns a commandRunner that records its invocation into rec and
+// then yields the supplied combined output and error — so no real `go install`
+// ever runs in the unit suite.
+func fakeRunner(rec *recordedInstall, out []byte, err error) commandRunner {
+	return func(_ context.Context, name string, args, env []string) ([]byte, error) {
+		rec.called = true
+		rec.name = name
+		rec.args = append([]string(nil), args...)
+		rec.env = append([]string(nil), env...)
+		return out, err
+	}
+}
+
+// failingRunner returns a commandRunner that fails the test if invoked. It
+// guards control-flow paths that must never reach the subprocess (e.g. the
+// main-package derivation failing first).
+func failingRunner(t *testing.T) commandRunner {
+	t.Helper()
+	return func(context.Context, string, []string, []string) ([]byte, error) {
+		t.Fatal("install runner invoked on a path that must not reach the subprocess")
+		return nil, nil
+	}
+}
+
+// lastEnvValue returns the last value bound to key in an os/exec-style env
+// slice (last write wins, matching exec semantics), and whether key was present.
+func lastEnvValue(env []string, key string) (string, bool) {
+	prefix := key + "="
+	val, ok := "", false
+	for _, kv := range env {
+		if after, found := strings.CutPrefix(kv, prefix); found {
+			val, ok = after, true
+		}
+	}
+	return val, ok
+}
+
+// goInstallDeps builds an updateDeps wired for the bare go-install branch with a
+// fake runner, an injected main-package path, and a fixed resolved binary dir.
+func goInstallDeps(rec *recordedInstall, out []byte, runErr error, binDir string) updateDeps {
+	return updateDeps{
+		currentVersion: "1.2.3",
+		method:         fixedMethod(installMethodGoInstall),
+		slug:           okSlug,
+		fetchLatest:    fakeFetch("v2.0.0", nil),
+		mainPackage:    func() (string, error) { return testMainPkg, nil },
+		binaryDir:      func() string { return binDir },
+		runInstall:     fakeRunner(rec, out, runErr),
+	}
+}
+
+// Task 1: bare go-install with an update available re-runs `go install` of the
+// command's own main package pinned to the resolved tag, augments GOBIN to the
+// running binary's directory, prints the old → new transition, and exits 0.
+func TestRunUpdateWithGoInstallSuccess(t *testing.T) {
+	const binDir = "/home/user/go/bin"
+	var rec recordedInstall
+	var stdout, stderr bytes.Buffer
+
+	code := runUpdateWith(context.Background(), false, &stdout, &stderr,
+		goInstallDeps(&rec, []byte("ok"), nil, binDir))
+
+	if code != 0 {
+		t.Fatalf("code = %d, want 0\nstderr: %s", code, stderr.String())
+	}
+	if !rec.called {
+		t.Fatal("install runner was not invoked")
+	}
+	if rec.name != "go" {
+		t.Errorf("command name = %q, want %q", rec.name, "go")
+	}
+	wantArgs := []string{"install", testMainPkg + "@v2.0.0"}
+	if len(rec.args) != len(wantArgs) {
+		t.Fatalf("args = %v, want %v", rec.args, wantArgs)
+	}
+	for i := range wantArgs {
+		if rec.args[i] != wantArgs[i] {
+			t.Fatalf("args = %v, want %v (pinned at the resolved tag)", rec.args, wantArgs)
+		}
+	}
+	if got, ok := lastEnvValue(rec.env, "GOBIN"); !ok || got != binDir {
+		t.Errorf("GOBIN = %q (present=%v), want %q (running binary's dir)", got, ok, binDir)
+	}
+	if !strings.Contains(stdout.String(), "1.2.3 → 2.0.0") {
+		t.Errorf("stdout missing old → new transition\nfull:\n%s", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), updateCheckingNarrative) {
+		t.Errorf("stdout missing the %q narrative\nfull:\n%s", updateCheckingNarrative, stdout.String())
+	}
+	if stderr.Len() != 0 {
+		t.Errorf("stderr = %q, want empty on success", stderr.String())
+	}
+}
+
+// When the running binary's directory cannot be resolved, GOBIN is not forced
+// and the toolchain default applies — the install still runs.
+func TestRunUpdateWithGoInstallNoBinaryDirOmitsGOBIN(t *testing.T) {
+	var rec recordedInstall
+	var stdout, stderr bytes.Buffer
+
+	code := runUpdateWith(context.Background(), false, &stdout, &stderr,
+		goInstallDeps(&rec, []byte("ok"), nil, ""))
+
+	if code != 0 {
+		t.Fatalf("code = %d, want 0\nstderr: %s", code, stderr.String())
+	}
+	if _, ok := lastEnvValue(rec.env, "GOBIN"); ok {
+		t.Errorf("GOBIN must not be forced when the binary dir is unresolved; env = %v", rec.env)
+	}
+}
+
+// The main-package derivation failing short-circuits before any subprocess runs.
+func TestRunUpdateWithGoInstallMainPackageError(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	deps := updateDeps{
+		currentVersion: "1.2.3",
+		method:         fixedMethod(installMethodGoInstall),
+		slug:           okSlug,
+		fetchLatest:    fakeFetch("v2.0.0", nil),
+		mainPackage:    func() (string, error) { return "", errors.New("no main package") },
+		binaryDir:      func() string { return "/home/user/go/bin" },
+		runInstall:     failingRunner(t),
+	}
+	code := runUpdateWith(context.Background(), false, &stdout, &stderr, deps)
+	if code == 0 {
+		t.Fatal("main-package derivation failure must exit non-zero")
+	}
+	if stderr.Len() == 0 {
+		t.Error("expected an error message on stderr")
+	}
+	if strings.Contains(stdout.String(), "→") {
+		t.Errorf("no old → new success line may be printed on failure\nfull:\n%s", stdout.String())
+	}
+}
+
+// mainPackagePath derives the command's own main-package import path from the
+// test binary's build info — proving the package is derived at runtime (not the
+// bare module path) and is testable like moduleSlug.
+func TestMainPackagePathDerivedFromBuildInfo(t *testing.T) {
+	pkg, err := mainPackagePath()
+	if err != nil {
+		t.Fatalf("mainPackagePath() error: %v", err)
+	}
+	if pkg != testMainPkg {
+		t.Errorf("mainPackagePath() = %q, want %q", pkg, testMainPkg)
+	}
+}
+
+// --- Phase 3 / Task 2: clear failure surfacing through the runner seam ------
+
+// Toolchain absent (the runner surfaces exec.ErrNotFound): a clear
+// toolchain-not-found message to stderr, non-zero exit, and no success line.
+func TestRunUpdateWithGoInstallToolchainMissing(t *testing.T) {
+	var rec recordedInstall
+	var stdout, stderr bytes.Buffer
+
+	notFound := &exec.Error{Name: "go", Err: exec.ErrNotFound}
+	code := runUpdateWith(context.Background(), false, &stdout, &stderr,
+		goInstallDeps(&rec, nil, notFound, "/home/user/go/bin"))
+
+	if code == 0 {
+		t.Fatal("toolchain-absent path must exit non-zero")
+	}
+	errOut := stderr.String()
+	if !strings.Contains(errOut, "Go toolchain") || !strings.Contains(errOut, "PATH") {
+		t.Errorf("stderr missing a clear toolchain-not-found message\nfull:\n%s", errOut)
+	}
+	if strings.Contains(stdout.String(), "→") {
+		t.Errorf("no old → new success line may be printed when the toolchain is absent\nfull:\n%s", stdout.String())
+	}
+}
+
+// `go install` exits non-zero: the captured combined output is wrapped into the
+// stderr error message and the command exits non-zero.
+func TestRunUpdateWithGoInstallExitsNonZero(t *testing.T) {
+	var rec recordedInstall
+	var stdout, stderr bytes.Buffer
+
+	const failOutput = "go: downloading module: 404 Not Found"
+	code := runUpdateWith(context.Background(), false, &stdout, &stderr,
+		goInstallDeps(&rec, []byte(failOutput), errors.New("exit status 1"), "/home/user/go/bin"))
+
+	if code == 0 {
+		t.Fatal("install failure must exit non-zero")
+	}
+	errOut := stderr.String()
+	if !strings.Contains(errOut, failOutput) {
+		t.Errorf("stderr must include the captured combined output\nfull:\n%s", errOut)
+	}
+	if strings.Contains(stdout.String(), "→") {
+		t.Errorf("no old → new success line may be printed on install failure\nfull:\n%s", stdout.String())
+	}
+}
+
+// The install context times out (the runner surfaces context.DeadlineExceeded):
+// a clear timeout error including the captured output, and a non-zero exit.
+func TestRunUpdateWithGoInstallTimeout(t *testing.T) {
+	var rec recordedInstall
+	var stdout, stderr bytes.Buffer
+
+	const partial = "go: downloading a very large dependency graph"
+	timeoutErr := fmt.Errorf("running go install: %w", context.DeadlineExceeded)
+	code := runUpdateWith(context.Background(), false, &stdout, &stderr,
+		goInstallDeps(&rec, []byte(partial), timeoutErr, "/home/user/go/bin"))
+
+	if code == 0 {
+		t.Fatal("install timeout must exit non-zero")
+	}
+	errOut := stderr.String()
+	if !strings.Contains(strings.ToLower(errOut), "timed out") && !strings.Contains(strings.ToLower(errOut), "timeout") {
+		t.Errorf("stderr missing a clear timeout error\nfull:\n%s", errOut)
+	}
+	if !strings.Contains(errOut, partial) {
+		t.Errorf("stderr must include the captured output on timeout\nfull:\n%s", errOut)
+	}
+	if strings.Contains(stdout.String(), "→") {
+		t.Errorf("no old → new success line may be printed on timeout\nfull:\n%s", stdout.String())
 	}
 }

--- a/cmd/agentico/update_test.go
+++ b/cmd/agentico/update_test.go
@@ -673,6 +673,105 @@ func goInstallDeps(rec *recordedInstall, out []byte, runErr error, binDir string
 	}
 }
 
+// --- Homebrew branch: delegate to `brew upgrade` (Codex dispatcher model) ----
+
+// homebrewDeps wires the bare Homebrew branch with a fake brew runner and an
+// available update.
+func homebrewDeps(rec *recordedInstall, out []byte, runErr error) updateDeps {
+	return updateDeps{
+		currentVersion: "1.2.3",
+		method:         fixedMethod(installMethodHomebrew),
+		slug:           okSlug,
+		fetchLatest:    fakeFetch("v2.0.0", nil),
+		runBrew:        fakeRunner(rec, out, runErr),
+	}
+}
+
+// Bare homebrew update delegates to `brew upgrade agentico` through the runBrew
+// seam and exits 0 without swapping the binary itself.
+func TestRunUpdateWithHomebrewSuccess(t *testing.T) {
+	var rec recordedInstall
+	var stdout, stderr bytes.Buffer
+
+	code := runUpdateWith(context.Background(), false, &stdout, &stderr,
+		homebrewDeps(&rec, []byte("==> Upgrading agentico\nPouring agentico"), nil))
+
+	if code != 0 {
+		t.Fatalf("code = %d, want 0\nstderr: %s", code, stderr.String())
+	}
+	if !rec.called {
+		t.Fatal("brew runner was not invoked")
+	}
+	if rec.name != "brew" {
+		t.Errorf("command name = %q, want %q", rec.name, "brew")
+	}
+	wantArgs := []string{"upgrade", "agentico"}
+	if len(rec.args) != len(wantArgs) {
+		t.Fatalf("args = %v, want %v", rec.args, wantArgs)
+	}
+	for i := range wantArgs {
+		if rec.args[i] != wantArgs[i] {
+			t.Errorf("args[%d] = %q, want %q", i, rec.args[i], wantArgs[i])
+		}
+	}
+	out := stdout.String()
+	for _, want := range []string{"brew upgrade agentico", "Homebrew", "Upgrading agentico"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("stdout missing %q\nfull:\n%s", want, out)
+		}
+	}
+}
+
+// --check on a homebrew install reports the method without invoking brew (the
+// runner must never be reached on the check path).
+func TestRunUpdateWithHomebrewCheckDoesNotRunBrew(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := runUpdateWith(context.Background(), true, &stdout, &stderr, updateDeps{
+		currentVersion: "1.2.3",
+		method:         fixedMethod(installMethodHomebrew),
+		slug:           okSlug,
+		fetchLatest:    fakeFetch("v2.0.0", nil),
+		runBrew:        failingRunner(t), // must not be invoked in --check mode
+	})
+	if code != 0 {
+		t.Fatalf("code = %d, want 0\nstderr: %s", code, stderr.String())
+	}
+	out := stdout.String()
+	for _, want := range []string{"Current version", "Latest version", "2.0.0", installMethodHomebrew.label(), "brew upgrade agentico"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("stdout missing %q\nfull:\n%s", want, out)
+		}
+	}
+}
+
+// A missing brew binary is reported with guidance and a non-zero exit.
+func TestRunUpdateWithHomebrewBrewMissing(t *testing.T) {
+	var rec recordedInstall
+	var stdout, stderr bytes.Buffer
+	code := runUpdateWith(context.Background(), false, &stdout, &stderr,
+		homebrewDeps(&rec, []byte("command not found: brew"), exec.ErrNotFound))
+	if code != 1 {
+		t.Fatalf("code = %d, want 1\nstderr: %s", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "not found on PATH") {
+		t.Errorf("stderr missing brew-not-found guidance\nfull:\n%s", stderr.String())
+	}
+}
+
+// A non-zero `brew upgrade` exit is reported as a failure.
+func TestRunUpdateWithHomebrewFailure(t *testing.T) {
+	var rec recordedInstall
+	var stdout, stderr bytes.Buffer
+	code := runUpdateWith(context.Background(), false, &stdout, &stderr,
+		homebrewDeps(&rec, []byte("Error: brew blew up"), errors.New("exit status 1")))
+	if code != 1 {
+		t.Fatalf("code = %d, want 1", code)
+	}
+	if !strings.Contains(stderr.String(), "failed") {
+		t.Errorf("stderr missing failure message\nfull:\n%s", stderr.String())
+	}
+}
+
 // Task 1: bare go-install with an update available re-runs `go install` of the
 // command's own main package pinned to the resolved tag, augments GOBIN to the
 // running binary's directory, prints the old → new transition, and exits 0.

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -51,6 +51,17 @@ func GetVersion() string {
 	return "dev"
 }
 
+// InjectedVersion returns the raw build-time ldflags version exactly as
+// injected ("" when unset), without the build-info/"dev" fallbacks GetVersion
+// layers on. The update command's install-method classifier needs this raw
+// signal kept separate from the collapsed GetVersion accessor: a clean injected
+// version implies a release tarball, whereas a build-info module version
+// implies a `go install`. Collapsing the two (as GetVersion does) loses that
+// distinction.
+func InjectedVersion() string {
+	return version
+}
+
 // listItemKind distinguishes section headers from feature rows in the virtual list.
 type listItemKind int
 

--- a/skills/chat/user-guide/configuration.md
+++ b/skills/chat/user-guide/configuration.md
@@ -175,6 +175,15 @@ Launch flags configure how the TUI starts. Start Agentic Orchestrator with `agen
 | `--help`, `-h` | Print usage | - |
 | `--version`, `-v` | Print version | - |
 
+## Updating
+
+Run `agentico update` to upgrade to the latest stable release, or `agentico update [--check|-n]` to report the current and latest available versions without installing. The `--check` form (alias `-n`) exits `0` and prints an already-up-to-date message when you are already on the newest release.
+
+| Invocation | Description |
+|------------|-------------|
+| `agentico update` | Upgrade to the latest stable release |
+| `agentico update --check` / `agentico update -n` | Check for a newer release without installing |
+
 ## State Directory Layout
 
 ```


### PR DESCRIPTION
## Summary

Adds a self-update capability to the `agentico` CLI: a new `agentico update` subcommand that upgrades the binary in place to the latest stable GitHub release, plus `agentico update --check` (alias `-n`) to report the current and latest versions without installing. The command detects how the running binary was installed and chooses the matching update strategy, refusing to touch builds it can't safely replace.

The work landed across five phases (tracer-bullet → TDD fill-in):

- **Command surface & dispatch (Phase 1).** `update` is parsed as a standalone first-argument subcommand with its own `--check`/`-n` flag; every other bare word still rejects as an unknown command, and `--check` outside `update` rejects as an unknown flag. Update mode dispatches through an injected `updater` seam ahead of the TUI branch (early-returning like `--help`/`--version`), so it never takes the instance lock, builds the fx container, or reconciles assets. Help/usage, the README, and the user-guide config docs document the new surface. `--check` is fully functional end to end.
- **Install-method detection & dev-build refusal (Phase 2).** A pure, table-tested `classifyInstallMethod` decides between **go-install** (real build-info module version, or binary in the Go bin dir — also covers `make install`), **tarball** (a clean `MAJOR.MINOR.PATCH` injected release version), and **dev-build** (anything else). Dev builds are refused entirely offline — no GitHub request, no binary touched. `tui.InjectedVersion()` was added to expose the raw ldflags version the classifier needs, kept distinct from `GetVersion()`'s collapsed fallback.
- **Go-install update branch (Phase 3).** A real bare update for go-installed binaries re-runs `go install <mainpkg>@<latest-tag>` through an injectable runner, pinned to the exact resolved tag, with `GOBIN` forced to the running binary's directory so the in-place binary is the one replaced. Failures surface to stderr with a non-zero exit and no success transition.
- **Tarball update branch (Phase 4).** For release-tarball installs, a verified, non-destructive in-place swap: resolve the latest stable tag and the per-OS/arch release assets via the GitHub REST API (honoring `GITHUB_API_URL` for Enterprise and `GITHUB_TOKEN` for auth), download the archive, **verify its SHA-256 against the published checksums**, extract the `agentico` binary, and atomically swap it via temp-create + rename. Any failure — partial download, checksum mismatch, missing asset, extraction error — leaves the existing binary untouched.
- **Tarball robustness (Phase 5).** Two environment-specific safety nets on the real tarball path: a **writability pre-flight** that verifies the binary's directory is writable before any network request (an unwritable, root-owned location like `/usr/local/bin` aborts with elevated-privilege guidance naming the directory and a non-zero exit, no download attempted, never self-escalating); and a **macOS ad-hoc re-sign** (`codesign -s -` on `darwin` only) immediately after a successful swap so Apple-Silicon users don't hit a "killed: 9" unlaunchable binary from goreleaser's unsigned archives. The re-sign is strictly best-effort — a missing tool or signing failure downgrades to a non-fatal warning while the success line still prints and the command exits 0; on Linux it is a no-op.

Throughout, behavior is gated precisely: `--check`, the already-current short-circuit, the go-install branch, and the dev-build refusal each only reach the logic that applies to them, and all external effects (GitHub, the Go toolchain, the tarball swap, `codesign`) run through injected seams so the suite exercises every path hermetically and deterministically.

## Test plan

**Automated**
- `go build ./...` and `go vet ./...` pass.
- `go test ./... -race` — full unit suite, including:
  - `installmethod_test.go` — table-driven `classifyInstallMethod` coverage (go-install / tarball / dev-build) and the supporting resolvers.
  - `update_test.go` — the full update flow against injected deps: `--check` reporting, already-up-to-date short-circuit, dev-build refusal, the go-install and tarball execution branches, checksum verification (match and mismatch), missing/per-arch asset handling, the writability pre-flight abort, and the darwin re-sign (invoked, missing-tool warning, signing-failure warning, off-darwin no-op).
  - `launch_contract.txtar` testscript — usage/help surface plus malformed `update` invocations rejecting at parse time before any seam runs; `update_dev_refusal.txtar` for the offline dev refusal.
  - The docs-contract test asserting the help/usage token table stays in sync.

**Manual**
- macOS Apple-Silicon: a real tarball update produces a binary that launches with no "killed: 9".
- Binary in a root-owned/unwritable directory: update prints directory-naming guidance, instructs re-running with elevated privileges, and exits non-zero without downloading.
- Linux: tarball update completes with no codesign step and no re-sign warning.
- `agentico update --check` reports current/latest/install-method and exits 0 when already current.

## Follow-up hardening (post-review)

Three stdlib-only robustness improvements to the tarball update path, added on top of the phases above (commit `8735e89`).

> A checksums-signing/verification enhancement (cosign-signed `checksums.txt` verified in-binary) was prototyped alongside these but **dropped for now**: without CI it would require a single maintainer's laptop to hold the release private key and be the only signer. The tarball path keeps its existing SHA-256 integrity check against `checksums.txt`; signing can drop in cleanly if CI is added later.

- **Never downgrade.** `parseReleaseVersion`/`compareReleaseVersions` order two clean `MAJOR.MINOR.PATCH` versions numerically. `runUpdateWith` now treats a current version equal to *or newer than* the latest published release as "already up to date" (with a distinct "…is newer than…" message when ahead) and proceeds only when the latest is strictly newer. Non-release versions (go-install pseudo-versions, dev builds) fall back to the prior string-inequality behavior, so the go-install path is unchanged. The writability pre-flight was reordered to run *after* the version check, so an up-to-date/ahead binary in a root-owned directory now reports up to date (exit 0) instead of a spurious "use sudo" error; `--check` still never triggers the pre-flight.
- **Forgiving OS/arch asset matching.** `matchArchiveAsset` matches the release archive case-insensitively against alias sets (`amd64`/`x86_64`/`x64`, `arm64`/`aarch64`, `darwin`/`macos`/`osx`/`mac`) over a `.tar.gz`/`.tgz` suffix, tolerating release-naming drift. A suffix match (rather than splitting on `_`) correctly handles arch tokens with embedded underscores like `x86_64`.
- **Preserve mode and ownership.** `swapBinary` now carries the existing binary's permission bits (guaranteeing owner-exec) across the atomic temp-create+rename swap and best-effort `chown`s to the original uid/gid via a build-tagged `fileOwnerIDs` helper (real on `//go:build unix`, a no-op elsewhere), instead of imposing a fixed `0o755`/invoking-user owner.

**Tests for the above:** version parsing/ordering tables; no-downgrade in both bare and `--check` modes; the ahead-in-unwritable-dir reorder; `--check` skips the pre-flight; tolerant asset matching (incl. an alias-named archive end-to-end); swap mode preservation; and the unix owner-id helper. Full suite (`go build`, `go vet`, `go test ./... -race`, `goreleaser check`) green, with the launch/docs-contract tests still passing as a regression (no command-surface changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

*Generated with [Agentic](https://github.com/doordash-oss/agentic-orchestrator)*