### PR TITLE
Discover model catalogs concurrently with live progress

### DIFF
--- a/cmd/agentico/main.go
+++ b/cmd/agentico/main.go
@@ -326,9 +326,18 @@ func formatProviderNameList(providers []llm.LLMProvider) string {
 	return strings.Join(names, ", ")
 }
 
-func discoverProviderCatalogs(ctx context.Context, providers []llm.LLMProvider, cacheRoot string) []string {
-	var warnings []string
-	for _, p := range providers {
+type providerCatalogDiscoveryProgress func(provider string, model llm.ModelInfo)
+
+type providerCatalogDiscoveryJob struct {
+	index      int
+	provider   llm.LLMProvider
+	discoverer llm.CatalogDiscoverer
+	enricher   llm.CatalogEnricher
+}
+
+func discoverProviderCatalogs(ctx context.Context, providers []llm.LLMProvider, cacheRoot string, report providerCatalogDiscoveryProgress) []string {
+	var jobs []providerCatalogDiscoveryJob
+	for i, p := range providers {
 		discoverer, ok := p.(llm.CatalogDiscoverer)
 		if !ok {
 			continue
@@ -337,58 +346,119 @@ func discoverProviderCatalogs(ctx context.Context, providers []llm.LLMProvider, 
 		if !ok {
 			continue
 		}
+		jobs = append(jobs, providerCatalogDiscoveryJob{
+			index:      i,
+			provider:   p,
+			discoverer: discoverer,
+			enricher:   enricher,
+		})
+	}
+	if len(jobs) == 0 {
+		return nil
+	}
 
-		version := ""
-		if cacheRoot != "" {
-			if rawVersion, err := p.VersionInfo(); err == nil {
-				version = strings.TrimSpace(rawVersion)
-			}
+	warningsByProvider := make([][]string, len(providers))
+	var wg sync.WaitGroup
+	var reportMu sync.Mutex
+	reportProgress := func(provider string, model llm.ModelInfo) {
+		if report == nil {
+			return
 		}
-		if version != "" {
-			models, err := loadProviderCatalogCache(cacheRoot, p.Name(), version)
-			if err == nil {
-				enricher.SetModelCatalog(models)
-				continue
-			}
-			if !os.IsNotExist(err) {
-				warnings = append(warnings, fmt.Sprintf(
-					"Warning: ignoring cached %s model catalog; refreshing: %v",
-					p.Name(),
-					err,
-				))
-			}
-		}
+		reportMu.Lock()
+		defer reportMu.Unlock()
+		report(provider, model)
+	}
+	wg.Add(len(jobs))
+	for _, job := range jobs {
+		go func(job providerCatalogDiscoveryJob) {
+			defer wg.Done()
+			warningsByProvider[job.index] = discoverOneProviderCatalog(ctx, job.provider, job.discoverer, job.enricher, cacheRoot, reportProgress)
+		}(job)
+	}
+	wg.Wait()
 
-		discoveryCtx, cancel := context.WithTimeout(ctx, providerCatalogDiscoveryTimeout)
-		models, err := discoverer.DiscoverModelCatalog(discoveryCtx)
-		cancel()
-		if err != nil {
+	var warnings []string
+	for _, providerWarnings := range warningsByProvider {
+		warnings = append(warnings, providerWarnings...)
+	}
+	return warnings
+}
+
+func discoverOneProviderCatalog(ctx context.Context, p llm.LLMProvider, discoverer llm.CatalogDiscoverer, enricher llm.CatalogEnricher, cacheRoot string, report providerCatalogDiscoveryProgress) []string {
+	var warnings []string
+	providerName := p.Name()
+	reportModel := func(model llm.ModelInfo) {
+		if report != nil {
+			report(providerName, model)
+		}
+	}
+
+	version := ""
+	if cacheRoot != "" {
+		if rawVersion, err := p.VersionInfo(); err == nil {
+			version = strings.TrimSpace(rawVersion)
+		}
+	}
+	if version != "" {
+		models, err := loadProviderCatalogCache(cacheRoot, providerName, version)
+		if err == nil {
+			enricher.SetModelCatalog(models)
+			return nil
+		}
+		if !os.IsNotExist(err) {
 			warnings = append(warnings, fmt.Sprintf(
-				"Warning: could not discover %s model catalog; using built-in fallback: %v",
-				p.Name(),
+				"Warning: ignoring cached %s model catalog; refreshing: %v",
+				providerName,
 				err,
 			))
-			continue
 		}
-		if len(models) == 0 {
+	}
+
+	discoveryCtx, cancel := context.WithTimeout(ctx, providerCatalogDiscoveryTimeout)
+	models, err := discoverModelCatalog(discoveryCtx, discoverer, reportModel)
+	cancel()
+	if err != nil {
+		warnings = append(warnings, fmt.Sprintf(
+			"Warning: could not discover %s model catalog; using built-in fallback: %v",
+			providerName,
+			err,
+		))
+		return warnings
+	}
+	if len(models) == 0 {
+		warnings = append(warnings, fmt.Sprintf(
+			"Warning: discovered empty %s model catalog; using built-in fallback",
+			providerName,
+		))
+		return warnings
+	}
+	enricher.SetModelCatalog(models)
+	if version != "" {
+		if err := saveProviderCatalogCache(cacheRoot, providerName, version, models); err != nil {
 			warnings = append(warnings, fmt.Sprintf(
-				"Warning: discovered empty %s model catalog; using built-in fallback",
-				p.Name(),
+				"Warning: could not cache %s model catalog: %v",
+				providerName,
+				err,
 			))
-			continue
-		}
-		enricher.SetModelCatalog(models)
-		if version != "" {
-			if err := saveProviderCatalogCache(cacheRoot, p.Name(), version, models); err != nil {
-				warnings = append(warnings, fmt.Sprintf(
-					"Warning: could not cache %s model catalog: %v",
-					p.Name(),
-					err,
-				))
-			}
 		}
 	}
 	return warnings
+}
+
+func discoverModelCatalog(ctx context.Context, discoverer llm.CatalogDiscoverer, report llm.ModelDiscoveryReporter) ([]llm.ModelInfo, error) {
+	if progressDiscoverer, ok := discoverer.(llm.CatalogProgressDiscoverer); ok {
+		return progressDiscoverer.DiscoverModelCatalogWithProgress(ctx, report)
+	}
+	models, err := discoverer.DiscoverModelCatalog(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if report != nil {
+		for _, model := range models {
+			report(model)
+		}
+	}
+	return models, nil
 }
 
 func showProviderStartupNotices(w io.Writer, notices []string, delay time.Duration) {
@@ -566,9 +636,9 @@ func runTUI(configPath, stateDir string, dangerouslySkipPerms bool, enabledProvi
 		}
 	}
 
-	stop = startSyncSpinner(os.Stderr, "Discovering models")
-	catalogWarnings := discoverProviderCatalogs(context.Background(), detected, filepath.Dir(stateDir))
-	stop()
+	modelDiscovery := newModelDiscoveryProgressPrinter(os.Stderr)
+	catalogWarnings := discoverProviderCatalogs(context.Background(), detected, filepath.Dir(stateDir), modelDiscovery.Report)
+	modelDiscovery.Done()
 	for _, w := range catalogWarnings {
 		fmt.Fprintln(os.Stderr, w)
 	}
@@ -642,20 +712,82 @@ func overrideColorProfile() (colorprofile.Profile, bool) {
 	return 0, false
 }
 
+type modelDiscoveryProgressPrinter struct {
+	mu      sync.Mutex
+	w       io.Writer
+	stop    func(doneLine bool)
+	stopped bool
+}
+
+func newModelDiscoveryProgressPrinter(w io.Writer) *modelDiscoveryProgressPrinter {
+	return &modelDiscoveryProgressPrinter{
+		w:    w,
+		stop: startSyncSpinnerControl(w, "Discovering models"),
+	}
+}
+
+func (p *modelDiscoveryProgressPrinter) Report(provider string, model llm.ModelInfo) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.stopSpinnerLocked(false)
+	fmt.Fprintf(
+		p.w,
+		"Discovered: %s - %s\n",
+		startupProviderDisplayName(provider),
+		startupModelDisplayName(model),
+	)
+}
+
+func (p *modelDiscoveryProgressPrinter) Done() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.stopSpinnerLocked(true)
+}
+
+func (p *modelDiscoveryProgressPrinter) stopSpinnerLocked(doneLine bool) {
+	if p.stopped {
+		return
+	}
+	p.stop(doneLine)
+	p.stopped = true
+}
+
+func startupProviderDisplayName(provider string) string {
+	provider = strings.TrimSpace(provider)
+	if provider == "" {
+		return "Provider"
+	}
+	return strings.ToUpper(provider[:1]) + provider[1:]
+}
+
+func startupModelDisplayName(model llm.ModelInfo) string {
+	if displayName := strings.TrimSpace(model.DisplayName); displayName != "" {
+		return displayName
+	}
+	return strings.TrimSpace(model.ID)
+}
+
 // startSyncSpinner shows a "<msg>..." startup indicator on w. On a TTY the
 // trailing dots animate so the user can tell the process is still doing work;
 // on a non-TTY (CI, piped output) a single static line is printed instead. The
 // returned stop() blocks until the animation goroutine has cleared its line, so
 // subsequent writes to w don't collide with the spinner.
 func startSyncSpinner(w io.Writer, msg string) func() {
+	stop := startSyncSpinnerControl(w, msg)
+	return func() {
+		stop(true)
+	}
+}
+
+func startSyncSpinnerControl(w io.Writer, msg string) func(doneLine bool) {
 	f, _ := w.(*os.File)
 	isTTY := f != nil && term.IsTerminal(int(f.Fd()))
 	if !isTTY {
 		fmt.Fprintf(w, "%s...\n", msg)
-		return func() {}
+		return func(bool) {}
 	}
 
-	done := make(chan struct{})
+	done := make(chan bool)
 	var wg sync.WaitGroup
 	wg.Go(func() {
 		frames := []string{".  ", ".. ", "..."}
@@ -665,9 +797,13 @@ func startSyncSpinner(w io.Writer, msg string) func() {
 		defer ticker.Stop()
 		for {
 			select {
-			case <-done:
+			case doneLine := <-done:
 				clear := strings.Repeat(" ", len(msg)+len(frames[0]))
-				fmt.Fprintf(w, "\r%s\r%s... done\n", clear, msg)
+				if doneLine {
+					fmt.Fprintf(w, "\r%s\r%s... done\n", clear, msg)
+				} else {
+					fmt.Fprintf(w, "\r%s\r", clear)
+				}
 				return
 			case <-ticker.C:
 				i = (i + 1) % len(frames)
@@ -675,8 +811,8 @@ func startSyncSpinner(w io.Writer, msg string) func() {
 			}
 		}
 	})
-	return func() {
-		close(done)
+	return func(doneLine bool) {
+		done <- doneLine
 		wg.Wait()
 	}
 }

--- a/cmd/agentico/main_test.go
+++ b/cmd/agentico/main_test.go
@@ -70,10 +70,14 @@ type stubCatalogDiscoveryProvider struct {
 	versionInfo string
 	versionErr  error
 	discoveries int
+	discoverFn  func(context.Context) ([]llm.ModelInfo, error)
 }
 
-func (s *stubCatalogDiscoveryProvider) DiscoverModelCatalog(context.Context) ([]llm.ModelInfo, error) {
+func (s *stubCatalogDiscoveryProvider) DiscoverModelCatalog(ctx context.Context) ([]llm.ModelInfo, error) {
 	s.discoveries++
+	if s.discoverFn != nil {
+		return s.discoverFn(ctx)
+	}
 	return s.discovered, s.discoverErr
 }
 
@@ -104,7 +108,7 @@ func TestDiscoverProviderCatalogsSetsCatalogAndWarnsOnFailure(t *testing.T) {
 	}
 	plain := &stubProvider{name: "plain", hasCLI: true}
 
-	warnings := discoverProviderCatalogs(context.Background(), []llm.LLMProvider{success, failure, plain}, t.TempDir())
+	warnings := discoverProviderCatalogs(context.Background(), []llm.LLMProvider{success, failure, plain}, t.TempDir(), nil)
 	if len(success.catalog) != 1 || success.catalog[0].ID != "live-model" {
 		t.Fatalf("success catalog = %+v, want live-model", success.catalog)
 	}
@@ -116,6 +120,88 @@ func TestDiscoverProviderCatalogsSetsCatalogAndWarnsOnFailure(t *testing.T) {
 	}
 	if !strings.Contains(warnings[0], "failure") || !strings.Contains(warnings[0], "catalog unavailable") {
 		t.Fatalf("warning = %q, want provider name and error", warnings[0])
+	}
+}
+
+func TestDiscoverProviderCatalogsReportsDiscoveredModels(t *testing.T) {
+	p := &stubCatalogDiscoveryProvider{
+		stubProvider: stubProvider{name: "success", hasCLI: true},
+		discovered: []llm.ModelInfo{
+			{ID: "live-model", DisplayName: "Live Model", ContextWindow: 123_000, Category: "capable"},
+		},
+	}
+	var reported []string
+
+	warnings := discoverProviderCatalogs(context.Background(), []llm.LLMProvider{p}, "", func(provider string, model llm.ModelInfo) {
+		reported = append(reported, provider+":"+model.DisplayName)
+	})
+	if len(warnings) != 0 {
+		t.Fatalf("warnings = %v, want none", warnings)
+	}
+	if !slices.Equal(reported, []string{"success:Live Model"}) {
+		t.Fatalf("reported = %v, want discovered model", reported)
+	}
+}
+
+func TestDiscoverProviderCatalogsRunsProvidersConcurrently(t *testing.T) {
+	started := make(chan string, 2)
+	release := make(chan struct{})
+	closeRelease := func() {
+		select {
+		case <-release:
+		default:
+			close(release)
+		}
+	}
+	defer closeRelease()
+
+	provider := func(name string) *stubCatalogDiscoveryProvider {
+		return &stubCatalogDiscoveryProvider{
+			stubProvider: stubProvider{name: name, hasCLI: true},
+			discoverFn: func(ctx context.Context) ([]llm.ModelInfo, error) {
+				started <- name
+				select {
+				case <-release:
+					return []llm.ModelInfo{{ID: name + "-model", DisplayName: name + " Model"}}, nil
+				case <-ctx.Done():
+					return nil, ctx.Err()
+				}
+			},
+		}
+	}
+	first := provider("first")
+	second := provider("second")
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	done := make(chan []string, 1)
+	go func() {
+		done <- discoverProviderCatalogs(ctx, []llm.LLMProvider{first, second}, "", nil)
+	}()
+
+	seen := make(map[string]bool)
+	for len(seen) < 2 {
+		select {
+		case name := <-started:
+			seen[name] = true
+		case <-time.After(250 * time.Millisecond):
+			closeRelease()
+			select {
+			case <-done:
+			case <-time.After(time.Second):
+			}
+			t.Fatalf("providers did not start concurrently; started = %v", seen)
+		}
+	}
+
+	closeRelease()
+	select {
+	case warnings := <-done:
+		if len(warnings) != 0 {
+			t.Fatalf("warnings = %v, want none", warnings)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("discoverProviderCatalogs did not return after releasing providers")
 	}
 }
 
@@ -133,7 +219,7 @@ func TestDiscoverProviderCatalogsLoadsVersionedCache(t *testing.T) {
 		discoverErr:  errors.New("discovery should not run"),
 	}
 
-	warnings := discoverProviderCatalogs(context.Background(), []llm.LLMProvider{p}, cacheRoot)
+	warnings := discoverProviderCatalogs(context.Background(), []llm.LLMProvider{p}, cacheRoot, nil)
 	if len(warnings) != 0 {
 		t.Fatalf("warnings = %v, want none", warnings)
 	}
@@ -156,7 +242,7 @@ func TestDiscoverProviderCatalogsWritesVersionedCacheOnMiss(t *testing.T) {
 		discovered:   discovered,
 	}
 
-	warnings := discoverProviderCatalogs(context.Background(), []llm.LLMProvider{p}, cacheRoot)
+	warnings := discoverProviderCatalogs(context.Background(), []llm.LLMProvider{p}, cacheRoot, nil)
 	if len(warnings) != 0 {
 		t.Fatalf("warnings = %v, want none", warnings)
 	}
@@ -189,7 +275,7 @@ func TestDiscoverProviderCatalogsRefreshesCorruptVersionedCache(t *testing.T) {
 		},
 	}
 
-	warnings := discoverProviderCatalogs(context.Background(), []llm.LLMProvider{p}, cacheRoot)
+	warnings := discoverProviderCatalogs(context.Background(), []llm.LLMProvider{p}, cacheRoot, nil)
 	if len(warnings) != 1 || !strings.Contains(warnings[0], "ignoring cached corrupt model catalog") {
 		t.Fatalf("warnings = %v, want corrupt cache warning", warnings)
 	}

--- a/internal/llm/claude/discovery.go
+++ b/internal/llm/claude/discovery.go
@@ -19,8 +19,10 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
+	"sync"
 
 	"github.com/doordash-oss/agentic-orchestrator/internal/llm"
 	"github.com/doordash-oss/agentic-orchestrator/internal/llm/clirun"
@@ -45,44 +47,95 @@ const (
 // ctx is cancelled partway through — keeps its hardcoded fallback catalog
 // metadata as a fallback.
 func (p *Provider) DiscoverModelCatalog(ctx context.Context) ([]llm.ModelInfo, error) {
+	return p.DiscoverModelCatalogWithProgress(ctx, nil)
+}
+
+// DiscoverModelCatalogWithProgress resolves Claude selectors concurrently and
+// reports each successful probe as soon as it completes. The final catalog is
+// still returned in the curated selector order so model defaults stay stable.
+func (p *Provider) DiscoverModelCatalogWithProgress(ctx context.Context, report llm.ModelDiscoveryReporter) ([]llm.ModelInfo, error) {
 	runner := p.runner
 	if runner == nil {
 		runner = clirun.DefaultRunner()
 	}
 
 	candidates := claudeModelProbeCandidates()
+	results := make([]claudeModelProbeResult, len(candidates))
+	var wg sync.WaitGroup
+	var reportMu sync.Mutex
+	reported := make(map[string]bool, len(candidates))
+	wg.Add(len(candidates))
+	for i, candidate := range candidates {
+		go func(i int, candidate claudeModelProbeCandidate) {
+			defer wg.Done()
+			if err := ctx.Err(); err != nil {
+				results[i] = claudeModelProbeResult{candidate: candidate, err: err}
+				return
+			}
+			resolved, contextWindow, err := probeClaudeModel(ctx, runner, candidate)
+			if err != nil {
+				results[i] = claudeModelProbeResult{candidate: candidate, err: err}
+				return
+			}
+
+			info := claudeModelInfoFromProbe(candidate, contextWindow, resolved)
+			results[i] = claudeModelProbeResult{candidate: candidate, info: info}
+			reportClaudeModelDiscovery(report, info, &reportMu, reported)
+		}(i, candidate)
+	}
+	wg.Wait()
+
 	models := make([]llm.ModelInfo, 0, len(candidates))
 	var failures []string
-	for i, candidate := range candidates {
-		if err := ctx.Err(); err != nil {
-			if len(models) > 0 {
-				models = appendClaudeFallbacks(models, candidates[i:])
+	var canceled []claudeModelProbeCandidate
+	for _, result := range results {
+		if result.err != nil {
+			if errors.Is(result.err, context.Canceled) || errors.Is(result.err, context.DeadlineExceeded) {
+				canceled = append(canceled, result.candidate)
+			} else {
+				failures = append(failures, fmt.Sprintf("%s: %v", result.candidate.Selector, result.err))
 			}
-			break
-		}
-		resolved, contextWindow, err := probeClaudeModel(ctx, runner, candidate)
-		if err != nil {
-			if ctx.Err() != nil {
-				if len(models) > 0 {
-					models = appendClaudeFallbacks(models, candidates[i:])
-				}
-				break
-			}
-			failures = append(failures, fmt.Sprintf("%s: %v", candidate.Selector, err))
 			continue
 		}
-
-		info := claudeModelInfoFromProbe(candidate, contextWindow, resolved)
-		models = appendClaudeModelInfo(models, info)
+		models = appendClaudeModelInfo(models, result.info)
+	}
+	if len(canceled) > 0 && len(models) > 0 {
+		models = appendClaudeFallbacks(models, canceled)
 	}
 
 	if len(models) == 0 {
-		if len(failures) == 0 && ctx.Err() != nil {
-			return nil, ctx.Err()
+		if len(failures) == 0 {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
+			if len(canceled) > 0 {
+				return nil, fmt.Errorf("no Claude model probes succeeded before cancellation")
+			}
 		}
 		return nil, fmt.Errorf("no Claude model probes succeeded: %s", strings.Join(failures, "; "))
 	}
 	return models, nil
+}
+
+type claudeModelProbeResult struct {
+	candidate claudeModelProbeCandidate
+	info      llm.ModelInfo
+	err       error
+}
+
+func reportClaudeModelDiscovery(report llm.ModelDiscoveryReporter, info llm.ModelInfo, mu *sync.Mutex, reported map[string]bool) {
+	if report == nil {
+		return
+	}
+	key := strings.ToLower(info.ID)
+	mu.Lock()
+	if reported[key] {
+		mu.Unlock()
+		return
+	}
+	reported[key] = true
+	mu.Unlock()
+	report(info)
 }
 
 func probeClaudeModel(ctx context.Context, runner clirun.CommandRunner, candidate claudeModelProbeCandidate) (string, int, error) {

--- a/internal/llm/claude/provider_test.go
+++ b/internal/llm/claude/provider_test.go
@@ -20,6 +20,7 @@ import (
 	"slices"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/doordash-oss/agentic-orchestrator/internal/llm"
 )
@@ -212,7 +213,143 @@ func TestClaudeProviderDiscoverModelCatalog_RetriesTransientProbeFailure(t *test
 	}
 }
 
-func TestClaudeProviderDiscoverModelCatalog_PreservesUnattemptedFallbacksOnTimeout(t *testing.T) {
+func TestClaudeProviderDiscoverModelCatalog_ProbesCandidatesConcurrently(t *testing.T) {
+	candidates := claudeModelProbeCandidates()
+	started := make(chan string, len(candidates)*claudeModelProbeAttempts)
+	release := make(chan struct{})
+	closeRelease := func() {
+		select {
+		case <-release:
+		default:
+			close(release)
+		}
+	}
+	defer closeRelease()
+
+	p := &Provider{
+		runner: func(ctx context.Context, name string, args []string, env []string) ([]byte, error) {
+			if name != "claude" {
+				t.Fatalf("command name = %q, want claude", name)
+			}
+			model := args[1]
+			started <- model
+			select {
+			case <-release:
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+			if model == "fable" {
+				return []byte(`{"type":"system","subtype":"init","model":"claude-fable-5"}` + "\n" +
+					`{"type":"result","subtype":"success","modelUsage":{"claude-fable-5":{"contextWindow":1000000}}}`), nil
+			}
+			return nil, errors.New("model not available")
+		},
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		models, err := p.DiscoverModelCatalog(context.Background())
+		if err == nil && (len(models) != 1 || models[0].ID != "fable[1M]") {
+			err = errors.New("expected only fable[1M] after releasing blocked probes")
+		}
+		done <- err
+	}()
+
+	seen := make(map[string]bool, len(candidates))
+	for len(seen) < len(candidates) {
+		select {
+		case model := <-started:
+			seen[model] = true
+		case <-time.After(250 * time.Millisecond):
+			closeRelease()
+			<-done
+			t.Fatalf("Claude probes did not start concurrently; started = %v", seen)
+		}
+	}
+
+	closeRelease()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("DiscoverModelCatalog did not return after releasing probes")
+	}
+}
+
+func TestClaudeProviderDiscoverModelCatalogWithProgress_ReportsBeforeReturn(t *testing.T) {
+	release := make(chan struct{})
+	closeRelease := func() {
+		select {
+		case <-release:
+		default:
+			close(release)
+		}
+	}
+	defer closeRelease()
+
+	p := &Provider{
+		runner: func(ctx context.Context, name string, args []string, env []string) ([]byte, error) {
+			if name != "claude" {
+				t.Fatalf("command name = %q, want claude", name)
+			}
+			model := args[1]
+			if model == "fable" {
+				return []byte(`{"type":"system","subtype":"init","model":"claude-fable-5"}` + "\n" +
+					`{"type":"result","subtype":"success","modelUsage":{"claude-fable-5":{"contextWindow":1000000}}}`), nil
+			}
+			select {
+			case <-release:
+				return nil, errors.New("model not available")
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+		},
+	}
+
+	reported := make(chan string, 1)
+	done := make(chan error, 1)
+	go func() {
+		_, err := p.DiscoverModelCatalogWithProgress(context.Background(), func(model llm.ModelInfo) {
+			reported <- model.ID
+		})
+		done <- err
+	}()
+
+	select {
+	case id := <-reported:
+		if id != "fable[1M]" {
+			t.Fatalf("reported model = %q, want fable[1M]", id)
+		}
+	case <-time.After(250 * time.Millisecond):
+		closeRelease()
+		<-done
+		t.Fatal("expected progress report before blocked probes returned")
+	}
+
+	select {
+	case err := <-done:
+		closeRelease()
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Fatal("DiscoverModelCatalogWithProgress returned before blocked probes were released")
+	default:
+	}
+
+	closeRelease()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("DiscoverModelCatalogWithProgress did not return after releasing probes")
+	}
+}
+
+func TestClaudeProviderDiscoverModelCatalog_PreservesCanceledFallbacksOnTimeout(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	p := &Provider{
 		runner: func(ctx context.Context, name string, args []string, env []string) ([]byte, error) {
@@ -221,7 +358,8 @@ func TestClaudeProviderDiscoverModelCatalog_PreservesUnattemptedFallbacksOnTimeo
 			}
 			model := args[1]
 			if model != "fable" {
-				t.Fatalf("runner should only be called for fable before cancellation, got %s", model)
+				<-ctx.Done()
+				return nil, ctx.Err()
 			}
 			cancel()
 			return []byte(`{"type":"system","subtype":"init","model":"claude-fable-5"}` + "\n" +

--- a/internal/llm/codex/discovery.go
+++ b/internal/llm/codex/discovery.go
@@ -42,6 +42,12 @@ type codexDiscoveredModel struct {
 // `codex debug models`. The command refreshes from Codex's remote catalog by
 // default; if that path fails, we fall back to the catalog bundled in the CLI.
 func (p *Provider) DiscoverModelCatalog(ctx context.Context) ([]llm.ModelInfo, error) {
+	return p.DiscoverModelCatalogWithProgress(ctx, nil)
+}
+
+// DiscoverModelCatalogWithProgress refreshes Codex's model catalog and reports
+// each parsed visible model before returning the final catalog.
+func (p *Provider) DiscoverModelCatalogWithProgress(ctx context.Context, report llm.ModelDiscoveryReporter) ([]llm.ModelInfo, error) {
 	runner := p.runner
 	if runner == nil {
 		runner = clirun.DefaultRunner()
@@ -49,7 +55,7 @@ func (p *Provider) DiscoverModelCatalog(ctx context.Context) ([]llm.ModelInfo, e
 
 	out, err := runner(ctx, "codex", []string{"debug", "models"}, nil)
 	if err == nil {
-		models, parseErr := parseCodexModelCatalog(out)
+		models, parseErr := parseCodexModelCatalogWithProgress(out, report)
 		if parseErr == nil {
 			return models, nil
 		}
@@ -60,7 +66,7 @@ func (p *Provider) DiscoverModelCatalog(ctx context.Context) ([]llm.ModelInfo, e
 	if bundledErr != nil {
 		return nil, fmt.Errorf("running codex debug models: %w; bundled fallback: %v", err, bundledErr)
 	}
-	models, parseErr := parseCodexModelCatalog(bundled)
+	models, parseErr := parseCodexModelCatalogWithProgress(bundled, report)
 	if parseErr != nil {
 		return nil, fmt.Errorf("parsing codex bundled model catalog after live catalog failure (%v): %w", err, parseErr)
 	}
@@ -68,6 +74,10 @@ func (p *Provider) DiscoverModelCatalog(ctx context.Context) ([]llm.ModelInfo, e
 }
 
 func parseCodexModelCatalog(out []byte) ([]llm.ModelInfo, error) {
+	return parseCodexModelCatalogWithProgress(out, nil)
+}
+
+func parseCodexModelCatalogWithProgress(out []byte, report llm.ModelDiscoveryReporter) ([]llm.ModelInfo, error) {
 	var payload codexModelCatalogPayload
 	if err := json.Unmarshal(out, &payload); err != nil {
 		return nil, fmt.Errorf("parse codex model catalog JSON: %w", err)
@@ -108,6 +118,9 @@ func parseCodexModelCatalog(out []byte) ([]llm.ModelInfo, error) {
 				info.Aliases = llm.AppendUniqueAlias(info.Aliases, info.ID, id)
 			}
 			models = append(models, info)
+			if report != nil {
+				report(info)
+			}
 		}
 		seen[id] = true
 	}

--- a/internal/llm/codex/provider_test.go
+++ b/internal/llm/codex/provider_test.go
@@ -541,6 +541,33 @@ func TestParseCodexModelCatalog_FiltersAndMapsVisibleAPIModels(t *testing.T) {
 	}
 }
 
+func TestParseCodexModelCatalogWithProgress_ReportsVisibleAPIModels(t *testing.T) {
+	catalogJSON := []byte(`{"models":[
+		{"slug":"gpt-5.5","display_name":"GPT-5.5","visibility":"list","supported_in_api":true,"context_window":272000,"max_context_window":272000},
+		{"slug":"hidden-model","display_name":"Hidden","visibility":"hide","supported_in_api":true,"context_window":272000},
+		{"slug":"gpt-5.4","display_name":"GPT-5.4","visibility":"list","supported_in_api":true,"context_window":272000,"max_context_window":1000000}
+	]}`)
+	var reported []string
+
+	models, err := parseCodexModelCatalogWithProgress(catalogJSON, func(model llm.ModelInfo) {
+		reported = append(reported, model.ID)
+	})
+	if err != nil {
+		t.Fatalf("parseCodexModelCatalogWithProgress() error: %v", err)
+	}
+	gotIDs := make([]string, 0, len(models))
+	for _, model := range models {
+		gotIDs = append(gotIDs, model.ID)
+	}
+	wantIDs := []string{"gpt-5.5[272K]", "gpt-5.4[272K]", "gpt-5.4[1M]"}
+	if !slices.Equal(gotIDs, wantIDs) {
+		t.Fatalf("model IDs = %v, want %v", gotIDs, wantIDs)
+	}
+	if !slices.Equal(reported, wantIDs) {
+		t.Fatalf("reported = %v, want %v", reported, wantIDs)
+	}
+}
+
 func TestProviderDiscoverModelCatalog_FallsBackToBundledCatalog(t *testing.T) {
 	var calls [][]string
 	p := &Provider{

--- a/internal/llm/provider.go
+++ b/internal/llm/provider.go
@@ -113,6 +113,17 @@ type CatalogDiscoverer interface {
 	DiscoverModelCatalog(ctx context.Context) ([]ModelInfo, error)
 }
 
+// ModelDiscoveryReporter receives models as soon as a provider discovers them.
+// It is best-effort and should be safe to call from provider discovery
+// goroutines.
+type ModelDiscoveryReporter func(ModelInfo)
+
+// CatalogProgressDiscoverer is implemented by providers that can stream
+// model discovery progress before returning the final catalog.
+type CatalogProgressDiscoverer interface {
+	DiscoverModelCatalogWithProgress(ctx context.Context, report ModelDiscoveryReporter) ([]ModelInfo, error)
+}
+
 // Protocol handles the wire-level communication with a provider's CLI process.
 // One instance is created per session. Implementations hold provider-specific
 // state (e.g. Codex thread IDs, handshake channels).


### PR DESCRIPTION
## Summary

Speeds up startup model discovery and surfaces live feedback while it runs.

- **Concurrent provider discovery** — `discoverProviderCatalogs` now fans each provider's catalog discovery out to its own goroutine instead of probing them serially, collecting warnings per-provider and preserving deterministic ordering.
- **Concurrent Claude probes** — `DiscoverModelCatalog` resolves all Claude selector candidates in parallel, then reassembles the catalog in curated selector order so model defaults stay stable. Canceled/timed-out probes fall back to built-in metadata.
- **Streaming progress API** — adds `ModelDiscoveryReporter` and the optional `CatalogProgressDiscoverer` interface so providers can report each model the moment it's resolved. Claude and Codex implement `DiscoverModelCatalogWithProgress`.
- **Live startup output** — replaces the static "Discovering models" spinner with `modelDiscoveryProgressPrinter`, printing `Discovered: <Provider> - <Model>` lines as they arrive. `startSyncSpinner` is refactored on top of a `startSyncSpinnerControl` that can clear without a "done" line.

## Test plan

- [x] `go vet ./...`
- [x] `go test ./cmd/agentico/ ./internal/llm/...`
- New tests cover: concurrent provider discovery, concurrent Claude probes, progress reporting before return, canceled-probe fallback, and Codex progress reporting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)