### PR TITLE
[codex] gate context handoff for small windows

### DIFF
--- a/internal/agent/implement.go
+++ b/internal/agent/implement.go
@@ -1175,6 +1175,11 @@ const (
 	agentStatusProtocolViolation = "PROTOCOL_VIOLATION"
 )
 
+// minContextHandoffWindowTokens disables the implementation wind-down nudge
+// for smaller context windows. Those models benefit less from a proactive
+// handoff because the prompt itself consumes meaningful remaining context.
+const minContextHandoffWindowTokens = 1_000_000
+
 // defaultContextHandoffThresholdPct is the context-window utilization
 // (percent) at which waitForStatus nudges the agent to wrap up cleanly for
 // providers without a provider-specific override. The default is chosen well
@@ -1182,11 +1187,6 @@ const (
 // to write a handoff and the phase_complete marker before the CLI would
 // otherwise compact and lose working memory.
 const defaultContextHandoffThresholdPct = 60
-
-// codexContextHandoffThresholdPct is higher because Codex reports its own
-// effective active context window via tokenUsage.modelContextWindow; 60% is
-// too early for Codex's current ~258K effective window.
-const codexContextHandoffThresholdPct = 80
 
 const largeCommandOutputThresholdChars = 20_000
 
@@ -1244,13 +1244,6 @@ type waitForStatusResult struct {
 	Handoff contextSnapshot
 }
 
-func contextHandoffThresholdForProvider(provider string) int {
-	if strings.EqualFold(provider, "codex") {
-		return codexContextHandoffThresholdPct
-	}
-	return defaultContextHandoffThresholdPct
-}
-
 func contextTotalTokens(usage *llm.Usage) int {
 	if usage == nil {
 		return 0
@@ -1287,7 +1280,7 @@ func iterationContextMeta(sess ports.SessionView, handoff contextSnapshot) *Cont
 	if sess == nil {
 		return nil
 	}
-	threshold := contextHandoffThresholdForProvider(sess.ProviderName())
+	threshold := defaultContextHandoffThresholdPct
 	final := currentContextSnapshot(sess, threshold)
 	if final.Pct < 0 || final.WindowTokens == 0 {
 		return nil
@@ -1375,7 +1368,7 @@ func waitForStatusDetailed(sess ports.SessionHandle, _ ports.SessionManager, _ s
 	handoffSent := false
 	handoff := contextSnapshot{
 		Pct:          -1,
-		ThresholdPct: contextHandoffThresholdForProvider(sess.ProviderName()),
+		ThresholdPct: defaultContextHandoffThresholdPct,
 	}
 
 	handleStatus := func(status string, sessionDone bool) (string, bool) {
@@ -1426,8 +1419,11 @@ func waitForStatusDetailed(sess ports.SessionHandle, _ ports.SessionManager, _ s
 			if handoffSent {
 				continue
 			}
-			threshold := contextHandoffThresholdForProvider(sess.ProviderName())
+			threshold := defaultContextHandoffThresholdPct
 			snap := currentContextSnapshot(sess, threshold)
+			if snap.WindowTokens < minContextHandoffWindowTokens {
+				continue
+			}
 			if snap.Pct < threshold {
 				continue
 			}

--- a/internal/agent/implement_test.go
+++ b/internal/agent/implement_test.go
@@ -1266,8 +1266,8 @@ func TestWaitForStatus_ContextHandoff_SendsOnceAtThreshold(t *testing.T) {
 	sess := session.NewSession("test", "feat", feature.PhaseImplement)
 	sink := attachCaptureSink(sess)
 
-	// Seed usage at exactly the threshold — 60%, on a 200K window.
-	sess.SetLatestUsage(&llm.Usage{InputTokens: 120_000, ContextWindow: 200_000})
+	// Seed usage at exactly the threshold — 60%, on a 1M window.
+	sess.SetLatestUsage(&llm.Usage{InputTokens: 600_000, ContextWindow: 1_000_000})
 
 	var ready atomic.Bool // stays false until the test flips it.
 	polls := make(chan struct{}, 8)
@@ -1315,40 +1315,31 @@ func TestWaitForStatus_ContextHandoff_SendsOnceAtThreshold(t *testing.T) {
 	}
 }
 
-func TestWaitForStatus_ContextHandoff_CodexUses80PercentThreshold(t *testing.T) {
+func TestWaitForStatus_ContextHandoff_CodexUsesDefaultThreshold(t *testing.T) {
 	withHandoffPollInterval(t, 2*time.Millisecond)
 
 	sess := session.NewSession("test", "feat", feature.PhaseImplement)
 	sess.SetProviderName("codex")
 	sink := attachCaptureSink(sess)
 
-	// 60% would trigger the default provider policy, but Codex should wait
-	// for its provider-specific 80% threshold.
-	sess.SetLatestUsage(&llm.Usage{InputTokens: 120_000, ContextWindow: 200_000})
-	polls := make(chan struct{}, 8)
+	// Codex follows the shared 60% threshold once the window is at least 1M.
+	sess.SetLatestUsage(&llm.Usage{InputTokens: 600_000, ContextWindow: 1_000_000})
 
 	done := make(chan string, 1)
 	go func() {
 		done <- waitForStatusDetailed(sess, nil, "", waitForStatusOptions{
-			ReadyCheck:             func() bool { return true },
-			EnableContextHandoff:   true,
-			ContextHandoffPollHook: handoffPollHook(polls),
+			ReadyCheck:           func() bool { return true },
+			EnableContextHandoff: true,
 		}).Status
 	}()
 
-	waitForHandoffPolls(t, polls, 3, 2*time.Second)
-	if got := countHandoffMessages(sink.contents()); got != 0 {
-		t.Errorf("handoff messages at 60%% for codex = %d, want 0", got)
-	}
-
-	sess.SetLatestUsage(&llm.Usage{InputTokens: 160_000, ContextWindow: 200_000})
 	sink.waitForWrite(t, 2*time.Second)
 
 	if got := countHandoffMessages(sink.contents()); got != 1 {
-		t.Errorf("handoff messages at 80%% for codex = %d, want 1", got)
+		t.Errorf("handoff messages at 60%% for codex = %d, want 1", got)
 	}
-	if !strings.Contains(sink.contents(), "above Agentic's 80% handoff threshold") {
-		t.Errorf("codex handoff message should include 80%% threshold, got: %s", sink.contents())
+	if !strings.Contains(sink.contents(), "above Agentic's 60% handoff threshold") {
+		t.Errorf("codex handoff message should include 60%% threshold, got: %s", sink.contents())
 	}
 
 	sess.SendStatus("SUCCESS")
@@ -1366,8 +1357,8 @@ func TestWaitForStatus_ContextHandoffReturnsSnapshot(t *testing.T) {
 	sess.SetProviderName("codex")
 	sink := attachCaptureSink(sess)
 	sess.SetLatestUsage(&llm.Usage{
-		ContextTotalTokens: 211_000,
-		ContextWindow:      258_400,
+		ContextTotalTokens: 604_800,
+		ContextWindow:      1_000_000,
 		ContextBaseline:    12_000,
 	})
 
@@ -1384,14 +1375,14 @@ func TestWaitForStatus_ContextHandoffReturnsSnapshot(t *testing.T) {
 
 	select {
 	case got := <-done:
-		if got.Handoff.Pct != 80 {
-			t.Errorf("Handoff.Pct = %d, want 80", got.Handoff.Pct)
+		if got.Handoff.Pct != 60 {
+			t.Errorf("Handoff.Pct = %d, want 60", got.Handoff.Pct)
 		}
-		if got.Handoff.TotalTokens != 211_000 {
-			t.Errorf("Handoff.TotalTokens = %d, want 211000", got.Handoff.TotalTokens)
+		if got.Handoff.TotalTokens != 604_800 {
+			t.Errorf("Handoff.TotalTokens = %d, want 604800", got.Handoff.TotalTokens)
 		}
-		if got.Handoff.WindowTokens != 258_400 {
-			t.Errorf("Handoff.WindowTokens = %d, want 258400", got.Handoff.WindowTokens)
+		if got.Handoff.WindowTokens != 1_000_000 {
+			t.Errorf("Handoff.WindowTokens = %d, want 1000000", got.Handoff.WindowTokens)
 		}
 		if got.Handoff.BaselineTokens != 12_000 {
 			t.Errorf("Handoff.BaselineTokens = %d, want 12000", got.Handoff.BaselineTokens)
@@ -1408,7 +1399,7 @@ func TestWaitForStatus_ContextHandoff_BelowThreshold_NoSend(t *testing.T) {
 	sink := attachCaptureSink(sess)
 
 	// 40% usage — comfortably below the 60% threshold.
-	sess.SetLatestUsage(&llm.Usage{InputTokens: 80_000, ContextWindow: 200_000})
+	sess.SetLatestUsage(&llm.Usage{InputTokens: 400_000, ContextWindow: 1_000_000})
 	polls := make(chan struct{}, 8)
 
 	done := make(chan string, 1)
@@ -1428,6 +1419,40 @@ func TestWaitForStatus_ContextHandoff_BelowThreshold_NoSend(t *testing.T) {
 	}
 
 	// Clean up.
+	sess.SendStatus("SUCCESS")
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for waitForStatus to return")
+	}
+}
+
+func TestWaitForStatus_ContextHandoff_DisabledBelowOneMillionWindow(t *testing.T) {
+	withHandoffPollInterval(t, 2*time.Millisecond)
+
+	sess := session.NewSession("test", "feat", feature.PhaseImplement)
+	sink := attachCaptureSink(sess)
+
+	// 90% usage would otherwise cross the default threshold, but the
+	// implementation nudge is disabled for context windows below 1M tokens.
+	sess.SetLatestUsage(&llm.Usage{InputTokens: 180_000, ContextWindow: 200_000})
+	polls := make(chan struct{}, 8)
+
+	done := make(chan string, 1)
+	go func() {
+		done <- waitForStatusDetailed(sess, nil, "", waitForStatusOptions{
+			ReadyCheck:             func() bool { return true },
+			EnableContextHandoff:   true,
+			ContextHandoffPollHook: handoffPollHook(polls),
+		}).Status
+	}()
+
+	waitForHandoffPolls(t, polls, 3, 2*time.Second)
+
+	if got := countHandoffMessages(sink.contents()); got != 0 {
+		t.Errorf("handoff messages below 1M window = %d, want 0", got)
+	}
+
 	sess.SendStatus("SUCCESS")
 	select {
 	case <-done:


### PR DESCRIPTION
## Summary

- Disable the implementation context-handoff nudge for reported context windows below 1M tokens.
- Remove the Codex-specific 80% threshold so eligible Codex sessions use the shared 60% threshold.
- Update context-handoff tests and add coverage for the below-1M disabled behavior.

## Impact

Agents with smaller effective context windows no longer receive the proactive wind-down prompt. Agents with windows at or above 1M tokens continue to receive the prompt at the shared threshold.

## Verification

- Fast suite: `make test-fast`
- Isolated integration: `go test ./test/integration/... -count=1`
- E2E Go (TUI / teatest): `go test ./test/e2e/... -count=1 -race`
- Skipped Race regression: narrow threshold-policy change; the E2E Go gate ran with `-race`.
