### PR TITLE
Style textareas centrally and refine wizard navigation

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -1166,7 +1166,7 @@ func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if f, err := m.featureManager.Get(msg.FeatureID); err == nil {
 			m.refactorFeatureName = f.Name
 		}
-		ta := textarea.New()
+		ta := newStyledTextarea()
 		ta.Placeholder = "Describe the refactoring for " + msg.RepoName + "..."
 		if m.dashboard.getLayoutMode() == layoutNarrow {
 			m = m.transitionTo(ViewDetail, msg.FeatureID)

--- a/internal/tui/attach.go
+++ b/internal/tui/attach.go
@@ -848,7 +848,7 @@ func NewAttachModel(tabs []repoTab, initialIdx int, featureID string, width, hei
 		PageDown: key.NewBinding(key.WithKeys("pgdown")),
 	}
 
-	ti := textarea.New()
+	ti := newStyledTextarea()
 	ti.Placeholder = attachMessagePlaceholder
 	ti.CharLimit = 4096
 	ti.SetWidth(inputW)

--- a/internal/tui/attach_test.go
+++ b/internal/tui/attach_test.go
@@ -120,6 +120,16 @@ func TestAttachModelView(t *testing.T) {
 	}
 }
 
+func TestAttachModelViewDoesNotUseDarkTextareaCursorLine(t *testing.T) {
+	sess := session.NewSession("test-view-light-bg", "feat-1", 0)
+	m := attachModelFromSession(sess, 80, 24)
+
+	view := m.View()
+	if strings.Contains(view, "\x1b[40m") || strings.Contains(view, "\x1b[48;5;0m") {
+		t.Fatalf("attach view rendered Bubble textarea's dark cursor-line background: %q", view)
+	}
+}
+
 func TestAttachModelViewUsesWatchVocabulary(t *testing.T) {
 	sess := session.NewSession("test-view-watch", "feat-1", feature.PhaseImplement)
 	m := attachModelFromSession(sess, 80, 24)

--- a/internal/tui/chat.go
+++ b/internal/tui/chat.go
@@ -112,7 +112,7 @@ type ChatModel struct {
 }
 
 func NewChatModel(width, height int, sm *session.Manager, workDir string, systemPrompt string, buildSession agent.BuildSessionFunc, chatModel string, skillsDir string) ChatModel {
-	ta := textarea.New()
+	ta := newStyledTextarea()
 	ta.Placeholder = "Ask me anything about Agentic Orchestrator..."
 	ta.CharLimit = 4096
 	ta.ShowLineNumbers = false

--- a/internal/tui/chat_test.go
+++ b/internal/tui/chat_test.go
@@ -77,6 +77,14 @@ func TestChatModelViewEmptyState(t *testing.T) {
 	}
 }
 
+func TestChatModelViewDoesNotUseDarkTextareaCursorLine(t *testing.T) {
+	m := NewChatModel(80, 24, nil, "/tmp", "test prompt", nil, "", "")
+	view := m.View()
+	if strings.Contains(view, "\x1b[40m") || strings.Contains(view, "\x1b[48;5;0m") {
+		t.Fatalf("chat view rendered Bubble textarea's dark cursor-line background: %q", view)
+	}
+}
+
 func TestChatModelEscWhileRespondingMinimizes(t *testing.T) {
 	m := NewChatModel(80, 24, nil, "/tmp", "test prompt", nil, "", "")
 	m.responding = true

--- a/internal/tui/publish.go
+++ b/internal/tui/publish.go
@@ -134,7 +134,7 @@ func newPublishViewport(width, height int, prTitle, prBody, diff string) (viewpo
 		ti.SetValue(prTitle)
 	}
 
-	ta := textarea.New()
+	ta := newStyledTextarea()
 	ta.Placeholder = "PR body (markdown)"
 	ta.SetWidth(max(width-8, 40))
 	ta.SetHeight(max(height-14, 8))

--- a/internal/tui/simpletextarea.go
+++ b/internal/tui/simpletextarea.go
@@ -137,6 +137,10 @@ func (t *SimpleTextarea) Line() int {
 	return t.row
 }
 
+func (t SimpleTextarea) atFirstVisualLine() bool {
+	return t.row == 0 && t.col < max(t.width, 1)
+}
+
 // LineCount returns the number of lines.
 func (t *SimpleTextarea) LineCount() int {
 	return len(t.lines)

--- a/internal/tui/textarea_style.go
+++ b/internal/tui/textarea_style.go
@@ -1,0 +1,51 @@
+// Copyright 2026 DoorDash, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tui
+
+import (
+	"charm.land/bubbles/v2/textarea"
+	"charm.land/lipgloss/v2"
+)
+
+func newStyledTextarea() textarea.Model {
+	ta := textarea.New()
+	applyTextareaPalette(&ta)
+	return ta
+}
+
+func applyTextareaPalette(ta *textarea.Model) {
+	styles := ta.Styles()
+
+	styles.Focused.Base = lipgloss.NewStyle()
+	styles.Focused.Text = lipgloss.NewStyle()
+	styles.Focused.CursorLine = lipgloss.NewStyle()
+	styles.Focused.CursorLineNumber = lipgloss.NewStyle().Foreground(colorOverlay)
+	styles.Focused.EndOfBuffer = lipgloss.NewStyle()
+	styles.Focused.LineNumber = lipgloss.NewStyle().Foreground(colorOverlay)
+	styles.Focused.Placeholder = lipgloss.NewStyle().Foreground(colorOverlay)
+	styles.Focused.Prompt = lipgloss.NewStyle().Foreground(colorBrand)
+
+	styles.Blurred.Base = lipgloss.NewStyle()
+	styles.Blurred.Text = lipgloss.NewStyle()
+	styles.Blurred.CursorLine = lipgloss.NewStyle()
+	styles.Blurred.CursorLineNumber = lipgloss.NewStyle().Foreground(colorOverlay)
+	styles.Blurred.EndOfBuffer = lipgloss.NewStyle()
+	styles.Blurred.LineNumber = lipgloss.NewStyle().Foreground(colorOverlay)
+	styles.Blurred.Placeholder = lipgloss.NewStyle().Foreground(colorOverlay)
+	styles.Blurred.Prompt = lipgloss.NewStyle().Foreground(colorOverlay)
+
+	styles.Cursor.Color = colorBrand
+	ta.SetStyles(styles)
+}

--- a/internal/tui/wizard.go
+++ b/internal/tui/wizard.go
@@ -420,6 +420,31 @@ func (m WizardModel) Init() tea.Cmd {
 	return textinput.Blink
 }
 
+func wizardDescriptionNewlineKey(msg tea.KeyPressMsg) bool {
+	if key.Matches(msg, key.NewBinding(key.WithKeys("ctrl+j", "alt+enter", "shift+enter"))) {
+		return true
+	}
+	return msg.Code == tea.KeyEnter && msg.Mod.Contains(tea.ModShift)
+}
+
+func (m *WizardModel) focusWhatName() tea.Cmd {
+	m.descInput.Blur()
+	m.whatFocus = 0
+	return m.nameInput.Focus()
+}
+
+func (m *WizardModel) focusWhatDescription() tea.Cmd {
+	m.nameInput.Blur()
+	m.whatFocus = 1
+	return m.descInput.Focus()
+}
+
+func (m WizardModel) insertDescriptionNewline() (WizardModel, tea.Cmd) {
+	var cmd tea.Cmd
+	m.descInput, cmd = m.descInput.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	return m, cmd
+}
+
 // isTextInputStep returns true if the current step has an active text input.
 func (m WizardModel) isTextInputStep() bool {
 	if m.step == wizardStepReview && m.summaryEditing &&
@@ -1187,12 +1212,14 @@ func (m WizardModel) Update(msg tea.Msg) (WizardModel, tea.Cmd) {
 			// Esc goes back; on first step goBack() cancels the wizard
 			return m.goBack()
 
-		case key.Matches(msg, key.NewBinding(key.WithKeys("ctrl+j", "alt+enter"))):
+		case wizardDescriptionNewlineKey(msg):
 			// On wizardStepWhat when description is focused, insert newline
 			if m.step == wizardStepWhat && m.whatFocus == 1 {
-				var cmd tea.Cmd
-				m.descInput, cmd = m.descInput.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
-				return m, cmd
+				return m.insertDescriptionNewline()
+			}
+			if key.Matches(msg, key.NewBinding(key.WithKeys("shift+enter"))) ||
+				msg.Mod.Contains(tea.ModShift) {
+				return m, nil
 			}
 			// On other steps/cases, treat as advance — respect picker guards
 			if m.filePicker.IsActive() {
@@ -1270,10 +1297,7 @@ func (m WizardModel) Update(msg tea.Msg) (WizardModel, tea.Cmd) {
 			}
 			// On wizardStepWhat with name focused, move to description first
 			if m.step == wizardStepWhat && m.whatFocus == 0 {
-				m.nameInput.Blur()
-				m.whatFocus = 1
-				cmd := m.descInput.Focus()
-				return m, cmd
+				return m, m.focusWhatDescription()
 			}
 			// Where step: Enter is contextual based on the focus axis.
 			if m.step == wizardStepWhere {
@@ -1298,10 +1322,7 @@ func (m WizardModel) Update(msg tea.Msg) (WizardModel, tea.Cmd) {
 			if m.step == wizardStepWhat {
 				// If description focused, switch to name
 				if m.whatFocus == 1 {
-					m.descInput.Blur()
-					m.whatFocus = 0
-					m.nameInput.Focus()
-					return m, textinput.Blink
+					return m, m.focusWhatName()
 				}
 				// Already on name (first step) — no-op
 				return m, nil
@@ -1315,15 +1336,9 @@ func (m WizardModel) Update(msg tea.Msg) (WizardModel, tea.Cmd) {
 			if m.step == wizardStepWhat {
 				// Toggle whatFocus between 0 (name) and 1 (description)
 				if m.whatFocus == 0 {
-					m.nameInput.Blur()
-					m.whatFocus = 1
-					cmd := m.descInput.Focus()
-					return m, cmd
+					return m, m.focusWhatDescription()
 				}
-				m.descInput.Blur()
-				m.whatFocus = 0
-				m.nameInput.Focus()
-				return m, textinput.Blink
+				return m, m.focusWhatName()
 			}
 			if m.step == wizardStepWhere {
 				// Tab cycles list -> Browse -> Create (if visible) -> Continue -> list.
@@ -1343,8 +1358,12 @@ func (m WizardModel) Update(msg tea.Msg) (WizardModel, tea.Cmd) {
 			if m.filePicker.IsActive() {
 				return m, nil
 			}
-			// On wizardStepWhat with description focused, let textarea handle cursor
+			// On wizardStepWhat with description focused, leave the field only
+			// from its top visual line; otherwise let textarea move the cursor.
 			if m.step == wizardStepWhat && m.whatFocus == 1 {
+				if m.descInput.atFirstVisualLine() {
+					return m, m.focusWhatName()
+				}
 				break
 			}
 			if m.step == wizardStepWhere {
@@ -1396,6 +1415,9 @@ func (m WizardModel) Update(msg tea.Msg) (WizardModel, tea.Cmd) {
 			(!m.isTextInputStep() && key.Matches(msg, key.NewBinding(key.WithKeys("j")))):
 			if m.filePicker.IsActive() {
 				return m, nil
+			}
+			if m.step == wizardStepWhat && m.whatFocus == 0 {
+				return m, m.focusWhatDescription()
 			}
 			// On wizardStepWhat with description focused, let textarea handle cursor
 			if m.step == wizardStepWhat && m.whatFocus == 1 {

--- a/internal/tui/wizard_test.go
+++ b/internal/tui/wizard_test.go
@@ -542,6 +542,79 @@ func TestWizardWhatStepShiftTabFromDesc(t *testing.T) {
 	}
 }
 
+func TestWizardWhatStepShiftEnterInDescriptionInsertsNewline(t *testing.T) {
+	m := NewWizardModel(nil, nil, nil, config.DefaultsConfig{}, "", nil, nil, nil, nil, nil, nil)
+
+	m, _ = m.Update(tea.KeyPressMsg{Text: "name"})
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	m, _ = m.Update(tea.KeyPressMsg{Text: "line1"})
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEnter, Mod: tea.ModShift})
+	m, _ = m.Update(tea.KeyPressMsg{Text: "line2"})
+
+	if got := m.descInput.Value(); got != "line1\nline2" {
+		t.Fatalf("description = %q, want %q", got, "line1\nline2")
+	}
+	if m.step != wizardStepWhat {
+		t.Fatalf("step = %d, want What after Shift+Enter newline", m.step)
+	}
+}
+
+func TestWizardWhatStepDownFromNameFocusesDescription(t *testing.T) {
+	m := NewWizardModel(nil, nil, nil, config.DefaultsConfig{}, "", nil, nil, nil, nil, nil, nil)
+
+	m, _ = m.Update(tea.KeyPressMsg{Text: "name"})
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+
+	if m.whatFocus != 1 {
+		t.Fatalf("whatFocus = %d, want description focus", m.whatFocus)
+	}
+	if m.nameInput.Focused() {
+		t.Fatal("name input should be blurred after Down")
+	}
+	if !m.descInput.Focused() {
+		t.Fatal("description input should be focused after Down")
+	}
+}
+
+func TestWizardWhatStepUpFromDescriptionFirstLineFocusesName(t *testing.T) {
+	m := NewWizardModel(nil, nil, nil, config.DefaultsConfig{}, "", nil, nil, nil, nil, nil, nil)
+
+	m.nameInput.SetValue("name")
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	m, _ = m.Update(tea.KeyPressMsg{Text: "description"})
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyUp})
+
+	if m.whatFocus != 0 {
+		t.Fatalf("whatFocus = %d, want name focus", m.whatFocus)
+	}
+	if !m.nameInput.Focused() {
+		t.Fatal("name input should be focused after Up from first description line")
+	}
+	if m.descInput.Focused() {
+		t.Fatal("description input should be blurred after Up from first description line")
+	}
+}
+
+func TestWizardWhatStepUpInsideWrappedDescriptionStaysInDescription(t *testing.T) {
+	m := NewWizardModel(nil, nil, nil, config.DefaultsConfig{}, "", nil, nil, nil, nil, nil, nil)
+
+	m.nameInput.SetValue("name")
+	m.descInput.SetWidth(4)
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	m, _ = m.Update(tea.KeyPressMsg{Text: "abcdef"})
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyUp})
+
+	if m.whatFocus != 1 {
+		t.Fatalf("whatFocus = %d, want description focus", m.whatFocus)
+	}
+	if !m.descInput.Focused() {
+		t.Fatal("description input should remain focused when moving within wrapped text")
+	}
+	if got := m.descInput.col; got != 2 {
+		t.Fatalf("description cursor col = %d, want 2 after moving up one visual line", got)
+	}
+}
+
 // --- Review step only responds to G ---
 
 func TestWizardReviewEnterIsNoOp(t *testing.T) {


### PR DESCRIPTION
## Summary
- Add `newStyledTextarea()` helper (`internal/tui/textarea_style.go`) that applies the shared brand/overlay palette to focused/blurred/cursor states. Wire chat, attach, publish, and refactor textareas through it for consistent appearance.
- Wizard "What" step: shift+enter / alt+enter / ctrl+j now insert a newline in the description; plain Enter advances. Up arrow from the top visual line of the description jumps back to the name field; down arrow from the name field jumps into the description.
- Factor the focus-swap and newline-insert logic into small helpers (`focusWhatName`, `focusWhatDescription`, `insertDescriptionNewline`, `wizardDescriptionNewlineKey`, `atFirstVisualLine`) to reduce duplication across the wizard's key handler.

## Test plan
- [ ] `go test ./internal/tui/...`
- [ ] Launch the TUI, open the new-feature wizard, verify the description field renders with the shared palette and that shift+enter inserts a newline while plain Enter advances.
- [ ] In the wizard's "What" step, confirm up arrow leaves the description only from the top visual line and down arrow enters the description from the name field.
- [ ] Open chat, attach, and publish views and confirm their textareas pick up the new styling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)