### PR TITLE
[codex] fix kb attach session handling

### DIFF
--- a/internal/agent/phase.go
+++ b/internal/agent/phase.go
@@ -570,6 +570,7 @@ func (pr *PhaseRunner) RunKnowledgeBaseForRepo(f *feature.Feature, repo feature.
 	workDir := repoPath
 
 	pidDir := filepath.Join(pr.StateDir, f.ID)
+	logPath := filepath.Join(kbDir, "output.txt")
 	cmd, env, sessOpts, err := pr.BuildSession(BuildSessionOpts{
 		Model:                          kbModel,
 		Prompt:                         prompt,
@@ -584,9 +585,16 @@ func (pr *PhaseRunner) RunKnowledgeBaseForRepo(f *feature.Feature, repo feature.
 		Phase:                          feature.PhaseKnowledgeBase,
 		SystemPromptHasUsefulResources: true,
 		MarkerPath:                     filepath.Join(kbDir, PhaseCompleteFile),
+		LogPath:                        logPath,
 	})
 	if err != nil {
 		return "", fmt.Errorf("building KB session: %w", err)
+	}
+	if sessOpts == nil {
+		sessOpts = &ports.SessionOpts{}
+	}
+	if sessOpts.LogPath == "" {
+		sessOpts.LogPath = logPath
 	}
 	WriteDebugPrompts(kbDir, sessOpts.DebugSystemPrompt, prompt)
 
@@ -613,11 +621,13 @@ func (pr *PhaseRunner) RunKnowledgeBaseForRepo(f *feature.Feature, repo feature.
 		_ = ReleaseKBLock(kbDir, featureID)
 	})
 
-	// Set up log file
-	logPath := filepath.Join(kbDir, "output.txt")
-	logFile, err := os.Create(logPath)
-	if err == nil {
-		sess.SetLogFile(logFile)
+	// Fallback for custom SessionManager implementations that do not honor
+	// SessionOpts.LogPath. The production manager opens it before Start().
+	if sess.LogFilePath() == "" {
+		logFile, err := os.Create(logPath)
+		if err == nil {
+			sess.SetLogFile(logFile)
+		}
 	}
 
 	return sessionID, nil
@@ -674,7 +684,7 @@ func (pr *PhaseRunner) RunPlanningWithValidation(f *feature.Feature, researchArt
 		FeatureStore:               pr.FeatureStore,
 		StateDir:                   pr.StateDir,
 		ResearchArtifactPath:       researchArtifactPath,
-		DesignArtifactPath:     f.DesignArtifactPath(),
+		DesignArtifactPath:         f.DesignArtifactPath(),
 		QAFilePaths:                qaFilePaths,
 		KBInfos:                    kbInfos,
 		WorkDir:                    workDir,
@@ -736,7 +746,7 @@ func (pr *PhaseRunner) RunPhasePlanning(f *feature.Feature, roadmapPath string, 
 			Feature:                    f,
 			FeatureStore:               pr.FeatureStore,
 			StateDir:                   pr.StateDir,
-			DesignArtifactPath:     f.DesignArtifactPath(),
+			DesignArtifactPath:         f.DesignArtifactPath(),
 			QAFilePaths:                qaFilePaths,
 			KBInfos:                    kbInfos,
 			WorkDir:                    workDir,
@@ -813,7 +823,7 @@ func (pr *PhaseRunner) RunImplementation(f *feature.Feature, planPath string, kb
 		StateDir:                   filepath.Join(pr.StateDir, f.ID),
 		PhaseType:                  phaseType,
 		RoadmapPath:                roadmapPath,
-		DesignArtifactPath:     f.DesignArtifactPath(),
+		DesignArtifactPath:         f.DesignArtifactPath(),
 		DangerouslySkipPermissions: pr.DangerouslySkipPermissions,
 		PermissionCache:            pr.PermissionCache,
 		BuildSession:               pr.BuildSession,

--- a/internal/agent/phase_test.go
+++ b/internal/agent/phase_test.go
@@ -15,6 +15,7 @@
 package agent
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -1099,6 +1100,60 @@ func TestRunKnowledgeBaseForRepo_RemovesStalePhaseCompleteBeforeSession(t *testi
 	}
 	if HasPhaseComplete(kbDir) {
 		t.Fatal("stale phase_complete still exists after RunKnowledgeBaseForRepo")
+	}
+}
+
+func TestRunKnowledgeBaseForRepo_PassesLogPathBeforeSessionStart(t *testing.T) {
+	tmpDir := t.TempDir()
+	stateDir := filepath.Join(tmpDir, "state")
+	repoDir := filepath.Join(tmpDir, "repo")
+	if err := os.MkdirAll(repoDir, 0o755); err != nil {
+		t.Fatalf("mkdir repo: %v", err)
+	}
+
+	sm := mocks.NewMockSessionManager()
+	cmd := mocks.NewMockCommandRunner()
+	cmd.RunFn = func(ctx context.Context, name string, args []string, opts ports.CommandOpts) ([]byte, error) {
+		return []byte("deadbeef\n"), nil
+	}
+
+	var capturedLogPath string
+	var startSessionLogPath string
+	sm.StartSessionFn = func(id, featureID string, phase feature.Phase, command []string, workdir string, env []string, opts ...*session.SessionOpts) (ports.SessionHandle, error) {
+		if len(opts) > 0 && opts[0] != nil {
+			startSessionLogPath = opts[0].LogPath
+		}
+		return session.NewSession(id, featureID, phase), nil
+	}
+	pr := &PhaseRunner{
+		SessionManager: sm,
+		StateDir:       stateDir,
+		CommandRunner:  cmd,
+		BuildSessionFn: func(opts BuildSessionOpts) ([]string, []string, *session.SessionOpts, error) {
+			capturedLogPath = opts.LogPath
+			return []string{"true"}, nil, &session.SessionOpts{}, nil
+		},
+	}
+
+	f := &feature.Feature{
+		ID:     "feat-kb-log",
+		Repos:  []feature.FeatureRepo{{Name: "repo-a", Path: repoDir}},
+		Models: config.ModelConfig{},
+	}
+
+	if _, err := pr.RunKnowledgeBaseForRepo(f, f.Repos[0]); err != nil {
+		t.Fatalf("RunKnowledgeBaseForRepo: %v", err)
+	}
+
+	want := filepath.Join(KBStateDir(stateDir, "repo-a"), "output.txt")
+	if capturedLogPath != want {
+		t.Fatalf("BuildSession LogPath = %q, want %q", capturedLogPath, want)
+	}
+	if len(sm.StartSessionCalls) != 1 {
+		t.Fatalf("StartSession calls = %d, want 1", len(sm.StartSessionCalls))
+	}
+	if got := startSessionLogPath; got != want {
+		t.Fatalf("StartSession SessionOpts.LogPath = %q, want %q", got, want)
 	}
 }
 

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -862,7 +862,14 @@ func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if f, err := m.featureManager.Get(m.attach.featureID); err == nil && f != nil {
 				next := m.buildRepoTabs(f)
 				if len(next) > 0 {
-					m.attach.rebuildTabs(next)
+					if m.attach.rebuildTabs(next) {
+						idx := m.attach.activeTabIdx
+						if idx >= 0 && idx < len(m.attach.repoTabs) && m.attach.repoTabs[idx].sess != nil {
+							var cmd tea.Cmd
+							m.attach, cmd = m.attach.switchToTab(idx)
+							return m, cmd
+						}
+					}
 				}
 			}
 		}

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -1012,6 +1012,49 @@ func TestDashboardWatchAttachPreservesMultiRepoTabs(t *testing.T) {
 	}
 }
 
+func TestUpdateAttach_TabbedDoneSessionDoesNotDetachOnOrdinaryKey(t *testing.T) {
+	app, fm := newTestAppModel(t)
+	fm.Config.Repos["api"] = config.RepoConfig{Path: "/tmp/api"}
+	fm.Config.Repos["web"] = config.RepoConfig{Path: "/tmp/web"}
+	fm.Config.Repos["worker"] = config.RepoConfig{Path: "/tmp/worker"}
+
+	f, err := fm.Create("KB Watch", "desc", []string{"api", "web", "worker"}, fm.Config.Defaults.Models, "", "", nil)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if err := fm.Store.Modify(f.ID, func(ff *feature.Feature) error {
+		ff.Status = feature.StatusBuildingKB
+		ff.CurrentPhase = feature.PhaseKnowledgeBase
+		ff.KBStatus = map[string]string{
+			"api":    "completed",
+			"web":    "completed",
+			"worker": "pending",
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("modify: %v", err)
+	}
+
+	workerSess := session.NewSession(f.ID+"-kb-worker", f.ID, feature.PhaseKnowledgeBase)
+	workerSess.SetKind(ports.KindPhase)
+	workerSess.SetRepoName("worker")
+
+	tabs := []repoTab{
+		{repoName: "api", kind: ports.KindRepoImpl, status: statusReviewPassed},
+		{repoName: "web", kind: ports.KindRepoImpl, status: statusReviewPassed},
+		{repoName: "worker", kind: ports.KindRepoImpl, sess: workerSess, status: statusImplementing},
+	}
+	app.currentView = ViewAttach
+	app.attach = NewAttachModel(tabs, 2, f.ID, app.width, app.height)
+	app.attach.done = true
+
+	result, _ := app.updateAttach(tea.KeyPressMsg{Code: 'x', Text: "x"})
+	updated := result.(AppModel)
+	if updated.currentView != ViewAttach {
+		t.Fatalf("currentView = %v, want ViewAttach; ordinary keys must not detach a tabbed KB view just because the active tab is done", updated.currentView)
+	}
+}
+
 func TestDashboardRightPanelOverviewReturnsToLivePreview(t *testing.T) {
 	app, fm := newTestAppModel(t)
 

--- a/internal/tui/attach.go
+++ b/internal/tui/attach.go
@@ -1964,6 +1964,19 @@ func (m AttachModel) Update(msg tea.Msg) (AttachModel, tea.Cmd) {
 			return m, m.forwardToViewport(msg)
 		}
 
+		if m.done {
+			switch {
+			case key.Matches(msg, keys.Detach):
+				m.detached = true
+				return m, nil
+			case key.Matches(msg, key.NewBinding(key.WithKeys("ctrl+f"))):
+				m.filter = m.filter.next()
+				m.updateViewport()
+				return m, nil
+			}
+			return m, m.forwardToViewport(msg)
+		}
+
 		// Handle plan review menu navigation
 		if m.showPlanReviewMenu {
 			switch msg.String() {
@@ -3273,6 +3286,9 @@ func (m AttachModel) TweakFinishing() bool {
 
 // Done returns true if the session has exited.
 func (m AttachModel) Done() bool {
+	if len(m.repoTabs) > 1 {
+		return false
+	}
 	return m.done
 }
 
@@ -3630,12 +3646,14 @@ func (m *AttachModel) rebuildTabs(next []repoTab) bool {
 	// Preserve the active tab if its identity still exists in the new list;
 	// otherwise fall back to the first live tab.
 	activeKey := ""
+	var activeSess session.SessionView
 	if m.activeTabIdx >= 0 && m.activeTabIdx < len(m.repoTabs) {
 		activeKey = m.repoTabs[m.activeTabIdx].repoName
+		activeSess = m.repoTabs[m.activeTabIdx].sess
 	}
 	newIdx := -1
 	for i, t := range next {
-		if t.repoName == activeKey {
+		if t.repoName == activeKey && t.sess != nil {
 			newIdx = i
 			break
 		}
@@ -3649,6 +3667,16 @@ func (m *AttachModel) rebuildTabs(next []repoTab) bool {
 			}
 		}
 		sessionSwapped = true
+	} else if !sameAttachSession(activeSess, next[newIdx].sess) {
+		sessionSwapped = true
+	}
+	if newIdx < 0 {
+		for i, t := range next {
+			if t.repoName == activeKey {
+				newIdx = i
+				break
+			}
+		}
 	}
 
 	m.repoTabs = next
@@ -3656,6 +3684,21 @@ func (m *AttachModel) rebuildTabs(next []repoTab) bool {
 		m.activeTabIdx = newIdx
 	}
 	return sessionSwapped
+}
+
+func sameAttachSession(a, b session.SessionView) bool {
+	if a == nil || b == nil {
+		return a == nil && b == nil
+	}
+	if a.ID() != b.ID() {
+		return false
+	}
+	aStarted := a.StartedAt()
+	bStarted := b.StartedAt()
+	if aStarted.IsZero() || bStarted.IsZero() {
+		return true
+	}
+	return aStarted.Equal(bStarted)
 }
 
 // ActiveRepoName returns the name of the currently active repo tab.

--- a/internal/tui/attach_test.go
+++ b/internal/tui/attach_test.go
@@ -1120,6 +1120,27 @@ func TestTabSwitchKeepsInteractiveControls(t *testing.T) {
 	})
 }
 
+func TestRebuildTabsReportsSessionSwapWhenActiveTabLosesSession(t *testing.T) {
+	apiSess := session.NewSession("f1-kb-api", "f1", feature.PhaseKnowledgeBase)
+	workerSess := session.NewSession("f1-kb-worker", "f1", feature.PhaseKnowledgeBase)
+	m := testAttachModel(apiSess, 80, 24, []repoTab{
+		{repoName: "api", sess: apiSess, status: statusImplementing},
+		{repoName: "worker", sess: workerSess, status: statusImplementing},
+	}, 0)
+
+	swapped := m.rebuildTabs([]repoTab{
+		{repoName: "api", status: statusReviewPassed},
+		{repoName: "worker", sess: workerSess, status: statusImplementing},
+	})
+
+	if !swapped {
+		t.Fatal("rebuildTabs should report a session swap when the active tab's session disappears")
+	}
+	if m.activeTabIdx != 1 {
+		t.Fatalf("activeTabIdx = %d, want 1 for remaining live session", m.activeTabIdx)
+	}
+}
+
 func TestActiveRepoName(t *testing.T) {
 	t.Run("returns repo name for multi-repo", func(t *testing.T) {
 		m := AttachModel{


### PR DESCRIPTION
## Summary
- Pass the KB output log path into session build/start before the session manager starts the process, with a fallback for custom managers.
- Refresh the active attach tab when rebuilt repo tabs replace or drop the active session.
- Keep multi-repo attach views attached when one tab has completed while other repo sessions are still live.

## Root Cause
KB session logging was configured after session start, so managers that consume `SessionOpts.LogPath` before launching could miss the output file. In the TUI, rebuilt tabs could preserve a completed active repo without a live session, and multi-repo attach state could be treated as globally done.

## Verification
- Fast suite: `make test-fast`
- E2E Go (TUI / teatest): `go test ./test/e2e/... -count=1 -race`
- Static analysis/build: `go vet ./...`; `go build ./...`
- Skipped Isolated integration: no lifecycle state-machine, runs layout, or protocol-violation behavior changed.
- Skipped TUI observability: no observer wiring or emitted observability events changed.