### PR TITLE
Backfill blank need-user-input gate from progress.md

### DIFF
--- a/internal/agent/implement.go
+++ b/internal/agent/implement.go
@@ -600,9 +600,9 @@ func RunImplementationLoop(cfg ImplementConfig, sm ports.SessionManager) (result
 			// later resume runs iteration N+1.
 			if parsed.State == StateNeedUserInput {
 				gatePath := NeedUserInputPath(iterDir)
-				rec := outcome.NeedUserInput
-				if rec == nil {
-					return nil, fmt.Errorf("validating implementer contract: need-user-input payload missing after successful validation")
+				rec := reconcileNeedUserInputGate(outcome.NeedUserInput, parsed, i)
+				if err := WriteNeedUserInputRecord(gatePath, rec); err != nil {
+					return nil, fmt.Errorf("persisting need-user-input gate: %w", err)
 				}
 				meta.AgentStatus = "NEED_USER_INPUT"
 				meta.ReviewStatus = "skipped_need_user_input"

--- a/internal/agent/implement_routing_test.go
+++ b/internal/agent/implement_routing_test.go
@@ -368,6 +368,77 @@ func TestImplementLoop_Routing_NEED_USER_INPUT_MalformedGateTripsProtocolViolati
 	}
 }
 
+// TestImplementLoop_Routing_NEED_USER_INPUT_StubGateBackfilledFromProgress
+// reproduces the real-world failure where the implementer emits a rich
+// progress.md (state note + numbered questions) but a blank need-user-input.yaml
+// stub. The persisted gate must be backfilled from progress.md so the TUI
+// renders the actual summary and questions rather than an empty form.
+func TestImplementLoop_Routing_NEED_USER_INPUT_StubGateBackfilledFromProgress(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	tmpDir := t.TempDir()
+	workDir := filepath.Join(tmpDir, "work")
+	artifactDir := filepath.Join(tmpDir, "artifacts")
+	stateDir := filepath.Join(tmpDir, "state", "test-feat-stub-gate")
+	scriptsDir := filepath.Join(tmpDir, "scripts")
+	for _, d := range []string{workDir, artifactDir, stateDir, scriptsDir} {
+		_ = os.MkdirAll(d, 0o755)
+	}
+
+	const note = "Plan contradicts the worktree; the owner must choose an ordering."
+	questions := []string{
+		"Should the pre-flight run before or after the latest-release fetch?",
+		"Is aborting an already-current install under an unwritable dir acceptable?",
+	}
+	agentScript := testutil.WriteScript(t, scriptsDir, "agent.sh",
+		testutil.JSONLInit+"\n"+
+			testutil.WriteImplementNeedUserInputStubGate(artifactDir, note, questions...)+"\n"+
+			testutil.JSONLSuccess+"\n")
+	reviewScript := testutil.WriteScript(t, scriptsDir, "review.sh",
+		testutil.JSONLInit+"\n"+testutil.WriteReviewApproved(artifactDir)+"\n"+testutil.JSONLSuccess+"\n")
+
+	eventCh := make(chan interface{}, 100)
+	sm := session.NewManager(eventCh)
+	defer sm.Shutdown()
+
+	f := newTestFeature(t, workDir)
+	planPath := writePlanFile(t, artifactDir, "Stub gate backfill test")
+	result, err := RunImplementationLoop(ImplementConfig{
+		Feature: f, WorkDir: workDir, PlanPath: planPath, MaxIterations: 5,
+		MaxConsecFails: 3, MaxConsecNoProgress: 3, ExitCriteria: "Relevant tests pass",
+		Model: "agent", ReviewModel: "reviewer", ArtifactDir: artifactDir, StateDir: stateDir,
+		BuildSession: mockBuildSession(agentScript, reviewScript),
+	}, sm)
+	if err != nil {
+		t.Fatalf("loop error: %v", err)
+	}
+	if result.FinalStatus != "need_user_input" {
+		t.Fatalf("FinalStatus = %q, want need_user_input (LastError=%q)", result.FinalStatus, result.LastError)
+	}
+	if result.NeedUserInputPath == "" {
+		t.Fatalf("NeedUserInputPath should be set when a gate is persisted")
+	}
+	rec, readErr := ReadNeedUserInputRecord(result.NeedUserInputPath)
+	if readErr != nil {
+		t.Fatalf("read gate: %v", readErr)
+	}
+	if rec.Summary != note {
+		t.Errorf("gate summary = %q, want backfilled progress note %q", rec.Summary, note)
+	}
+	if len(rec.Questions) != len(questions) {
+		t.Fatalf("gate questions = %d, want %d backfilled from progress.md", len(rec.Questions), len(questions))
+	}
+	for i, want := range questions {
+		if rec.Questions[i].Prompt != want {
+			t.Errorf("gate Q%d prompt = %q, want %q", i+1, rec.Questions[i].Prompt, want)
+		}
+		if rec.Questions[i].Index != i+1 {
+			t.Errorf("gate Q%d index = %d, want %d", i+1, rec.Questions[i].Index, i+1)
+		}
+	}
+}
+
 // TestImplementLoop_Routing_MisplacedQuestionsStayOnProtocolViolationPath
 // locks in the conditional ordering rule: even when the agent emits a
 // `## Questions for User` section with valid numbered prompts, placing it

--- a/internal/agent/need_user_input.go
+++ b/internal/agent/need_user_input.go
@@ -46,6 +46,55 @@ type NeedUserInputQuestion struct {
 // inside an iteration directory.
 const NeedUserInputArtifactName = "need-user-input.yaml"
 
+// reconcileNeedUserInputGate returns the gate questionnaire to persist for a
+// paused NEED_USER_INPUT iteration. The implementer-authored agentRec is
+// authoritative, but each empty field falls back to the validated progress.md
+// handoff (state note for the summary, numbered questions for the prompts) so a
+// blank stub never surfaces as an empty gate. Surviving questions are
+// re-indexed 1-based.
+func reconcileNeedUserInputGate(agentRec *NeedUserInputRecord, progress *ParsedProgress, iteration int) NeedUserInputRecord {
+	var rec NeedUserInputRecord
+	if agentRec != nil {
+		rec = *agentRec
+	}
+	rec.Iteration = iteration
+	rec.Summary = strings.TrimSpace(rec.Summary)
+
+	questions := make([]NeedUserInputQuestion, 0, len(rec.Questions))
+	for _, q := range rec.Questions {
+		prompt := strings.TrimSpace(q.Prompt)
+		if prompt == "" {
+			continue
+		}
+		questions = append(questions, NeedUserInputQuestion{
+			Index:  len(questions) + 1,
+			Prompt: prompt,
+			Answer: q.Answer,
+		})
+	}
+
+	if progress != nil {
+		if rec.Summary == "" {
+			rec.Summary = strings.TrimSpace(progress.StateNote)
+		}
+		if len(questions) == 0 {
+			for _, p := range progress.Questions {
+				prompt := strings.TrimSpace(p)
+				if prompt == "" {
+					continue
+				}
+				questions = append(questions, NeedUserInputQuestion{
+					Index:  len(questions) + 1,
+					Prompt: prompt,
+				})
+			}
+		}
+	}
+
+	rec.Questions = questions
+	return rec
+}
+
 // NeedUserInputPath returns the absolute path of the gate artifact for the
 // supplied iteration directory.
 func NeedUserInputPath(iterDir string) string {

--- a/internal/agent/need_user_input_test.go
+++ b/internal/agent/need_user_input_test.go
@@ -1,0 +1,112 @@
+// Copyright 2026 DoorDash, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agent
+
+import "testing"
+
+// TestReconcileNeedUserInputGate covers the gate-questionnaire reconciliation:
+// a well-formed agent-authored record is preserved, while blank fields fall
+// back to the validated progress.md handoff so the TUI never shows an empty
+// gate.
+func TestReconcileNeedUserInputGate(t *testing.T) {
+	progress := &ParsedProgress{
+		StateNote: "Plan contradicts the worktree; pick an ordering.",
+		Questions: []string{
+			"Should the pre-flight run before or after the fetch?",
+			"Is aborting an already-current install acceptable?",
+		},
+	}
+
+	tests := []struct {
+		name        string
+		agentRec    *NeedUserInputRecord
+		progress    *ParsedProgress
+		wantSummary string
+		wantPrompts []string
+	}{
+		{
+			name: "well-formed agent gate preserved verbatim",
+			agentRec: &NeedUserInputRecord{
+				Summary: "Concise gate summary distinct from the note.",
+				Questions: []NeedUserInputQuestion{
+					{Index: 1, Prompt: "Question one?"},
+					{Index: 2, Prompt: "Question two?"},
+				},
+			},
+			progress:    progress,
+			wantSummary: "Concise gate summary distinct from the note.",
+			wantPrompts: []string{"Question one?", "Question two?"},
+		},
+		{
+			name: "blank stub falls back to progress.md",
+			agentRec: &NeedUserInputRecord{
+				Summary:   "",
+				Questions: []NeedUserInputQuestion{{Index: 0, Prompt: ""}},
+			},
+			progress:    progress,
+			wantSummary: "Plan contradicts the worktree; pick an ordering.",
+			wantPrompts: []string{
+				"Should the pre-flight run before or after the fetch?",
+				"Is aborting an already-current install acceptable?",
+			},
+		},
+		{
+			name: "summary present but questions blank backfills questions only",
+			agentRec: &NeedUserInputRecord{
+				Summary:   "Agent summary stays.",
+				Questions: nil,
+			},
+			progress:    progress,
+			wantSummary: "Agent summary stays.",
+			wantPrompts: []string{
+				"Should the pre-flight run before or after the fetch?",
+				"Is aborting an already-current install acceptable?",
+			},
+		},
+		{
+			name:        "nil agent record builds entirely from progress.md",
+			agentRec:    nil,
+			progress:    progress,
+			wantSummary: "Plan contradicts the worktree; pick an ordering.",
+			wantPrompts: []string{
+				"Should the pre-flight run before or after the fetch?",
+				"Is aborting an already-current install acceptable?",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := reconcileNeedUserInputGate(tt.agentRec, tt.progress, 3)
+			if rec.Iteration != 3 {
+				t.Errorf("Iteration = %d, want 3", rec.Iteration)
+			}
+			if rec.Summary != tt.wantSummary {
+				t.Errorf("Summary = %q, want %q", rec.Summary, tt.wantSummary)
+			}
+			if len(rec.Questions) != len(tt.wantPrompts) {
+				t.Fatalf("question count = %d, want %d", len(rec.Questions), len(tt.wantPrompts))
+			}
+			for i, want := range tt.wantPrompts {
+				if rec.Questions[i].Prompt != want {
+					t.Errorf("Q%d prompt = %q, want %q", i+1, rec.Questions[i].Prompt, want)
+				}
+				if rec.Questions[i].Index != i+1 {
+					t.Errorf("Q%d index = %d, want %d", i+1, rec.Questions[i].Index, i+1)
+				}
+			}
+		})
+	}
+}

--- a/test/testutil/mock_agent.go
+++ b/test/testutil/mock_agent.go
@@ -183,6 +183,15 @@ func WriteImplementNeedUserInputWithoutGate(artifactDir, note string, questions 
 	return writeImplArtifactsWithOptionalGate(artifactDir, "NEED_USER_INPUT", note, nil, questions...)
 }
 
+// WriteImplementNeedUserInputStubGate returns a NEED_USER_INPUT handoff whose
+// progress.md carries the real note + numbered questions but whose
+// need-user-input.yaml is a parseable blank stub (empty summary, one empty
+// prompt), reproducing the agent behaviour the gate reconciliation backfills.
+func WriteImplementNeedUserInputStubGate(artifactDir, note string, questions ...string) string {
+	gateBody := "summary: \"\"\nquestions:\n  - index: 0\n    prompt: \"\"\n    answer: \"\"\niteration: 1"
+	return writeImplArtifactsWithOptionalGate(artifactDir, "NEED_USER_INPUT", note, &gateBody, questions...)
+}
+
 // WriteImplementNeedUserInputMalformedGate returns a NEED_USER_INPUT handoff
 // with corrupt need-user-input.yaml content.
 func WriteImplementNeedUserInputMalformedGate(artifactDir, note string, questions ...string) string {


### PR DESCRIPTION
## Summary

A NEED_USER_INPUT gate could render as an empty, unanswerable questionnaire in the TUI (just `0.` with no prompt and an `Answer for Q1...` placeholder).

**Root cause:** the gate questionnaire has two representations — the heavily-validated `## Questions for User` / state note in `progress.md`, and the agent-authored `need-user-input.yaml` that the TUI actually renders. The contract validator only checks that the YAML exists and parses, so when the implementer emitted a rich `progress.md` but a blank stub YAML (`summary: ""`, one question with `index: 0`, `prompt: ""`), the stub passed validation and surfaced as a blank gate.

**Fix:** reconcile the gate when it's persisted. The agent-authored record stays authoritative when populated (preserving the existing behavior where the gate summary may intentionally differ from the progress note), but each empty field falls back to the validated `progress.md` handoff — state note → summary, numbered questions → prompts — so the gate is never blank. Surviving questions are re-indexed 1-based.

This reconcile-with-fallback approach was chosen over synthesizing the gate purely from `progress.md` because the existing routing test encodes a deliberate decision that the YAML summary is authoritative and distinct from the progress note; reconciliation fixes the bug without reversing that, and avoids burning a full retry iteration.

## Test plan

- [x] `go build ./...`
- [x] New unit test `TestReconcileNeedUserInputGate` (well-formed preserved, blank stub backfilled, partial backfill, nil record)
- [x] New end-to-end routing test `TestImplementLoop_Routing_NEED_USER_INPUT_StubGateBackfilledFromProgress` reproducing the exact failure (rich progress.md + stub YAML → persisted gate carries real summary and questions)
- [x] Existing NEED_USER_INPUT agent / integration / TUI tests pass
- [x] `gofmt` clean, `go vet ./internal/agent/` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)