### PR TITLE
Claude Fable support & expose context-window variants as selectable models

### DIFF
--- a/internal/llm/claude/discovery.go
+++ b/internal/llm/claude/discovery.go
@@ -29,6 +29,7 @@ import (
 const (
 	claudeModelProbePrompt       = "Return exactly: OK"
 	claudeModelProbeMaxBudgetUSD = "0.05"
+	claudeModelProbeAttempts     = 2
 )
 
 // DiscoverModelCatalog resolves Agentic's curated Claude selectors against the
@@ -59,19 +60,7 @@ func (p *Provider) DiscoverModelCatalog(ctx context.Context) ([]llm.ModelInfo, e
 			}
 			break
 		}
-		out, err := runner(ctx, "claude", claudeModelProbeArgs(candidate.Selector), nil)
-		if err != nil {
-			if ctx.Err() != nil {
-				if len(models) > 0 {
-					models = appendClaudeFallbacks(models, candidates[i:])
-				}
-				break
-			}
-			failures = append(failures, fmt.Sprintf("%s: %v", candidate.Selector, err))
-			continue
-		}
-
-		resolved, contextWindow, err := parseClaudeModelProbe(candidate.Selector, out)
+		resolved, contextWindow, err := probeClaudeModel(ctx, runner, candidate)
 		if err != nil {
 			if ctx.Err() != nil {
 				if len(models) > 0 {
@@ -94,6 +83,36 @@ func (p *Provider) DiscoverModelCatalog(ctx context.Context) ([]llm.ModelInfo, e
 		return nil, fmt.Errorf("no Claude model probes succeeded: %s", strings.Join(failures, "; "))
 	}
 	return models, nil
+}
+
+func probeClaudeModel(ctx context.Context, runner clirun.CommandRunner, candidate claudeModelProbeCandidate) (string, int, error) {
+	var lastErr error
+	for range claudeModelProbeAttempts {
+		if err := ctx.Err(); err != nil {
+			return "", 0, err
+		}
+		out, err := runner(ctx, "claude", claudeModelProbeArgs(candidate.Selector), nil)
+		if err != nil {
+			if ctx.Err() != nil {
+				return "", 0, ctx.Err()
+			}
+			lastErr = err
+			continue
+		}
+
+		resolved, contextWindow, err := parseClaudeModelProbe(candidate.Selector, out)
+		if err == nil {
+			return resolved, contextWindow, nil
+		}
+		if ctx.Err() != nil {
+			return "", 0, ctx.Err()
+		}
+		lastErr = err
+	}
+	if lastErr == nil {
+		lastErr = fmt.Errorf("probe for %s failed", candidate.Selector)
+	}
+	return "", 0, lastErr
 }
 
 func appendClaudeFallbacks(models []llm.ModelInfo, candidates []claudeModelProbeCandidate) []llm.ModelInfo {
@@ -161,13 +180,13 @@ func parseClaudeModelProbe(requestedModel string, out []byte) (string, int, erro
 			if msg.Result.Usage != nil && msg.Result.Usage.ContextWindow > 0 {
 				contextWindow = msg.Result.Usage.ContextWindow
 			}
-			for model, usage := range msg.Result.ModelUsage {
-				if resolvedModel == "" && model != "" {
+			if len(msg.Result.ModelUsage) == 1 && resolvedModel == "" {
+				for model := range msg.Result.ModelUsage {
 					resolvedModel = model
 				}
-				if usage.ContextWindow > 0 {
-					contextWindow = usage.ContextWindow
-				}
+			}
+			if window := contextWindowForResolvedModel(resolvedModel, msg.Result.ModelUsage); window > 0 {
+				contextWindow = window
 			}
 		}
 	}
@@ -178,4 +197,28 @@ func parseClaudeModelProbe(requestedModel string, out []byte) (string, int, erro
 		return "", 0, fmt.Errorf("probe for %s did not include model metadata", requestedModel)
 	}
 	return resolvedModel, contextWindow, nil
+}
+
+func contextWindowForResolvedModel(resolvedModel string, usage map[string]llm.ModelUsageEntry) int {
+	if len(usage) == 0 {
+		return 0
+	}
+	if resolvedModel != "" {
+		if entry, ok := usage[resolvedModel]; ok && entry.ContextWindow > 0 {
+			return entry.ContextWindow
+		}
+		for model, entry := range usage {
+			if strings.EqualFold(model, resolvedModel) && entry.ContextWindow > 0 {
+				return entry.ContextWindow
+			}
+		}
+	}
+	if len(usage) == 1 {
+		for _, entry := range usage {
+			if entry.ContextWindow > 0 {
+				return entry.ContextWindow
+			}
+		}
+	}
+	return 0
 }

--- a/internal/llm/claude/discovery.go
+++ b/internal/llm/claude/discovery.go
@@ -31,17 +31,17 @@ const (
 	claudeModelProbeMaxBudgetUSD = "0.05"
 )
 
-// DiscoverModelCatalog resolves Agentic's curated Claude aliases against the
-// live CLI by probing each one with a tiny `claude --model <alias> -p` request
+// DiscoverModelCatalog resolves Agentic's curated Claude selectors against the
+// live CLI by probing each one with a tiny `claude --model <selector> -p` request
 // and reading the resolved model + context window back from the stream-json
 // output.
 //
 // Probing is the only mechanism used because Claude Code exposes no
 // machine-readable model catalog command, and probing is the only
-// provider-agnostic way to learn what `--model <alias>` actually resolves to on
-// this machine (aliases resolve to different concrete models on the Anthropic
-// API vs. Bedrock/Vertex/Foundry). Any alias whose probe is skipped — e.g. when
-// ctx is cancelled partway through — keeps its hardcoded defaultModelInfos
+// provider-agnostic way to learn what `--model <selector>` actually resolves to on
+// this machine (selectors resolve to different concrete models on the Anthropic
+// API vs. Bedrock/Vertex/Foundry). Any selector whose probe is skipped — e.g. when
+// ctx is cancelled partway through — keeps its hardcoded fallback catalog
 // metadata as a fallback.
 func (p *Provider) DiscoverModelCatalog(ctx context.Context) ([]llm.ModelInfo, error) {
 	runner := p.runner
@@ -49,46 +49,42 @@ func (p *Provider) DiscoverModelCatalog(ctx context.Context) ([]llm.ModelInfo, e
 		runner = clirun.DefaultRunner()
 	}
 
-	candidates := p.defaultModelInfos()
+	candidates := claudeModelProbeCandidates()
 	models := make([]llm.ModelInfo, 0, len(candidates))
 	var failures []string
 	for i, candidate := range candidates {
 		if err := ctx.Err(); err != nil {
 			if len(models) > 0 {
-				models = append(models, candidates[i:]...)
+				models = appendClaudeFallbacks(models, candidates[i:])
 			}
 			break
 		}
-		out, err := runner(ctx, "claude", claudeModelProbeArgs(claudeCLIModelForCatalogEntry(candidate)), nil)
+		out, err := runner(ctx, "claude", claudeModelProbeArgs(candidate.Selector), nil)
 		if err != nil {
 			if ctx.Err() != nil {
 				if len(models) > 0 {
-					models = append(models, candidates[i:]...)
+					models = appendClaudeFallbacks(models, candidates[i:])
 				}
 				break
 			}
-			failures = append(failures, fmt.Sprintf("%s: %v", candidate.ID, err))
+			failures = append(failures, fmt.Sprintf("%s: %v", candidate.Selector, err))
 			continue
 		}
 
-		resolved, contextWindow, err := parseClaudeModelProbe(candidate.ID, out)
+		resolved, contextWindow, err := parseClaudeModelProbe(candidate.Selector, out)
 		if err != nil {
 			if ctx.Err() != nil {
 				if len(models) > 0 {
-					models = append(models, candidates[i:]...)
+					models = appendClaudeFallbacks(models, candidates[i:])
 				}
 				break
 			}
-			failures = append(failures, fmt.Sprintf("%s: %v", candidate.ID, err))
+			failures = append(failures, fmt.Sprintf("%s: %v", candidate.Selector, err))
 			continue
 		}
 
-		info := candidate
-		if contextWindow > 0 {
-			info.ContextWindow = contextWindow
-		}
-		info.Aliases = llm.AppendUniqueAlias(info.Aliases, info.ID, resolved)
-		models = append(models, info)
+		info := claudeModelInfoFromProbe(candidate, contextWindow, resolved)
+		models = appendClaudeModelInfo(models, info)
 	}
 
 	if len(models) == 0 {
@@ -98,6 +94,29 @@ func (p *Provider) DiscoverModelCatalog(ctx context.Context) ([]llm.ModelInfo, e
 		return nil, fmt.Errorf("no Claude model probes succeeded: %s", strings.Join(failures, "; "))
 	}
 	return models, nil
+}
+
+func appendClaudeFallbacks(models []llm.ModelInfo, candidates []claudeModelProbeCandidate) []llm.ModelInfo {
+	for _, candidate := range candidates {
+		models = appendClaudeModelInfo(models, claudeModelInfoFromProbe(candidate, candidate.FallbackContextWindow, ""))
+	}
+	return models
+}
+
+func appendClaudeModelInfo(models []llm.ModelInfo, info llm.ModelInfo) []llm.ModelInfo {
+	for i := range models {
+		if !strings.EqualFold(models[i].ID, info.ID) {
+			continue
+		}
+		if info.ContextWindow > 0 {
+			models[i].ContextWindow = info.ContextWindow
+		}
+		for _, alias := range info.Aliases {
+			models[i].Aliases = appendClaudeAlias(models[i].Aliases, models[i].ID, alias)
+		}
+		return models
+	}
+	return append(models, info)
 }
 
 func claudeModelProbeArgs(model string) []string {

--- a/internal/llm/claude/discovery.go
+++ b/internal/llm/claude/discovery.go
@@ -59,7 +59,7 @@ func (p *Provider) DiscoverModelCatalog(ctx context.Context) ([]llm.ModelInfo, e
 			}
 			break
 		}
-		out, err := runner(ctx, "claude", claudeModelProbeArgs(candidate.ID), nil)
+		out, err := runner(ctx, "claude", claudeModelProbeArgs(claudeCLIModel(candidate.ID)), nil)
 		if err != nil {
 			if ctx.Err() != nil {
 				if len(models) > 0 {
@@ -87,9 +87,7 @@ func (p *Provider) DiscoverModelCatalog(ctx context.Context) ([]llm.ModelInfo, e
 		if contextWindow > 0 {
 			info.ContextWindow = contextWindow
 		}
-		if resolved != "" && !strings.EqualFold(resolved, info.ID) {
-			info.Aliases = []string{resolved}
-		}
+		info.Aliases = llm.AppendUniqueAlias(info.Aliases, info.ID, resolved)
 		models = append(models, info)
 	}
 

--- a/internal/llm/claude/discovery.go
+++ b/internal/llm/claude/discovery.go
@@ -59,7 +59,7 @@ func (p *Provider) DiscoverModelCatalog(ctx context.Context) ([]llm.ModelInfo, e
 			}
 			break
 		}
-		out, err := runner(ctx, "claude", claudeModelProbeArgs(claudeCLIModel(candidate.ID)), nil)
+		out, err := runner(ctx, "claude", claudeModelProbeArgs(claudeCLIModelForCatalogEntry(candidate)), nil)
 		if err != nil {
 			if ctx.Err() != nil {
 				if len(models) > 0 {

--- a/internal/llm/claude/provider.go
+++ b/internal/llm/claude/provider.go
@@ -256,7 +256,7 @@ func (p *Provider) CLIVersion() (string, error) {
 // alias (e.g. claude-opus-4-8) because what an alias resolves to is
 // provider-dependent (Anthropic API vs Bedrock/Vertex/Foundry) and drifts over
 // time — a hardcoded version is a frequently-wrong guess. The probe sets the
-// resolved model when it runs. Base and `[1m]` variants stay as separate
+// resolved model when it runs. Base and `[1M]` variants stay as separate
 // entries because `--model opus` (200K) and `--model opus[1m]` (1M) are
 // distinct CLI inputs.
 //
@@ -269,10 +269,10 @@ func (p *Provider) CLIVersion() (string, error) {
 // (compaction at ~167K on --model opus ≈ 83% of 200K).
 func (p *Provider) defaultModelInfos() []llm.ModelInfo {
 	return []llm.ModelInfo{
-		{ID: "opus", DisplayName: "Claude Opus", ContextWindow: 200_000, Category: "capable"},
-		{ID: "opus[1m]", DisplayName: "Claude Opus (1M)", ContextWindow: 1_000_000, Category: "capable"},
-		{ID: "sonnet", DisplayName: "Claude Sonnet", ContextWindow: 200_000, Category: "balanced"},
-		{ID: "sonnet[1m]", DisplayName: "Claude Sonnet (1M)", ContextWindow: 1_000_000, Category: "balanced"},
+		{ID: "opus[200K]", DisplayName: "Claude Opus (200K)", ContextWindow: 200_000, Aliases: []string{"opus"}, Category: "capable"},
+		{ID: "opus[1M]", DisplayName: "Claude Opus (1M)", ContextWindow: 1_000_000, Aliases: []string{"opus[1m]"}, Category: "capable"},
+		{ID: "sonnet[200K]", DisplayName: "Claude Sonnet (200K)", ContextWindow: 200_000, Aliases: []string{"sonnet"}, Category: "balanced"},
+		{ID: "sonnet[1M]", DisplayName: "Claude Sonnet (1M)", ContextWindow: 1_000_000, Aliases: []string{"sonnet[1m]"}, Category: "balanced"},
 		{ID: "haiku", DisplayName: "Claude Haiku", ContextWindow: 200_000, Category: "cheap"},
 	}
 }
@@ -308,7 +308,7 @@ func InsertAfterBinary(cmd []string, flags ...string) []string {
 
 func buildInteractiveCommand(opts llm.CommandBuildOpts) []string {
 	args := []string{"claude",
-		"--model", opts.Model,
+		"--model", claudeCLIModel(opts.Model),
 		"--output-format", "stream-json",
 		"--input-format", "stream-json",
 		"--verbose",
@@ -345,6 +345,21 @@ func buildInteractiveCommand(opts llm.CommandBuildOpts) []string {
 		}
 	}
 	return args
+}
+
+func claudeCLIModel(model string) string {
+	switch strings.ToLower(model) {
+	case "opus[200k]":
+		return "opus"
+	case "opus[1m]":
+		return "opus[1m]"
+	case "sonnet[200k]":
+		return "sonnet"
+	case "sonnet[1m]":
+		return "sonnet[1m]"
+	default:
+		return model
+	}
 }
 
 func applyStreamingOpts(args []string, opts llm.CommandBuildOpts) []string {

--- a/internal/llm/claude/provider.go
+++ b/internal/llm/claude/provider.go
@@ -76,6 +76,7 @@ func (p *Provider) AvailableModels() []string {
 }
 
 func (p *Provider) BuildCommand(opts llm.CommandBuildOpts) ([]string, []string, error) {
+	opts.Model = p.claudeCLIModel(opts.Model)
 	args := buildInteractiveCommand(opts)
 	return args, nil, nil
 }
@@ -308,7 +309,7 @@ func InsertAfterBinary(cmd []string, flags ...string) []string {
 
 func buildInteractiveCommand(opts llm.CommandBuildOpts) []string {
 	args := []string{"claude",
-		"--model", claudeCLIModel(opts.Model),
+		"--model", opts.Model,
 		"--output-format", "stream-json",
 		"--input-format", "stream-json",
 		"--verbose",
@@ -347,19 +348,41 @@ func buildInteractiveCommand(opts llm.CommandBuildOpts) []string {
 	return args
 }
 
-func claudeCLIModel(model string) string {
-	switch strings.ToLower(model) {
-	case "opus[200k]":
-		return "opus"
-	case "opus[1m]":
-		return "opus[1m]"
-	case "sonnet[200k]":
-		return "sonnet"
-	case "sonnet[1m]":
-		return "sonnet[1m]"
-	default:
-		return model
+func (p *Provider) claudeCLIModel(model string) string {
+	p.mu.RLock()
+	cat := p.catalog
+	p.mu.RUnlock()
+	if len(cat) == 0 {
+		cat = p.defaultModelInfos()
 	}
+	for _, entry := range cat {
+		if strings.EqualFold(entry.ID, model) {
+			return claudeCLIModelForCatalogEntry(entry)
+		}
+		for _, alias := range entry.Aliases {
+			if strings.EqualFold(alias, model) {
+				return claudeCLIModelForCatalogEntry(entry)
+			}
+		}
+	}
+	return model
+}
+
+func claudeCLIModelForCatalogEntry(entry llm.ModelInfo) string {
+	for _, alias := range entry.Aliases {
+		if isStableClaudeCLISelector(alias) {
+			return alias
+		}
+	}
+	if isStableClaudeCLISelector(entry.ID) {
+		return entry.ID
+	}
+	return entry.ID
+}
+
+func isStableClaudeCLISelector(model string) bool {
+	model = strings.TrimSpace(model)
+	return model != "" && !strings.HasPrefix(strings.ToLower(model), "claude-")
 }
 
 func applyStreamingOpts(args []string, opts llm.CommandBuildOpts) []string {

--- a/internal/llm/claude/provider.go
+++ b/internal/llm/claude/provider.go
@@ -260,6 +260,7 @@ type claudeModelProbeCandidate struct {
 
 func claudeModelProbeCandidates() []claudeModelProbeCandidate {
 	return []claudeModelProbeCandidate{
+		{Family: "fable", Selector: "fable", DisplayName: "Claude Fable 5", FallbackContextWindow: 1_000_000, Category: "capable"},
 		{Family: "opus", Selector: "opus", DisplayName: "Claude Opus", FallbackContextWindow: 200_000, Category: "capable"},
 		{Family: "opus", Selector: "opus[1m]", DisplayName: "Claude Opus", FallbackContextWindow: 1_000_000, Category: "capable"},
 		{Family: "sonnet", Selector: "sonnet", DisplayName: "Claude Sonnet", FallbackContextWindow: 200_000, Category: "balanced"},
@@ -320,9 +321,10 @@ func appendClaudeAlias(aliases []string, id, alias string) []string {
 // so the offline fallback has to keep curated probe selectors and context
 // windows.
 //
-// Context-window sources (verified 2026-06-05):
+// Context-window sources (verified 2026-06-09):
 //   - https://platform.claude.com/docs/en/about-claude/models/overview
 //   - https://code.claude.com/docs/en/model-config
+//   - https://platform.claude.com/docs/en/about-claude/models/introducing-claude-fable-5-and-claude-mythos-5
 //
 // The 200K base windows for opus/sonnet were confirmed empirically from
 // auto-compact thresholds observed in live Claude Code sessions

--- a/internal/llm/claude/provider.go
+++ b/internal/llm/claude/provider.go
@@ -250,6 +250,65 @@ func (p *Provider) CLIVersion() (string, error) {
 	return clirun.ParseVersionOutput(out)
 }
 
+type claudeModelProbeCandidate struct {
+	Family                string
+	Selector              string
+	DisplayName           string
+	Category              string
+	FallbackContextWindow int
+}
+
+func claudeModelProbeCandidates() []claudeModelProbeCandidate {
+	return []claudeModelProbeCandidate{
+		{Family: "opus", Selector: "opus", DisplayName: "Claude Opus", FallbackContextWindow: 200_000, Category: "capable"},
+		{Family: "opus", Selector: "opus[1m]", DisplayName: "Claude Opus", FallbackContextWindow: 1_000_000, Category: "capable"},
+		{Family: "sonnet", Selector: "sonnet", DisplayName: "Claude Sonnet", FallbackContextWindow: 200_000, Category: "balanced"},
+		{Family: "sonnet", Selector: "sonnet[1m]", DisplayName: "Claude Sonnet", FallbackContextWindow: 1_000_000, Category: "balanced"},
+		{Family: "haiku", Selector: "haiku", DisplayName: "Claude Haiku", FallbackContextWindow: 200_000, Category: "cheap"},
+	}
+}
+
+func claudeModelInfoFromProbe(candidate claudeModelProbeCandidate, contextWindow int, resolved string) llm.ModelInfo {
+	if contextWindow <= 0 {
+		contextWindow = candidate.FallbackContextWindow
+	}
+	id := candidate.Family
+	displayName := candidate.DisplayName
+	if label := llm.ContextWindowLabel(contextWindow); label != "" {
+		id = candidate.Family + "[" + label + "]"
+		displayName = candidate.DisplayName + " (" + label + ")"
+	}
+	info := llm.ModelInfo{
+		ID:            id,
+		DisplayName:   displayName,
+		ContextWindow: contextWindow,
+		Category:      candidate.Category,
+	}
+	info.Aliases = appendClaudeAlias(info.Aliases, info.ID, candidate.Selector)
+	info.Aliases = appendClaudeAlias(info.Aliases, info.ID, resolved)
+	return info
+}
+
+func appendClaudeAlias(aliases []string, id, alias string) []string {
+	alias = strings.TrimSpace(alias)
+	if alias == "" || alias == id {
+		return aliases
+	}
+	for _, existing := range aliases {
+		if existing == alias {
+			return aliases
+		}
+	}
+	if !strings.EqualFold(alias, id) {
+		for _, existing := range aliases {
+			if strings.EqualFold(existing, alias) {
+				return aliases
+			}
+		}
+	}
+	return append(aliases, alias)
+}
+
 // defaultModelInfos returns Agentic's curated Claude Code model catalog.
 //
 // Runtime startup tries to refresh these with DiscoverModelCatalog; they are
@@ -257,9 +316,9 @@ func (p *Provider) CLIVersion() (string, error) {
 // alias (e.g. claude-opus-4-8) because what an alias resolves to is
 // provider-dependent (Anthropic API vs Bedrock/Vertex/Foundry) and drifts over
 // time — a hardcoded version is a frequently-wrong guess. The probe sets the
-// resolved model when it runs. Base and `[1M]` variants stay as separate
-// entries because `--model opus` (200K) and `--model opus[1m]` (1M) are
-// distinct CLI inputs.
+// resolved model when it runs. Claude exposes no machine-readable model catalog,
+// so the offline fallback has to keep curated probe selectors and context
+// windows.
 //
 // Context-window sources (verified 2026-06-05):
 //   - https://platform.claude.com/docs/en/about-claude/models/overview
@@ -269,13 +328,12 @@ func (p *Provider) CLIVersion() (string, error) {
 // auto-compact thresholds observed in live Claude Code sessions
 // (compaction at ~167K on --model opus ≈ 83% of 200K).
 func (p *Provider) defaultModelInfos() []llm.ModelInfo {
-	return []llm.ModelInfo{
-		{ID: "opus[200K]", DisplayName: "Claude Opus (200K)", ContextWindow: 200_000, Aliases: []string{"opus"}, Category: "capable"},
-		{ID: "opus[1M]", DisplayName: "Claude Opus (1M)", ContextWindow: 1_000_000, Aliases: []string{"opus[1m]"}, Category: "capable"},
-		{ID: "sonnet[200K]", DisplayName: "Claude Sonnet (200K)", ContextWindow: 200_000, Aliases: []string{"sonnet"}, Category: "balanced"},
-		{ID: "sonnet[1M]", DisplayName: "Claude Sonnet (1M)", ContextWindow: 1_000_000, Aliases: []string{"sonnet[1m]"}, Category: "balanced"},
-		{ID: "haiku", DisplayName: "Claude Haiku", ContextWindow: 200_000, Category: "cheap"},
+	candidates := claudeModelProbeCandidates()
+	models := make([]llm.ModelInfo, 0, len(candidates))
+	for _, candidate := range candidates {
+		models = append(models, claudeModelInfoFromProbe(candidate, candidate.FallbackContextWindow, ""))
 	}
+	return models
 }
 
 // --- Command building helpers ---

--- a/internal/llm/claude/provider_test.go
+++ b/internal/llm/claude/provider_test.go
@@ -281,7 +281,7 @@ func TestClaudeProvider_ModelCatalog_FallsBackToHardcoded(t *testing.T) {
 	}
 }
 
-func TestBuildInteractiveCommand_MapsDisplayContextModelsToClaudeCLIModels(t *testing.T) {
+func TestProviderBuildCommand_UsesCatalogAliasForClaudeCLIModel(t *testing.T) {
 	tests := []struct {
 		model string
 		want  string
@@ -293,22 +293,56 @@ func TestBuildInteractiveCommand_MapsDisplayContextModelsToClaudeCLIModels(t *te
 	}
 	for _, tt := range tests {
 		t.Run(tt.model, func(t *testing.T) {
-			args := buildInteractiveCommand(llm.CommandBuildOpts{Model: tt.model})
-			found := false
-			for i, arg := range args {
-				if arg != "--model" {
-					continue
-				}
-				found = true
-				if i+1 >= len(args) || args[i+1] != tt.want {
-					t.Fatalf("--model = %q, want %q; args=%v", args[i+1], tt.want, args)
-				}
+			p := &Provider{}
+			args, env, err := p.BuildCommand(llm.CommandBuildOpts{Model: tt.model})
+			if err != nil {
+				t.Fatalf("BuildCommand() error: %v", err)
 			}
-			if !found {
-				t.Fatalf("command args = %v, want --model", args)
+			if env != nil {
+				t.Fatalf("BuildCommand() env = %v, want nil", env)
 			}
+			assertModelArg(t, args, tt.want)
 		})
 	}
+}
+
+func TestProviderBuildCommand_UsesDiscoveredCatalogAliasForClaudeCLIModel(t *testing.T) {
+	p := &Provider{}
+	p.SetModelCatalog([]llm.ModelInfo{
+		{
+			ID:            "experimental[1M]",
+			DisplayName:   "Experimental (1M)",
+			ContextWindow: 1_000_000,
+			Aliases:       []string{"experimental[1m]", "claude-experimental-1"},
+			Category:      "capable",
+		},
+	})
+
+	args, env, err := p.BuildCommand(llm.CommandBuildOpts{Model: "experimental[1M]"})
+	if err != nil {
+		t.Fatalf("BuildCommand() error: %v", err)
+	}
+	if env != nil {
+		t.Fatalf("BuildCommand() env = %v, want nil", env)
+	}
+	assertModelArg(t, args, "experimental[1m]")
+}
+
+func assertModelArg(t *testing.T, args []string, want string) {
+	t.Helper()
+	for i, arg := range args {
+		if arg != "--model" {
+			continue
+		}
+		if i+1 >= len(args) {
+			t.Fatalf("command args = %v, want --model value", args)
+		}
+		if args[i+1] != want {
+			t.Fatalf("--model = %q, want %q; args=%v", args[i+1], want, args)
+		}
+		return
+	}
+	t.Fatalf("command args = %v, want --model", args)
 }
 
 // TestBuildInteractiveCommand_PermissionMode pins the wiring that prevents

--- a/internal/llm/claude/provider_test.go
+++ b/internal/llm/claude/provider_test.go
@@ -113,6 +113,25 @@ func TestParseClaudeModelProbe_ExtractsResolvedModelAndContextWindow(t *testing.
 	}
 }
 
+func TestParseClaudeModelProbe_UsesResolvedModelContextWindow(t *testing.T) {
+	out := []byte(strings.Join([]string{
+		`{"type":"system","subtype":"init","session_id":"s1","model":"claude-fable-5"}`,
+		`{"type":"assistant","message":{"role":"assistant","model":"claude-fable-5","content":[{"type":"text","text":"OK"}],"usage":{"input_tokens":12,"output_tokens":1}}}`,
+		`{"type":"result","subtype":"success","session_id":"s1","modelUsage":{"claude-haiku-4-5-20251001":{"contextWindow":200000},"claude-fable-5":{"contextWindow":1000000}}}`,
+	}, "\n"))
+
+	model, contextWindow, err := parseClaudeModelProbe("fable", out)
+	if err != nil {
+		t.Fatalf("parseClaudeModelProbe() error: %v", err)
+	}
+	if model != "claude-fable-5" {
+		t.Fatalf("model = %q, want claude-fable-5", model)
+	}
+	if contextWindow != 1_000_000 {
+		t.Fatalf("contextWindow = %d, want 1000000", contextWindow)
+	}
+}
+
 func TestClaudeProviderDiscoverModelCatalog_PartialSuccessUpdatesAliases(t *testing.T) {
 	p := &Provider{
 		runner: func(ctx context.Context, name string, args []string, env []string) ([]byte, error) {
@@ -127,6 +146,9 @@ func TestClaudeProviderDiscoverModelCatalog_PartialSuccessUpdatesAliases(t *test
 				t.Fatalf("command args for %s = %v, want %v", model, args, claudeModelProbeArgs(model))
 			}
 			switch model {
+			case "fable":
+				return []byte(`{"type":"system","subtype":"init","model":"claude-fable-5"}` + "\n" +
+					`{"type":"result","subtype":"success","modelUsage":{"claude-fable-5":{"contextWindow":1000000}}}`), nil
 			case "opus":
 				return []byte(`{"type":"system","subtype":"init","model":"claude-opus-4-8"}` + "\n" +
 					`{"type":"result","subtype":"success","modelUsage":{"claude-opus-4-8":{"contextWindow":200000}}}`), nil
@@ -143,14 +165,50 @@ func TestClaudeProviderDiscoverModelCatalog_PartialSuccessUpdatesAliases(t *test
 	if err != nil {
 		t.Fatalf("DiscoverModelCatalog() error: %v", err)
 	}
-	if len(models) != 2 {
-		t.Fatalf("DiscoverModelCatalog() returned %d models, want 2: %+v", len(models), models)
+	if len(models) != 3 {
+		t.Fatalf("DiscoverModelCatalog() returned %d models, want 3: %+v", len(models), models)
 	}
-	if models[0].ID != "opus[200K]" || !slices.Equal(models[0].Aliases, []string{"opus", "claude-opus-4-8"}) {
-		t.Fatalf("first model = %+v, want opus[200K] with stable and concrete aliases", models[0])
+	if models[0].ID != "fable[1M]" || !slices.Equal(models[0].Aliases, []string{"fable", "claude-fable-5"}) {
+		t.Fatalf("first model = %+v, want fable[1M] with stable and concrete aliases", models[0])
 	}
-	if models[1].ID != "sonnet[200K]" || !slices.Equal(models[1].Aliases, []string{"sonnet", "claude-sonnet-4-6"}) {
-		t.Fatalf("second model = %+v, want sonnet[200K] with stable and concrete aliases", models[1])
+	if models[1].ID != "opus[200K]" || !slices.Equal(models[1].Aliases, []string{"opus", "claude-opus-4-8"}) {
+		t.Fatalf("second model = %+v, want opus[200K] with stable and concrete aliases", models[1])
+	}
+	if models[2].ID != "sonnet[200K]" || !slices.Equal(models[2].Aliases, []string{"sonnet", "claude-sonnet-4-6"}) {
+		t.Fatalf("third model = %+v, want sonnet[200K] with stable and concrete aliases", models[2])
+	}
+}
+
+func TestClaudeProviderDiscoverModelCatalog_RetriesTransientProbeFailure(t *testing.T) {
+	var fableCalls int
+	p := &Provider{
+		runner: func(ctx context.Context, name string, args []string, env []string) ([]byte, error) {
+			if name != "claude" {
+				t.Fatalf("command name = %q, want claude", name)
+			}
+			switch model := args[1]; model {
+			case "fable":
+				fableCalls++
+				if fableCalls == 1 {
+					return nil, errors.New("transient unavailable")
+				}
+				return []byte(`{"type":"system","subtype":"init","model":"claude-fable-5"}` + "\n" +
+					`{"type":"result","subtype":"success","modelUsage":{"claude-fable-5":{"contextWindow":1000000}}}`), nil
+			default:
+				return nil, errors.New("model not available")
+			}
+		},
+	}
+
+	models, err := p.DiscoverModelCatalog(context.Background())
+	if err != nil {
+		t.Fatalf("DiscoverModelCatalog() error: %v", err)
+	}
+	if fableCalls != 2 {
+		t.Fatalf("fable probe calls = %d, want 2", fableCalls)
+	}
+	if len(models) != 1 || models[0].ID != "fable[1M]" {
+		t.Fatalf("models = %+v, want only fable[1M]", models)
 	}
 }
 
@@ -162,12 +220,12 @@ func TestClaudeProviderDiscoverModelCatalog_PreservesUnattemptedFallbacksOnTimeo
 				t.Fatalf("command name = %q, want claude", name)
 			}
 			model := args[1]
-			if model != "opus" {
-				t.Fatalf("runner should only be called for opus before cancellation, got %s", model)
+			if model != "fable" {
+				t.Fatalf("runner should only be called for fable before cancellation, got %s", model)
 			}
 			cancel()
-			return []byte(`{"type":"system","subtype":"init","model":"claude-opus-4-8"}` + "\n" +
-				`{"type":"result","subtype":"success","modelUsage":{"claude-opus-4-8":{"contextWindow":1000000}}}`), nil
+			return []byte(`{"type":"system","subtype":"init","model":"claude-fable-5"}` + "\n" +
+				`{"type":"result","subtype":"success","modelUsage":{"claude-fable-5":{"contextWindow":1000000}}}`), nil
 		},
 	}
 
@@ -179,12 +237,12 @@ func TestClaudeProviderDiscoverModelCatalog_PreservesUnattemptedFallbacksOnTimeo
 	for _, model := range models {
 		gotIDs = append(gotIDs, model.ID)
 	}
-	wantIDs := []string{"opus[1M]", "sonnet[200K]", "sonnet[1M]", "haiku[200K]"}
+	wantIDs := []string{"fable[1M]", "opus[200K]", "opus[1M]", "sonnet[200K]", "sonnet[1M]", "haiku[200K]"}
 	if !slices.Equal(gotIDs, wantIDs) {
 		t.Fatalf("model IDs = %v, want %v", gotIDs, wantIDs)
 	}
-	if models[0].ContextWindow != 1_000_000 || !slices.Equal(models[0].Aliases, []string{"opus", "claude-opus-4-8", "opus[1m]"}) {
-		t.Fatalf("opus entry = %+v, want discovered metadata", models[0])
+	if models[0].ContextWindow != 1_000_000 || !slices.Equal(models[0].Aliases, []string{"fable", "claude-fable-5"}) {
+		t.Fatalf("fable entry = %+v, want discovered metadata", models[0])
 	}
 	if models[len(models)-1].ID != "haiku[200K]" || models[len(models)-1].ContextWindow != 200_000 {
 		t.Fatalf("last entry = %+v, want fallback haiku", models[len(models)-1])
@@ -234,6 +292,7 @@ func TestClaudeProvider_DefaultCatalog_Invariants(t *testing.T) {
 	}
 
 	wantWindows := map[string]int{
+		"fable[1M]":    1_000_000,
 		"opus[200K]":   200_000,
 		"opus[1M]":     1_000_000,
 		"sonnet[200K]": 200_000,
@@ -282,6 +341,8 @@ func TestClaudeProvider_ContextWindowForModel_ReturnsHardcodedWithoutSeed(t *tes
 	p := &Provider{}
 
 	tests := map[string]int{
+		"fable":        1_000_000,
+		"fable[1M]":    1_000_000,
 		"opus":         200_000,
 		"opus[200K]":   200_000,
 		"opus[1m]":     1_000_000,
@@ -318,6 +379,7 @@ func TestProviderBuildCommand_UsesCatalogAliasForClaudeCLIModel(t *testing.T) {
 		model string
 		want  string
 	}{
+		{"fable[1M]", "fable"},
 		{"opus[200K]", "opus"},
 		{"opus[1M]", "opus[1m]"},
 		{"sonnet[200K]", "sonnet"},

--- a/internal/llm/claude/provider_test.go
+++ b/internal/llm/claude/provider_test.go
@@ -146,11 +146,11 @@ func TestClaudeProviderDiscoverModelCatalog_PartialSuccessUpdatesAliases(t *test
 	if len(models) != 2 {
 		t.Fatalf("DiscoverModelCatalog() returned %d models, want 2: %+v", len(models), models)
 	}
-	if models[0].ID != "opus" || !slices.Equal(models[0].Aliases, []string{"claude-opus-4-8"}) {
-		t.Fatalf("first model = %+v, want opus with claude-opus-4-8 alias", models[0])
+	if models[0].ID != "opus[200K]" || !slices.Equal(models[0].Aliases, []string{"opus", "claude-opus-4-8"}) {
+		t.Fatalf("first model = %+v, want opus[200K] with stable and concrete aliases", models[0])
 	}
-	if models[1].ID != "sonnet" || !slices.Equal(models[1].Aliases, []string{"claude-sonnet-4-6"}) {
-		t.Fatalf("second model = %+v, want sonnet with claude-sonnet-4-6 alias", models[1])
+	if models[1].ID != "sonnet[200K]" || !slices.Equal(models[1].Aliases, []string{"sonnet", "claude-sonnet-4-6"}) {
+		t.Fatalf("second model = %+v, want sonnet[200K] with stable and concrete aliases", models[1])
 	}
 }
 
@@ -179,11 +179,11 @@ func TestClaudeProviderDiscoverModelCatalog_PreservesUnattemptedFallbacksOnTimeo
 	for _, model := range models {
 		gotIDs = append(gotIDs, model.ID)
 	}
-	wantIDs := []string{"opus", "opus[1m]", "sonnet", "sonnet[1m]", "haiku"}
+	wantIDs := []string{"opus[200K]", "opus[1M]", "sonnet[200K]", "sonnet[1M]", "haiku"}
 	if !slices.Equal(gotIDs, wantIDs) {
 		t.Fatalf("model IDs = %v, want %v", gotIDs, wantIDs)
 	}
-	if models[0].ContextWindow != 1_000_000 || !slices.Equal(models[0].Aliases, []string{"claude-opus-4-8"}) {
+	if models[0].ContextWindow != 1_000_000 || !slices.Equal(models[0].Aliases, []string{"opus", "claude-opus-4-8"}) {
 		t.Fatalf("opus entry = %+v, want discovered metadata", models[0])
 	}
 	if models[len(models)-1].ID != "haiku" || models[len(models)-1].ContextWindow != 200_000 {
@@ -203,11 +203,11 @@ func TestClaudeProvider_DefaultCatalog_Invariants(t *testing.T) {
 	}
 
 	wantWindows := map[string]int{
-		"opus":       200_000,
-		"opus[1m]":   1_000_000,
-		"sonnet":     200_000,
-		"sonnet[1m]": 1_000_000,
-		"haiku":      200_000,
+		"opus[200K]":   200_000,
+		"opus[1M]":     1_000_000,
+		"sonnet[200K]": 200_000,
+		"sonnet[1M]":   1_000_000,
+		"haiku":        200_000,
 	}
 
 	for id, want := range wantWindows {
@@ -221,14 +221,11 @@ func TestClaudeProvider_DefaultCatalog_Invariants(t *testing.T) {
 		}
 	}
 
-	// The `[1m]` variants must be distinct catalog entries, not aliases of
-	// the base ID. This is load-bearing: canonicalModelForProvider rewrites
-	// alias matches to the canonical ID, which would silently downgrade
-	// `--model opus[1m]` (1M) to `--model opus` (200K).
-	for _, m := range cat {
-		for _, alias := range m.Aliases {
-			if alias == m.ID+"[1m]" {
-				t.Errorf("entry %q must not carry %q as an alias; %q must be its own catalog ID", m.ID, alias, alias)
+	for _, baseID := range []string{"opus", "sonnet"} {
+		baseEntry := byID[baseID+"[200K]"]
+		for _, alias := range baseEntry.Aliases {
+			if strings.EqualFold(alias, baseID+"[1M]") || strings.EqualFold(alias, baseID+"[1m]") {
+				t.Errorf("entry %q must not carry 1M alias %q; 1M must stay its own catalog ID", baseEntry.ID, alias)
 			}
 		}
 	}
@@ -254,10 +251,15 @@ func TestClaudeProvider_ContextWindowForModel_ReturnsHardcodedWithoutSeed(t *tes
 	p := &Provider{}
 
 	tests := map[string]int{
-		"opus":       200_000,
-		"opus[1m]":   1_000_000,
-		"sonnet[1m]": 1_000_000,
-		"haiku":      200_000,
+		"opus":         200_000,
+		"opus[200K]":   200_000,
+		"opus[1m]":     1_000_000,
+		"opus[1M]":     1_000_000,
+		"sonnet":       200_000,
+		"sonnet[1m]":   1_000_000,
+		"sonnet[1M]":   1_000_000,
+		"sonnet[200K]": 200_000,
+		"haiku":        200_000,
 	}
 	for model, want := range tests {
 		t.Run(model, func(t *testing.T) {
@@ -276,6 +278,36 @@ func TestClaudeProvider_ModelCatalog_FallsBackToHardcoded(t *testing.T) {
 	want := p.defaultModelInfos()
 	if len(got) != len(want) {
 		t.Fatalf("ModelCatalog() len = %d, want %d", len(got), len(want))
+	}
+}
+
+func TestBuildInteractiveCommand_MapsDisplayContextModelsToClaudeCLIModels(t *testing.T) {
+	tests := []struct {
+		model string
+		want  string
+	}{
+		{"opus[200K]", "opus"},
+		{"opus[1M]", "opus[1m]"},
+		{"sonnet[200K]", "sonnet"},
+		{"sonnet[1M]", "sonnet[1m]"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.model, func(t *testing.T) {
+			args := buildInteractiveCommand(llm.CommandBuildOpts{Model: tt.model})
+			found := false
+			for i, arg := range args {
+				if arg != "--model" {
+					continue
+				}
+				found = true
+				if i+1 >= len(args) || args[i+1] != tt.want {
+					t.Fatalf("--model = %q, want %q; args=%v", args[i+1], tt.want, args)
+				}
+			}
+			if !found {
+				t.Fatalf("command args = %v, want --model", args)
+			}
+		})
 	}
 }
 

--- a/internal/llm/claude/provider_test.go
+++ b/internal/llm/claude/provider_test.go
@@ -179,15 +179,46 @@ func TestClaudeProviderDiscoverModelCatalog_PreservesUnattemptedFallbacksOnTimeo
 	for _, model := range models {
 		gotIDs = append(gotIDs, model.ID)
 	}
-	wantIDs := []string{"opus[200K]", "opus[1M]", "sonnet[200K]", "sonnet[1M]", "haiku"}
+	wantIDs := []string{"opus[1M]", "sonnet[200K]", "sonnet[1M]", "haiku[200K]"}
 	if !slices.Equal(gotIDs, wantIDs) {
 		t.Fatalf("model IDs = %v, want %v", gotIDs, wantIDs)
 	}
-	if models[0].ContextWindow != 1_000_000 || !slices.Equal(models[0].Aliases, []string{"opus", "claude-opus-4-8"}) {
+	if models[0].ContextWindow != 1_000_000 || !slices.Equal(models[0].Aliases, []string{"opus", "claude-opus-4-8", "opus[1m]"}) {
 		t.Fatalf("opus entry = %+v, want discovered metadata", models[0])
 	}
-	if models[len(models)-1].ID != "haiku" || models[len(models)-1].ContextWindow != 200_000 {
+	if models[len(models)-1].ID != "haiku[200K]" || models[len(models)-1].ContextWindow != 200_000 {
 		t.Fatalf("last entry = %+v, want fallback haiku", models[len(models)-1])
+	}
+}
+
+func TestClaudeProviderDiscoverModelCatalog_DerivesIDFromDiscoveredContextWindow(t *testing.T) {
+	p := &Provider{
+		runner: func(ctx context.Context, name string, args []string, env []string) ([]byte, error) {
+			if name != "claude" {
+				t.Fatalf("command name = %q, want claude", name)
+			}
+			switch model := args[1]; model {
+			case "opus":
+				return []byte(`{"type":"system","subtype":"init","model":"claude-opus-4-8"}` + "\n" +
+					`{"type":"result","subtype":"success","modelUsage":{"claude-opus-4-8":{"contextWindow":1000000}}}`), nil
+			default:
+				return nil, errors.New("model not available")
+			}
+		},
+	}
+
+	models, err := p.DiscoverModelCatalog(context.Background())
+	if err != nil {
+		t.Fatalf("DiscoverModelCatalog() error: %v", err)
+	}
+	if len(models) != 1 {
+		t.Fatalf("DiscoverModelCatalog() returned %d models, want 1: %+v", len(models), models)
+	}
+	if models[0].ID != "opus[1M]" {
+		t.Fatalf("model ID = %q, want opus[1M]", models[0].ID)
+	}
+	if !slices.Equal(models[0].Aliases, []string{"opus", "claude-opus-4-8"}) {
+		t.Fatalf("aliases = %v, want [opus claude-opus-4-8]", models[0].Aliases)
 	}
 }
 
@@ -207,7 +238,7 @@ func TestClaudeProvider_DefaultCatalog_Invariants(t *testing.T) {
 		"opus[1M]":     1_000_000,
 		"sonnet[200K]": 200_000,
 		"sonnet[1M]":   1_000_000,
-		"haiku":        200_000,
+		"haiku[200K]":  200_000,
 	}
 
 	for id, want := range wantWindows {
@@ -259,6 +290,7 @@ func TestClaudeProvider_ContextWindowForModel_ReturnsHardcodedWithoutSeed(t *tes
 		"sonnet[1m]":   1_000_000,
 		"sonnet[1M]":   1_000_000,
 		"sonnet[200K]": 200_000,
+		"haiku[200K]":  200_000,
 		"haiku":        200_000,
 	}
 	for model, want := range tests {
@@ -290,6 +322,7 @@ func TestProviderBuildCommand_UsesCatalogAliasForClaudeCLIModel(t *testing.T) {
 		{"opus[1M]", "opus[1m]"},
 		{"sonnet[200K]", "sonnet"},
 		{"sonnet[1M]", "sonnet[1m]"},
+		{"haiku[200K]", "haiku"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.model, func(t *testing.T) {

--- a/internal/llm/codex/discovery.go
+++ b/internal/llm/codex/discovery.go
@@ -103,12 +103,9 @@ func parseCodexModelCatalog(out []byte) ([]llm.ModelInfo, error) {
 			if label := llm.ContextWindowLabel(window); label != "" {
 				info.ID = llm.ModelWithContextWindow(id, window)
 				info.DisplayName = displayName + " (" + label + ")"
-				if i == 0 {
-					info.Aliases = llm.AppendUniqueAlias(info.Aliases, info.ID, id)
-				}
 			}
-			if id == "gpt-5.3-codex" && i == 0 {
-				info.Aliases = llm.AppendUniqueAlias(info.Aliases, info.ID, "codex")
+			if i == 0 {
+				info.Aliases = llm.AppendUniqueAlias(info.Aliases, info.ID, id)
 			}
 			models = append(models, info)
 		}

--- a/internal/llm/codex/discovery.go
+++ b/internal/llm/codex/discovery.go
@@ -87,31 +87,50 @@ func parseCodexModelCatalog(out []byte) ([]llm.ModelInfo, error) {
 			continue
 		}
 
-		contextWindow := raw.ContextWindow
-		if contextWindow <= 0 {
-			contextWindow = raw.MaxContextWindow
-		}
 		displayName := strings.TrimSpace(raw.DisplayName)
 		if displayName == "" {
 			displayName = codexDisplayNameFromSlug(id)
 		}
 
-		info := llm.ModelInfo{
-			ID:            id,
-			DisplayName:   displayName,
-			ContextWindow: contextWindow,
-			Category:      codexCategoryForDiscoveredModel(id),
+		windows := codexContextWindowOptions(raw.ContextWindow, raw.MaxContextWindow)
+		for i, window := range windows {
+			info := llm.ModelInfo{
+				ID:            id,
+				DisplayName:   displayName,
+				ContextWindow: window,
+				Category:      codexCategoryForDiscoveredModel(id),
+			}
+			if label := llm.ContextWindowLabel(window); label != "" {
+				info.ID = llm.ModelWithContextWindow(id, window)
+				info.DisplayName = displayName + " (" + label + ")"
+				if i == 0 {
+					info.Aliases = llm.AppendUniqueAlias(info.Aliases, info.ID, id)
+				}
+			}
+			if id == "gpt-5.3-codex" && i == 0 {
+				info.Aliases = llm.AppendUniqueAlias(info.Aliases, info.ID, "codex")
+			}
+			models = append(models, info)
 		}
-		if id == "gpt-5.3-codex" {
-			info.Aliases = []string{"codex"}
-		}
-		models = append(models, info)
 		seen[id] = true
 	}
 	if len(models) == 0 {
 		return nil, fmt.Errorf("codex model catalog contained no visible API-supported models")
 	}
 	return models, nil
+}
+
+func codexContextWindowOptions(contextWindow, maxContextWindow int) []int {
+	if contextWindow <= 0 {
+		if maxContextWindow > 0 {
+			return []int{maxContextWindow}
+		}
+		return []int{0}
+	}
+	if maxContextWindow > 0 && maxContextWindow != contextWindow {
+		return []int{contextWindow, maxContextWindow}
+	}
+	return []int{contextWindow}
 }
 
 func codexDisplayNameFromSlug(slug string) string {

--- a/internal/llm/codex/protocol.go
+++ b/internal/llm/codex/protocol.go
@@ -84,7 +84,7 @@ func NewProtocol(opts llm.ProtocolOpts) *Protocol {
 	}
 	return &Protocol{
 		opts:           opts,
-		model:          opts.Model,
+		model:          llm.StripModelContextWindow(opts.Model),
 		approvalPolicy: policy,
 	}
 }

--- a/internal/llm/codex/protocol_test.go
+++ b/internal/llm/codex/protocol_test.go
@@ -272,6 +272,28 @@ func TestCodexProtocolStartTurn_DeveloperInstructionsEncoding(t *testing.T) {
 	}
 }
 
+func TestCodexProtocol_StripsContextWindowFromModel(t *testing.T) {
+	var buf bytes.Buffer
+
+	p := NewProtocol(llm.ProtocolOpts{
+		Model:   "gpt-5.4[1M]",
+		WorkDir: "/tmp/test",
+	})
+	p.SetStdin(&buf)
+	p.SetThreadIDForTest("thread-123")
+
+	if err := p.startTurn("do something"); err != nil {
+		t.Fatalf("startTurn() error: %v", err)
+	}
+	got := buf.String()
+	if !strings.Contains(got, `"model":"gpt-5.4"`) {
+		t.Fatalf("startTurn payload = %s, want base model gpt-5.4", got)
+	}
+	if strings.Contains(got, "gpt-5.4[1M]") {
+		t.Fatalf("startTurn payload leaked context-window model ID: %s", got)
+	}
+}
+
 func TestTokenUsageUpdatedSurfacesAsSDKMessage(t *testing.T) {
 	p := NewProtocol(llm.ProtocolOpts{WorkDir: "/tmp/test"})
 	p.SetThreadIDForTest("thread-abc")

--- a/internal/llm/codex/provider.go
+++ b/internal/llm/codex/provider.go
@@ -100,6 +100,9 @@ func (p *Provider) BuildCommand(opts llm.CommandBuildOpts) ([]string, []string, 
 	if opts.EffortLevel != "" {
 		args = append(args, "-c", "model_reasoning_effort="+MapEffortLevel(opts.EffortLevel))
 	}
+	if window := p.contextWindowOverrideForModel(opts.Model); window > 0 {
+		args = append(args, "-c", fmt.Sprintf("model_context_window=%d", window))
+	}
 	// Enable live web search so agents can fetch current web pages.
 	args = append(args, "-c", "web_search=live")
 
@@ -177,6 +180,24 @@ func (p *Provider) ContextWindowForModel(model string) int {
 					return entry.ContextWindow
 				}
 			}
+		}
+	}
+	return 0
+}
+
+func (p *Provider) contextWindowOverrideForModel(model string) int {
+	if strings.TrimSpace(model) == "" || model == llm.StripModelContextWindow(model) {
+		return 0
+	}
+	p.mu.RLock()
+	cat := p.catalog
+	p.mu.RUnlock()
+	if len(cat) == 0 {
+		cat = p.defaultModelInfos()
+	}
+	for _, entry := range cat {
+		if strings.EqualFold(entry.ID, model) {
+			return entry.ContextWindow
 		}
 	}
 	return 0
@@ -311,17 +332,14 @@ func (p *Provider) OutputPricePerMToken(model string) float64 {
 //   - https://developers.openai.com/api/docs/models/gpt-5.4-mini
 //   - https://developers.openai.com/api/docs/models/gpt-5.3-codex
 //   - https://developers.openai.com/api/docs/models/gpt-5.2
-//
-// Note: gpt-5.4 has a 272K pricing inflection point (2× input / 1.5× output
-// above that) but the hard context limit is 1.05M. We encode the capacity,
-// not the pricing boundary.
 func (p *Provider) defaultModelInfos() []llm.ModelInfo {
 	return []llm.ModelInfo{
-		{ID: "gpt-5.5", DisplayName: "GPT-5.5", ContextWindow: 1_050_000, Category: "capable"},
-		{ID: "gpt-5.4", DisplayName: "GPT-5.4", ContextWindow: 1_050_000, Category: "capable"},
-		{ID: "gpt-5.4-mini", DisplayName: "GPT-5.4 Mini", ContextWindow: 400_000, Category: "balanced"},
-		{ID: "gpt-5.3-codex", DisplayName: "GPT-5.3 Codex", Aliases: []string{"codex"}, ContextWindow: 400_000, Category: "balanced"},
-		{ID: "gpt-5.2", DisplayName: "GPT-5.2", ContextWindow: 400_000},
+		{ID: "gpt-5.5[272K]", DisplayName: "GPT-5.5 (272K)", ContextWindow: 272_000, Aliases: []string{"gpt-5.5"}, Category: "capable"},
+		{ID: "gpt-5.4[272K]", DisplayName: "GPT-5.4 (272K)", ContextWindow: 272_000, Aliases: []string{"gpt-5.4"}, Category: "capable"},
+		{ID: "gpt-5.4[1M]", DisplayName: "GPT-5.4 (1M)", ContextWindow: 1_000_000, Category: "capable"},
+		{ID: "gpt-5.4-mini[400K]", DisplayName: "GPT-5.4 Mini (400K)", ContextWindow: 400_000, Aliases: []string{"gpt-5.4-mini"}, Category: "balanced"},
+		{ID: "gpt-5.3-codex[400K]", DisplayName: "GPT-5.3 Codex (400K)", Aliases: []string{"gpt-5.3-codex", "codex"}, ContextWindow: 400_000, Category: "balanced"},
+		{ID: "gpt-5.2[400K]", DisplayName: "GPT-5.2 (400K)", ContextWindow: 400_000, Aliases: []string{"gpt-5.2"}},
 	}
 }
 

--- a/internal/llm/codex/provider.go
+++ b/internal/llm/codex/provider.go
@@ -338,7 +338,7 @@ func (p *Provider) defaultModelInfos() []llm.ModelInfo {
 		{ID: "gpt-5.4[272K]", DisplayName: "GPT-5.4 (272K)", ContextWindow: 272_000, Aliases: []string{"gpt-5.4"}, Category: "capable"},
 		{ID: "gpt-5.4[1M]", DisplayName: "GPT-5.4 (1M)", ContextWindow: 1_000_000, Category: "capable"},
 		{ID: "gpt-5.4-mini[400K]", DisplayName: "GPT-5.4 Mini (400K)", ContextWindow: 400_000, Aliases: []string{"gpt-5.4-mini"}, Category: "balanced"},
-		{ID: "gpt-5.3-codex[400K]", DisplayName: "GPT-5.3 Codex (400K)", Aliases: []string{"gpt-5.3-codex", "codex"}, ContextWindow: 400_000, Category: "balanced"},
+		{ID: "gpt-5.3-codex[400K]", DisplayName: "GPT-5.3 Codex (400K)", Aliases: []string{"gpt-5.3-codex"}, ContextWindow: 400_000, Category: "balanced"},
 		{ID: "gpt-5.2[400K]", DisplayName: "GPT-5.2 (400K)", ContextWindow: 400_000, Aliases: []string{"gpt-5.2"}},
 	}
 }

--- a/internal/llm/codex/provider_test.go
+++ b/internal/llm/codex/provider_test.go
@@ -533,8 +533,8 @@ func TestParseCodexModelCatalog_FiltersAndMapsVisibleAPIModels(t *testing.T) {
 	if got := codexModel.DisplayName; got != "GPT-5.3 Codex (400K)" {
 		t.Errorf("gpt-5.3-codex display name = %q, want generated display name", got)
 	}
-	if !slices.Equal(codexModel.Aliases, []string{"gpt-5.3-codex", "codex"}) {
-		t.Errorf("gpt-5.3-codex aliases = %v, want [gpt-5.3-codex codex]", codexModel.Aliases)
+	if !slices.Equal(codexModel.Aliases, []string{"gpt-5.3-codex"}) {
+		t.Errorf("gpt-5.3-codex aliases = %v, want [gpt-5.3-codex]", codexModel.Aliases)
 	}
 	if got := codexModel.ContextWindow; got != 400_000 {
 		t.Errorf("gpt-5.3-codex context window = %d, want 400000", got)
@@ -648,7 +648,6 @@ func TestCodexProvider_ContextWindowForModel_ReturnsHardcodedWithoutSeed(t *test
 		"gpt-5.4-mini[400K]":  400_000,
 		"gpt-5.3-codex":       400_000,
 		"gpt-5.3-codex[400K]": 400_000,
-		"codex":               400_000, // alias of gpt-5.3-codex
 		"gpt-5.2":             400_000,
 		"gpt-5.2[400K]":       400_000,
 	}

--- a/internal/llm/codex/provider_test.go
+++ b/internal/llm/codex/provider_test.go
@@ -491,6 +491,7 @@ func TestParseCodexModelCatalog_FiltersAndMapsVisibleAPIModels(t *testing.T) {
 	catalogJSON := []byte(`{"models":[
 		{"slug":"gpt-5.5","display_name":"GPT-5.5","visibility":"list","supported_in_api":true,"context_window":272000,"max_context_window":272000},
 		{"slug":"codex-auto-review","display_name":"Codex Auto Review","visibility":"hide","supported_in_api":true,"context_window":272000},
+		{"slug":"gpt-5.4","display_name":"GPT-5.4","visibility":"list","supported_in_api":true,"context_window":272000,"max_context_window":1000000},
 		{"slug":"gpt-5.4-mini","display_name":"GPT-5.4-Mini","visibility":"list","supported_in_api":true,"context_window":272000},
 		{"slug":"gpt-5.3-codex","display_name":"","visibility":"list","supported_in_api":true,"context_window":400000},
 		{"slug":"private-model","display_name":"Private","visibility":"list","supported_in_api":false,"context_window":123000}
@@ -506,22 +507,34 @@ func TestParseCodexModelCatalog_FiltersAndMapsVisibleAPIModels(t *testing.T) {
 		gotIDs = append(gotIDs, model.ID)
 		byID[model.ID] = model
 	}
-	wantIDs := []string{"gpt-5.5", "gpt-5.4-mini", "gpt-5.3-codex"}
+	wantIDs := []string{"gpt-5.5[272K]", "gpt-5.4[272K]", "gpt-5.4[1M]", "gpt-5.4-mini[272K]", "gpt-5.3-codex[400K]"}
 	if !slices.Equal(gotIDs, wantIDs) {
 		t.Fatalf("model IDs = %v, want %v", gotIDs, wantIDs)
 	}
-	if got := byID["gpt-5.5"].Category; got != "capable" {
+	if got := byID["gpt-5.5[272K]"].Category; got != "capable" {
 		t.Errorf("gpt-5.5 category = %q, want capable", got)
 	}
-	if got := byID["gpt-5.4-mini"].Category; got != "balanced" {
+	if got := byID["gpt-5.4-mini[272K]"].Category; got != "balanced" {
 		t.Errorf("gpt-5.4-mini category = %q, want balanced", got)
 	}
-	codexModel := byID["gpt-5.3-codex"]
-	if got := codexModel.DisplayName; got != "GPT-5.3 Codex" {
+	if !slices.Equal(byID["gpt-5.5[272K]"].Aliases, []string{"gpt-5.5"}) {
+		t.Errorf("gpt-5.5[272K] aliases = %v, want [gpt-5.5]", byID["gpt-5.5[272K]"].Aliases)
+	}
+	if got := byID["gpt-5.4[272K]"].ContextWindow; got != 272_000 {
+		t.Errorf("gpt-5.4[272K] context window = %d, want 272000", got)
+	}
+	if got := byID["gpt-5.4[1M]"].ContextWindow; got != 1_000_000 {
+		t.Errorf("gpt-5.4[1M] context window = %d, want 1000000", got)
+	}
+	if !slices.Equal(byID["gpt-5.4[272K]"].Aliases, []string{"gpt-5.4"}) {
+		t.Errorf("gpt-5.4[272K] aliases = %v, want [gpt-5.4]", byID["gpt-5.4[272K]"].Aliases)
+	}
+	codexModel := byID["gpt-5.3-codex[400K]"]
+	if got := codexModel.DisplayName; got != "GPT-5.3 Codex (400K)" {
 		t.Errorf("gpt-5.3-codex display name = %q, want generated display name", got)
 	}
-	if !slices.Equal(codexModel.Aliases, []string{"codex"}) {
-		t.Errorf("gpt-5.3-codex aliases = %v, want [codex]", codexModel.Aliases)
+	if !slices.Equal(codexModel.Aliases, []string{"gpt-5.3-codex", "codex"}) {
+		t.Errorf("gpt-5.3-codex aliases = %v, want [gpt-5.3-codex codex]", codexModel.Aliases)
 	}
 	if got := codexModel.ContextWindow; got != 400_000 {
 		t.Errorf("gpt-5.3-codex context window = %d, want 400000", got)
@@ -552,8 +565,8 @@ func TestProviderDiscoverModelCatalog_FallsBackToBundledCatalog(t *testing.T) {
 	if err != nil {
 		t.Fatalf("DiscoverModelCatalog() error: %v", err)
 	}
-	if len(models) != 1 || models[0].ID != "gpt-5.4" {
-		t.Fatalf("DiscoverModelCatalog() = %+v, want gpt-5.4", models)
+	if len(models) != 1 || models[0].ID != "gpt-5.4[272K]" {
+		t.Fatalf("DiscoverModelCatalog() = %+v, want gpt-5.4[272K]", models)
 	}
 	wantCalls := [][]string{
 		{"debug", "models"},
@@ -569,6 +582,26 @@ func TestProviderDiscoverModelCatalog_FallsBackToBundledCatalog(t *testing.T) {
 	}
 }
 
+func TestProviderBuildCommand_AddsSelectedContextWindowOverride(t *testing.T) {
+	p := &Provider{}
+	homeDir := t.TempDir()
+	stateDir := t.TempDir()
+	t.Setenv("CODEX_HOME", "")
+	t.Setenv("HOME", homeDir)
+
+	cmd, env, err := p.BuildCommand(llm.CommandBuildOpts{
+		Model:    "gpt-5.4[1M]",
+		StateDir: stateDir,
+	})
+	if err != nil {
+		t.Fatalf("BuildCommand() error: %v", err)
+	}
+	if env != nil {
+		t.Fatalf("BuildCommand() env = %v, want nil", env)
+	}
+	assertConfigOverride(t, cmd, "model_context_window=1000000")
+}
+
 // TestCodexProvider_DefaultCatalog_Invariants locks in the hardcoded
 // Codex catalog that replaced the former discovery pipeline.
 func TestCodexProvider_DefaultCatalog_Invariants(t *testing.T) {
@@ -581,10 +614,12 @@ func TestCodexProvider_DefaultCatalog_Invariants(t *testing.T) {
 	}
 
 	wantWindows := map[string]int{
-		"gpt-5.4":       1_050_000,
-		"gpt-5.4-mini":  400_000,
-		"gpt-5.3-codex": 400_000,
-		"gpt-5.2":       400_000,
+		"gpt-5.5[272K]":       272_000,
+		"gpt-5.4[272K]":       272_000,
+		"gpt-5.4[1M]":         1_000_000,
+		"gpt-5.4-mini[400K]":  400_000,
+		"gpt-5.3-codex[400K]": 400_000,
+		"gpt-5.2[400K]":       400_000,
 	}
 	for id, want := range wantWindows {
 		m, ok := byID[id]
@@ -604,11 +639,18 @@ func TestCodexProvider_DefaultCatalog_Invariants(t *testing.T) {
 func TestCodexProvider_ContextWindowForModel_ReturnsHardcodedWithoutSeed(t *testing.T) {
 	p := &Provider{}
 	tests := map[string]int{
-		"gpt-5.4":       1_050_000,
-		"gpt-5.4-mini":  400_000,
-		"gpt-5.3-codex": 400_000,
-		"codex":         400_000, // alias of gpt-5.3-codex
-		"gpt-5.2":       400_000,
+		"gpt-5.5":             272_000,
+		"gpt-5.5[272K]":       272_000,
+		"gpt-5.4":             272_000,
+		"gpt-5.4[272K]":       272_000,
+		"gpt-5.4[1M]":         1_000_000,
+		"gpt-5.4-mini":        400_000,
+		"gpt-5.4-mini[400K]":  400_000,
+		"gpt-5.3-codex":       400_000,
+		"gpt-5.3-codex[400K]": 400_000,
+		"codex":               400_000, // alias of gpt-5.3-codex
+		"gpt-5.2":             400_000,
+		"gpt-5.2[400K]":       400_000,
 	}
 	for model, want := range tests {
 		t.Run(model, func(t *testing.T) {

--- a/internal/llm/codex/rates.go
+++ b/internal/llm/codex/rates.go
@@ -14,7 +14,11 @@
 
 package codex
 
-import "strings"
+import (
+	"strings"
+
+	"github.com/doordash-oss/agentic-orchestrator/internal/llm"
+)
 
 // tokenRate holds per-million-token pricing for a model.
 type tokenRate struct {
@@ -37,7 +41,7 @@ const defaultModel = "gpt-5.4"
 // It handles aliases (e.g. "codex" → "gpt-5.4") and falls back to
 // the default model rate for unrecognized gpt-* variants.
 func lookupRate(model string) (tokenRate, bool) {
-	m := strings.ToLower(model)
+	m := strings.ToLower(llm.StripModelContextWindow(model))
 
 	// Direct match first.
 	if r, ok := modelRates[m]; ok {

--- a/internal/llm/codex/rates.go
+++ b/internal/llm/codex/rates.go
@@ -38,8 +38,8 @@ var modelRates = map[string]tokenRate{
 const defaultModel = "gpt-5.4"
 
 // lookupRate resolves a model string to its token rate.
-// It handles aliases (e.g. "codex" → "gpt-5.4") and falls back to
-// the default model rate for unrecognized gpt-* variants.
+// It strips explicit context-window suffixes and falls back to the default
+// model rate for unrecognized gpt-* variants.
 func lookupRate(model string) (tokenRate, bool) {
 	m := strings.ToLower(llm.StripModelContextWindow(model))
 
@@ -48,8 +48,7 @@ func lookupRate(model string) (tokenRate, bool) {
 		return r, true
 	}
 
-	// "codex" is an alias for the default model.
-	if m == "codex" || m == "" {
+	if m == "" {
 		return modelRates[defaultModel], true
 	}
 

--- a/internal/llm/codex/rates_test.go
+++ b/internal/llm/codex/rates_test.go
@@ -28,7 +28,9 @@ func TestLookupRate(t *testing.T) {
 	}{
 		// Direct matches
 		{"gpt-5.4", true, 2.50, 15.00},
+		{"gpt-5.4[1M]", true, 2.50, 15.00},
 		{"gpt-5.4-mini", true, 0.75, 4.50},
+		{"gpt-5.4-mini[1M]", true, 0.75, 4.50},
 		{"gpt-5.3-codex", true, 1.75, 14.00},
 
 		// Aliases that should resolve to gpt-5.4 rates

--- a/internal/llm/codex/rates_test.go
+++ b/internal/llm/codex/rates_test.go
@@ -33,8 +33,7 @@ func TestLookupRate(t *testing.T) {
 		{"gpt-5.4-mini[1M]", true, 0.75, 4.50},
 		{"gpt-5.3-codex", true, 1.75, 14.00},
 
-		// Aliases that should resolve to gpt-5.4 rates
-		{"codex", true, 2.50, 15.00},
+		// Empty model uses the default model rate.
 		{"", true, 2.50, 15.00},
 
 		// Unknown gpt-* variants fall back to default
@@ -43,9 +42,8 @@ func TestLookupRate(t *testing.T) {
 
 		// Case insensitive
 		{"GPT-5.4", true, 2.50, 15.00},
-		{"Codex", true, 2.50, 15.00},
-
 		// Non-matching models
+		{"codex", false, 0, 0},
 		{"opus", false, 0, 0},
 		{"sonnet", false, 0, 0},
 		{"unknown", false, 0, 0},
@@ -77,12 +75,6 @@ func TestComputeCost(t *testing.T) {
 		t.Errorf("computeCost(gpt-5.4, 1M, 1M) = %f, want 17.50", cost)
 	}
 
-	// "codex" alias should produce the same result
-	costCodex := computeCost("codex", 1_000_000, 1_000_000)
-	if math.Abs(costCodex-17.50) > 0.001 {
-		t.Errorf("computeCost(codex, 1M, 1M) = %f, want 17.50", costCodex)
-	}
-
 	// Empty model should also work (default)
 	costEmpty := computeCost("", 1_000_000, 1_000_000)
 	if math.Abs(costEmpty-17.50) > 0.001 {
@@ -99,10 +91,10 @@ func TestComputeCost(t *testing.T) {
 func TestProviderComputeCost(t *testing.T) {
 	p := &Provider{}
 
-	// "codex" alias must produce non-zero cost
+	// The provider name is not a model alias.
 	cost := p.ComputeCost("codex", 1_000_000, 1_000_000)
-	if math.Abs(cost-17.50) > 0.001 {
-		t.Errorf("Provider.ComputeCost(codex, 1M, 1M) = %f, want 17.50", cost)
+	if cost != 0 {
+		t.Errorf("Provider.ComputeCost(codex, 1M, 1M) = %f, want 0", cost)
 	}
 
 	// gpt-5.4-mini rates

--- a/internal/llm/types.go
+++ b/internal/llm/types.go
@@ -14,15 +14,74 @@
 
 package llm
 
+import (
+	"strconv"
+	"strings"
+)
+
 // ModelInfo represents discovered metadata for a single model.
 // Pricing is handled at runtime by each provider's rate table (e.g. codex/rates.go),
 // not stored in discovery metadata.
 type ModelInfo struct {
-	ID            string   `yaml:"id"`                // CLI model name, e.g. "opus", "sonnet", "gpt-5.4"
+	ID            string   `yaml:"id"`                // Selectable model name, e.g. "opus[200K]", "gpt-5.4[1M]"
 	DisplayName   string   `yaml:"display_name"`      // Human-readable name
 	ContextWindow int      `yaml:"context_window"`    // Max tokens
-	Aliases       []string `yaml:"aliases,omitempty"` // Alternative names, e.g. ["opus[1m]"]
+	Aliases       []string `yaml:"aliases,omitempty"` // Alternative names, e.g. ["opus", "claude-opus-4-8"]
 	Category      string   `yaml:"category"`          // "cheap", "balanced", "capable"
+}
+
+// ContextWindowLabel formats a token window for compact model IDs.
+// Sub-million windows use K (e.g. 272K); million-scale windows use M
+// (e.g. 1M, 1.05M).
+func ContextWindowLabel(tokens int) string {
+	if tokens <= 0 {
+		return ""
+	}
+	if tokens < 1_000_000 {
+		return strconv.Itoa((tokens+500)/1000) + "K"
+	}
+	if tokens%1_000_000 == 0 {
+		return strconv.Itoa(tokens/1_000_000) + "M"
+	}
+	label := strconv.FormatFloat(float64(tokens)/1_000_000, 'f', 2, 64)
+	label = strings.TrimRight(strings.TrimRight(label, "0"), ".")
+	return label + "M"
+}
+
+// ModelWithContextWindow returns a display/selectable model ID with an
+// explicit context-window suffix.
+func ModelWithContextWindow(model string, tokens int) string {
+	label := ContextWindowLabel(tokens)
+	if strings.TrimSpace(model) == "" || label == "" {
+		return model
+	}
+	return model + "[" + label + "]"
+}
+
+// StripModelContextWindow removes a trailing [<window>] selector suffix.
+func StripModelContextWindow(model string) string {
+	if !strings.HasSuffix(model, "]") {
+		return model
+	}
+	if idx := strings.LastIndex(model, "["); idx > 0 {
+		return model[:idx]
+	}
+	return model
+}
+
+// AppendUniqueAlias returns aliases with alias appended if not already present
+// case-insensitively and not equal to the canonical ID.
+func AppendUniqueAlias(aliases []string, id, alias string) []string {
+	alias = strings.TrimSpace(alias)
+	if alias == "" || strings.EqualFold(alias, id) {
+		return aliases
+	}
+	for _, existing := range aliases {
+		if strings.EqualFold(existing, alias) {
+			return aliases
+		}
+	}
+	return append(aliases, alias)
 }
 
 // CatalogEnricher is implemented by providers whose model catalog can be

--- a/internal/llm/types_test.go
+++ b/internal/llm/types_test.go
@@ -274,6 +274,34 @@ func TestLargestContextFrom(t *testing.T) {
 	}
 }
 
+func TestContextWindowLabel(t *testing.T) {
+	tests := []struct {
+		tokens int
+		want   string
+	}{
+		{0, ""},
+		{272_000, "272K"},
+		{400_000, "400K"},
+		{1_000_000, "1M"},
+		{1_050_000, "1.05M"},
+		{2_000_000, "2M"},
+	}
+	for _, tt := range tests {
+		if got := llm.ContextWindowLabel(tt.tokens); got != tt.want {
+			t.Errorf("ContextWindowLabel(%d) = %q, want %q", tt.tokens, got, tt.want)
+		}
+	}
+}
+
+func TestModelContextWindowHelpers(t *testing.T) {
+	if got := llm.ModelWithContextWindow("gpt-5.4", 1_000_000); got != "gpt-5.4[1M]" {
+		t.Fatalf("ModelWithContextWindow() = %q, want gpt-5.4[1M]", got)
+	}
+	if got := llm.StripModelContextWindow("gpt-5.4[272K]"); got != "gpt-5.4" {
+		t.Fatalf("StripModelContextWindow() = %q, want gpt-5.4", got)
+	}
+}
+
 // --- test helpers ---
 
 func modelIDs(models []llm.ModelInfo) []string {


### PR DESCRIPTION
## Summary

Model catalogs now expose each context-window option as its own selectable model entry, rather than encoding a single hardcoded capacity per model.

- Model IDs carry an explicit context-window suffix: `opus[200K]`, `opus[1M]`, `sonnet[200K]`, `sonnet[1M]`, `gpt-5.5[272K]`, `gpt-5.4[272K]`, `gpt-5.4[1M]`, `gpt-5.4-mini[400K]`, `gpt-5.3-codex[400K]`, `gpt-5.2[400K]`.
- Bare names (`opus`, `gpt-5.4`, `codex`, …) and the concrete resolved IDs (`claude-opus-4-8`) become **aliases** of the default-window entry, so existing configs keep working.
- **Codex**: the selected window is passed through as a `model_context_window` config override (`-c model_context_window=<n>`). The base model name is stripped via `StripModelContextWindow` before it reaches the protocol payload and the rate lookup, so pricing/threading are unaffected by the suffix. Discovery now emits one entry per `(context_window, max_context_window)` pair.
- **Claude**: display IDs are mapped back to the CLI's expected `--model` inputs (`opus[200K]` → `opus`, `opus[1M]` → `opus[1m]`, etc.) in `buildInteractiveCommand` and the discovery probe. `[1M]` variants stay distinct catalog entries (never aliases of the base) to avoid silently downgrading a 1M selection to 200K.

New shared helpers in `internal/llm/types.go`:
- `ContextWindowLabel(tokens)` — compact `K`/`M` labels (`272K`, `1M`, `1.05M`).
- `ModelWithContextWindow(model, tokens)` / `StripModelContextWindow(model)` — add/remove the `[<window>]` suffix.
- `AppendUniqueAlias(aliases, id, alias)` — case-insensitive, dedup-aware alias appends.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./internal/llm/...`
- [x] `go test ./internal/llm/...` (all packages pass)
- Added coverage: context-window label formatting, suffix add/strip helpers, Claude CLI model mapping, Codex protocol model stripping, Codex `model_context_window` override wiring, and updated catalog/discovery invariants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)