### PR TITLE
Add model catalog discovery for LLM providers

### DIFF
--- a/cmd/agentico/main.go
+++ b/cmd/agentico/main.go
@@ -223,6 +223,7 @@ runtime parent is used in place so legacy installs remain discoverable.`)
 
 const providerReadinessTimeout = 5 * time.Second
 const providerReadinessNoticeDelay = 3 * time.Second
+const providerCatalogDiscoveryTimeout = 45 * time.Second
 
 type providerReadinessIssue struct {
 	provider llm.LLMProvider
@@ -323,6 +324,71 @@ func formatProviderNameList(providers []llm.LLMProvider) string {
 		names = append(names, p.Name())
 	}
 	return strings.Join(names, ", ")
+}
+
+func discoverProviderCatalogs(ctx context.Context, providers []llm.LLMProvider, cacheRoot string) []string {
+	var warnings []string
+	for _, p := range providers {
+		discoverer, ok := p.(llm.CatalogDiscoverer)
+		if !ok {
+			continue
+		}
+		enricher, ok := p.(llm.CatalogEnricher)
+		if !ok {
+			continue
+		}
+
+		version := ""
+		if cacheRoot != "" {
+			if rawVersion, err := p.VersionInfo(); err == nil {
+				version = strings.TrimSpace(rawVersion)
+			}
+		}
+		if version != "" {
+			models, err := loadProviderCatalogCache(cacheRoot, p.Name(), version)
+			if err == nil {
+				enricher.SetModelCatalog(models)
+				continue
+			}
+			if !os.IsNotExist(err) {
+				warnings = append(warnings, fmt.Sprintf(
+					"Warning: ignoring cached %s model catalog; refreshing: %v",
+					p.Name(),
+					err,
+				))
+			}
+		}
+
+		discoveryCtx, cancel := context.WithTimeout(ctx, providerCatalogDiscoveryTimeout)
+		models, err := discoverer.DiscoverModelCatalog(discoveryCtx)
+		cancel()
+		if err != nil {
+			warnings = append(warnings, fmt.Sprintf(
+				"Warning: could not discover %s model catalog; using built-in fallback: %v",
+				p.Name(),
+				err,
+			))
+			continue
+		}
+		if len(models) == 0 {
+			warnings = append(warnings, fmt.Sprintf(
+				"Warning: discovered empty %s model catalog; using built-in fallback",
+				p.Name(),
+			))
+			continue
+		}
+		enricher.SetModelCatalog(models)
+		if version != "" {
+			if err := saveProviderCatalogCache(cacheRoot, p.Name(), version, models); err != nil {
+				warnings = append(warnings, fmt.Sprintf(
+					"Warning: could not cache %s model catalog: %v",
+					p.Name(),
+					err,
+				))
+			}
+		}
+	}
+	return warnings
 }
 
 func showProviderStartupNotices(w io.Writer, notices []string, delay time.Duration) {
@@ -500,6 +566,13 @@ func runTUI(configPath, stateDir string, dangerouslySkipPerms bool, enabledProvi
 		}
 	}
 
+	stop = startSyncSpinner(os.Stderr, "Discovering models")
+	catalogWarnings := discoverProviderCatalogs(context.Background(), detected, filepath.Dir(stateDir))
+	stop()
+	for _, w := range catalogWarnings {
+		fmt.Fprintln(os.Stderr, w)
+	}
+
 	// First-run setup: when both CLIs are detected and config is new,
 	// prompt user to choose a preferred provider.
 	var preferredProvider string
@@ -569,11 +642,10 @@ func overrideColorProfile() (colorprofile.Profile, bool) {
 	return 0, false
 }
 
-// startSyncSpinner shows a "<msg>..." indicator on w while the embedded
-// skills/guidelines reconcile runs. On a TTY the trailing dots animate so
-// the user can tell the process is still doing work; on a non-TTY (CI,
-// piped output) a single static line is printed instead. The returned
-// stop() blocks until the animation goroutine has cleared its line, so
+// startSyncSpinner shows a "<msg>..." startup indicator on w. On a TTY the
+// trailing dots animate so the user can tell the process is still doing work;
+// on a non-TTY (CI, piped output) a single static line is printed instead. The
+// returned stop() blocks until the animation goroutine has cleared its line, so
 // subsequent writes to w don't collide with the spinner.
 func startSyncSpinner(w io.Writer, msg string) func() {
 	f, _ := w.(*os.File)

--- a/cmd/agentico/main_test.go
+++ b/cmd/agentico/main_test.go
@@ -17,6 +17,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -59,6 +60,149 @@ func (s *stubProvider) CheckReadiness(context.Context) llm.ProviderReadiness {
 		return s.readiness
 	}
 	return llm.ProviderReadiness{Ready: true}
+}
+
+type stubCatalogDiscoveryProvider struct {
+	stubProvider
+	discovered  []llm.ModelInfo
+	discoverErr error
+	catalog     []llm.ModelInfo
+	versionInfo string
+	versionErr  error
+	discoveries int
+}
+
+func (s *stubCatalogDiscoveryProvider) DiscoverModelCatalog(context.Context) ([]llm.ModelInfo, error) {
+	s.discoveries++
+	return s.discovered, s.discoverErr
+}
+
+func (s *stubCatalogDiscoveryProvider) SetModelCatalog(models []llm.ModelInfo) {
+	s.catalog = models
+}
+
+func (s *stubCatalogDiscoveryProvider) VersionInfo() (string, error) {
+	if s.versionErr != nil {
+		return "", s.versionErr
+	}
+	if s.versionInfo != "" {
+		return s.versionInfo, nil
+	}
+	return s.stubProvider.VersionInfo()
+}
+
+func TestDiscoverProviderCatalogsSetsCatalogAndWarnsOnFailure(t *testing.T) {
+	success := &stubCatalogDiscoveryProvider{
+		stubProvider: stubProvider{name: "success", hasCLI: true},
+		discovered: []llm.ModelInfo{
+			{ID: "live-model", DisplayName: "Live Model", ContextWindow: 123_000, Category: "capable"},
+		},
+	}
+	failure := &stubCatalogDiscoveryProvider{
+		stubProvider: stubProvider{name: "failure", hasCLI: true},
+		discoverErr:  errors.New("catalog unavailable"),
+	}
+	plain := &stubProvider{name: "plain", hasCLI: true}
+
+	warnings := discoverProviderCatalogs(context.Background(), []llm.LLMProvider{success, failure, plain}, t.TempDir())
+	if len(success.catalog) != 1 || success.catalog[0].ID != "live-model" {
+		t.Fatalf("success catalog = %+v, want live-model", success.catalog)
+	}
+	if len(failure.catalog) != 0 {
+		t.Fatalf("failure catalog = %+v, want unchanged empty catalog", failure.catalog)
+	}
+	if len(warnings) != 1 {
+		t.Fatalf("warnings = %v, want one warning", warnings)
+	}
+	if !strings.Contains(warnings[0], "failure") || !strings.Contains(warnings[0], "catalog unavailable") {
+		t.Fatalf("warning = %q, want provider name and error", warnings[0])
+	}
+}
+
+func TestDiscoverProviderCatalogsLoadsVersionedCache(t *testing.T) {
+	cacheRoot := t.TempDir()
+	cachedModels := []llm.ModelInfo{
+		{ID: "cached-model", DisplayName: "Cached Model", ContextWindow: 456_000, Category: "balanced"},
+	}
+	if err := saveProviderCatalogCache(cacheRoot, "cached", "provider 2.0.0", cachedModels); err != nil {
+		t.Fatalf("saveProviderCatalogCache() error: %v", err)
+	}
+	p := &stubCatalogDiscoveryProvider{
+		stubProvider: stubProvider{name: "cached", hasCLI: true},
+		versionInfo:  "provider 2.0.0",
+		discoverErr:  errors.New("discovery should not run"),
+	}
+
+	warnings := discoverProviderCatalogs(context.Background(), []llm.LLMProvider{p}, cacheRoot)
+	if len(warnings) != 0 {
+		t.Fatalf("warnings = %v, want none", warnings)
+	}
+	if p.discoveries != 0 {
+		t.Fatalf("discovery calls = %d, want 0", p.discoveries)
+	}
+	if len(p.catalog) != 1 || p.catalog[0].ID != "cached-model" {
+		t.Fatalf("catalog = %+v, want cached-model", p.catalog)
+	}
+}
+
+func TestDiscoverProviderCatalogsWritesVersionedCacheOnMiss(t *testing.T) {
+	cacheRoot := t.TempDir()
+	discovered := []llm.ModelInfo{
+		{ID: "fresh-model", DisplayName: "Fresh Model", ContextWindow: 789_000, Category: "capable"},
+	}
+	p := &stubCatalogDiscoveryProvider{
+		stubProvider: stubProvider{name: "fresh", hasCLI: true},
+		versionInfo:  "fresh 3.0.0",
+		discovered:   discovered,
+	}
+
+	warnings := discoverProviderCatalogs(context.Background(), []llm.LLMProvider{p}, cacheRoot)
+	if len(warnings) != 0 {
+		t.Fatalf("warnings = %v, want none", warnings)
+	}
+	if p.discoveries != 1 {
+		t.Fatalf("discovery calls = %d, want 1", p.discoveries)
+	}
+	cached, err := loadProviderCatalogCache(cacheRoot, "fresh", "fresh 3.0.0")
+	if err != nil {
+		t.Fatalf("loadProviderCatalogCache() error: %v", err)
+	}
+	if len(cached) != 1 || cached[0].ID != "fresh-model" {
+		t.Fatalf("cached models = %+v, want fresh-model", cached)
+	}
+}
+
+func TestDiscoverProviderCatalogsRefreshesCorruptVersionedCache(t *testing.T) {
+	cacheRoot := t.TempDir()
+	path := providerCatalogCachePath(cacheRoot, "corrupt", "corrupt 4.0.0")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error: %v", err)
+	}
+	if err := os.WriteFile(path, []byte("{not-json"), 0o644); err != nil {
+		t.Fatalf("WriteFile() error: %v", err)
+	}
+	p := &stubCatalogDiscoveryProvider{
+		stubProvider: stubProvider{name: "corrupt", hasCLI: true},
+		versionInfo:  "corrupt 4.0.0",
+		discovered: []llm.ModelInfo{
+			{ID: "refreshed-model", DisplayName: "Refreshed Model", ContextWindow: 321_000, Category: "capable"},
+		},
+	}
+
+	warnings := discoverProviderCatalogs(context.Background(), []llm.LLMProvider{p}, cacheRoot)
+	if len(warnings) != 1 || !strings.Contains(warnings[0], "ignoring cached corrupt model catalog") {
+		t.Fatalf("warnings = %v, want corrupt cache warning", warnings)
+	}
+	if p.discoveries != 1 {
+		t.Fatalf("discovery calls = %d, want 1", p.discoveries)
+	}
+	cached, err := loadProviderCatalogCache(cacheRoot, "corrupt", "corrupt 4.0.0")
+	if err != nil {
+		t.Fatalf("loadProviderCatalogCache() error: %v", err)
+	}
+	if len(cached) != 1 || cached[0].ID != "refreshed-model" {
+		t.Fatalf("cached models = %+v, want refreshed-model", cached)
+	}
 }
 
 func TestRunArgsLaunchesTUIByDefault(t *testing.T) {

--- a/cmd/agentico/model_catalog_cache.go
+++ b/cmd/agentico/model_catalog_cache.go
@@ -1,0 +1,115 @@
+// Copyright 2026 DoorDash, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/doordash-oss/agentic-orchestrator/internal/llm"
+)
+
+const providerCatalogCacheDirName = "model-catalogs"
+
+type providerCatalogCacheFile struct {
+	Provider     string          `json:"provider"`
+	Version      string          `json:"version"`
+	DiscoveredAt time.Time       `json:"discovered_at"`
+	Models       []llm.ModelInfo `json:"models"`
+}
+
+func providerCatalogCachePath(cacheRoot, provider, version string) string {
+	return filepath.Join(
+		cacheRoot,
+		providerCatalogCacheDirName,
+		safeCacheSegment(provider),
+		safeCacheSegment(version)+".json",
+	)
+}
+
+func loadProviderCatalogCache(cacheRoot, provider, version string) ([]llm.ModelInfo, error) {
+	path := providerCatalogCachePath(cacheRoot, provider, version)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var cached providerCatalogCacheFile
+	if err := json.Unmarshal(data, &cached); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+	if cached.Provider != provider || cached.Version != version {
+		return nil, fmt.Errorf("cache metadata mismatch in %s", path)
+	}
+	if len(cached.Models) == 0 {
+		return nil, fmt.Errorf("empty model catalog in %s", path)
+	}
+	return cached.Models, nil
+}
+
+func saveProviderCatalogCache(cacheRoot, provider, version string, models []llm.ModelInfo) error {
+	if len(models) == 0 {
+		return fmt.Errorf("cannot cache empty model catalog")
+	}
+	path := providerCatalogCachePath(cacheRoot, provider, version)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("creating model catalog cache dir: %w", err)
+	}
+	payload := providerCatalogCacheFile{
+		Provider:     provider,
+		Version:      version,
+		DiscoveredAt: time.Now().UTC(),
+		Models:       models,
+	}
+	data, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal model catalog cache: %w", err)
+	}
+	data = append(data, '\n')
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return fmt.Errorf("write model catalog cache: %w", err)
+	}
+	return nil
+}
+
+func safeCacheSegment(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return "unknown"
+	}
+	var b strings.Builder
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z':
+			b.WriteRune(r)
+		case r >= 'A' && r <= 'Z':
+			b.WriteRune(r)
+		case r >= '0' && r <= '9':
+			b.WriteRune(r)
+		case r == '.', r == '_', r == '-':
+			b.WriteRune(r)
+		default:
+			b.WriteByte('_')
+		}
+	}
+	if b.Len() == 0 {
+		return "unknown"
+	}
+	return b.String()
+}

--- a/internal/llm/claude/discovery.go
+++ b/internal/llm/claude/discovery.go
@@ -1,0 +1,164 @@
+// Copyright 2026 DoorDash, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package claude
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/doordash-oss/agentic-orchestrator/internal/llm"
+	"github.com/doordash-oss/agentic-orchestrator/internal/llm/clirun"
+)
+
+const (
+	claudeModelProbePrompt       = "Return exactly: OK"
+	claudeModelProbeMaxBudgetUSD = "0.05"
+)
+
+// DiscoverModelCatalog resolves Agentic's curated Claude aliases against the
+// live CLI by probing each one with a tiny `claude --model <alias> -p` request
+// and reading the resolved model + context window back from the stream-json
+// output.
+//
+// Probing is the only mechanism used because Claude Code exposes no
+// machine-readable model catalog command, and probing is the only
+// provider-agnostic way to learn what `--model <alias>` actually resolves to on
+// this machine (aliases resolve to different concrete models on the Anthropic
+// API vs. Bedrock/Vertex/Foundry). Any alias whose probe is skipped — e.g. when
+// ctx is cancelled partway through — keeps its hardcoded defaultModelInfos
+// metadata as a fallback.
+func (p *Provider) DiscoverModelCatalog(ctx context.Context) ([]llm.ModelInfo, error) {
+	runner := p.runner
+	if runner == nil {
+		runner = clirun.DefaultRunner()
+	}
+
+	candidates := p.defaultModelInfos()
+	models := make([]llm.ModelInfo, 0, len(candidates))
+	var failures []string
+	for i, candidate := range candidates {
+		if err := ctx.Err(); err != nil {
+			if len(models) > 0 {
+				models = append(models, candidates[i:]...)
+			}
+			break
+		}
+		out, err := runner(ctx, "claude", claudeModelProbeArgs(candidate.ID), nil)
+		if err != nil {
+			if ctx.Err() != nil {
+				if len(models) > 0 {
+					models = append(models, candidates[i:]...)
+				}
+				break
+			}
+			failures = append(failures, fmt.Sprintf("%s: %v", candidate.ID, err))
+			continue
+		}
+
+		resolved, contextWindow, err := parseClaudeModelProbe(candidate.ID, out)
+		if err != nil {
+			if ctx.Err() != nil {
+				if len(models) > 0 {
+					models = append(models, candidates[i:]...)
+				}
+				break
+			}
+			failures = append(failures, fmt.Sprintf("%s: %v", candidate.ID, err))
+			continue
+		}
+
+		info := candidate
+		if contextWindow > 0 {
+			info.ContextWindow = contextWindow
+		}
+		if resolved != "" && !strings.EqualFold(resolved, info.ID) {
+			info.Aliases = []string{resolved}
+		}
+		models = append(models, info)
+	}
+
+	if len(models) == 0 {
+		if len(failures) == 0 && ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		return nil, fmt.Errorf("no Claude model probes succeeded: %s", strings.Join(failures, "; "))
+	}
+	return models, nil
+}
+
+func claudeModelProbeArgs(model string) []string {
+	return []string{
+		"--model", model,
+		"--verbose",
+		"-p", claudeModelProbePrompt,
+		"--output-format", "stream-json",
+		"--tools", "",
+		"--no-session-persistence",
+		"--max-budget-usd", claudeModelProbeMaxBudgetUSD,
+	}
+}
+
+func parseClaudeModelProbe(requestedModel string, out []byte) (string, int, error) {
+	scanner := bufio.NewScanner(bytes.NewReader(out))
+	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+
+	var resolvedModel string
+	var contextWindow int
+	for scanner.Scan() {
+		line := bytes.TrimSpace(scanner.Bytes())
+		if len(line) == 0 {
+			continue
+		}
+		var msg llm.SDKMessage
+		if err := json.Unmarshal(line, &msg); err != nil {
+			continue
+		}
+		if msg.Init != nil && msg.Init.Model != "" {
+			resolvedModel = msg.Init.Model
+		}
+		if msg.Assistant != nil {
+			if msg.Assistant.Message.Model != "" {
+				resolvedModel = msg.Assistant.Message.Model
+			}
+			if msg.Assistant.Message.Usage != nil && msg.Assistant.Message.Usage.ContextWindow > 0 {
+				contextWindow = msg.Assistant.Message.Usage.ContextWindow
+			}
+		}
+		if msg.Result != nil {
+			if msg.Result.Usage != nil && msg.Result.Usage.ContextWindow > 0 {
+				contextWindow = msg.Result.Usage.ContextWindow
+			}
+			for model, usage := range msg.Result.ModelUsage {
+				if resolvedModel == "" && model != "" {
+					resolvedModel = model
+				}
+				if usage.ContextWindow > 0 {
+					contextWindow = usage.ContextWindow
+				}
+			}
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return "", 0, fmt.Errorf("scan Claude probe output for %s: %w", requestedModel, err)
+	}
+	if resolvedModel == "" && contextWindow == 0 {
+		return "", 0, fmt.Errorf("probe for %s did not include model metadata", requestedModel)
+	}
+	return resolvedModel, contextWindow, nil
+}

--- a/internal/llm/claude/provider.go
+++ b/internal/llm/claude/provider.go
@@ -251,14 +251,16 @@ func (p *Provider) CLIVersion() (string, error) {
 
 // defaultModelInfos returns Agentic's curated Claude Code model catalog.
 //
-// These values replace the former discovery pipeline (Anthropic models API
-// and docs scraper) because that pipeline collapsed each family's base and
-// `[1m]` variants into a single entry, which then hid the fact that
-// `--model opus` (200K) and `--model opus[1m]` (1M) are distinct CLI
-// inputs. Hardcoding keeps the catalog aligned with how the Claude Code
-// CLI actually interprets --model strings.
+// Runtime startup tries to refresh these with DiscoverModelCatalog; they are
+// the offline fallback when probing fails. Entries carry no concrete-version
+// alias (e.g. claude-opus-4-8) because what an alias resolves to is
+// provider-dependent (Anthropic API vs Bedrock/Vertex/Foundry) and drifts over
+// time — a hardcoded version is a frequently-wrong guess. The probe sets the
+// resolved model when it runs. Base and `[1m]` variants stay as separate
+// entries because `--model opus` (200K) and `--model opus[1m]` (1M) are
+// distinct CLI inputs.
 //
-// Sources (verified 2026-04-18):
+// Context-window sources (verified 2026-06-05):
 //   - https://platform.claude.com/docs/en/about-claude/models/overview
 //   - https://code.claude.com/docs/en/model-config
 //
@@ -267,11 +269,11 @@ func (p *Provider) CLIVersion() (string, error) {
 // (compaction at ~167K on --model opus ≈ 83% of 200K).
 func (p *Provider) defaultModelInfos() []llm.ModelInfo {
 	return []llm.ModelInfo{
-		{ID: "opus", DisplayName: "Claude Opus", Aliases: []string{"claude-opus-4-7"}, ContextWindow: 200_000, Category: "capable"},
-		{ID: "opus[1m]", DisplayName: "Claude Opus (1M)", Aliases: []string{"claude-opus-4-7[1m]"}, ContextWindow: 1_000_000, Category: "capable"},
-		{ID: "sonnet", DisplayName: "Claude Sonnet", Aliases: []string{"claude-sonnet-4-6"}, ContextWindow: 200_000, Category: "balanced"},
-		{ID: "sonnet[1m]", DisplayName: "Claude Sonnet (1M)", Aliases: []string{"claude-sonnet-4-6[1m]"}, ContextWindow: 1_000_000, Category: "balanced"},
-		{ID: "haiku", DisplayName: "Claude Haiku", Aliases: []string{"claude-haiku-4-5"}, ContextWindow: 200_000, Category: "cheap"},
+		{ID: "opus", DisplayName: "Claude Opus", ContextWindow: 200_000, Category: "capable"},
+		{ID: "opus[1m]", DisplayName: "Claude Opus (1M)", ContextWindow: 1_000_000, Category: "capable"},
+		{ID: "sonnet", DisplayName: "Claude Sonnet", ContextWindow: 200_000, Category: "balanced"},
+		{ID: "sonnet[1m]", DisplayName: "Claude Sonnet (1M)", ContextWindow: 1_000_000, Category: "balanced"},
+		{ID: "haiku", DisplayName: "Claude Haiku", ContextWindow: 200_000, Category: "cheap"},
 	}
 }
 

--- a/internal/llm/claude/provider_test.go
+++ b/internal/llm/claude/provider_test.go
@@ -94,10 +94,105 @@ func assertCommand(t *testing.T, gotName string, gotArgs []string, wantName stri
 	}
 }
 
+func TestParseClaudeModelProbe_ExtractsResolvedModelAndContextWindow(t *testing.T) {
+	out := []byte(strings.Join([]string{
+		`{"type":"system","subtype":"init","session_id":"s1","model":"claude-opus-4-8[1m]"}`,
+		`{"type":"assistant","message":{"role":"assistant","model":"claude-opus-4-8[1m]","content":[{"type":"text","text":"OK"}],"usage":{"input_tokens":12,"output_tokens":1}}}`,
+		`{"type":"result","subtype":"success","session_id":"s1","modelUsage":{"claude-opus-4-8[1m]":{"contextWindow":1000000}}}`,
+	}, "\n"))
+
+	model, contextWindow, err := parseClaudeModelProbe("opus[1m]", out)
+	if err != nil {
+		t.Fatalf("parseClaudeModelProbe() error: %v", err)
+	}
+	if model != "claude-opus-4-8[1m]" {
+		t.Fatalf("model = %q, want claude-opus-4-8[1m]", model)
+	}
+	if contextWindow != 1_000_000 {
+		t.Fatalf("contextWindow = %d, want 1000000", contextWindow)
+	}
+}
+
+func TestClaudeProviderDiscoverModelCatalog_PartialSuccessUpdatesAliases(t *testing.T) {
+	p := &Provider{
+		runner: func(ctx context.Context, name string, args []string, env []string) ([]byte, error) {
+			if name != "claude" {
+				t.Fatalf("command name = %q, want claude", name)
+			}
+			if len(args) < 2 || args[0] != "--model" {
+				t.Fatalf("command args = %v, want --model first", args)
+			}
+			model := args[1]
+			if !slices.Equal(args, claudeModelProbeArgs(model)) {
+				t.Fatalf("command args for %s = %v, want %v", model, args, claudeModelProbeArgs(model))
+			}
+			switch model {
+			case "opus":
+				return []byte(`{"type":"system","subtype":"init","model":"claude-opus-4-8"}` + "\n" +
+					`{"type":"result","subtype":"success","modelUsage":{"claude-opus-4-8":{"contextWindow":200000}}}`), nil
+			case "sonnet":
+				return []byte(`{"type":"system","subtype":"init","model":"claude-sonnet-4-6"}` + "\n" +
+					`{"type":"result","subtype":"success","modelUsage":{"claude-sonnet-4-6":{"contextWindow":200000}}}`), nil
+			default:
+				return nil, errors.New("model not available")
+			}
+		},
+	}
+
+	models, err := p.DiscoverModelCatalog(context.Background())
+	if err != nil {
+		t.Fatalf("DiscoverModelCatalog() error: %v", err)
+	}
+	if len(models) != 2 {
+		t.Fatalf("DiscoverModelCatalog() returned %d models, want 2: %+v", len(models), models)
+	}
+	if models[0].ID != "opus" || !slices.Equal(models[0].Aliases, []string{"claude-opus-4-8"}) {
+		t.Fatalf("first model = %+v, want opus with claude-opus-4-8 alias", models[0])
+	}
+	if models[1].ID != "sonnet" || !slices.Equal(models[1].Aliases, []string{"claude-sonnet-4-6"}) {
+		t.Fatalf("second model = %+v, want sonnet with claude-sonnet-4-6 alias", models[1])
+	}
+}
+
+func TestClaudeProviderDiscoverModelCatalog_PreservesUnattemptedFallbacksOnTimeout(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	p := &Provider{
+		runner: func(ctx context.Context, name string, args []string, env []string) ([]byte, error) {
+			if name != "claude" {
+				t.Fatalf("command name = %q, want claude", name)
+			}
+			model := args[1]
+			if model != "opus" {
+				t.Fatalf("runner should only be called for opus before cancellation, got %s", model)
+			}
+			cancel()
+			return []byte(`{"type":"system","subtype":"init","model":"claude-opus-4-8"}` + "\n" +
+				`{"type":"result","subtype":"success","modelUsage":{"claude-opus-4-8":{"contextWindow":1000000}}}`), nil
+		},
+	}
+
+	models, err := p.DiscoverModelCatalog(ctx)
+	if err != nil {
+		t.Fatalf("DiscoverModelCatalog() error: %v", err)
+	}
+	gotIDs := make([]string, 0, len(models))
+	for _, model := range models {
+		gotIDs = append(gotIDs, model.ID)
+	}
+	wantIDs := []string{"opus", "opus[1m]", "sonnet", "sonnet[1m]", "haiku"}
+	if !slices.Equal(gotIDs, wantIDs) {
+		t.Fatalf("model IDs = %v, want %v", gotIDs, wantIDs)
+	}
+	if models[0].ContextWindow != 1_000_000 || !slices.Equal(models[0].Aliases, []string{"claude-opus-4-8"}) {
+		t.Fatalf("opus entry = %+v, want discovered metadata", models[0])
+	}
+	if models[len(models)-1].ID != "haiku" || models[len(models)-1].ContextWindow != 200_000 {
+		t.Fatalf("last entry = %+v, want fallback haiku", models[len(models)-1])
+	}
+}
+
 // TestClaudeProvider_DefaultCatalog_Invariants locks in the hardcoded
-// catalog that replaced the former discovery pipeline. Whenever Anthropic
-// ships new model variants, update this table deliberately — that's the
-// point of hardcoding.
+// fallback catalog used when CLI discovery is unavailable.
 func TestClaudeProvider_DefaultCatalog_Invariants(t *testing.T) {
 	p := &Provider{}
 	cat := p.defaultModelInfos()
@@ -134,6 +229,17 @@ func TestClaudeProvider_DefaultCatalog_Invariants(t *testing.T) {
 		for _, alias := range m.Aliases {
 			if alias == m.ID+"[1m]" {
 				t.Errorf("entry %q must not carry %q as an alias; %q must be its own catalog ID", m.ID, alias, alias)
+			}
+		}
+	}
+
+	// The offline fallback must not pin a concrete model version: what an
+	// alias resolves to is provider-dependent and drifts, so a hardcoded
+	// claude-* version is a frequently-wrong guess. The probe sets it instead.
+	for _, m := range cat {
+		for _, alias := range m.Aliases {
+			if strings.HasPrefix(alias, "claude-") {
+				t.Errorf("entry %q pins concrete-version alias %q; offline fallback must use the stable alias only", m.ID, alias)
 			}
 		}
 	}

--- a/internal/llm/codex/discovery.go
+++ b/internal/llm/codex/discovery.go
@@ -1,0 +1,157 @@
+// Copyright 2026 DoorDash, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package codex
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/doordash-oss/agentic-orchestrator/internal/llm"
+	"github.com/doordash-oss/agentic-orchestrator/internal/llm/clirun"
+)
+
+type codexModelCatalogPayload struct {
+	Models []codexDiscoveredModel `json:"models"`
+}
+
+type codexDiscoveredModel struct {
+	Slug             string `json:"slug"`
+	DisplayName      string `json:"display_name"`
+	Description      string `json:"description"`
+	Visibility       string `json:"visibility"`
+	SupportedInAPI   *bool  `json:"supported_in_api"`
+	ContextWindow    int    `json:"context_window"`
+	MaxContextWindow int    `json:"max_context_window"`
+}
+
+// DiscoverModelCatalog refreshes Codex's local model catalog via
+// `codex debug models`. The command refreshes from Codex's remote catalog by
+// default; if that path fails, we fall back to the catalog bundled in the CLI.
+func (p *Provider) DiscoverModelCatalog(ctx context.Context) ([]llm.ModelInfo, error) {
+	runner := p.runner
+	if runner == nil {
+		runner = clirun.DefaultRunner()
+	}
+
+	out, err := runner(ctx, "codex", []string{"debug", "models"}, nil)
+	if err == nil {
+		models, parseErr := parseCodexModelCatalog(out)
+		if parseErr == nil {
+			return models, nil
+		}
+		err = parseErr
+	}
+
+	bundled, bundledErr := runner(ctx, "codex", []string{"debug", "models", "--bundled"}, nil)
+	if bundledErr != nil {
+		return nil, fmt.Errorf("running codex debug models: %w; bundled fallback: %v", err, bundledErr)
+	}
+	models, parseErr := parseCodexModelCatalog(bundled)
+	if parseErr != nil {
+		return nil, fmt.Errorf("parsing codex bundled model catalog after live catalog failure (%v): %w", err, parseErr)
+	}
+	return models, nil
+}
+
+func parseCodexModelCatalog(out []byte) ([]llm.ModelInfo, error) {
+	var payload codexModelCatalogPayload
+	if err := json.Unmarshal(out, &payload); err != nil {
+		return nil, fmt.Errorf("parse codex model catalog JSON: %w", err)
+	}
+
+	models := make([]llm.ModelInfo, 0, len(payload.Models))
+	seen := make(map[string]bool, len(payload.Models))
+	for _, raw := range payload.Models {
+		id := strings.TrimSpace(raw.Slug)
+		if id == "" || seen[id] {
+			continue
+		}
+		if raw.Visibility != "" && raw.Visibility != "list" {
+			continue
+		}
+		if raw.SupportedInAPI != nil && !*raw.SupportedInAPI {
+			continue
+		}
+
+		contextWindow := raw.ContextWindow
+		if contextWindow <= 0 {
+			contextWindow = raw.MaxContextWindow
+		}
+		displayName := strings.TrimSpace(raw.DisplayName)
+		if displayName == "" {
+			displayName = codexDisplayNameFromSlug(id)
+		}
+
+		info := llm.ModelInfo{
+			ID:            id,
+			DisplayName:   displayName,
+			ContextWindow: contextWindow,
+			Category:      codexCategoryForDiscoveredModel(id),
+		}
+		if id == "gpt-5.3-codex" {
+			info.Aliases = []string{"codex"}
+		}
+		models = append(models, info)
+		seen[id] = true
+	}
+	if len(models) == 0 {
+		return nil, fmt.Errorf("codex model catalog contained no visible API-supported models")
+	}
+	return models, nil
+}
+
+func codexDisplayNameFromSlug(slug string) string {
+	rawParts := strings.Split(slug, "-")
+	parts := make([]string, 0, len(rawParts))
+	if len(rawParts) >= 2 && strings.EqualFold(rawParts[0], "gpt") {
+		parts = append(parts, "GPT-"+rawParts[1])
+		rawParts = rawParts[2:]
+	}
+	for _, raw := range rawParts {
+		if raw != "" {
+			parts = append(parts, raw)
+		}
+	}
+	for i, part := range parts {
+		if strings.EqualFold(part, "gpt") {
+			parts[i] = "GPT"
+			continue
+		}
+		if len(part) > 0 {
+			parts[i] = strings.ToUpper(part[:1]) + part[1:]
+		}
+	}
+	return strings.Join(parts, " ")
+}
+
+func codexCategoryForDiscoveredModel(id string) string {
+	lower := strings.ToLower(id)
+	switch {
+	case strings.Contains(lower, "nano"):
+		return "cheap"
+	case strings.Contains(lower, "mini"):
+		return "balanced"
+	case lower == "gpt-5.3-codex":
+		return "balanced"
+	case strings.HasPrefix(lower, "gpt-5."):
+		return "capable"
+	case strings.Contains(lower, "codex"):
+		return "balanced"
+	default:
+		return ""
+	}
+}

--- a/internal/llm/codex/provider.go
+++ b/internal/llm/codex/provider.go
@@ -300,11 +300,10 @@ func (p *Provider) OutputPricePerMToken(model string) float64 {
 
 // defaultModelInfos returns Agentic's curated Codex/OpenAI model catalog.
 //
-// These values replace the former discovery pipeline (OpenAI models API and
-// codex app-server) because that pipeline never recorded a ContextWindow,
-// leaving the Session.ContextPercentage() signal dead until a runtime
-// tokenUsage event arrived. The handoff ticker and TUI badge need a window
-// from session start, so we hardcode one per model.
+// Runtime startup refreshes these values with `codex debug models`, which
+// exposes Codex's raw catalog including context windows. These values remain
+// as an offline fallback so the Session.ContextPercentage() signal works from
+// session start even when discovery is unavailable.
 //
 // Sources (verified 2026-04-18):
 //   - https://developers.openai.com/api/docs/models/gpt-5.5

--- a/internal/llm/codex/provider_test.go
+++ b/internal/llm/codex/provider_test.go
@@ -487,6 +487,88 @@ func TestCodexProvider_EnvVarsToExclude(t *testing.T) {
 	}
 }
 
+func TestParseCodexModelCatalog_FiltersAndMapsVisibleAPIModels(t *testing.T) {
+	catalogJSON := []byte(`{"models":[
+		{"slug":"gpt-5.5","display_name":"GPT-5.5","visibility":"list","supported_in_api":true,"context_window":272000,"max_context_window":272000},
+		{"slug":"codex-auto-review","display_name":"Codex Auto Review","visibility":"hide","supported_in_api":true,"context_window":272000},
+		{"slug":"gpt-5.4-mini","display_name":"GPT-5.4-Mini","visibility":"list","supported_in_api":true,"context_window":272000},
+		{"slug":"gpt-5.3-codex","display_name":"","visibility":"list","supported_in_api":true,"context_window":400000},
+		{"slug":"private-model","display_name":"Private","visibility":"list","supported_in_api":false,"context_window":123000}
+	]}`)
+
+	models, err := parseCodexModelCatalog(catalogJSON)
+	if err != nil {
+		t.Fatalf("parseCodexModelCatalog() error: %v", err)
+	}
+	gotIDs := make([]string, 0, len(models))
+	byID := make(map[string]llm.ModelInfo, len(models))
+	for _, model := range models {
+		gotIDs = append(gotIDs, model.ID)
+		byID[model.ID] = model
+	}
+	wantIDs := []string{"gpt-5.5", "gpt-5.4-mini", "gpt-5.3-codex"}
+	if !slices.Equal(gotIDs, wantIDs) {
+		t.Fatalf("model IDs = %v, want %v", gotIDs, wantIDs)
+	}
+	if got := byID["gpt-5.5"].Category; got != "capable" {
+		t.Errorf("gpt-5.5 category = %q, want capable", got)
+	}
+	if got := byID["gpt-5.4-mini"].Category; got != "balanced" {
+		t.Errorf("gpt-5.4-mini category = %q, want balanced", got)
+	}
+	codexModel := byID["gpt-5.3-codex"]
+	if got := codexModel.DisplayName; got != "GPT-5.3 Codex" {
+		t.Errorf("gpt-5.3-codex display name = %q, want generated display name", got)
+	}
+	if !slices.Equal(codexModel.Aliases, []string{"codex"}) {
+		t.Errorf("gpt-5.3-codex aliases = %v, want [codex]", codexModel.Aliases)
+	}
+	if got := codexModel.ContextWindow; got != 400_000 {
+		t.Errorf("gpt-5.3-codex context window = %d, want 400000", got)
+	}
+}
+
+func TestProviderDiscoverModelCatalog_FallsBackToBundledCatalog(t *testing.T) {
+	var calls [][]string
+	p := &Provider{
+		runner: func(ctx context.Context, name string, args []string, env []string) ([]byte, error) {
+			if name != "codex" {
+				t.Fatalf("command name = %q, want codex", name)
+			}
+			calls = append(calls, slices.Clone(args))
+			switch len(calls) {
+			case 1:
+				return []byte("{not-json"), nil
+			case 2:
+				return []byte(`{"models":[{"slug":"gpt-5.4","display_name":"GPT-5.4","visibility":"list","supported_in_api":true,"context_window":272000}]}`), nil
+			default:
+				t.Fatalf("unexpected runner call %d: %v", len(calls), args)
+				return nil, nil
+			}
+		},
+	}
+
+	models, err := p.DiscoverModelCatalog(context.Background())
+	if err != nil {
+		t.Fatalf("DiscoverModelCatalog() error: %v", err)
+	}
+	if len(models) != 1 || models[0].ID != "gpt-5.4" {
+		t.Fatalf("DiscoverModelCatalog() = %+v, want gpt-5.4", models)
+	}
+	wantCalls := [][]string{
+		{"debug", "models"},
+		{"debug", "models", "--bundled"},
+	}
+	if len(calls) != len(wantCalls) {
+		t.Fatalf("runner calls = %v, want %v", calls, wantCalls)
+	}
+	for i := range calls {
+		if !slices.Equal(calls[i], wantCalls[i]) {
+			t.Fatalf("runner call %d = %v, want %v", i, calls[i], wantCalls[i])
+		}
+	}
+}
+
 // TestCodexProvider_DefaultCatalog_Invariants locks in the hardcoded
 // Codex catalog that replaced the former discovery pipeline.
 func TestCodexProvider_DefaultCatalog_Invariants(t *testing.T) {

--- a/internal/llm/provider.go
+++ b/internal/llm/provider.go
@@ -106,6 +106,13 @@ type CatalogProvider interface {
 	ModelCatalog() []ModelInfo
 }
 
+// CatalogDiscoverer is implemented by providers that can refresh their model
+// catalog from the local provider CLI. Discovery is best-effort: callers should
+// fall back to CatalogProvider/default catalogs when it fails.
+type CatalogDiscoverer interface {
+	DiscoverModelCatalog(ctx context.Context) ([]ModelInfo, error)
+}
+
 // Protocol handles the wire-level communication with a provider's CLI process.
 // One instance is created per session. Implementations hold provider-specific
 // state (e.g. Codex thread IDs, handshake channels).

--- a/internal/llm/types.go
+++ b/internal/llm/types.go
@@ -26,8 +26,7 @@ type ModelInfo struct {
 }
 
 // CatalogEnricher is implemented by providers whose model catalog can be
-// overridden at runtime (e.g. from tests). Production code reads the
-// provider's hardcoded defaults — there is no automated discovery pipeline.
+// overridden at runtime, either from provider CLI discovery or from tests.
 type CatalogEnricher interface {
 	SetModelCatalog(models []ModelInfo)
 }


### PR DESCRIPTION
## Summary

Adds startup model-catalog discovery for the Claude and Codex providers, so Agentico begins each run with an up-to-date view of the models each CLI actually offers, with a built-in fallback when discovery is unavailable.

- **Claude** — Claude Code exposes no machine-readable model-list command, so the catalog is built by probing each curated alias (`opus`, `sonnet`, `haiku`, and the `[1m]` variants) with a tiny `claude --model <alias> -p` request and reading the resolved model + context window from the stream-json output. Probing is the only provider-agnostic way to learn what an alias resolves to, which differs across the Anthropic API, Bedrock, Vertex, and Foundry. The offline fallback catalog no longer pins concrete model versions (e.g. `claude-opus-4-8`), since what an alias resolves to is provider-dependent and drifts over time.
- **Codex** — refreshes from `codex debug models`, falling back to the CLI's bundled catalog.
- Discovered catalogs are cached on disk per provider + CLI version (`model-catalogs/`), so the probe cost is paid once per CLI version.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./internal/llm/... ./cmd/agentico/...`
- [x] `go test ./internal/llm/... ./cmd/agentico/...` — all green
- [x] Manual (not yet run): launch Agentico with the Claude CLI installed and confirm the discovered catalog populates (probe resolves `opus`/`sonnet`/`haiku`), and that it falls back to the built-in catalog when `claude` is unavailable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
