### PR TITLE
[codex] Implement worktree setup UX

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -10,6 +10,34 @@ with the common fields defined by `internal/observe.Event`, including
 `event_type`, `feature_id`, optional `phase`, optional `data`, and optional
 `run_number`.
 
+### Setup Lifecycle Events
+
+Worktree setup, retry, and reconciliation diagnostics emit setup lifecycle
+events before any agent phase starts:
+
+- `setup.started`
+- `setup.progress`
+- `setup.completed`
+- `setup.failed`
+
+These are pre-phase events and do not carry a phase name. Do not confuse them
+with agent phase telemetry, which is emitted after setup and uses the pipeline
+phase context.
+
+Common event fields and `data` keys:
+
+- `feature_id`: feature identifier associated with the setup work.
+- `run_number`: active run number for the setup work.
+- `attempt`: setup attempt number.
+- `setup_log`: setup log path or message.
+- `setup_task`: setup task name.
+- `setup_kind`: setup operation kind.
+- `setup_status`: setup status value.
+- `repo_name`: repository name being prepared.
+- `path`: worktree or repository path.
+- `branch`: branch used for the setup operation.
+- `error`: failure details when setup fails.
+
 ### `feature.rewound`
 
 Successful rewinds emit a dedicated `feature.rewound` event after the sealed

--- a/internal/feature/feature.go
+++ b/internal/feature/feature.go
@@ -262,6 +262,7 @@ const (
 	FailureMissingArtifact   = "missing_artifact"
 	FailureProtocolViolation = "protocol_violation"
 	FailureInfrastructure    = "infrastructure"
+	FailureWorktreeSetup     = "worktree_setup"
 	// FailureNeedUserInput marks a feature failure caused by an
 	// implement iteration emitting `## Iteration State: NEED_USER_INPUT`
 	// in progress.md. The harness treats this as a terminal state today;
@@ -307,6 +308,9 @@ const (
 	// StatusReviewPassed → StatusFinalReviewing on entry and
 	// StatusFinalReviewing → StatusCodeReady on success.
 	StatusFinalReviewing
+	// StatusSettingUpWorktrees marks durable first-run setup before any phase
+	// session starts. It is active work, but not a formal pipeline phase.
+	StatusSettingUpWorktrees
 )
 
 func (s Status) String() string {
@@ -361,6 +365,8 @@ func (s Status) String() string {
 		return "NeedUserInput"
 	case StatusFinalReviewing:
 		return "FinalReviewing"
+	case StatusSettingUpWorktrees:
+		return "SettingUpWorktrees"
 	default:
 		return fmt.Sprintf("Status(%d)", int(s))
 	}
@@ -368,7 +374,7 @@ func (s Status) String() string {
 
 // IsRunning returns true if this status represents an actively executing phase.
 func (s Status) IsRunning() bool {
-	return s == StatusResearching || s == StatusPlanning || s == StatusImplementing || s == StatusBuildingKB || s == StatusInquiring || s == StatusDesigning || s == StatusFinalReviewing
+	return s == StatusResearching || s == StatusPlanning || s == StatusImplementing || s == StatusBuildingKB || s == StatusInquiring || s == StatusDesigning || s == StatusFinalReviewing || s == StatusSettingUpWorktrees
 }
 
 // IsNeedsReview returns true if this status represents a pending artifact review.
@@ -436,6 +442,7 @@ func (s *Status) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		"Reviewing":           StatusReviewing,
 		"NeedUserInput":       StatusNeedUserInput,
 		"FinalReviewing":      StatusFinalReviewing,
+		"SettingUpWorktrees":  StatusSettingUpWorktrees,
 	}
 
 	// Legacy integer mapping. Values 0-11 are unchanged from the original iota.
@@ -832,6 +839,7 @@ var validTransitions = map[Status][]Status{
 	StatusInquiryNeedsReview:  {StatusResearching, StatusFailed},
 	StatusResearchNeedsReview: {StatusDesigning, StatusFailed},
 	StatusDesignNeedsReview:   {StatusPlanning, StatusFailed},
+	StatusSettingUpWorktrees:  {StatusCreated, StatusFailed},
 }
 
 // accumulateActiveTime moves elapsed time from ActivePhaseStart into

--- a/internal/feature/manager.go
+++ b/internal/feature/manager.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/doordash-oss/agentic-orchestrator/internal/config"
@@ -48,6 +49,7 @@ type BranchOps interface {
 	HasOriginRemote(repoPath string) (bool, error)
 	BranchName(featureSlug string) string
 	BranchExistsOnRemote(repoPath, branch string) (bool, error)
+	CurrentBranch(repoPath string) (string, error)
 	CreateBackupBranch(worktreePath, slug string) (string, error)
 }
 
@@ -64,6 +66,9 @@ type Manager struct {
 	Worktrees WorktreeOps // optional; nil skips worktree creation
 	Branches  BranchOps   // optional; nil skips branch lookups during Create/Rewind
 	PRs       PRCloser    // optional; nil skips PR close on rewind
+
+	setupMu    sync.Mutex
+	setupLocks map[string]struct{}
 }
 
 // SlugExists checks if any existing feature has the given slug.
@@ -122,6 +127,7 @@ type CreateOptions struct {
 	Attachments             []string // temp attachment file paths
 	RiskLevel               RiskLevel
 	Pipeline                PipelineProfile
+	QueueSetup              bool
 }
 
 // Re-entrancy / crash recovery:
@@ -193,7 +199,7 @@ func (m *Manager) Create(name, description string, repos []string, models config
 
 	// Ensure the branch name doesn't conflict with an existing upstream branch.
 	// If it does, append a random 4-char hex suffix and recheck (up to 5 attempts).
-	if m.Worktrees != nil && m.Branches != nil {
+	if (opt.QueueSetup || m.Worktrees != nil) && m.Branches != nil {
 		baseSlug := slug
 		for attempt := 0; attempt < 5; attempt++ {
 			branch := m.Branches.BranchName(slug)
@@ -215,22 +221,8 @@ func (m *Manager) Create(name, description string, repos []string, models config
 		}
 	}
 
-	// Create worktrees for each repo if worktree manager is configured
-	if m.Worktrees != nil {
-		for i, fr := range featureRepos {
-			startPoint := fr.BaseBranch
-			useCurrent := opt.UseCurrentBranch
-			if v, ok := opt.UseCurrentBranchPerRepo[fr.Name]; ok {
-				useCurrent = v
-			}
-			if useCurrent {
-				startPoint = "" // empty → HEAD in worktree.Create
-			}
-			wtPath, err := m.Worktrees.Create(fr.Path, slug, fr.Name, startPoint)
-			if err != nil {
-				return nil, fmt.Errorf("creating worktree for %s: %w", fr.Name, err)
-			}
-			featureRepos[i].WorktreePath = wtPath
+	if opt.QueueSetup || m.Worktrees != nil {
+		for i := range featureRepos {
 			if m.Branches != nil {
 				featureRepos[i].Branch = m.Branches.BranchName(slug)
 			} else {
@@ -244,13 +236,18 @@ func (m *Manager) Create(name, description string, repos []string, models config
 		inq = Inquireness(m.Config.Defaults.Inquireness)
 	}
 
+	now := time.Now()
+	status := StatusCreated
+	if opt.QueueSetup {
+		status = StatusSettingUpWorktrees
+	}
 	f := &Feature{
 		ID:            id,
 		Name:          name,
 		Slug:          slug,
 		Description:   description,
-		Created:       time.Now(),
-		Status:        StatusCreated,
+		Created:       now,
+		Status:        status,
 		CurrentPhase:  opt.Pipeline.FirstPhase(),
 		Pipeline:      opt.Pipeline,
 		Repos:         featureRepos,
@@ -279,10 +276,45 @@ func (m *Manager) Create(name, description string, repos []string, models config
 			run.RepoStates[fr.Name] = &RepoState{}
 		}
 	}
+	if opt.QueueSetup {
+		run.Setup = NewActiveSetupState(featureRepos, images, opt.Attachments, now, SetupInitOptions{
+			UseCurrentBranch:        opt.UseCurrentBranch,
+			UseCurrentBranchPerRepo: opt.UseCurrentBranchPerRepo,
+		})
+	}
 	f.SetRun(run)
 
-	if err := m.Store.Save(f); err != nil {
-		return nil, fmt.Errorf("saving feature: %w", err)
+	if opt.QueueSetup {
+		if err := m.Store.Save(f); err != nil {
+			return nil, fmt.Errorf("saving feature: %w", err)
+		}
+		return f, nil
+	}
+
+	saved := false
+
+	// Create worktrees for each repo if worktree manager is configured.
+	if m.Worktrees != nil {
+		for i, fr := range featureRepos {
+			startPoint := fr.BaseBranch
+			useCurrent := opt.UseCurrentBranch
+			if v, ok := opt.UseCurrentBranchPerRepo[fr.Name]; ok {
+				useCurrent = v
+			}
+			if useCurrent {
+				startPoint = "" // empty → HEAD in worktree.Create
+			}
+			wtPath, err := m.Worktrees.Create(fr.Path, slug, fr.Name, startPoint)
+			if err != nil {
+				return nil, fmt.Errorf("creating worktree for %s: %w", fr.Name, err)
+			}
+			featureRepos[i].WorktreePath = wtPath
+			f.Repos[i].WorktreePath = wtPath
+		}
+		if err := m.Store.Save(f); err != nil {
+			return nil, fmt.Errorf("saving feature with worktrees: %w", err)
+		}
+		saved = true
 	}
 
 	// Copy images from temp paths to feature directory
@@ -301,6 +333,7 @@ func (m *Manager) Create(name, description string, repos []string, models config
 		if err := m.Store.Save(f); err != nil {
 			return nil, fmt.Errorf("saving feature with images: %w", err)
 		}
+		saved = true
 	}
 
 	// Copy attachments from temp paths to feature directory
@@ -319,6 +352,13 @@ func (m *Manager) Create(name, description string, repos []string, models config
 		}
 		if err := m.Store.Save(f); err != nil {
 			return nil, fmt.Errorf("saving feature with attachments: %w", err)
+		}
+		saved = true
+	}
+
+	if !saved {
+		if err := m.Store.Save(f); err != nil {
+			return nil, fmt.Errorf("saving feature: %w", err)
 		}
 	}
 
@@ -1593,9 +1633,20 @@ func (m *Manager) Delete(featureID string) error {
 	}
 
 	if m.Worktrees != nil {
+		seen := make(map[string]bool)
 		for _, repo := range f.Repos {
 			if repo.WorktreePath != "" {
+				seen[repo.WorktreePath] = true
 				_ = m.Worktrees.Remove(repo.WorktreePath, true)
+			}
+		}
+		if setup := f.Run().Setup; setup != nil {
+			for _, task := range setup.Tasks {
+				if task.Kind != SetupTaskWorktree || task.Path == "" || seen[task.Path] {
+					continue
+				}
+				seen[task.Path] = true
+				_ = m.Worktrees.Remove(task.Path, true)
 			}
 		}
 	}

--- a/internal/feature/manager_test.go
+++ b/internal/feature/manager_test.go
@@ -289,6 +289,629 @@ func TestManagerCreateWithWorktree(t *testing.T) {
 	}
 }
 
+func TestManagerCreateQueuesActiveSetupWithoutWorktreeSideEffects(t *testing.T) {
+	t.Parallel()
+	// parallel-candidate: per-test temp dirs and mocks isolate filesystem and collaborator state.
+	storeDir := t.TempDir()
+	store := feature.NewStore(storeDir)
+	cfg := config.NewDefault()
+	cfg.Repos["test-repo"] = config.RepoConfig{Path: "/repos/test-repo"}
+
+	mgr := feature.NewManager(store, cfg)
+	mgr.Branches = newMockBranches(false)
+	worktrees := mocks.NewMockWorktreeOperator()
+	worktrees.CreateFn = func(repoPath, featureSlug, repoName, startPoint string) (string, error) {
+		return "", fmt.Errorf("worktree side effect should not run while setup is only queued")
+	}
+	mgr.Worktrees = worktrees
+	mgr.PRs = mocks.NewMockPublisher()
+
+	f, err := mgr.Create("Worktree Feature", "test worktree", []string{"test-repo"}, cfg.Defaults.Models, "", "", nil, feature.CreateOptions{QueueSetup: true})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	if len(worktrees.Calls) != 0 {
+		t.Fatalf("worktree create calls = %d, want 0", len(worktrees.Calls))
+	}
+	if f.Status != feature.StatusSettingUpWorktrees {
+		t.Errorf("created status = %v, want %v", f.Status, feature.StatusSettingUpWorktrees)
+	}
+	features, err := store.List()
+	if err != nil {
+		t.Fatalf("listing persisted features: %v", err)
+	}
+	if len(features) != 1 {
+		t.Fatalf("persisted features = %d, want 1", len(features))
+	}
+	persisted := features[0]
+	wantBranch := git.BranchName(persisted.Slug)
+	if got := persisted.Repos[0].Branch; got != wantBranch {
+		t.Fatalf("persisted branch = %q, want %q", got, wantBranch)
+	}
+	setup := persisted.Run().Setup
+	if setup == nil {
+		t.Fatal("persisted run setup state is nil")
+	}
+	if setup.Status != feature.SetupStatusRunning {
+		t.Fatalf("persisted setup status = %q, want %q", setup.Status, feature.SetupStatusRunning)
+	}
+	task, ok := setup.Tasks["worktree:test-repo"]
+	if !ok {
+		t.Fatal("persisted setup task worktree:test-repo missing")
+	}
+	if task.Kind != feature.SetupTaskWorktree || task.Status != feature.SetupStatusQueued || task.Branch != wantBranch {
+		t.Fatalf("persisted setup task = %+v, want queued worktree task on %s", task, wantBranch)
+	}
+	if persisted.StartedAt != nil {
+		t.Fatal("persisted setup feature started first phase")
+	}
+}
+
+func TestManagerCreateQueuedSetupDeduplicatesUpstreamBranchBeforeSave(t *testing.T) {
+	t.Parallel()
+	// parallel-candidate: per-test temp dirs and mocks isolate filesystem and collaborator state.
+	storeDir := t.TempDir()
+	store := feature.NewStore(storeDir)
+	cfg := config.NewDefault()
+	cfg.Repos["test-repo"] = config.RepoConfig{Path: "/repos/test-repo"}
+
+	mgr := feature.NewManager(store, cfg)
+	branches := newMockBranches(true)
+	branches.BranchExistsOnRemoteFn = func(repoPath, branch string) (bool, error) {
+		return branch == "feature/upstream-conflict", nil
+	}
+	mgr.Branches = branches
+	worktrees := mocks.NewMockWorktreeOperator()
+	worktrees.CreateFn = func(repoPath, featureSlug, repoName, startPoint string) (string, error) {
+		return "", fmt.Errorf("worktree side effect should not run while setup is only queued")
+	}
+	mgr.Worktrees = worktrees
+	mgr.PRs = mocks.NewMockPublisher()
+
+	f, err := mgr.Create("Upstream Conflict", "test", []string{"test-repo"}, cfg.Defaults.Models, "", "", nil, feature.CreateOptions{QueueSetup: true})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if f.Slug == "upstream-conflict" {
+		t.Fatal("slug should have been modified to avoid upstream conflict")
+	}
+	if !strings.HasPrefix(f.Slug, "upstream-conflict-") {
+		t.Fatalf("slug = %q, want upstream-conflict-*", f.Slug)
+	}
+	if len(worktrees.Calls) != 0 {
+		t.Fatalf("worktree create calls = %d, want 0", len(worktrees.Calls))
+	}
+
+	persisted, err := store.Load(f.ID)
+	if err != nil {
+		t.Fatalf("load persisted feature: %v", err)
+	}
+	wantBranch := git.BranchName(f.Slug)
+	if persisted.Repos[0].Branch != wantBranch {
+		t.Fatalf("persisted branch = %q, want %q", persisted.Repos[0].Branch, wantBranch)
+	}
+	task := persisted.Run().Setup.Tasks["worktree:test-repo"]
+	if task.Branch != wantBranch {
+		t.Fatalf("setup task branch = %q, want %q", task.Branch, wantBranch)
+	}
+}
+
+func TestManagerRunSetupCompletesQueuedSetupAndCopiesAssets(t *testing.T) {
+	storeDir := t.TempDir()
+	wtDir := t.TempDir()
+	store := feature.NewStore(storeDir)
+	cfg := config.NewDefault()
+	cfg.Repos["repo-a"] = config.RepoConfig{Path: "/repos/repo-a"}
+	cfg.Repos["repo-b"] = config.RepoConfig{Path: "/repos/repo-b"}
+	mgr := feature.NewManager(store, cfg)
+	mgr.Branches = newMockBranches(false)
+	worktrees := mocks.NewMockWorktreeOperator()
+	worktrees.CreateFn = func(repoPath, featureSlug, repoName, startPoint string) (string, error) {
+		return filepath.Join(wtDir, featureSlug, repoName), nil
+	}
+	mgr.Worktrees = worktrees
+	mgr.PRs = mocks.NewMockPublisher()
+
+	tmpDir := t.TempDir()
+	imagePath := filepath.Join(tmpDir, "screenshot.png")
+	if err := os.WriteFile(imagePath, []byte("png bytes"), 0o644); err != nil {
+		t.Fatalf("write image: %v", err)
+	}
+	attachmentPath := filepath.Join(tmpDir, "notes.md")
+	if err := os.WriteFile(attachmentPath, []byte("notes bytes"), 0o644); err != nil {
+		t.Fatalf("write attachment: %v", err)
+	}
+
+	f, err := mgr.Create("Setup Complete", "copy assets", []string{"repo-a", "repo-b"}, cfg.Defaults.Models, "", "", []string{imagePath}, feature.CreateOptions{
+		QueueSetup:  true,
+		Attachments: []string{attachmentPath},
+	})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	var events []feature.SetupEvent
+	if err := mgr.RunSetup(f.ID, feature.SetupRunnerOptions{OnEvent: func(ev feature.SetupEvent) {
+		events = append(events, ev)
+	}}); err != nil {
+		t.Fatalf("run setup: %v", err)
+	}
+
+	loaded, err := mgr.Get(f.ID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if loaded.Status != feature.StatusCreated {
+		t.Fatalf("Status = %s, want Created", loaded.Status)
+	}
+	setup := loaded.Run().Setup
+	if setup == nil || setup.Status != feature.SetupStatusDone {
+		t.Fatalf("setup = %+v, want done setup", setup)
+	}
+	if loaded.ActiveRun != 1 || loaded.RunCount != 1 {
+		t.Fatalf("run identity = active %d count %d, want active 1 count 1", loaded.ActiveRun, loaded.RunCount)
+	}
+	for _, key := range []string{"worktree:repo-a", "worktree:repo-b", "image:1", "attachment:1"} {
+		task := setup.Tasks[key]
+		if task.Status != feature.SetupStatusDone {
+			t.Fatalf("task %s status = %s, want done", key, task.Status)
+		}
+		if task.Path == "" {
+			t.Fatalf("task %s path is empty", key)
+		}
+	}
+	for _, repo := range loaded.Repos {
+		wantPath := filepath.Join(wtDir, loaded.Slug, repo.Name)
+		if repo.WorktreePath != wantPath {
+			t.Fatalf("%s worktree path = %q, want %q", repo.Name, repo.WorktreePath, wantPath)
+		}
+		if repo.Branch != git.BranchName(loaded.Slug) {
+			t.Fatalf("%s branch = %q, want %q", repo.Name, repo.Branch, git.BranchName(loaded.Slug))
+		}
+	}
+	if got, want := len(loaded.Images), 1; got != want {
+		t.Fatalf("images = %d, want %d", got, want)
+	}
+	if data, err := os.ReadFile(loaded.Images[0]); err != nil || string(data) != "png bytes" {
+		t.Fatalf("copied image content = %q, err=%v", string(data), err)
+	}
+	if got, want := len(loaded.Attachments), 1; got != want {
+		t.Fatalf("attachments = %d, want %d", got, want)
+	}
+	if data, err := os.ReadFile(loaded.Attachments[0]); err != nil || string(data) != "notes bytes" {
+		t.Fatalf("copied attachment content = %q, err=%v", string(data), err)
+	}
+	logBytes, err := os.ReadFile(setup.LatestLogPath)
+	if err != nil {
+		t.Fatalf("read setup log: %v", err)
+	}
+	logText := string(logBytes)
+	wantOrder := []string{"task worktree:repo-a started", "task worktree:repo-b started", "task image:1 started", "task attachment:1 started", "setup attempt 1 completed"}
+	last := -1
+	for _, marker := range wantOrder {
+		idx := strings.Index(logText, marker)
+		if idx < 0 {
+			t.Fatalf("setup log missing %q:\n%s", marker, logText)
+		}
+		if idx <= last {
+			t.Fatalf("setup log marker %q out of order:\n%s", marker, logText)
+		}
+		last = idx
+	}
+	if len(events) == 0 || events[0].Kind != feature.SetupEventStarted || events[len(events)-1].Kind != feature.SetupEventCompleted {
+		t.Fatalf("events = %+v, want started...completed", events)
+	}
+	for _, ev := range events {
+		if ev.RunNumber != 1 || ev.Attempt != 1 {
+			t.Fatalf("event = %+v, want run 1 attempt 1", ev)
+		}
+	}
+}
+
+func TestManagerRunSetupFailurePersistsDiagnosticsAndLog(t *testing.T) {
+	mgr := newTestManager(t)
+	worktrees := mocks.NewMockWorktreeOperator()
+	worktrees.CreateFn = func(repoPath, featureSlug, repoName, startPoint string) (string, error) {
+		return "", errors.New("git worktree add failed: branch exists")
+	}
+	mgr.Worktrees = worktrees
+
+	f, err := mgr.Create("Setup Failure", "fail worktree", []string{"test-repo"}, mgr.Config.Defaults.Models, "", "", nil, feature.CreateOptions{QueueSetup: true})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	err = mgr.RunSetup(f.ID)
+	if err == nil {
+		t.Fatal("RunSetup succeeded, want failure")
+	}
+
+	loaded, loadErr := mgr.Get(f.ID)
+	if loadErr != nil {
+		t.Fatalf("get: %v", loadErr)
+	}
+	if loaded.ID != f.ID || loaded.Slug != f.Slug || loaded.ActiveRun != 1 || loaded.RunCount != 1 {
+		t.Fatalf("feature identity changed after failure: id=%q slug=%q active=%d count=%d", loaded.ID, loaded.Slug, loaded.ActiveRun, loaded.RunCount)
+	}
+	if loaded.Status != feature.StatusFailed || loaded.FailureType != feature.FailureWorktreeSetup {
+		t.Fatalf("status/failure = %s/%s, want Failed/%s", loaded.Status, loaded.FailureType, feature.FailureWorktreeSetup)
+	}
+	if !strings.Contains(loaded.LastError, "git worktree add failed") {
+		t.Fatalf("LastError = %q, want worktree diagnostic", loaded.LastError)
+	}
+	setup := loaded.Run().Setup
+	if setup == nil || setup.Status != feature.SetupStatusFailed || setup.LatestLogPath == "" {
+		t.Fatalf("setup = %+v, want failed setup with latest log", setup)
+	}
+	task := setup.Tasks["worktree:test-repo"]
+	if task.Status != feature.SetupStatusFailed || !strings.Contains(task.LastError, "git worktree add failed") {
+		t.Fatalf("task = %+v, want failed task diagnostic", task)
+	}
+	logBytes, err := os.ReadFile(setup.LatestLogPath)
+	if err != nil {
+		t.Fatalf("read setup log: %v", err)
+	}
+	if logText := string(logBytes); !strings.Contains(logText, "setup failed on worktree:test-repo") || !strings.Contains(logText, "git worktree add failed") {
+		t.Fatalf("setup log missing failure diagnostic:\n%s", logText)
+	}
+}
+
+func TestManagerRunSetupImageFailurePreservesCompletedWorktree(t *testing.T) {
+	wtDir := t.TempDir()
+	mgr := newTestManager(t)
+	mgr.Worktrees = &mocks.MockWorktreeOperator{
+		CreateFn: func(repoPath, featureSlug, repoName, startPoint string) (string, error) {
+			return filepath.Join(wtDir, featureSlug, repoName), nil
+		},
+	}
+
+	f, err := mgr.Create("Setup Image Failure", "missing image", []string{"test-repo"}, mgr.Config.Defaults.Models, "", "", []string{filepath.Join(t.TempDir(), "missing.png")}, feature.CreateOptions{QueueSetup: true})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	err = mgr.RunSetup(f.ID)
+	if err == nil {
+		t.Fatal("RunSetup succeeded, want missing image failure")
+	}
+
+	loaded, err := mgr.Get(f.ID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if loaded.Status != feature.StatusFailed || loaded.FailureType != feature.FailureWorktreeSetup {
+		t.Fatalf("status/failure = %s/%s, want Failed/%s", loaded.Status, loaded.FailureType, feature.FailureWorktreeSetup)
+	}
+	setup := loaded.Run().Setup
+	if setup.Tasks["worktree:test-repo"].Status != feature.SetupStatusDone {
+		t.Fatalf("worktree task = %+v, want completed before image failure", setup.Tasks["worktree:test-repo"])
+	}
+	if setup.Tasks["image:1"].Status != feature.SetupStatusFailed {
+		t.Fatalf("image task = %+v, want failed", setup.Tasks["image:1"])
+	}
+	if loaded.Repos[0].WorktreePath == "" {
+		t.Fatal("canonical worktree path was not preserved after later setup failure")
+	}
+}
+
+func TestManagerRetrySetupSkipsDoneTasksAndCompletesOriginalRun(t *testing.T) {
+	storeDir := t.TempDir()
+	wtDir := t.TempDir()
+	store := feature.NewStore(storeDir)
+	cfg := config.NewDefault()
+	cfg.Repos["repo-a"] = config.RepoConfig{Path: "/repos/repo-a"}
+	cfg.Repos["repo-b"] = config.RepoConfig{Path: "/repos/repo-b"}
+	mgr := feature.NewManager(store, cfg)
+	mgr.Branches = newMockBranches(false)
+	worktrees := mocks.NewMockWorktreeOperator()
+	failRepoB := true
+	worktrees.CreateFn = func(repoPath, featureSlug, repoName, startPoint string) (string, error) {
+		if repoName == "repo-b" && failRepoB {
+			return "", errors.New("repo-b checkout failed")
+		}
+		return filepath.Join(wtDir, featureSlug, repoName), nil
+	}
+	mgr.Worktrees = worktrees
+	mgr.PRs = mocks.NewMockPublisher()
+
+	f, err := mgr.Create("Setup Retry", "retry missing repo", []string{"repo-a", "repo-b"}, cfg.Defaults.Models, "", "", nil, feature.CreateOptions{QueueSetup: true})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if err := mgr.RunSetup(f.ID); err == nil {
+		t.Fatal("initial RunSetup succeeded, want repo-b failure")
+	}
+	failed, err := mgr.Get(f.ID)
+	if err != nil {
+		t.Fatalf("get failed: %v", err)
+	}
+	firstLog := failed.Run().Setup.LatestLogPath
+	if failed.Run().Setup.Tasks["worktree:repo-a"].Status != feature.SetupStatusDone {
+		t.Fatalf("repo-a task = %+v, want done", failed.Run().Setup.Tasks["worktree:repo-a"])
+	}
+
+	failRepoB = false
+	if err := mgr.RetrySetup(f.ID); err != nil {
+		t.Fatalf("retry setup: %v", err)
+	}
+	loaded, err := mgr.Get(f.ID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	setup := loaded.Run().Setup
+	if loaded.ID != f.ID || loaded.Slug != f.Slug || loaded.ActiveRun != 1 || loaded.RunCount != 1 {
+		t.Fatalf("feature/run identity changed after retry: id=%q slug=%q active=%d count=%d", loaded.ID, loaded.Slug, loaded.ActiveRun, loaded.RunCount)
+	}
+	if loaded.Status != feature.StatusCreated || setup.Status != feature.SetupStatusDone || setup.Attempt != 2 {
+		t.Fatalf("status/setup/attempt = %s/%s/%d, want Created/done/2", loaded.Status, setup.Status, setup.Attempt)
+	}
+	if setup.Tasks["worktree:repo-a"].Attempt != 1 {
+		t.Fatalf("repo-a attempt = %d, want preserved attempt 1", setup.Tasks["worktree:repo-a"].Attempt)
+	}
+	if setup.Tasks["worktree:repo-b"].Attempt != 2 {
+		t.Fatalf("repo-b attempt = %d, want retry attempt 2", setup.Tasks["worktree:repo-b"].Attempt)
+	}
+	if setup.LatestLogPath == firstLog {
+		t.Fatal("retry did not create a new latest attempt log")
+	}
+	if _, err := os.Stat(firstLog); err != nil {
+		t.Fatalf("first attempt log not preserved: %v", err)
+	}
+	var repoACreates int
+	for _, call := range worktrees.Calls {
+		if call.Method == "Create" && len(call.Args) >= 3 && call.Args[2] == "repo-a" {
+			repoACreates++
+		}
+	}
+	if repoACreates != 1 {
+		t.Fatalf("repo-a create calls = %d, want 1; calls=%+v", repoACreates, worktrees.Calls)
+	}
+}
+
+func TestManagerRetrySetupRefusesDuplicateActiveRunner(t *testing.T) {
+	mgr := newTestManager(t)
+	wtDir := t.TempDir()
+	started := make(chan struct{})
+	release := make(chan struct{})
+	mgr.Worktrees = &mocks.MockWorktreeOperator{
+		CreateFn: func(repoPath, featureSlug, repoName, startPoint string) (string, error) {
+			close(started)
+			<-release
+			return filepath.Join(wtDir, featureSlug, repoName), nil
+		},
+	}
+	f, err := mgr.Create("Setup Duplicate", "duplicate retry", []string{"test-repo"}, mgr.Config.Defaults.Models, "", "", nil, feature.CreateOptions{QueueSetup: true})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- mgr.RunSetup(f.ID) }()
+	<-started
+
+	err = mgr.RetrySetup(f.ID)
+	if !errors.Is(err, feature.ErrSetupAlreadyRunning) {
+		t.Fatalf("RetrySetup while RunSetup active = %v, want ErrSetupAlreadyRunning", err)
+	}
+	close(release)
+	if err := <-done; err != nil {
+		t.Fatalf("background RunSetup: %v", err)
+	}
+}
+
+func TestManagerRetrySetupFailsOnExpectedWorktreeBranchMismatch(t *testing.T) {
+	mgr := newTestManager(t)
+	conflictPath := filepath.Join(t.TempDir(), "setup-feature", "test-repo")
+	if err := os.MkdirAll(conflictPath, 0o755); err != nil {
+		t.Fatalf("mkdir conflict path: %v", err)
+	}
+	worktrees := mocks.NewMockWorktreeOperator()
+	worktrees.CreateFn = func(repoPath, featureSlug, repoName, startPoint string) (string, error) {
+		t.Fatalf("Create called despite persisted path conflict")
+		return "", nil
+	}
+	mgr.Worktrees = worktrees
+	branches := newMockBranches(false)
+	branches.CurrentBranchFn = func(repoPath string) (string, error) {
+		return "feature/someone-else", nil
+	}
+	mgr.Branches = branches
+	f, err := mgr.Create("Setup Branch Mismatch", "conflict", []string{"test-repo"}, mgr.Config.Defaults.Models, "", "", nil, feature.CreateOptions{QueueSetup: true})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if err := mgr.Store.Modify(f.ID, func(ff *feature.Feature) error {
+		setup := ff.Run().Setup
+		setup.Status = feature.SetupStatusFailed
+		task := setup.Tasks["worktree:test-repo"]
+		task.Status = feature.SetupStatusFailed
+		task.Path = conflictPath
+		setup.Tasks[task.Key] = task
+		ff.Status = feature.StatusFailed
+		ff.FailureType = feature.FailureWorktreeSetup
+		return nil
+	}); err != nil {
+		t.Fatalf("seed failed setup: %v", err)
+	}
+
+	err = mgr.RetrySetup(f.ID)
+	if err == nil {
+		t.Fatal("RetrySetup succeeded, want branch mismatch failure")
+	}
+	if !strings.Contains(err.Error(), "want") || !strings.Contains(err.Error(), "someone-else") {
+		t.Fatalf("RetrySetup error = %v, want branch mismatch diagnostic", err)
+	}
+	if _, statErr := os.Stat(conflictPath); statErr != nil {
+		t.Fatalf("conflict path was removed: %v", statErr)
+	}
+	for _, call := range worktrees.Calls {
+		if call.Method == "Remove" {
+			t.Fatalf("unexpected destructive cleanup during retry: %+v", worktrees.Calls)
+		}
+	}
+}
+
+func TestManagerRetrySetupReusesExpectedWorktreeWhenTaskPathWasNotPersisted(t *testing.T) {
+	mgr := newTestManager(t)
+	expectedBase := t.TempDir()
+	expectedPath := filepath.Join(expectedBase, "setup-crash-window", "test-repo")
+	if err := os.MkdirAll(expectedPath, 0o755); err != nil {
+		t.Fatalf("mkdir expected path: %v", err)
+	}
+	worktrees := mocks.NewMockWorktreeOperator()
+	worktrees.ExpectedPathFn = func(featureSlug, repoName string) string {
+		return expectedPath
+	}
+	worktrees.CreateFn = func(repoPath, featureSlug, repoName, startPoint string) (string, error) {
+		t.Fatalf("Create called even though expected worktree path exists")
+		return "", nil
+	}
+	mgr.Worktrees = worktrees
+
+	var expectedBranch string
+	branches := newMockBranches(false)
+	branches.CurrentBranchFn = func(repoPath string) (string, error) {
+		if repoPath != expectedPath {
+			t.Fatalf("CurrentBranch path = %q, want %q", repoPath, expectedPath)
+		}
+		return expectedBranch, nil
+	}
+	mgr.Branches = branches
+
+	f, err := mgr.Create("Setup Crash Window", "reattach expected path", []string{"test-repo"}, mgr.Config.Defaults.Models, "", "", nil, feature.CreateOptions{QueueSetup: true})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	expectedBranch = git.BranchName(f.Slug)
+	if err := mgr.Store.Modify(f.ID, func(ff *feature.Feature) error {
+		setup := ff.Run().Setup
+		setup.Status = feature.SetupStatusFailed
+		task := setup.Tasks["worktree:test-repo"]
+		task.Status = feature.SetupStatusFailed
+		task.Path = ""
+		task.LastError = "process exited before setup state saved"
+		setup.Tasks[task.Key] = task
+		ff.Status = feature.StatusFailed
+		ff.FailureType = feature.FailureWorktreeSetup
+		ff.LastError = task.LastError
+		return nil
+	}); err != nil {
+		t.Fatalf("seed failed setup: %v", err)
+	}
+
+	if err := mgr.RetrySetup(f.ID); err != nil {
+		t.Fatalf("retry setup: %v", err)
+	}
+	loaded, err := mgr.Get(f.ID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if loaded.Status != feature.StatusCreated {
+		t.Fatalf("Status = %s, want Created", loaded.Status)
+	}
+	task := loaded.Run().Setup.Tasks["worktree:test-repo"]
+	if task.Status != feature.SetupStatusDone || task.Path != expectedPath {
+		t.Fatalf("task = %+v, want done with expected path %s", task, expectedPath)
+	}
+	if loaded.Repos[0].WorktreePath != expectedPath {
+		t.Fatalf("canonical worktree = %q, want %q", loaded.Repos[0].WorktreePath, expectedPath)
+	}
+	for _, call := range worktrees.Calls {
+		if call.Method == "Create" {
+			t.Fatalf("unexpected Create call while reusing expected path: %+v", worktrees.Calls)
+		}
+	}
+}
+
+func TestManagerDeleteRemovesSetupTaskWorktreePaths(t *testing.T) {
+	mgr := newTestManager(t)
+	removed := make(map[string]bool)
+	mgr.Worktrees = &mocks.MockWorktreeOperator{
+		RemoveFn: func(worktreePath string, deleteBranch bool) error {
+			if !deleteBranch {
+				t.Fatalf("deleteBranch = false for %s, want true", worktreePath)
+			}
+			removed[worktreePath] = true
+			return nil
+		},
+	}
+	f, err := mgr.Create("Setup Delete", "cleanup partial setup", []string{"test-repo"}, mgr.Config.Defaults.Models, "", "", nil, feature.CreateOptions{QueueSetup: true})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	setupPath := filepath.Join(t.TempDir(), "setup-delete", "test-repo")
+	if err := mgr.Store.Modify(f.ID, func(ff *feature.Feature) error {
+		task := ff.Run().Setup.Tasks["worktree:test-repo"]
+		task.Path = setupPath
+		task.Status = feature.SetupStatusFailed
+		ff.Run().Setup.Tasks[task.Key] = task
+		ff.Run().Setup.Status = feature.SetupStatusFailed
+		ff.Status = feature.StatusFailed
+		ff.FailureType = feature.FailureWorktreeSetup
+		return nil
+	}); err != nil {
+		t.Fatalf("seed setup task path: %v", err)
+	}
+
+	if err := mgr.Delete(f.ID); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if !removed[setupPath] {
+		t.Fatalf("removed paths = %v, want setup task path %s", removed, setupPath)
+	}
+}
+
+func TestManagerReconcileAbandonedSetupsMarksFailed(t *testing.T) {
+	mgr := newTestManager(t)
+	f, err := mgr.Create("Setup Reconcile", "stale active setup", []string{"test-repo"}, mgr.Config.Defaults.Models, "", "", nil, feature.CreateOptions{QueueSetup: true})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	logPath := filepath.Join(mgr.Store.RunDir(f.ID, 1), "setup", "attempt-01-output.txt")
+	if err := os.MkdirAll(filepath.Dir(logPath), 0o755); err != nil {
+		t.Fatalf("mkdir log dir: %v", err)
+	}
+	if err := os.WriteFile(logPath, []byte("partial setup log"), 0o644); err != nil {
+		t.Fatalf("write log: %v", err)
+	}
+	if err := mgr.Store.Modify(f.ID, func(ff *feature.Feature) error {
+		setup := ff.Run().Setup
+		setup.LatestLogPath = logPath
+		task := setup.Tasks["worktree:test-repo"]
+		task.Status = feature.SetupStatusRunning
+		task.Path = "/tmp/worktrees/setup-reconcile/test-repo"
+		setup.Tasks[task.Key] = task
+		return nil
+	}); err != nil {
+		t.Fatalf("seed running task: %v", err)
+	}
+
+	reconciled, err := mgr.ReconcileAbandonedSetups()
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if len(reconciled) != 1 || reconciled[0] != f.ID {
+		t.Fatalf("reconciled = %v, want [%s]", reconciled, f.ID)
+	}
+	loaded, err := mgr.Get(f.ID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if loaded.Status != feature.StatusFailed || loaded.FailureType != feature.FailureWorktreeSetup {
+		t.Fatalf("status/failure = %s/%s, want Failed/%s", loaded.Status, loaded.FailureType, feature.FailureWorktreeSetup)
+	}
+	setup := loaded.Run().Setup
+	if setup.Status != feature.SetupStatusFailed || !strings.Contains(setup.LastError, "interrupted by shutdown or crash") {
+		t.Fatalf("setup = %+v, want failed crash diagnostic", setup)
+	}
+	if setup.LatestLogPath != logPath {
+		t.Fatalf("latest log = %q, want preserved %q", setup.LatestLogPath, logPath)
+	}
+	task := setup.Tasks["worktree:test-repo"]
+	if task.Status != feature.SetupStatusFailed || task.Path == "" || task.Branch == "" {
+		t.Fatalf("task = %+v, want failed task preserving path and branch", task)
+	}
+}
+
 func TestManagerCreateWithoutWorktree(t *testing.T) {
 	t.Parallel()
 	// parallel-candidate: per-test temp dirs and mocks isolate filesystem and collaborator state.
@@ -1237,11 +1860,11 @@ func TestRewindToPhase_ArtifactMap_ForwardCarriesCorrectSubset_SealedPreserved(t
 		f.Status = feature.StatusImplementing
 		f.CurrentPhase = feature.PhaseImplement
 		f.Artifacts = map[string]string{
-			"inquire":    "/path/to/inquire.md",
-			"research":   "/path/to/research.md",
-			"design": "/path/to/design.md",
-			"plan":       "/path/to/plan.md",
-			"implement":  "/path/to/impl.md",
+			"inquire":   "/path/to/inquire.md",
+			"research":  "/path/to/research.md",
+			"design":    "/path/to/design.md",
+			"plan":      "/path/to/plan.md",
+			"implement": "/path/to/impl.md",
 		}
 		return nil
 	})
@@ -4611,7 +5234,7 @@ func seedCarryForwardFixtures(t *testing.T, run1Dir string) {
 	files := map[string]string{
 		filepath.Join("inquire", "marker.txt"):            "inquire",
 		filepath.Join("research", "marker.txt"):           "research",
-		filepath.Join("design", "marker.txt"):         "design",
+		filepath.Join("design", "marker.txt"):             "design",
 		filepath.Join("plan", "plan.md"):                  "plan",
 		filepath.Join("roadmap", "roadmap.md"):            "roadmap",
 		filepath.Join("phase-01", "plan", "plan.md"):      "phase-01-plan",
@@ -5502,12 +6125,12 @@ func TestRewindToPhase_ArtifactMapCarriedForward(t *testing.T) {
 
 		if err := mgr.Store.Modify(f.ID, func(ff *feature.Feature) error {
 			ff.Artifacts = map[string]string{
-				"inquire":    absInquire,
-				"research":   absResearch,
-				"design": absDesign,
-				"plan":       absPlan,
-				"implement":  absImpl,
-				"pr_url":     "https://github.com/o/r/pull/1",
+				"inquire":   absInquire,
+				"research":  absResearch,
+				"design":    absDesign,
+				"plan":      absPlan,
+				"implement": absImpl,
+				"pr_url":    "https://github.com/o/r/pull/1",
 			}
 			return nil
 		}); err != nil {
@@ -5523,9 +6146,9 @@ func TestRewindToPhase_ArtifactMapCarriedForward(t *testing.T) {
 			t.Fatalf("Get: %v", err)
 		}
 		wantRel := map[string]string{
-			"inquire":    filepath.Join("inquire", "inquire.md"),
-			"research":   filepath.Join("research", "research.md"),
-			"design": filepath.Join("design", "design.md"),
+			"inquire":  filepath.Join("inquire", "inquire.md"),
+			"research": filepath.Join("research", "research.md"),
+			"design":   filepath.Join("design", "design.md"),
 		}
 		if len(got.Artifacts) != len(wantRel) {
 			t.Errorf("new run Artifacts len = %d, want %d: %v", len(got.Artifacts), len(wantRel), got.Artifacts)
@@ -5572,7 +6195,7 @@ func TestRewindToPhase_ArtifactMapCarriedForward(t *testing.T) {
 		absMap := map[string]string{
 			"inquire":      filepath.Join(run1Dir, "inquire", "inquire.md"),
 			"research":     filepath.Join(run1Dir, "research", "research.md"),
-			"design":   filepath.Join(run1Dir, "design", "design.md"),
+			"design":       filepath.Join(run1Dir, "design", "design.md"),
 			"plan":         filepath.Join(run1Dir, "plan", "plan.md"),
 			"roadmap":      filepath.Join(run1Dir, "roadmap", "roadmap.md"),
 			"phase-1-plan": filepath.Join(run1Dir, "phase-01", "plan", "plan.md"),

--- a/internal/feature/run.go
+++ b/internal/feature/run.go
@@ -46,6 +46,9 @@ type Run struct {
 	RunNumber int        `yaml:"run_number"`
 	StartedAt *time.Time `yaml:"started_at,omitempty"`
 
+	// Setup tracks first-run preparation before any phase session starts.
+	Setup *SetupState `yaml:"setup,omitempty"`
+
 	// Sealing (set only by rewind; absent/zero on active runs).
 	SealedAt     *time.Time `yaml:"sealed_at,omitempty"`
 	SealReason   SealReason `yaml:"seal_reason,omitempty"`

--- a/internal/feature/setup.go
+++ b/internal/feature/setup.go
@@ -1,0 +1,135 @@
+// Copyright 2026 DoorDash, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package feature
+
+import (
+	"strconv"
+	"time"
+)
+
+type SetupStatus string
+
+const (
+	SetupStatusQueued  SetupStatus = "queued"
+	SetupStatusRunning SetupStatus = "running"
+	SetupStatusDone    SetupStatus = "done"
+	SetupStatusFailed  SetupStatus = "failed"
+)
+
+type SetupTaskKind string
+
+const (
+	SetupTaskWorktree   SetupTaskKind = "worktree"
+	SetupTaskImage      SetupTaskKind = "image"
+	SetupTaskAttachment SetupTaskKind = "attachment"
+)
+
+type SetupTask struct {
+	Key              string        `yaml:"key"`
+	Kind             SetupTaskKind `yaml:"kind"`
+	Label            string        `yaml:"label"`
+	Repo             string        `yaml:"repo,omitempty"`
+	Status           SetupStatus   `yaml:"status"`
+	Path             string        `yaml:"path,omitempty"`
+	SourcePath       string        `yaml:"source_path,omitempty"`
+	Branch           string        `yaml:"branch,omitempty"`
+	StartPoint       string        `yaml:"start_point,omitempty"`
+	UseCurrentBranch bool          `yaml:"use_current_branch,omitempty"`
+	Attempt          int           `yaml:"attempt,omitempty"`
+	StartedAt        *time.Time    `yaml:"started_at,omitempty"`
+	EndedAt          *time.Time    `yaml:"ended_at,omitempty"`
+	LastError        string        `yaml:"last_error,omitempty"`
+}
+
+type SetupState struct {
+	Status        SetupStatus          `yaml:"status"`
+	Attempt       int                  `yaml:"attempt"`
+	StartedAt     *time.Time           `yaml:"started_at,omitempty"`
+	CompletedAt   *time.Time           `yaml:"completed_at,omitempty"`
+	LatestLogPath string               `yaml:"latest_log_path,omitempty"`
+	Tasks         map[string]SetupTask `yaml:"tasks,omitempty"`
+	TaskOrder     []string             `yaml:"task_order,omitempty"`
+	LastError     string               `yaml:"last_error,omitempty"`
+}
+
+type SetupInitOptions struct {
+	UseCurrentBranch        bool
+	UseCurrentBranchPerRepo map[string]bool
+}
+
+func NewActiveSetupState(repos []FeatureRepo, images, attachments []string, now time.Time, opts ...SetupInitOptions) *SetupState {
+	var opt SetupInitOptions
+	if len(opts) > 0 {
+		opt = opts[0]
+	}
+	tasks := make(map[string]SetupTask, len(repos)+len(images)+len(attachments))
+	var order []string
+	for _, repo := range repos {
+		useCurrent := opt.UseCurrentBranch
+		if v, ok := opt.UseCurrentBranchPerRepo[repo.Name]; ok {
+			useCurrent = v
+		}
+		startPoint := repo.BaseBranch
+		if useCurrent {
+			startPoint = ""
+		}
+		key := "worktree:" + repo.Name
+		tasks[key] = SetupTask{
+			Key:              key,
+			Kind:             SetupTaskWorktree,
+			Label:            "Worktree: " + repo.Name,
+			Repo:             repo.Name,
+			Status:           SetupStatusQueued,
+			Branch:           repo.Branch,
+			StartPoint:       startPoint,
+			UseCurrentBranch: useCurrent,
+			Attempt:          1,
+		}
+		order = append(order, key)
+	}
+	for i := range images {
+		n := strconv.Itoa(i + 1)
+		key := "image:" + n
+		tasks[key] = SetupTask{
+			Key:        key,
+			Kind:       SetupTaskImage,
+			Label:      "Image " + n,
+			Status:     SetupStatusQueued,
+			SourcePath: images[i],
+			Attempt:    1,
+		}
+		order = append(order, key)
+	}
+	for i := range attachments {
+		n := strconv.Itoa(i + 1)
+		key := "attachment:" + n
+		tasks[key] = SetupTask{
+			Key:        key,
+			Kind:       SetupTaskAttachment,
+			Label:      "Attachment " + n,
+			Status:     SetupStatusQueued,
+			SourcePath: attachments[i],
+			Attempt:    1,
+		}
+		order = append(order, key)
+	}
+	return &SetupState{
+		Status:    SetupStatusRunning,
+		Attempt:   1,
+		StartedAt: &now,
+		Tasks:     tasks,
+		TaskOrder: order,
+	}
+}

--- a/internal/feature/setup_runner.go
+++ b/internal/feature/setup_runner.go
@@ -1,0 +1,595 @@
+// Copyright 2026 DoorDash, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package feature
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+var ErrSetupAlreadyRunning = errors.New("setup already running")
+
+type SetupEventKind string
+
+const (
+	SetupEventStarted       SetupEventKind = "started"
+	SetupEventTaskStarted   SetupEventKind = "task_started"
+	SetupEventTaskCompleted SetupEventKind = "task_completed"
+	SetupEventCompleted     SetupEventKind = "completed"
+	SetupEventFailed        SetupEventKind = "failed"
+)
+
+type SetupEvent struct {
+	Kind      SetupEventKind
+	FeatureID string
+	RunNumber int
+	Attempt   int
+	LogPath   string
+
+	TaskKey    string
+	TaskKind   SetupTaskKind
+	TaskStatus SetupStatus
+	Repo       string
+	Path       string
+	Branch     string
+	Error      string
+}
+
+type SetupRunnerOptions struct {
+	OnEvent func(SetupEvent)
+}
+
+func (m *Manager) setupLock(featureID string) (func(), error) {
+	m.setupMu.Lock()
+	defer m.setupMu.Unlock()
+	if m.setupLocks == nil {
+		m.setupLocks = make(map[string]struct{})
+	}
+	if _, ok := m.setupLocks[featureID]; ok {
+		return nil, ErrSetupAlreadyRunning
+	}
+	m.setupLocks[featureID] = struct{}{}
+	return func() {
+		m.setupMu.Lock()
+		delete(m.setupLocks, featureID)
+		m.setupMu.Unlock()
+	}, nil
+}
+
+func (m *Manager) RunSetup(featureID string, opts ...SetupRunnerOptions) error {
+	return m.runSetup(featureID, false, opts...)
+}
+
+func (m *Manager) RetrySetup(featureID string, opts ...SetupRunnerOptions) error {
+	return m.runSetup(featureID, true, opts...)
+}
+
+func (m *Manager) runSetup(featureID string, retry bool, opts ...SetupRunnerOptions) error {
+	unlock, err := m.setupLock(featureID)
+	if err != nil {
+		return err
+	}
+	defer unlock()
+
+	var opt SetupRunnerOptions
+	if len(opts) > 0 {
+		opt = opts[0]
+	}
+	emit := func(ev SetupEvent) {
+		if opt.OnEvent != nil {
+			opt.OnEvent(ev)
+		}
+	}
+
+	f, err := m.Store.Load(featureID)
+	if err != nil {
+		return fmt.Errorf("loading feature: %w", err)
+	}
+	setup := f.Run().Setup
+	if setup == nil {
+		return fmt.Errorf("feature %s has no setup state", featureID)
+	}
+	if setup.Status == SetupStatusDone {
+		return nil
+	}
+	if retry {
+		if f.Status != StatusFailed || f.FailureType != FailureWorktreeSetup || setup.Status != SetupStatusFailed {
+			return fmt.Errorf("setup retry requires Failed (%s) feature with failed setup state", FailureWorktreeSetup)
+		}
+	} else if f.Status != StatusSettingUpWorktrees || setup.Status != SetupStatusRunning {
+		return fmt.Errorf("setup can only run from active setup state")
+	}
+
+	attempt := setup.Attempt
+	if retry {
+		attempt++
+		if err := m.prepareSetupRetry(featureID, attempt); err != nil {
+			return err
+		}
+	} else if attempt <= 0 {
+		attempt = 1
+	}
+
+	f, err = m.Store.Load(featureID)
+	if err != nil {
+		return fmt.Errorf("reloading feature: %w", err)
+	}
+	setup = f.Run().Setup
+	logPath := setupAttemptLogPath(m.Store, f, attempt)
+	if err := os.MkdirAll(filepath.Dir(logPath), 0o755); err != nil {
+		_ = m.failSetupTask(featureID, "", err.Error())
+		return fmt.Errorf("creating setup log directory: %w", err)
+	}
+	if err := os.WriteFile(logPath, nil, 0o644); err != nil {
+		_ = m.failSetupTask(featureID, "", err.Error())
+		return fmt.Errorf("creating setup log: %w", err)
+	}
+	if err := m.Store.Modify(featureID, func(ff *Feature) error {
+		s := ff.Run().Setup
+		if s == nil {
+			return fmt.Errorf("feature %s has no setup state", featureID)
+		}
+		now := time.Now()
+		s.Status = SetupStatusRunning
+		s.Attempt = attempt
+		s.StartedAt = &now
+		s.CompletedAt = nil
+		s.LatestLogPath = logPath
+		s.LastError = ""
+		ff.Status = StatusSettingUpWorktrees
+		ff.FailureType = ""
+		ff.LastError = ""
+		return nil
+	}); err != nil {
+		return err
+	}
+	appendSetupLog(logPath, "setup attempt %d started for feature %s", attempt, featureID)
+	emit(SetupEvent{Kind: SetupEventStarted, FeatureID: featureID, RunNumber: f.ActiveRun, Attempt: attempt, LogPath: logPath})
+
+	for _, key := range setupTaskOrder(setup) {
+		current, err := m.Store.Load(featureID)
+		if err != nil {
+			return fmt.Errorf("loading feature before setup task: %w", err)
+		}
+		task, ok := current.Run().Setup.Tasks[key]
+		if !ok {
+			continue
+		}
+		if task.Status == SetupStatusDone {
+			appendSetupLog(logPath, "skip %s: already done", task.Key)
+			continue
+		}
+		task.Attempt = attempt
+		if err := m.markSetupTaskRunning(featureID, task, logPath); err != nil {
+			return err
+		}
+		emit(setupTaskEvent(SetupEventTaskStarted, featureID, current.ActiveRun, attempt, logPath, task, ""))
+
+		completed, err := m.executeSetupTask(current, task, logPath)
+		if err != nil {
+			msg := err.Error()
+			if markErr := m.failSetupTask(featureID, task.Key, msg); markErr != nil {
+				return errors.Join(err, markErr)
+			}
+			completed.Status = SetupStatusFailed
+			completed.LastError = msg
+			appendSetupLog(logPath, "setup failed on %s: %s", task.Key, msg)
+			emit(setupTaskEvent(SetupEventFailed, featureID, current.ActiveRun, attempt, logPath, completed, msg))
+			return err
+		}
+		if err := m.completeSetupTask(featureID, completed); err != nil {
+			return err
+		}
+		appendSetupLog(logPath, "task %s completed", completed.Key)
+		emit(setupTaskEvent(SetupEventTaskCompleted, featureID, current.ActiveRun, attempt, logPath, completed, ""))
+	}
+
+	if err := m.completeSetup(featureID); err != nil {
+		return err
+	}
+	appendSetupLog(logPath, "setup attempt %d completed", attempt)
+	emit(SetupEvent{Kind: SetupEventCompleted, FeatureID: featureID, RunNumber: f.ActiveRun, Attempt: attempt, LogPath: logPath})
+	return nil
+}
+
+func (m *Manager) prepareSetupRetry(featureID string, attempt int) error {
+	return m.Store.Modify(featureID, func(f *Feature) error {
+		setup := f.Run().Setup
+		if setup == nil {
+			return fmt.Errorf("feature %s has no setup state", featureID)
+		}
+		now := time.Now()
+		setup.Status = SetupStatusRunning
+		setup.Attempt = attempt
+		setup.StartedAt = &now
+		setup.CompletedAt = nil
+		setup.LastError = ""
+		for _, key := range setupTaskOrder(setup) {
+			task := setup.Tasks[key]
+			if task.Status == SetupStatusDone {
+				continue
+			}
+			task.Status = SetupStatusQueued
+			task.Attempt = attempt
+			task.StartedAt = nil
+			task.EndedAt = nil
+			task.LastError = ""
+			setup.Tasks[key] = task
+		}
+		f.Status = StatusSettingUpWorktrees
+		f.FailureType = ""
+		f.LastError = ""
+		return nil
+	})
+}
+
+func (m *Manager) markSetupTaskRunning(featureID string, task SetupTask, logPath string) error {
+	return m.Store.Modify(featureID, func(f *Feature) error {
+		setup := f.Run().Setup
+		if setup == nil {
+			return fmt.Errorf("feature %s has no setup state", featureID)
+		}
+		now := time.Now()
+		task.Status = SetupStatusRunning
+		task.StartedAt = &now
+		task.EndedAt = nil
+		task.LastError = ""
+		setup.LatestLogPath = logPath
+		setup.Tasks[task.Key] = task
+		return nil
+	})
+}
+
+func (m *Manager) executeSetupTask(f *Feature, task SetupTask, logPath string) (SetupTask, error) {
+	appendSetupLog(logPath, "task %s started: kind=%s repo=%s branch=%s path=%s", task.Key, task.Kind, task.Repo, task.Branch, task.Path)
+	switch task.Kind {
+	case SetupTaskWorktree:
+		return m.executeWorktreeSetupTask(f, task, logPath)
+	case SetupTaskImage:
+		return m.executeImageSetupTask(f, task, logPath)
+	case SetupTaskAttachment:
+		return m.executeAttachmentSetupTask(f, task, logPath)
+	default:
+		return task, fmt.Errorf("unknown setup task kind %q", task.Kind)
+	}
+}
+
+func (m *Manager) executeWorktreeSetupTask(f *Feature, task SetupTask, logPath string) (SetupTask, error) {
+	if m.Worktrees == nil {
+		return task, fmt.Errorf("worktree manager not configured")
+	}
+	idx := repoIndexByName(f, task.Repo)
+	if idx < 0 {
+		return task, fmt.Errorf("repo %q no longer exists on feature", task.Repo)
+	}
+	repo := f.Repos[idx]
+	if task.Branch == "" {
+		task.Branch = repo.Branch
+	}
+	if task.StartPoint == "" && !task.UseCurrentBranch {
+		task.StartPoint = repo.BaseBranch
+	}
+	if task.Path == "" {
+		if pather, ok := m.Worktrees.(interface {
+			ExpectedPath(featureSlug, repoName string) string
+		}); ok {
+			task.Path = pather.ExpectedPath(f.Slug, repo.Name)
+		}
+	}
+	if task.Path != "" {
+		if err := m.reuseExpectedWorktree(task); err == nil {
+			appendSetupLog(logPath, "reused expected worktree path %s for branch %s", task.Path, task.Branch)
+			return task, nil
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return task, err
+		}
+	}
+	startPoint := task.StartPoint
+	if task.UseCurrentBranch {
+		startPoint = ""
+	}
+	appendSetupLog(logPath, "creating worktree repo=%s branch=%s start_point=%s", repo.Name, task.Branch, startPoint)
+	path, err := m.Worktrees.Create(repo.Path, f.Slug, repo.Name, startPoint)
+	if err != nil {
+		return task, fmt.Errorf("creating worktree for %s: %w", repo.Name, err)
+	}
+	task.Path = path
+	if task.Branch == "" {
+		task.Branch = repo.Branch
+	}
+	appendSetupLog(logPath, "created worktree repo=%s path=%s branch=%s", repo.Name, task.Path, task.Branch)
+	return task, nil
+}
+
+func (m *Manager) reuseExpectedWorktree(task SetupTask) error {
+	info, err := os.Stat(task.Path)
+	if err != nil {
+		return err
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("expected worktree path %s exists but is not a directory", task.Path)
+	}
+	if m.Branches != nil {
+		branch, err := m.Branches.CurrentBranch(task.Path)
+		if err != nil {
+			return fmt.Errorf("checking branch for expected worktree path %s: %w", task.Path, err)
+		}
+		if task.Branch != "" && branch != task.Branch {
+			return fmt.Errorf("expected worktree path %s is on branch %q, want %q", task.Path, branch, task.Branch)
+		}
+	}
+	return nil
+}
+
+func (m *Manager) executeImageSetupTask(f *Feature, task SetupTask, logPath string) (SetupTask, error) {
+	if task.SourcePath == "" {
+		return task, fmt.Errorf("image setup task %s is missing source path", task.Key)
+	}
+	n, err := setupTaskOrdinal(task.Key, "image:")
+	if err != nil {
+		return task, err
+	}
+	if task.Path == "" {
+		task.Path = filepath.Join(m.Store.BaseDir, f.ID, "images", fmt.Sprintf("image-%d.png", n))
+	}
+	if err := os.MkdirAll(filepath.Dir(task.Path), 0o755); err != nil {
+		return task, fmt.Errorf("creating images directory: %w", err)
+	}
+	appendSetupLog(logPath, "copying image source=%s destination=%s", task.SourcePath, task.Path)
+	if err := copyFile(task.SourcePath, task.Path); err != nil {
+		return task, fmt.Errorf("copying image %d: %w", n, err)
+	}
+	return task, nil
+}
+
+func (m *Manager) executeAttachmentSetupTask(f *Feature, task SetupTask, logPath string) (SetupTask, error) {
+	if task.SourcePath == "" {
+		return task, fmt.Errorf("attachment setup task %s is missing source path", task.Key)
+	}
+	if _, err := setupTaskOrdinal(task.Key, "attachment:"); err != nil {
+		return task, err
+	}
+	if task.Path == "" {
+		task.Path = filepath.Join(m.Store.BaseDir, f.ID, "attachments", filepath.Base(task.SourcePath))
+	}
+	if err := os.MkdirAll(filepath.Dir(task.Path), 0o755); err != nil {
+		return task, fmt.Errorf("creating attachments directory: %w", err)
+	}
+	appendSetupLog(logPath, "copying attachment source=%s destination=%s", task.SourcePath, task.Path)
+	if err := copyFile(task.SourcePath, task.Path); err != nil {
+		return task, fmt.Errorf("copying attachment %s: %w", filepath.Base(task.SourcePath), err)
+	}
+	return task, nil
+}
+
+func (m *Manager) completeSetupTask(featureID string, task SetupTask) error {
+	return m.Store.Modify(featureID, func(f *Feature) error {
+		setup := f.Run().Setup
+		if setup == nil {
+			return fmt.Errorf("feature %s has no setup state", featureID)
+		}
+		now := time.Now()
+		task.Status = SetupStatusDone
+		task.EndedAt = &now
+		task.LastError = ""
+		setup.Tasks[task.Key] = task
+		switch task.Kind {
+		case SetupTaskWorktree:
+			idx := repoIndexByName(f, task.Repo)
+			if idx >= 0 {
+				f.Repos[idx].WorktreePath = task.Path
+				if task.Branch != "" {
+					f.Repos[idx].Branch = task.Branch
+				}
+			}
+		case SetupTaskImage:
+			f.Images = appendUniqueString(f.Images, task.Path)
+		case SetupTaskAttachment:
+			f.Attachments = appendUniqueString(f.Attachments, task.Path)
+		}
+		return nil
+	})
+}
+
+func (m *Manager) failSetupTask(featureID, taskKey, errMsg string) error {
+	return m.Store.Modify(featureID, func(f *Feature) error {
+		setup := f.Run().Setup
+		if setup == nil {
+			return fmt.Errorf("feature %s has no setup state", featureID)
+		}
+		now := time.Now()
+		setup.Status = SetupStatusFailed
+		setup.CompletedAt = &now
+		setup.LastError = errMsg
+		if task, ok := setup.Tasks[taskKey]; ok {
+			task.Status = SetupStatusFailed
+			task.EndedAt = &now
+			task.LastError = errMsg
+			setup.Tasks[taskKey] = task
+		}
+		f.Status = StatusFailed
+		f.FailureType = FailureWorktreeSetup
+		f.LastError = errMsg
+		return nil
+	})
+}
+
+func (m *Manager) completeSetup(featureID string) error {
+	return m.Store.Modify(featureID, func(f *Feature) error {
+		setup := f.Run().Setup
+		if setup == nil {
+			return fmt.Errorf("feature %s has no setup state", featureID)
+		}
+		now := time.Now()
+		setup.Status = SetupStatusDone
+		setup.CompletedAt = &now
+		setup.LastError = ""
+		for _, key := range setupTaskOrder(setup) {
+			task := setup.Tasks[key]
+			if task.Status != SetupStatusDone {
+				return fmt.Errorf("setup task %s is %s, want done", key, task.Status)
+			}
+		}
+		if err := f.Transition(StatusCreated); err != nil {
+			return err
+		}
+		f.FailureType = ""
+		f.LastError = ""
+		return nil
+	})
+}
+
+func (m *Manager) ReconcileAbandonedSetups() ([]string, error) {
+	features, err := m.List()
+	if err != nil && !IsPartialLoadError(err) {
+		return nil, err
+	}
+	var reconciled []string
+	for _, f := range features {
+		setup := f.Run().Setup
+		if setup == nil || setup.Status != SetupStatusRunning || f.Status != StatusSettingUpWorktrees {
+			continue
+		}
+		msg := "setup was interrupted by shutdown or crash; retry setup to continue"
+		if err := m.failAbandonedSetup(f.ID, msg); err != nil {
+			return reconciled, err
+		}
+		reconciled = append(reconciled, f.ID)
+	}
+	return reconciled, nil
+}
+
+func (m *Manager) failAbandonedSetup(featureID, msg string) error {
+	return m.Store.Modify(featureID, func(f *Feature) error {
+		setup := f.Run().Setup
+		if setup == nil || setup.Status != SetupStatusRunning {
+			return nil
+		}
+		now := time.Now()
+		setup.Status = SetupStatusFailed
+		setup.CompletedAt = &now
+		setup.LastError = msg
+		for _, key := range setupTaskOrder(setup) {
+			task := setup.Tasks[key]
+			if task.Status == SetupStatusRunning {
+				task.Status = SetupStatusFailed
+				task.EndedAt = &now
+				task.LastError = msg
+				setup.Tasks[key] = task
+				break
+			}
+		}
+		f.Status = StatusFailed
+		f.FailureType = FailureWorktreeSetup
+		f.LastError = msg
+		return nil
+	})
+}
+
+func setupAttemptLogPath(store *Store, f *Feature, attempt int) string {
+	return filepath.Join(store.RunDir(f.ID, f.ActiveRun), "setup", fmt.Sprintf("attempt-%02d-output.txt", attempt))
+}
+
+func appendSetupLog(path, format string, args ...any) {
+	line := fmt.Sprintf(format, args...)
+	line = fmt.Sprintf("%s %s\n", time.Now().Format(time.RFC3339), line)
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		return
+	}
+	defer file.Close()
+	_, _ = file.WriteString(line)
+}
+
+func setupTaskOrder(setup *SetupState) []string {
+	if setup == nil {
+		return nil
+	}
+	seen := make(map[string]bool, len(setup.Tasks))
+	var order []string
+	for _, key := range setup.TaskOrder {
+		if _, ok := setup.Tasks[key]; ok && !seen[key] {
+			order = append(order, key)
+			seen[key] = true
+		}
+	}
+	var rest []string
+	for key := range setup.Tasks {
+		if !seen[key] {
+			rest = append(rest, key)
+		}
+	}
+	sort.Strings(rest)
+	return append(order, rest...)
+}
+
+func setupTaskEvent(kind SetupEventKind, featureID string, runNumber, attempt int, logPath string, task SetupTask, errMsg string) SetupEvent {
+	return SetupEvent{
+		Kind:       kind,
+		FeatureID:  featureID,
+		RunNumber:  runNumber,
+		Attempt:    attempt,
+		LogPath:    logPath,
+		TaskKey:    task.Key,
+		TaskKind:   task.Kind,
+		TaskStatus: task.Status,
+		Repo:       task.Repo,
+		Path:       task.Path,
+		Branch:     task.Branch,
+		Error:      errMsg,
+	}
+}
+
+func setupTaskOrdinal(key, prefix string) (int, error) {
+	raw, ok := strings.CutPrefix(key, prefix)
+	if !ok || raw == "" {
+		return 0, fmt.Errorf("setup task %q has invalid key for prefix %q", key, prefix)
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil || n <= 0 {
+		return 0, fmt.Errorf("setup task %q has invalid ordinal", key)
+	}
+	return n, nil
+}
+
+func repoIndexByName(f *Feature, name string) int {
+	if f == nil {
+		return -1
+	}
+	for i, repo := range f.Repos {
+		if repo.Name == name {
+			return i
+		}
+	}
+	return -1
+}
+
+func appendUniqueString(values []string, value string) []string {
+	if value == "" {
+		return values
+	}
+	for _, existing := range values {
+		if existing == value {
+			return values
+		}
+	}
+	return append(values, value)
+}

--- a/internal/feature/store_test.go
+++ b/internal/feature/store_test.go
@@ -990,6 +990,68 @@ artifacts: {}
 	if loaded.SchemaVersion != SchemaVersionCurrent {
 		t.Errorf("loaded.SchemaVersion = %d, want %d", loaded.SchemaVersion, SchemaVersionCurrent)
 	}
+	if loaded.Run().Setup != nil {
+		t.Fatalf("legacy run setup = %+v, want nil", loaded.Run().Setup)
+	}
+}
+
+func TestStoreSetupStateRoundTrip(t *testing.T) {
+	t.Parallel()
+	// parallel-candidate: per-test temp dirs and isolated store state.
+	dir := t.TempDir()
+	store := NewStore(dir)
+	now := time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC)
+	repos := []FeatureRepo{{
+		Name:   "api",
+		Path:   "/tmp/api",
+		Branch: "feature/setup-state",
+	}}
+	f := &Feature{
+		ID:            "setup-001",
+		Name:          "Setup State",
+		Slug:          "setup-state",
+		Description:   "setup serialization",
+		Created:       now,
+		Status:        StatusSettingUpWorktrees,
+		CurrentPhase:  PhaseKnowledgeBase,
+		Repos:         repos,
+		Models:        config.ModelConfig{},
+		ExitCriteria:  "",
+		Inquireness:   InquirenessMedium,
+		ActiveRun:     1,
+		RunCount:      1,
+		SchemaVersion: SchemaVersionCurrent,
+	}
+	setup := NewActiveSetupState(repos, []string{"/tmp/image.png"}, []string{"/tmp/spec.md"}, now)
+	task := setup.Tasks["worktree:api"]
+	task.Path = "/tmp/worktrees/setup-state/api"
+	setup.Tasks["worktree:api"] = task
+	f.SetRun(&Run{RunNumber: 1, Setup: setup})
+
+	if err := store.Save(f); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+
+	loaded, err := store.Load(f.ID)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	got := loaded.Run().Setup
+	if got == nil {
+		t.Fatal("loaded setup state is nil")
+	}
+	if got.Status != SetupStatusRunning || got.Attempt != 1 {
+		t.Fatalf("loaded setup status/attempt = %q/%d, want running/1", got.Status, got.Attempt)
+	}
+	if !slices.Equal(got.TaskOrder, []string{"worktree:api", "image:1", "attachment:1"}) {
+		t.Fatalf("loaded task order = %v, want worktree/image/attachment", got.TaskOrder)
+	}
+	if got.Tasks["worktree:api"].Path != "/tmp/worktrees/setup-state/api" {
+		t.Fatalf("loaded worktree path = %q", got.Tasks["worktree:api"].Path)
+	}
+	if got.Tasks["worktree:api"].Branch != "feature/setup-state" {
+		t.Fatalf("loaded worktree branch = %q", got.Tasks["worktree:api"].Branch)
+	}
 }
 
 func TestStoreLoadMigratesLegacyBrainstormStatusAndArtifact(t *testing.T) {

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -35,11 +35,15 @@ func NewWorktreeManager(baseDir string) *WorktreeManager {
 	return &WorktreeManager{BaseDir: baseDir}
 }
 
+func (w *WorktreeManager) ExpectedPath(featureSlug, repoName string) string {
+	return filepath.Join(w.BaseDir, featureSlug, repoName)
+}
+
 // Create creates a new worktree branching from startPoint. If startPoint is
 // empty, HEAD is used (preserving legacy behavior).
 func (w *WorktreeManager) Create(repoPath, featureSlug, repoName, startPoint string) (string, error) {
 	branch := BranchName(featureSlug)
-	wtPath := filepath.Join(w.BaseDir, featureSlug, repoName)
+	wtPath := w.ExpectedPath(featureSlug, repoName)
 
 	if err := os.MkdirAll(filepath.Dir(wtPath), 0o755); err != nil {
 		return "", fmt.Errorf("creating worktree directory: %w", err)

--- a/internal/observe/observer.go
+++ b/internal/observe/observer.go
@@ -478,6 +478,61 @@ func (o *Observer) FeatureFailed(sc SpanContext, failureType, errorMsg string) {
 	})
 }
 
+// SetupLifecycle emits a pre-phase setup lifecycle event.
+func (o *Observer) SetupLifecycle(sc SpanContext, ev feature.SetupEvent) {
+	if o == nil || !o.enabled {
+		return
+	}
+	eventType := "setup.progress"
+	switch ev.Kind {
+	case feature.SetupEventStarted:
+		eventType = "setup.started"
+	case feature.SetupEventCompleted:
+		eventType = "setup.completed"
+	case feature.SetupEventFailed:
+		eventType = "setup.failed"
+	}
+	data := map[string]any{
+		"attempt": ev.Attempt,
+	}
+	if ev.TaskKey != "" {
+		data["setup_task"] = ev.TaskKey
+	}
+	if ev.TaskKind != "" {
+		data["setup_kind"] = string(ev.TaskKind)
+	}
+	if ev.TaskStatus != "" {
+		data["setup_status"] = string(ev.TaskStatus)
+	}
+	if ev.LogPath != "" {
+		data["setup_log"] = ev.LogPath
+	}
+	if ev.Repo != "" {
+		data["repo_name"] = ev.Repo
+	}
+	if ev.Path != "" {
+		data["path"] = ev.Path
+	}
+	if ev.Branch != "" {
+		data["branch"] = ev.Branch
+	}
+	if ev.Error != "" {
+		data["error"] = ev.Error
+	}
+	o.emit(sc, Event{
+		Timestamp:    time.Now(),
+		TraceID:      sc.TraceID,
+		SpanID:       sc.SpanID,
+		ParentSpanID: sc.ParentSpanID,
+		EventType:    eventType,
+		FeatureID:    sc.FeatureID,
+		RepoName:     ev.Repo,
+		Status:       string(ev.TaskStatus),
+		Error:        ev.Error,
+		Data:         data,
+	})
+}
+
 // FeatureInterrupted emits a feature.interrupted event.
 func (o *Observer) FeatureInterrupted(sc SpanContext, phase string) {
 	if o == nil || !o.enabled {

--- a/internal/observe/observer_test.go
+++ b/internal/observe/observer_test.go
@@ -1084,6 +1084,69 @@ func TestFeatureStartedEmitsEvent(t *testing.T) {
 	}
 }
 
+func TestSetupLifecycleEmitsPrePhaseEventWithDocumentedFields(t *testing.T) {
+	stateDir := t.TempDir()
+	featureID := "setup_lifecycle_feat"
+	if err := os.MkdirAll(filepath.Join(stateDir, featureID), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	obs := New(true, stateDir, false, "", false, "agentic")
+	sc := SpanContextForFeature(featureID, "", "", "").WithRun(3)
+
+	obs.SetupLifecycle(sc, feature.SetupEvent{
+		Kind:       feature.SetupEventTaskCompleted,
+		FeatureID:  featureID,
+		RunNumber:  3,
+		Attempt:    2,
+		LogPath:    "/tmp/state/features/setup_lifecycle_feat/runs/run-001/setup/attempt-02-output.txt",
+		TaskKey:    "worktree:api",
+		TaskKind:   feature.SetupTaskWorktree,
+		TaskStatus: feature.SetupStatusDone,
+		Repo:       "api",
+		Path:       "/tmp/worktrees/setup-lifecycle/api",
+		Branch:     "feature/setup-lifecycle",
+	})
+
+	events := readEvents(t, stateDir, featureID)
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	evt := events[0]
+	if evt.EventType != "setup.progress" {
+		t.Fatalf("EventType = %q, want setup.progress", evt.EventType)
+	}
+	if evt.Phase != "" {
+		t.Fatalf("Phase = %q, want empty for setup lifecycle", evt.Phase)
+	}
+	if evt.RunNumber != 3 {
+		t.Fatalf("RunNumber = %d, want 3", evt.RunNumber)
+	}
+	if evt.RepoName != "api" {
+		t.Fatalf("RepoName = %q, want api", evt.RepoName)
+	}
+	wantData := map[string]any{
+		"attempt":      float64(2),
+		"setup_log":    "/tmp/state/features/setup_lifecycle_feat/runs/run-001/setup/attempt-02-output.txt",
+		"setup_task":   "worktree:api",
+		"setup_kind":   "worktree",
+		"setup_status": "done",
+		"repo_name":    "api",
+		"path":         "/tmp/worktrees/setup-lifecycle/api",
+		"branch":       "feature/setup-lifecycle",
+	}
+	for key, want := range wantData {
+		if got := evt.Data[key]; got != want {
+			t.Fatalf("Data[%s] = %#v, want %#v; data=%v", key, got, want, evt.Data)
+		}
+	}
+	if _, ok := evt.Data["task_key"]; ok {
+		t.Fatalf("Data contains legacy task_key key: %v", evt.Data)
+	}
+	if _, ok := evt.Data["log_path"]; ok {
+		t.Fatalf("Data contains legacy log_path key: %v", evt.Data)
+	}
+}
+
 func TestFeatureCompletedEmitsEvent(t *testing.T) {
 	stateDir := t.TempDir()
 	featureID := "feat_completed_feat"
@@ -1700,6 +1763,7 @@ func TestEmit_IncludesRunNumber(t *testing.T) {
 	obs.FeatureStarted(sc, "my-feature", []string{"repo-a"}, "large")
 	obs.FeatureCompleted(sc, 0.5, time.Second)
 	obs.FeatureFailed(sc, "infrastructure", "boom")
+	obs.SetupLifecycle(sc, feature.SetupEvent{Kind: feature.SetupEventStarted, FeatureID: featureID, Attempt: 1})
 	obs.FeatureInterrupted(sc, "implement")
 	obs.PermissionRequested(sc, "s1", "repo-a", 1, "Edit", "preview")
 	obs.PermissionResolved(sc, "s1", "repo-a", 1, "Edit", "allow")
@@ -1723,8 +1787,8 @@ func TestEmit_IncludesRunNumber(t *testing.T) {
 	})
 
 	events := readEvents(t, stateDir, featureID)
-	if len(events) != 29 {
-		t.Fatalf("expected 29 events, got %d", len(events))
+	if len(events) != 30 {
+		t.Fatalf("expected 30 events, got %d", len(events))
 	}
 	for i, evt := range events {
 		if evt.RunNumber != wantRun {

--- a/internal/orchestrator/hooks.go
+++ b/internal/orchestrator/hooks.go
@@ -104,6 +104,19 @@ func BuildHooks(obs *observe.Observer, permStore *permission.Store, fs ports.Fea
 			}
 			obs.FeatureInterrupted(sc, f.CurrentPhase.String())
 		},
+		OnSetupEvent: func(ev feature.SetupEvent) {
+			if obs == nil {
+				return
+			}
+			sc, ok := loadSpan(ev.FeatureID)
+			if !ok {
+				return
+			}
+			if ev.RunNumber > 0 {
+				sc = sc.WithRun(ev.RunNumber)
+			}
+			obs.SetupLifecycle(sc, ev)
+		},
 		OnPhaseStarted: func(featureID string, phase feature.Phase) {
 			if obs == nil {
 				return

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -39,6 +39,7 @@ type Hooks struct {
 	OnFeatureCreated     func(f *feature.Feature)
 	OnFeatureStarted     func(featureID string)
 	OnFeatureInterrupted func(featureID string)
+	OnSetupEvent         func(feature.SetupEvent)
 	OnPhaseStarted       func(featureID string, phase feature.Phase)
 	OnPhaseCompleted     func(featureID string, phase feature.Phase, err error)
 
@@ -431,6 +432,9 @@ func (o *Orchestrator) StartFeature(featureID string) error {
 	f, err := o.deps.Lifecycle.Get(featureID)
 	if err != nil {
 		return fmt.Errorf("loading feature: %w", err)
+	}
+	if f.Status == feature.StatusSettingUpWorktrees {
+		return fmt.Errorf("feature %s is still setting up worktrees", featureID)
 	}
 
 	phase := f.CurrentPhase
@@ -1205,6 +1209,12 @@ func (o *Orchestrator) InterruptAllRunning() error {
 	var errs []error
 	for _, f := range features {
 		switch {
+		case f.Status == feature.StatusSettingUpWorktrees:
+			// Worktree setup is pre-phase lifecycle work, not a session-backed
+			// phase. Startup reconciliation converts stale setup to Failed;
+			// the interrupt sweep should not attempt an invalid Interrupted
+			// transition here.
+			continue
 		case f.Status.IsRunning():
 			if err := o.InterruptFeature(f.ID); err != nil {
 				errs = append(errs, fmt.Errorf("interrupt %s: %w", f.ID, err))

--- a/internal/orchestrator/orchestrator_interrupt_test.go
+++ b/internal/orchestrator/orchestrator_interrupt_test.go
@@ -159,8 +159,9 @@ func TestOrchestrator_InterruptAllRunning(t *testing.T) {
 		KBStatus: map[string]string{"r": "completed"},
 	}
 	done := &feature.Feature{ID: "done-1", Status: feature.StatusDone}
+	setup := &feature.Feature{ID: "setup-1", Status: feature.StatusSettingUpWorktrees}
 
-	fs := newFeatureStore(running1, running2, published, done)
+	fs := newFeatureStore(running1, running2, published, done, setup)
 	lc := mocks.NewMockFeatureLifecycle()
 	lc.GetFn = func(id string) (*feature.Feature, error) {
 		switch id {
@@ -172,6 +173,8 @@ func TestOrchestrator_InterruptAllRunning(t *testing.T) {
 			return published, nil
 		case "done-1":
 			return done, nil
+		case "setup-1":
+			return setup, nil
 		}
 		return nil, nil
 	}
@@ -221,6 +224,9 @@ func TestOrchestrator_InterruptAllRunning(t *testing.T) {
 	// Done feature untouched.
 	if done.Status != feature.StatusDone {
 		t.Error("done feature status changed unexpectedly")
+	}
+	if setup.Status != feature.StatusSettingUpWorktrees {
+		t.Errorf("setup feature status = %s, want SettingUpWorktrees", setup.Status)
 	}
 
 	events := drainEvents(o)

--- a/internal/orchestrator/recovery.go
+++ b/internal/orchestrator/recovery.go
@@ -48,6 +48,17 @@ func (o *Orchestrator) ScanRecovery(ctx context.Context) ([]ports.RecoveryItem, 
 			return nil, fmt.Errorf("cleanup orphan runs: %w", err)
 		}
 	}
+	if reconciler, ok := o.deps.Lifecycle.(interface {
+		ReconcileAbandonedSetups() ([]string, error)
+	}); ok {
+		ids, err := reconciler.ReconcileAbandonedSetups()
+		if err != nil {
+			return nil, fmt.Errorf("reconcile abandoned setup: %w", err)
+		}
+		for _, id := range ids {
+			o.emitSetupReconciled(id)
+		}
+	}
 	items, err := o.deps.Recovery.ScanForRecovery(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("scan for recovery: %w", err)
@@ -60,6 +71,24 @@ func (o *Orchestrator) ScanRecovery(ctx context.Context) ([]ports.RecoveryItem, 
 		o.hooks.OnRecoveryScanned(items)
 	}
 	return items, nil
+}
+
+func (o *Orchestrator) emitSetupReconciled(featureID string) {
+	ev := feature.SetupEvent{
+		Kind:      feature.SetupEventFailed,
+		FeatureID: featureID,
+		Error:     "setup was interrupted by shutdown or crash; retry setup to continue",
+	}
+	if o.deps.Store != nil {
+		if f, err := o.deps.Store.Load(featureID); err == nil && f != nil {
+			ev.RunNumber = f.ActiveRun
+			if setup := f.Run().Setup; setup != nil {
+				ev.Attempt = setup.Attempt
+				ev.LogPath = setup.LatestLogPath
+			}
+		}
+	}
+	o.emitSetupEvent(ev)
 }
 
 // cleanupOrphanRuns enumerates all features (including those surfaced via

--- a/internal/orchestrator/recovery_test.go
+++ b/internal/orchestrator/recovery_test.go
@@ -919,6 +919,89 @@ func TestScanRecovery_CallsCleanupOrphanRunsBeforeScan(t *testing.T) {
 	}
 }
 
+func TestScanRecovery_ReconcilesAbandonedSetupBeforeScan(t *testing.T) {
+	store := feature.NewStore(t.TempDir())
+	cfg := config.NewDefault()
+	cfg.Repos["test-repo"] = config.RepoConfig{Path: "/repos/test-repo"}
+	mgr := feature.NewManager(store, cfg)
+	branches := mocks.NewMockBranchOperator()
+	branches.DefaultBranchFn = func(repoPath string) (string, error) { return "main", nil }
+	branches.HasOriginRemoteFn = func(repoPath string) (bool, error) { return false, nil }
+	branches.BranchNameFn = func(featureSlug string) string { return "feature/" + featureSlug }
+	mgr.Branches = branches
+
+	f, err := mgr.Create("Abandoned Setup", "stale setup", []string{"test-repo"}, cfg.Defaults.Models, "", "", nil, feature.CreateOptions{QueueSetup: true})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	logPath := filepath.Join(store.RunDir(f.ID, 1), "setup", "attempt-01-output.txt")
+	if err := os.MkdirAll(filepath.Dir(logPath), 0o755); err != nil {
+		t.Fatalf("mkdir log dir: %v", err)
+	}
+	if err := os.WriteFile(logPath, []byte("partial setup"), 0o644); err != nil {
+		t.Fatalf("write setup log: %v", err)
+	}
+	if err := store.Modify(f.ID, func(ff *feature.Feature) error {
+		setup := ff.Run().Setup
+		setup.LatestLogPath = logPath
+		task := setup.Tasks["worktree:test-repo"]
+		task.Status = feature.SetupStatusRunning
+		task.Path = "/tmp/worktrees/abandoned-setup/test-repo"
+		setup.Tasks[task.Key] = task
+		return nil
+	}); err != nil {
+		t.Fatalf("seed setup state: %v", err)
+	}
+
+	var scanSawFailed bool
+	fake := &fakeRecoveryOp{
+		ScanFn: func(ctx context.Context) ([]ports.RecoveryItem, error) {
+			got, err := store.Load(f.ID)
+			if err != nil {
+				t.Fatalf("load during scan: %v", err)
+			}
+			scanSawFailed = got.Status == feature.StatusFailed &&
+				got.FailureType == feature.FailureWorktreeSetup &&
+				got.Run().Setup != nil &&
+				got.Run().Setup.Status == feature.SetupStatusFailed
+			return nil, nil
+		},
+	}
+
+	o := orchestrator.New(orchestrator.Deps{Store: store, Lifecycle: mgr, Recovery: fake}, orchestrator.Hooks{})
+	if _, err := o.ScanRecovery(context.Background()); err != nil {
+		t.Fatalf("ScanRecovery: %v", err)
+	}
+	if !scanSawFailed {
+		t.Fatal("ScanForRecovery ran before abandoned setup was marked failed")
+	}
+	loaded, err := store.Load(f.ID)
+	if err != nil {
+		t.Fatalf("load reconciled feature: %v", err)
+	}
+	if loaded.Run().Setup.LatestLogPath != logPath {
+		t.Fatalf("LatestLogPath = %q, want preserved %q", loaded.Run().Setup.LatestLogPath, logPath)
+	}
+	events := drainEvents(o)
+	var setupFailed, recoveryScanned bool
+	for _, ev := range events {
+		switch ev.Type {
+		case ports.SetupFailed:
+			setupFailed = true
+			if ev.FeatureID != f.ID || ev.RunNumber != 1 || ev.Attempt != 1 || ev.SetupLog != logPath {
+				t.Fatalf("SetupFailed event = %+v, want reconciled setup metadata", ev)
+			}
+		case ports.RecoveryScanned:
+			recoveryScanned = true
+		case ports.PhaseStarted, ports.PhaseCompleted:
+			t.Fatalf("unexpected phase telemetry for setup reconciliation: %+v", ev)
+		}
+	}
+	if !setupFailed || !recoveryScanned {
+		t.Fatalf("events = %+v, want SetupFailed and RecoveryScanned", events)
+	}
+}
+
 // TestScanRecovery_CleanupError_SuppressesScan asserts that when cleanup
 // returns an error for any feature, ScanRecovery propagates the error and
 // does NOT call ScanForRecovery. This encodes the "recovery decisions always

--- a/internal/orchestrator/setup.go
+++ b/internal/orchestrator/setup.go
@@ -1,0 +1,103 @@
+// Copyright 2026 DoorDash, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package orchestrator
+
+import (
+	"fmt"
+
+	"github.com/doordash-oss/agentic-orchestrator/internal/feature"
+	"github.com/doordash-oss/agentic-orchestrator/internal/ports"
+)
+
+type setupRunner interface {
+	RunSetup(featureID string, opts ...feature.SetupRunnerOptions) error
+	RetrySetup(featureID string, opts ...feature.SetupRunnerOptions) error
+}
+
+func (o *Orchestrator) RunSetup(featureID string) error {
+	if err := o.runSetupWith(false, featureID); err != nil {
+		return err
+	}
+	return o.StartFeature(featureID)
+}
+
+func (o *Orchestrator) RetrySetup(featureID string) error {
+	if err := o.runSetupWith(true, featureID); err != nil {
+		return err
+	}
+	return o.StartFeature(featureID)
+}
+
+func (o *Orchestrator) runSetupWith(retry bool, featureID string) error {
+	runner, ok := o.deps.Lifecycle.(setupRunner)
+	if !ok {
+		return fmt.Errorf("setup runner not configured")
+	}
+	opt := feature.SetupRunnerOptions{
+		OnEvent: func(ev feature.SetupEvent) {
+			o.emitSetupEvent(ev)
+		},
+	}
+	if retry {
+		return runner.RetrySetup(featureID, opt)
+	}
+	return runner.RunSetup(featureID, opt)
+}
+
+func (o *Orchestrator) emitSetupEvent(ev feature.SetupEvent) {
+	if o.hooks.OnSetupEvent != nil {
+		o.hooks.OnSetupEvent(ev)
+	}
+	pe := setupPortsEvent(ev)
+	if pe.Type == ports.SetupFailed {
+		o.emitEventBlocking(pe)
+		return
+	}
+	o.emitEvent(pe)
+}
+
+func setupPortsEvent(ev feature.SetupEvent) ports.Event {
+	eventType := ports.SetupProgress
+	switch ev.Kind {
+	case feature.SetupEventStarted:
+		eventType = ports.SetupStarted
+	case feature.SetupEventCompleted:
+		eventType = ports.SetupCompleted
+	case feature.SetupEventFailed:
+		eventType = ports.SetupFailed
+	}
+	return ports.Event{
+		Type:        eventType,
+		FeatureID:   ev.FeatureID,
+		RunNumber:   ev.RunNumber,
+		Attempt:     ev.Attempt,
+		SetupLog:    ev.LogPath,
+		SetupTask:   ev.TaskKey,
+		SetupKind:   ev.TaskKind,
+		SetupStatus: ev.TaskStatus,
+		RepoName:    ev.Repo,
+		Path:        ev.Path,
+		Branch:      ev.Branch,
+		Message:     string(ev.Kind),
+		Error:       setupEventError(ev),
+	}
+}
+
+func setupEventError(ev feature.SetupEvent) error {
+	if ev.Error == "" {
+		return nil
+	}
+	return fmt.Errorf("%s", ev.Error)
+}

--- a/internal/ports/events.go
+++ b/internal/ports/events.go
@@ -55,6 +55,10 @@ const (
 	// the gate artifact. The TUI consumes it to surface a `Needs user input`
 	// banner. Message carries the agent's gate summary.
 	NeedUserInputRequired
+	SetupStarted
+	SetupProgress
+	SetupCompleted
+	SetupFailed
 )
 
 // Event is a typed domain event emitted by the orchestrator.
@@ -65,4 +69,14 @@ type Event struct {
 	Phase     feature.Phase    // set for phase-related events
 	Error     error            // set for failure events
 	Message   string           // human-readable detail
+
+	RunNumber   int
+	Attempt     int
+	SetupLog    string
+	SetupTask   string
+	SetupKind   feature.SetupTaskKind
+	SetupStatus feature.SetupStatus
+	RepoName    string
+	Path        string
+	Branch      string
 }

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -309,6 +309,12 @@ type FeatureCreatedMsg struct {
 	Err        error
 }
 
+type setupCommandDoneMsg struct {
+	FeatureID string
+	Retry     bool
+	Err       error
+}
+
 // featureSummaryMsg carries a Claude-generated summary for a feature.
 type featureSummaryMsg struct {
 	featureID string
@@ -964,6 +970,7 @@ func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		OrchFeatureCompletedMsg,
 		OrchFeatureFailedMsg,
 		OrchFeatureInterruptedMsg,
+		OrchSetupLifecycleMsg,
 		OrchPhaseStartedMsg,
 		OrchPhaseCompletedMsg,
 		OrchReviewRequiredMsg,
@@ -1312,16 +1319,45 @@ func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 			}
 		}
+		featuresByID := make(map[string]*feature.Feature)
+		if features, err := m.featureManager.List(); err == nil || feature.IsPartialLoadError(err) {
+			m.dashboard.SetFeatures(features)
+			for _, f := range features {
+				if f != nil {
+					featuresByID[f.ID] = f
+				}
+			}
+			if len(msg.FeatureIDs) > 0 {
+				m.dashboard.SelectFeatureID(msg.FeatureIDs[0])
+			}
+		}
 
 		var cmds []tea.Cmd
 		cmds = append(cmds, func() tea.Msg { return RefreshFeaturesMsg{} })
-		for _, fid := range msg.FeatureIDs {
-			cmds = append(cmds, m.startFirstPhaseCmd(fid))
+		if m.orchestrator != nil {
+			for _, fid := range msg.FeatureIDs {
+				if isSetupLifecycle(featuresByID[fid]) {
+					cmds = append(cmds, m.runSetupCmd(fid))
+				} else {
+					cmds = append(cmds, m.startFirstPhaseCmd(fid))
+				}
+			}
 		}
 		for _, fid := range msg.FeatureIDs {
 			cmds = append(cmds, m.generateSummaryCmd(fid))
 		}
 		return m, tea.Batch(cmds...)
+
+	case setupCommandDoneMsg:
+		if msg.Err != nil {
+			action := "Setup"
+			if msg.Retry {
+				action = "Setup retry"
+			}
+			m.statusMessage = action + " failed: " + firstLine(msg.Err.Error())
+			m.statusTime = time.Now()
+		}
+		return m, func() tea.Msg { return RefreshFeaturesMsg{} }
 
 	case featureSummaryMsg:
 		if msg.summary != "" {
@@ -2212,6 +2248,15 @@ func orchEventToMsg(ev ports.Event) tea.Msg {
 		return OrchFeatureFailedMsg{FeatureID: ev.FeatureID, Message: ev.Message, Error: ev.Error}
 	case ports.FeatureInterrupted:
 		return OrchFeatureInterruptedMsg{FeatureID: ev.FeatureID}
+	case ports.SetupStarted, ports.SetupProgress, ports.SetupCompleted, ports.SetupFailed:
+		return OrchSetupLifecycleMsg{
+			FeatureID: ev.FeatureID,
+			RunNumber: ev.RunNumber,
+			Attempt:   ev.Attempt,
+			TaskKey:   ev.SetupTask,
+			RepoName:  ev.RepoName,
+			Error:     ev.Error,
+		}
 	case ports.PhaseStarted:
 		return OrchPhaseStartedMsg{FeatureID: ev.FeatureID, Phase: ev.Phase}
 	case ports.PhaseCompleted:
@@ -3513,12 +3558,15 @@ func (m AppModel) updateDashboardRightPanel(msg tea.KeyPressMsg) (tea.Model, tea
 		}
 
 	case key.Matches(msg, keys.Restart):
-		if f != nil {
+		if canRetrySetup(f) {
+			return m, m.retrySetupCmd(f.ID)
+		}
+		if f != nil && !isSetupLifecycle(f) {
 			return m, m.restartPhaseCmd(f.ID)
 		}
 
 	case key.Matches(msg, keys.Stop):
-		if f != nil && isRunningFeature(f) {
+		if f != nil && !isSetupLifecycle(f) && isRunningFeature(f) {
 			return m.confirmStop(f.ID, f.Name), nil
 		}
 
@@ -3809,20 +3857,23 @@ func (m AppModel) updateDetail(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		// Retry the failed phase atomically across every phase-declared
 		// repo — only when feature is quiescent (Failed/Interrupted) so
 		// we don't kill unrelated in-flight sessions.
-		if m.detail.feature != nil && featureHasFailedRepos(m.detail.feature) &&
+		if m.detail.feature != nil && !isSetupLifecycle(m.detail.feature) && featureHasFailedRepos(m.detail.feature) &&
 			(m.detail.feature.Status == feature.StatusFailed || m.detail.feature.Status == feature.StatusInterrupted) {
 			return m, m.retryPhaseCmd(m.detail.feature.ID)
 		}
 		return m, nil
 
 	case key.Matches(msg, keys.Restart):
-		if m.detail.feature != nil {
+		if canRetrySetup(m.detail.feature) {
+			return m, m.retrySetupCmd(m.detail.feature.ID)
+		}
+		if m.detail.feature != nil && !isSetupLifecycle(m.detail.feature) {
 			return m, m.restartPhaseCmd(m.detail.feature.ID)
 		}
 		return m, nil
 
 	case key.Matches(msg, keys.Stop):
-		if m.detail.feature != nil && isRunningFeature(m.detail.feature) {
+		if m.detail.feature != nil && !isSetupLifecycle(m.detail.feature) && isRunningFeature(m.detail.feature) {
 			return m.confirmStop(m.detail.feature.ID, m.detail.feature.Name), nil
 		}
 		return m, nil
@@ -4224,6 +4275,7 @@ func (m AppModel) createFeatureCmd(result *WizardResult) tea.Cmd {
 			Attachments:             result.Attachments,
 			RiskLevel:               riskLevel,
 			Pipeline:                result.Pipeline,
+			QueueSetup:              true,
 		}
 
 		// Route creation through the orchestrator so its post-creation hook
@@ -4309,6 +4361,26 @@ func (m AppModel) startFirstPhaseCmd(featureID string) tea.Cmd {
 	return func() tea.Msg {
 		_ = m.orchestrator.StartFeature(featureID)
 		return RefreshFeaturesMsg{}
+	}
+}
+
+func (m AppModel) runSetupCmd(featureID string) tea.Cmd {
+	return func() tea.Msg {
+		var err error
+		if m.orchestrator != nil {
+			err = m.orchestrator.RunSetup(featureID)
+		}
+		return setupCommandDoneMsg{FeatureID: featureID, Err: err}
+	}
+}
+
+func (m AppModel) retrySetupCmd(featureID string) tea.Cmd {
+	return func() tea.Msg {
+		var err error
+		if m.orchestrator != nil {
+			err = m.orchestrator.RetrySetup(featureID)
+		}
+		return setupCommandDoneMsg{FeatureID: featureID, Retry: true, Err: err}
 	}
 }
 
@@ -5146,6 +5218,22 @@ func (m AppModel) viewLogsCmd(featureID string, phase feature.Phase, roadmapPhas
 		if loadErr != nil {
 			return RefreshFeaturesMsg{}
 		}
+		if setup := setupState(f); setup != nil && setup.LatestLogPath != "" {
+			data, err := os.ReadFile(setup.LatestLogPath)
+			if err != nil {
+				return LogsContentMsg{
+					FeatureID: featureID,
+					Title:     fmt.Sprintf("Logs: %s (setup)", featureID),
+					Content:   fmt.Sprintf("Setup log not found: %s", setup.LatestLogPath),
+				}
+			}
+			lines := splitLastN(string(data), 100)
+			return LogsContentMsg{
+				FeatureID: featureID,
+				Title:     fmt.Sprintf("Logs: %s (setup \u2014 %s)", featureID, filepath.Base(setup.LatestLogPath)),
+				Content:   strings.Join(lines, "\n"),
+			}
+		}
 		var phaseDir string
 		if roadmapPhase > 0 {
 			// Roadmap features store logs under phase-NN/<phase>/
@@ -5356,11 +5444,21 @@ func (m AppModel) transitionToHelpOverlay() (tea.Model, tea.Cmd) {
 	switch m.currentView {
 	case ViewDashboard:
 		if m.dashboard.focusPanel == 1 {
+			if f := m.dashboard.SelectedFeature(); isSetupLifecycle(f) {
+				m.helpOverlay = NewHelpOverlayModel(setupDetailPanelHelp(setupLogsAvailable(f), canRetrySetup(f)), m.width, m.height)
+				m.helpOverlayActive = true
+				return m, nil
+			}
 			ctxName = "Detail Panel"
 		} else {
 			ctxName = "Dashboard"
 		}
 	case ViewDetail:
+		if isSetupLifecycle(m.detail.feature) {
+			m.helpOverlay = NewHelpOverlayModel(setupDetailHelp(setupLogsAvailable(m.detail.feature), canRetrySetup(m.detail.feature)), m.width, m.height)
+			m.helpOverlayActive = true
+			return m, nil
+		}
 		ctxName = "Detail"
 	case ViewWizard:
 		ctxName = "Wizard"
@@ -5384,6 +5482,11 @@ func (m AppModel) transitionToHelpOverlay() (tea.Model, tea.Cmd) {
 	m.helpOverlay = NewHelpOverlayModel(ctx, m.width, m.height)
 	m.helpOverlayActive = true
 	return m, nil
+}
+
+func setupLogsAvailable(f *feature.Feature) bool {
+	setup := setupState(f)
+	return setup != nil && setup.LatestLogPath != ""
 }
 
 // transitionToWorkspaceManager opens the workspace manager overlay.

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -566,6 +566,89 @@ func TestViewLogsCmdReturnsContent(t *testing.T) {
 	}
 }
 
+func TestViewLogsCmdUsesLatestSetupLog(t *testing.T) {
+	dir := t.TempDir()
+	store := feature.NewStore(dir)
+	cfg := config.NewDefault()
+	fm := feature.NewManager(store, cfg)
+
+	logPath := filepath.Join(dir, "feat-setup", "runs", "run-001", "setup", "attempt-01-output.txt")
+	if err := os.MkdirAll(filepath.Dir(logPath), 0o755); err != nil {
+		t.Fatalf("mkdir setup log dir: %v", err)
+	}
+	if err := os.WriteFile(logPath, []byte("setup started\ncreated worktree\n"), 0o644); err != nil {
+		t.Fatalf("write setup log: %v", err)
+	}
+	now := time.Now()
+	f := &feature.Feature{
+		ID:            "feat-setup",
+		Name:          "setup",
+		Slug:          "setup",
+		Status:        feature.StatusSettingUpWorktrees,
+		CurrentPhase:  feature.PhaseKnowledgeBase,
+		ActiveRun:     1,
+		RunCount:      1,
+		SchemaVersion: feature.SchemaVersionCurrent,
+	}
+	setup := feature.NewActiveSetupState(nil, nil, nil, now)
+	setup.LatestLogPath = logPath
+	f.SetRun(&feature.Run{RunNumber: 1, Setup: setup})
+	if err := store.Save(f); err != nil {
+		t.Fatalf("save feature: %v", err)
+	}
+
+	app := AppModel{featureManager: fm}
+	msg := app.viewLogsCmd("feat-setup", feature.PhaseKnowledgeBase, 0)()
+
+	logsMsg, ok := msg.(LogsContentMsg)
+	if !ok {
+		t.Fatalf("expected LogsContentMsg, got %T", msg)
+	}
+	if !strings.Contains(logsMsg.Content, "created worktree") {
+		t.Fatalf("setup log content = %q, want setup output", logsMsg.Content)
+	}
+	if !strings.Contains(logsMsg.Title, "setup") {
+		t.Fatalf("setup log title = %q, want setup", logsMsg.Title)
+	}
+}
+
+func TestViewLogsCmdMissingSetupLogReturnsDiagnostic(t *testing.T) {
+	dir := t.TempDir()
+	store := feature.NewStore(dir)
+	cfg := config.NewDefault()
+	fm := feature.NewManager(store, cfg)
+
+	missingLog := filepath.Join(dir, "feat-setup", "runs", "run-001", "setup", "missing.txt")
+	now := time.Now()
+	f := &feature.Feature{
+		ID:            "feat-setup",
+		Name:          "setup",
+		Slug:          "setup",
+		Status:        feature.StatusSettingUpWorktrees,
+		CurrentPhase:  feature.PhaseKnowledgeBase,
+		ActiveRun:     1,
+		RunCount:      1,
+		SchemaVersion: feature.SchemaVersionCurrent,
+	}
+	setup := feature.NewActiveSetupState(nil, nil, nil, now)
+	setup.LatestLogPath = missingLog
+	f.SetRun(&feature.Run{RunNumber: 1, Setup: setup})
+	if err := store.Save(f); err != nil {
+		t.Fatalf("save feature: %v", err)
+	}
+
+	app := AppModel{featureManager: fm}
+	msg := app.viewLogsCmd("feat-setup", feature.PhaseKnowledgeBase, 0)()
+
+	logsMsg, ok := msg.(LogsContentMsg)
+	if !ok {
+		t.Fatalf("expected LogsContentMsg, got %T", msg)
+	}
+	if !strings.Contains(logsMsg.Content, "Setup log not found") || !strings.Contains(logsMsg.Content, missingLog) {
+		t.Fatalf("missing setup log content = %q, want diagnostic with path", logsMsg.Content)
+	}
+}
+
 func TestViewLogsCmdMissingFile(t *testing.T) {
 	dir := t.TempDir()
 	store := feature.NewStore(dir)
@@ -8417,6 +8500,154 @@ func TestCreateFeatureCmdSavesGatesToConfig(t *testing.T) {
 	}
 	if loadedPref.Models.Review != "codex:gpt-5.4-mini" {
 		t.Errorf("loaded review model = %q, want %q", loadedPref.Models.Review, "codex:gpt-5.4-mini")
+	}
+}
+
+func TestFeatureCreatedMsgSelectsPersistedSetupWithoutStartingPhase(t *testing.T) {
+	app, fm := newTestAppModel(t)
+	orch := newFakeOrch()
+	app.orchestrator = orch
+	app.currentView = ViewDashboard
+	app.wizardCreating = true
+	app.wizardCreatingName = "setup-feature"
+	app.dashboard.creatingName = "setup-feature"
+	app.kbStaleWarnings = make(map[string]string)
+
+	now := time.Now()
+	setupFeature := &feature.Feature{
+		ID:            "feat-setup",
+		Name:          "Setup Feature",
+		Slug:          "setup-feature",
+		Description:   "persisted setup",
+		Created:       now,
+		Status:        feature.StatusSettingUpWorktrees,
+		CurrentPhase:  feature.PhaseKnowledgeBase,
+		Repos:         []feature.FeatureRepo{{Name: "test-repo", Path: "/tmp/test-repo", Branch: "feature/setup-feature"}},
+		Models:        fm.Config.Defaults.Models,
+		ExitCriteria:  fm.Config.Defaults.ExitCriteria,
+		Inquireness:   feature.Inquireness(fm.Config.Defaults.Inquireness),
+		ActiveRun:     1,
+		RunCount:      1,
+		SchemaVersion: feature.SchemaVersionCurrent,
+	}
+	setupFeature.SetRun(&feature.Run{
+		RunNumber: 1,
+		Setup:     feature.NewActiveSetupState(setupFeature.Repos, nil, nil, now),
+	})
+	if err := fm.Store.Save(setupFeature); err != nil {
+		t.Fatalf("save setup feature: %v", err)
+	}
+
+	model, cmd := app.Update(FeatureCreatedMsg{FeatureIDs: []string{setupFeature.ID}})
+	app = model.(AppModel)
+	msgs := executeBatchCmd(t, cmd)
+
+	if len(orch.startFeatureIDs) != 0 {
+		t.Fatalf("StartFeature calls = %v, want none while setup is active", orch.startFeatureIDs)
+	}
+	foundRunSetup := false
+	for _, call := range orch.lifecycleCalls {
+		if call == "RunSetup:"+setupFeature.ID {
+			foundRunSetup = true
+			break
+		}
+	}
+	if !foundRunSetup {
+		t.Fatalf("lifecycle calls = %v, want RunSetup:%s", orch.lifecycleCalls, setupFeature.ID)
+	}
+	if app.wizardCreating || app.wizardCreatingName != "" || app.dashboard.creatingName != "" {
+		t.Fatalf("creation placeholders not cleared: wizardCreating=%v wizardName=%q dashboardName=%q", app.wizardCreating, app.wizardCreatingName, app.dashboard.creatingName)
+	}
+	for _, msg := range msgs {
+		if _, ok := msg.(RefreshFeaturesMsg); ok {
+			model, _ = app.Update(msg)
+			app = model.(AppModel)
+		}
+	}
+	if got := app.dashboard.SelectedFeatureID(); got != setupFeature.ID {
+		t.Fatalf("selected feature = %q, want %q", got, setupFeature.ID)
+	}
+}
+
+func TestActiveSetupDetailIgnoresPhaseStopAndRestartKeys(t *testing.T) {
+	app, fm := newTestAppModel(t)
+	orch := newFakeOrch()
+	app.orchestrator = orch
+	app.currentView = ViewDetail
+
+	now := time.Now()
+	f := &feature.Feature{
+		ID:            "feat-setup",
+		Name:          "Setup Feature",
+		Slug:          "setup-feature",
+		Status:        feature.StatusSettingUpWorktrees,
+		CurrentPhase:  feature.PhaseKnowledgeBase,
+		ActiveRun:     1,
+		RunCount:      1,
+		SchemaVersion: feature.SchemaVersionCurrent,
+	}
+	f.SetRun(&feature.Run{RunNumber: 1, Setup: feature.NewActiveSetupState(nil, nil, nil, now)})
+	if err := fm.Store.Save(f); err != nil {
+		t.Fatalf("save setup feature: %v", err)
+	}
+	app.detail = NewDetailModel(f, fm.Store.BaseDir)
+
+	model, cmd := app.Update(tea.KeyPressMsg{Code: 's', Text: "s"})
+	app = model.(AppModel)
+	if cmd != nil {
+		t.Fatalf("stop key returned cmd during active setup")
+	}
+	if app.stopConfirmActive {
+		t.Fatalf("stop confirmation opened during active setup")
+	}
+
+	model, cmd = app.Update(tea.KeyPressMsg{Code: 'r', Text: "r"})
+	app = model.(AppModel)
+	if cmd != nil {
+		msgs := executeBatchCmd(t, cmd)
+		t.Fatalf("restart key returned command during active setup: %T %v", cmd, msgs)
+	}
+	if len(orch.lifecycleCalls) != 0 {
+		t.Fatalf("orchestrator lifecycle calls = %v, want none", orch.lifecycleCalls)
+	}
+}
+
+func TestFailedSetupDetailRestartKeyRetriesSetup(t *testing.T) {
+	app, fm := newTestAppModel(t)
+	orch := newFakeOrch()
+	app.orchestrator = orch
+	app.currentView = ViewDetail
+
+	now := time.Now()
+	f := &feature.Feature{
+		ID:            "feat-setup-failed",
+		Name:          "Setup Failed",
+		Slug:          "setup-failed",
+		Status:        feature.StatusFailed,
+		FailureType:   feature.FailureWorktreeSetup,
+		LastError:     "worktree path already exists",
+		CurrentPhase:  feature.PhaseKnowledgeBase,
+		ActiveRun:     1,
+		RunCount:      1,
+		SchemaVersion: feature.SchemaVersionCurrent,
+	}
+	setup := feature.NewActiveSetupState(nil, nil, nil, now)
+	setup.Status = feature.SetupStatusFailed
+	setup.LastError = f.LastError
+	f.SetRun(&feature.Run{RunNumber: 1, Setup: setup, FailureType: feature.FailureWorktreeSetup})
+	if err := fm.Store.Save(f); err != nil {
+		t.Fatalf("save setup feature: %v", err)
+	}
+	app.detail = NewDetailModel(f, fm.Store.BaseDir)
+
+	model, cmd := app.Update(tea.KeyPressMsg{Code: 'r', Text: "r"})
+	app = model.(AppModel)
+	msgs := executeBatchCmd(t, cmd)
+	if got, want := orch.lifecycleCalls, []string{"RetrySetup:" + f.ID}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("lifecycle calls = %v, want %v; msgs=%v", got, want, msgs)
+	}
+	if len(orch.startFeatureIDs) != 0 || len(orch.restartPhaseArgs) != 0 {
+		t.Fatalf("phase restart was invoked: start=%v restart=%v", orch.startFeatureIDs, orch.restartPhaseArgs)
 	}
 }
 

--- a/internal/tui/attention.go
+++ b/internal/tui/attention.go
@@ -183,6 +183,9 @@ func isWatchAttentionEligible(f *feature.Feature) bool {
 	if f.Status == feature.StatusCreated {
 		return true
 	}
+	if f.Status == feature.StatusSettingUpWorktrees {
+		return false
+	}
 	if f.Status.IsRunning() {
 		return true
 	}

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -1057,6 +1057,19 @@ func (m DashboardModel) SelectedFeatureID() string {
 	return ""
 }
 
+func (m *DashboardModel) SelectFeatureID(featureID string) bool {
+	for i, item := range m.visibleItems {
+		if item.kind == listItemFeature && item.feature != nil && item.feature.ID == featureID {
+			m.cursor = i
+			m.computeCursorLine()
+			m.updateScrollState(0)
+			m.syncPreview()
+			return true
+		}
+	}
+	return false
+}
+
 func (m *DashboardModel) SetFeatures(features []*feature.Feature) {
 	sortFeatures(features)
 	m.features = features
@@ -1339,6 +1352,8 @@ func formatStatus(f *feature.Feature) string {
 	elapsed := formatElapsed(f)
 
 	switch f.Status {
+	case feature.StatusSettingUpWorktrees:
+		return lipgloss.NewStyle().Foreground(colorInfo).Render("Setting up worktrees") + elapsed
 	case feature.StatusImplementing:
 		planPath := ""
 		if f.Artifacts != nil {
@@ -1526,6 +1541,8 @@ func formatFailureType(ft string) string {
 		return "protocol violation"
 	case feature.FailureInfrastructure:
 		return "error"
+	case feature.FailureWorktreeSetup:
+		return "worktree setup"
 	default:
 		return ft
 	}

--- a/internal/tui/dashboard_test.go
+++ b/internal/tui/dashboard_test.go
@@ -332,6 +332,37 @@ func TestCreatingFeatureRowCreatesInProgressSection(t *testing.T) {
 	}
 }
 
+func TestPersistedSetupFeatureRendersAsSelectableInProgressRow(t *testing.T) {
+	t.Parallel()
+	f := &feature.Feature{
+		ID:      "feat-setup",
+		Name:    "setup",
+		Slug:    "setup-feature",
+		Status:  feature.StatusSettingUpWorktrees,
+		Created: time.Now(),
+	}
+	m := NewDashboardModel([]*feature.Feature{f}, "")
+
+	if !m.SelectFeatureID(f.ID) {
+		t.Fatalf("setup feature was not selectable")
+	}
+	if got := m.SelectedFeatureID(); got != f.ID {
+		t.Fatalf("selected feature = %q, want %q", got, f.ID)
+	}
+
+	lines := strings.Split(strings.TrimRight(ansi.Strip(m.renderFeatureList()), "\n"), "\n")
+	if len(lines) < 3 || !strings.Contains(lines[0], "IN PROGRESS (1)") {
+		t.Fatalf("rendered lines = %q, want setup feature under in-progress", lines)
+	}
+	row := ansi.Strip(m.renderFeatureRowCompact(f, false))
+	if !strings.Contains(row, "Setting up worktrees") {
+		t.Fatalf("setup row = %q, want Setting up worktrees label", row)
+	}
+	if strings.Contains(row, "SettingUpWorktrees") {
+		t.Fatalf("setup row = %q, should not render raw status token", row)
+	}
+}
+
 func TestGhostCTAReappearsAfterDeletion(t *testing.T) {
 	t.Parallel()
 	m := NewDashboardModel([]*feature.Feature{

--- a/internal/tui/detail.go
+++ b/internal/tui/detail.go
@@ -17,6 +17,7 @@ package tui
 import (
 	"fmt"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -259,53 +260,63 @@ func (m DetailModel) View() string {
 	// Footer (pinned to bottom)
 	var actionParts []string
 	var leadHint string
-	if actionHint, lead := contextualAActionHint(f); actionHint != "" {
-		if lead {
-			leadHint = WarningStyle.Bold(true).Render(actionHint)
-		} else {
-			actionParts = append(actionParts, actionHint)
+	if isSetupLifecycle(f) {
+		if setup := setupState(f); setup != nil && setup.LatestLogPath != "" {
+			actionParts = append(actionParts, "[l] Logs")
 		}
-	}
-	// Phase retry action — only when the feature is quiescent (Failed/Interrupted)
-	// so we don't kill unrelated in-flight repo sessions.
-	if (f.Status == feature.StatusFailed || f.Status == feature.StatusInterrupted) &&
-		featureHasFailedRepos(f) {
-		actionParts = append(actionParts, "[Shift+R] Retry phase")
-	}
-	if isRunningFeature(f) {
-		actionParts = append(actionParts, "[s] Stop")
+		if canRetrySetup(f) {
+			actionParts = append(actionParts, "[r] Retry setup")
+		}
+		actionParts = append(actionParts, "[d] Delete", "[esc] Back")
 	} else {
-		actionParts = append(actionParts, "[r] Restart")
-	}
-	actionParts = append(actionParts, "[ctrl+r] Rewind")
-	if f.Status == feature.StatusFailed || f.Status == feature.StatusInterrupted || featureHasDisplayFailure(f) {
-		actionParts = append(actionParts, "[l] Logs")
-	}
-	if f.Status == feature.StatusCodeReady && len(f.Repos) > 0 && f.Repos[0].WorktreePath != "" {
-		actionParts = append(actionParts, "[v] Diff")
-	}
-	if f.Status == feature.StatusCodeReady && !f.Checkpoints.AutoPublish() && f.IsPublishable() {
-		actionParts = append(actionParts, "[p] Publish", "[m] Manual publish")
-	}
-	if f.Status == feature.StatusPublished || (f.Status == feature.StatusCodeReady && !f.Checkpoints.AutoPublish()) {
-		actionParts = append(actionParts, "[t] Tweak", "[Shift+F] Refactor", "[b] Rebase")
-	}
-	if f.Status == feature.StatusCodeReady && !f.IsPublishable() {
-		actionParts = append(actionParts, "[Shift+M] Merge to base", "[Shift+D] Mark done")
-	}
-	if f.Status == feature.StatusPublished {
-		actionParts = append(actionParts, "[Shift+D] Mark done")
-		if len(f.PRURLs()) > 0 && f.IsPublishable() {
-			actionParts = append(actionParts, "[g] Reviews")
+		if actionHint, lead := contextualAActionHint(f); actionHint != "" {
+			if lead {
+				leadHint = WarningStyle.Bold(true).Render(actionHint)
+			} else {
+				actionParts = append(actionParts, actionHint)
+			}
 		}
+		// Phase retry action — only when the feature is quiescent (Failed/Interrupted)
+		// so we don't kill unrelated in-flight repo sessions.
+		if (f.Status == feature.StatusFailed || f.Status == feature.StatusInterrupted) &&
+			featureHasFailedRepos(f) {
+			actionParts = append(actionParts, "[Shift+R] Retry phase")
+		}
+		if isRunningFeature(f) {
+			actionParts = append(actionParts, "[s] Stop")
+		} else {
+			actionParts = append(actionParts, "[r] Restart")
+		}
+		actionParts = append(actionParts, "[ctrl+r] Rewind")
+		if f.Status == feature.StatusFailed || f.Status == feature.StatusInterrupted || featureHasDisplayFailure(f) {
+			actionParts = append(actionParts, "[l] Logs")
+		}
+		if f.Status == feature.StatusCodeReady && len(f.Repos) > 0 && f.Repos[0].WorktreePath != "" {
+			actionParts = append(actionParts, "[v] Diff")
+		}
+		if f.Status == feature.StatusCodeReady && !f.Checkpoints.AutoPublish() && f.IsPublishable() {
+			actionParts = append(actionParts, "[p] Publish", "[m] Manual publish")
+		}
+		if f.Status == feature.StatusPublished || (f.Status == feature.StatusCodeReady && !f.Checkpoints.AutoPublish()) {
+			actionParts = append(actionParts, "[t] Tweak", "[Shift+F] Refactor", "[b] Rebase")
+		}
+		if f.Status == feature.StatusCodeReady && !f.IsPublishable() {
+			actionParts = append(actionParts, "[Shift+M] Merge to base", "[Shift+D] Mark done")
+		}
+		if f.Status == feature.StatusPublished {
+			actionParts = append(actionParts, "[Shift+D] Mark done")
+			if len(f.PRURLs()) > 0 && f.IsPublishable() {
+				actionParts = append(actionParts, "[g] Reviews")
+			}
+		}
+		if (f.Status == feature.StatusPublished || f.Status == feature.StatusDone) && len(f.Repos) > 0 && f.Repos[0].WorktreePath != "" {
+			actionParts = append(actionParts, "[c] Clean worktree")
+		}
+		if isFeatureQuiescent(f) {
+			actionParts = append(actionParts, "[e] Edit config")
+		}
+		actionParts = append(actionParts, "[Shift+N] Input alerts", "[d] Delete", "[esc] Back")
 	}
-	if (f.Status == feature.StatusPublished || f.Status == feature.StatusDone) && len(f.Repos) > 0 && f.Repos[0].WorktreePath != "" {
-		actionParts = append(actionParts, "[c] Clean worktree")
-	}
-	if isFeatureQuiescent(f) {
-		actionParts = append(actionParts, "[e] Edit config")
-	}
-	actionParts = append(actionParts, "[Shift+N] Input alerts", "[d] Delete", "[esc] Back")
 	actions := " " + strings.Join(actionParts, "  ")
 	brandHintStyle := lipgloss.NewStyle().Foreground(colorBrand).Bold(true)
 	helpHint := brandHintStyle.Render("[" + HelpKeyHint() + "] Help")
@@ -537,7 +548,145 @@ func formatContextUsage(contextPct int) string {
 	}
 }
 
+func setupState(f *feature.Feature) *feature.SetupState {
+	if f == nil {
+		return nil
+	}
+	return f.Run().Setup
+}
+
+func isSetupLifecycle(f *feature.Feature) bool {
+	if f == nil {
+		return false
+	}
+	if f.Status == feature.StatusSettingUpWorktrees || f.FailureType == feature.FailureWorktreeSetup {
+		return true
+	}
+	if setup := setupState(f); setup != nil {
+		return setup.Status == feature.SetupStatusRunning || setup.Status == feature.SetupStatusFailed
+	}
+	return false
+}
+
+func canRetrySetup(f *feature.Feature) bool {
+	setup := setupState(f)
+	return f != nil &&
+		f.Status == feature.StatusFailed &&
+		f.FailureType == feature.FailureWorktreeSetup &&
+		setup != nil &&
+		setup.Status == feature.SetupStatusFailed
+}
+
+func (m DetailModel) renderSetupProgress(_ *feature.Feature, setup *feature.SetupState) string {
+	var b strings.Builder
+	header := "Setup"
+	if setup.Attempt > 0 {
+		header += fmt.Sprintf(" attempt %d", setup.Attempt)
+	}
+	b.WriteString(fmt.Sprintf("  %s %s %s\n", setupStatusIcon(setup.Status, m), header, setupStatusLabel(setup.Status)))
+	if setup.LatestLogPath != "" {
+		b.WriteString("    " + LabelStyle.Render("Log") + "  " + MutedStyle.Render(setup.LatestLogPath) + "\n")
+	}
+	if setup.LastError != "" {
+		b.WriteString("    " + LabelStyle.Render("Error") + "  " + ErrorStyle.Render(setup.LastError) + "\n")
+	}
+	for _, key := range setupTaskOrder(setup) {
+		task := setup.Tasks[key]
+		b.WriteString(renderSetupTask(task, m))
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
+func setupTaskOrder(setup *feature.SetupState) []string {
+	if setup == nil {
+		return nil
+	}
+	seen := make(map[string]bool, len(setup.Tasks))
+	var order []string
+	for _, key := range setup.TaskOrder {
+		if _, ok := setup.Tasks[key]; ok && !seen[key] {
+			order = append(order, key)
+			seen[key] = true
+		}
+	}
+	var rest []string
+	for key := range setup.Tasks {
+		if !seen[key] {
+			rest = append(rest, key)
+		}
+	}
+	sort.Strings(rest)
+	return append(order, rest...)
+}
+
+func renderSetupTask(task feature.SetupTask, m DetailModel) string {
+	var b strings.Builder
+	icon := setupStatusIcon(task.Status, m)
+	label := task.Label
+	if label == "" {
+		label = task.Key
+	}
+	b.WriteString(fmt.Sprintf("  %s  \u21b3 %s [%s] %s", MutedStyle.Render(" "), icon+" "+label, task.Kind, setupStatusLabel(task.Status)))
+	if task.Attempt > 0 {
+		b.WriteString(fmt.Sprintf(" attempt %d", task.Attempt))
+	}
+	b.WriteString("\n")
+	if task.Repo != "" {
+		b.WriteString("      " + LabelStyle.Render("Repo") + "  " + MutedStyle.Render(task.Repo) + "\n")
+	}
+	if task.Branch != "" {
+		b.WriteString("      " + LabelStyle.Render("Branch") + "  " + MutedStyle.Render(task.Branch) + "\n")
+	}
+	if task.Path != "" {
+		b.WriteString("      " + LabelStyle.Render("Path") + "  " + MutedStyle.Render(task.Path) + "\n")
+	}
+	if task.StartedAt != nil {
+		b.WriteString("      " + LabelStyle.Render("Started") + "  " + MutedStyle.Render(formatSetupTime(*task.StartedAt)) + "\n")
+	}
+	if task.EndedAt != nil {
+		b.WriteString("      " + LabelStyle.Render("Ended") + "  " + MutedStyle.Render(formatSetupTime(*task.EndedAt)) + "\n")
+	}
+	if task.LastError != "" {
+		b.WriteString("      " + LabelStyle.Render("Error") + "  " + ErrorStyle.Render(task.LastError) + "\n")
+	}
+	return b.String()
+}
+
+func setupStatusIcon(status feature.SetupStatus, m DetailModel) string {
+	switch status {
+	case feature.SetupStatusRunning:
+		return m.activeProgressIcon()
+	case feature.SetupStatusDone:
+		return SuccessStyle.Render("\u2713")
+	case feature.SetupStatusFailed:
+		return ErrorStyle.Render("\u2717")
+	default:
+		return MutedStyle.Render("\u25cb")
+	}
+}
+
+func setupStatusLabel(status feature.SetupStatus) string {
+	switch status {
+	case feature.SetupStatusRunning:
+		return lipgloss.NewStyle().Foreground(colorInfo).Render("running")
+	case feature.SetupStatusDone:
+		return SuccessStyle.Render("done")
+	case feature.SetupStatusFailed:
+		return ErrorStyle.Render("failed")
+	default:
+		return MutedStyle.Render("queued")
+	}
+}
+
+func formatSetupTime(t time.Time) string {
+	return t.Format("2006-01-02 15:04:05")
+}
+
 func (m DetailModel) renderPhaseProgressFull(f *feature.Feature) string {
+	if setup := setupState(f); setup != nil && isSetupLifecycle(f) {
+		return m.renderSetupProgress(f, setup)
+	}
+
 	var b strings.Builder
 	allPhases := []struct {
 		name     string
@@ -849,6 +998,10 @@ func (m DetailModel) renderMetadataCompact(f *feature.Feature) string {
 }
 
 func (m DetailModel) renderPhaseProgress(f *feature.Feature) string {
+	if setup := setupState(f); setup != nil && isSetupLifecycle(f) {
+		return m.renderSetupProgress(f, setup)
+	}
+
 	var b strings.Builder
 	allPhases := []struct {
 		name     string
@@ -1261,6 +1414,23 @@ func finalReviewStatusText(f *feature.Feature) string {
 }
 
 func formatDetailStatus(f *feature.Feature) string {
+	if setup := setupState(f); setup != nil && setup.Status == feature.SetupStatusFailed {
+		msg := "Failed"
+		if f.FailureType != "" {
+			msg = "Failed (" + formatFailureType(f.FailureType) + ")"
+		}
+		var hints []string
+		if canRetrySetup(f) {
+			hints = append(hints, "press [r] to retry setup")
+		}
+		if setup.LatestLogPath != "" {
+			hints = append(hints, "[l] logs")
+		}
+		if len(hints) > 0 {
+			msg += " \u2014 " + strings.Join(hints, ", ")
+		}
+		return ErrorStyle.Render(msg)
+	}
 	if featureHasDisplayFailure(f) && f.Status != feature.StatusFailed && !isRunningStatus(f.Status) {
 		msg := "Failed"
 		if f.FailureType != "" {
@@ -1269,6 +1439,8 @@ func formatDetailStatus(f *feature.Feature) string {
 		return ErrorStyle.Render(msg + " — press [r] to restart, [l] logs")
 	}
 	switch f.Status {
+	case feature.StatusSettingUpWorktrees:
+		return lipgloss.NewStyle().Foreground(colorInfo).Render("Setting up worktrees")
 	case feature.StatusImplementing:
 		var label string
 		switch f.ActiveCycleType() {

--- a/internal/tui/detail_test.go
+++ b/internal/tui/detail_test.go
@@ -100,6 +100,140 @@ func TestDetailViewFooterActions(t *testing.T) {
 	}
 }
 
+func TestDetailViewRendersActiveSetupProgressAndActions(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC)
+	f := &feature.Feature{
+		ID:           "feat-setup",
+		Slug:         "setup-feature",
+		Status:       feature.StatusSettingUpWorktrees,
+		CurrentPhase: feature.PhaseKnowledgeBase,
+		Repos: []feature.FeatureRepo{{
+			Name:   "payments",
+			Path:   "/tmp/payments",
+			Branch: "feature/setup-feature",
+		}},
+		Models: config.ModelConfig{Research: "opus", Planning: "opus", Implementation: "opus", Review: "opus"},
+	}
+	setup := feature.NewActiveSetupState(f.Repos, []string{"/tmp/image.png"}, []string{"/tmp/spec.md"}, now)
+	setup.LatestLogPath = "/tmp/setup-attempt-1.log"
+	task := setup.Tasks["worktree:payments"]
+	task.Path = "/tmp/worktrees/setup-feature/payments"
+	task.StartedAt = &now
+	setup.Tasks["worktree:payments"] = task
+	f.SetRun(&feature.Run{RunNumber: 1, Setup: setup})
+
+	m := NewDetailModel(f, "")
+	m.width = 100
+	m.height = 40
+
+	view := m.View()
+	for _, want := range []string{
+		"Setting up worktrees",
+		"Worktree: payments",
+		"worktree",
+		"queued",
+		"feature/setup-feature",
+		"/tmp/worktrees/setup-feature/payments",
+		"attempt 1",
+		"Image 1",
+		"Attachment 1",
+		"[l] Logs",
+		"[d] Delete",
+	} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("DetailModel.View() missing %q:\n%s", want, view)
+		}
+	}
+	for _, absent := range []string{"[s] Stop", "[r] Restart", "Retry phase", "context window"} {
+		if strings.Contains(view, absent) {
+			t.Fatalf("DetailModel.View() contained %q during active setup:\n%s", absent, view)
+		}
+	}
+}
+
+func TestDetailViewRendersFailedSetupErrorAndRetryAction(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC)
+	f := &feature.Feature{
+		ID:           "feat-setup-failed",
+		Slug:         "setup-failed",
+		Status:       feature.StatusFailed,
+		FailureType:  feature.FailureWorktreeSetup,
+		CurrentPhase: feature.PhaseKnowledgeBase,
+		Repos: []feature.FeatureRepo{{
+			Name:   "payments",
+			Path:   "/tmp/payments",
+			Branch: "feature/setup-failed",
+		}},
+		Models: config.ModelConfig{Research: "opus", Planning: "opus", Implementation: "opus", Review: "opus"},
+	}
+	setup := feature.NewActiveSetupState(f.Repos, nil, nil, now)
+	setup.Status = feature.SetupStatusFailed
+	setup.LastError = "worktree path already exists"
+	setup.LatestLogPath = "/tmp/setup-attempt-1.log"
+	task := setup.Tasks["worktree:payments"]
+	task.Status = feature.SetupStatusFailed
+	task.LastError = "worktree path already exists"
+	task.EndedAt = &now
+	setup.Tasks["worktree:payments"] = task
+	f.SetRun(&feature.Run{
+		RunNumber:   1,
+		Setup:       setup,
+		FailureType: feature.FailureWorktreeSetup,
+	})
+
+	m := NewDetailModel(f, "")
+	m.width = 100
+	m.height = 40
+
+	view := m.View()
+	for _, want := range []string{
+		"Failed (worktree setup)",
+		"worktree path already exists",
+		"[r] Retry setup",
+		"[l] Logs",
+		"[d] Delete",
+	} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("DetailModel.View() missing %q:\n%s", want, view)
+		}
+	}
+	for _, absent := range []string{"[Shift+R] Retry phase", "[s] Stop", "press [r] to restart"} {
+		if strings.Contains(view, absent) {
+			t.Fatalf("DetailModel.View() contained %q for failed setup:\n%s", absent, view)
+		}
+	}
+}
+
+func TestDetailViewHidesRetryForNonWorktreeSetupFailure(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC)
+	f := &feature.Feature{
+		ID:           "feat-setup-failed",
+		Slug:         "setup-failed",
+		Status:       feature.StatusFailed,
+		CurrentPhase: feature.PhaseKnowledgeBase,
+		Models:       config.ModelConfig{Research: "opus", Planning: "opus", Implementation: "opus", Review: "opus"},
+	}
+	setup := feature.NewActiveSetupState(nil, nil, nil, now)
+	setup.Status = feature.SetupStatusFailed
+	setup.LastError = "setup did not finish"
+	f.SetRun(&feature.Run{RunNumber: 1, Setup: setup})
+
+	m := NewDetailModel(f, "")
+	m.width = 100
+	m.height = 40
+
+	view := m.View()
+	if strings.Contains(view, "[r] Retry setup") || strings.Contains(view, "press [r] to retry setup") {
+		t.Fatalf("DetailModel.View() exposed setup retry without worktree setup failure:\n%s", view)
+	}
+	if !strings.Contains(view, "setup did not finish") {
+		t.Fatalf("DetailModel.View() missing setup error:\n%s", view)
+	}
+}
+
 func TestDetailViewFooterUsesContextualAttentionLabel(t *testing.T) {
 	t.Parallel()
 

--- a/internal/tui/help.go
+++ b/internal/tui/help.go
@@ -204,6 +204,70 @@ func detailHelp() ViewHelpContext {
 	}
 }
 
+func setupDetailPanelHelp(logsAvailable, retryAvailable bool) ViewHelpContext {
+	actions := []HelpBinding{
+		{"o", "Show overview"},
+	}
+	if logsAvailable {
+		actions = append(actions, HelpBinding{"l", "View setup logs"})
+	}
+	if retryAvailable {
+		actions = append(actions, HelpBinding{"r", "Retry setup"})
+	}
+	actions = append(actions, HelpBinding{"d", "Delete feature"})
+
+	return ViewHelpContext{
+		Name: "Setup Detail Panel",
+		Sections: []HelpSection{
+			{
+				Title: "NAVIGATION",
+				Bindings: []HelpBinding{
+					{"←/esc", "Back to list"},
+					{"tab", "Switch panel"},
+				},
+			},
+			{
+				Title:    "ACTIONS",
+				Bindings: actions,
+			},
+			{
+				Title: "TOOLS",
+				Bindings: []HelpBinding{
+					{ChatKeyHint(), "Ask AI"},
+					{"?", "Help"},
+				},
+			},
+		},
+	}
+}
+
+func setupDetailHelp(logsAvailable, retryAvailable bool) ViewHelpContext {
+	var actions []HelpBinding
+	if logsAvailable {
+		actions = append(actions, HelpBinding{"l", "View setup logs"})
+	}
+	if retryAvailable {
+		actions = append(actions, HelpBinding{"r", "Retry setup"})
+	}
+	actions = append(actions, HelpBinding{"d", "Delete feature"})
+
+	return ViewHelpContext{
+		Name: "Setup Detail",
+		Sections: []HelpSection{
+			{
+				Title: "NAVIGATION",
+				Bindings: []HelpBinding{
+					{"esc", "Back to dashboard"},
+				},
+			},
+			{
+				Title:    "ACTIONS",
+				Bindings: actions,
+			},
+		},
+	}
+}
+
 func wizardHelp() ViewHelpContext {
 	return ViewHelpContext{
 		Name: "Wizard",

--- a/internal/tui/help_test.go
+++ b/internal/tui/help_test.go
@@ -17,6 +17,7 @@ package tui
 import (
 	"strings"
 	"testing"
+	"time"
 
 	tea "charm.land/bubbletea/v2"
 	"github.com/doordash-oss/agentic-orchestrator/internal/config"
@@ -317,6 +318,108 @@ func TestHelpOverlayOpensInAllViews(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestHelpOverlayUsesSetupContextForSetupLifecycle(t *testing.T) {
+	tests := []struct {
+		name       string
+		view       View
+		focusPanel bool
+		feature    *feature.Feature
+		wantCtx    string
+		want       []string
+		absent     []string
+	}{
+		{
+			name:       "dashboard right active setup",
+			view:       ViewDashboard,
+			focusPanel: true,
+			feature:    newSetupHelpFeature("feat-setup-active", feature.StatusSettingUpWorktrees, feature.SetupStatusRunning, "", "/tmp/setup.log"),
+			wantCtx:    "Setup Detail Panel",
+			want:       []string{"View setup logs", "Delete feature"},
+			absent:     []string{"Stop running feature", "Restart phase", "Retry setup", "Rewind"},
+		},
+		{
+			name:    "detail active setup",
+			view:    ViewDetail,
+			feature: newSetupHelpFeature("feat-setup-active", feature.StatusSettingUpWorktrees, feature.SetupStatusRunning, "", "/tmp/setup.log"),
+			wantCtx: "Setup Detail",
+			want:    []string{"View setup logs", "Delete feature"},
+			absent:  []string{"Stop running feature", "Restart phase", "Retry setup", "Rewind"},
+		},
+		{
+			name:    "detail failed worktree setup",
+			view:    ViewDetail,
+			feature: newSetupHelpFeature("feat-setup-failed", feature.StatusFailed, feature.SetupStatusFailed, feature.FailureWorktreeSetup, "/tmp/setup.log"),
+			wantCtx: "Setup Detail",
+			want:    []string{"View setup logs", "Retry setup", "Delete feature"},
+			absent:  []string{"Stop running feature", "Restart phase", "Rewind"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			app := newHelpTestApp(t)
+			app.currentView = tt.view
+			switch tt.view {
+			case ViewDashboard:
+				app.dashboard = NewDashboardModel([]*feature.Feature{tt.feature}, "")
+				app.dashboard.width = 80
+				app.dashboard.height = 24
+				app.dashboard.focusPanel = 1
+				if !app.dashboard.SelectFeatureID(tt.feature.ID) {
+					t.Fatalf("setup feature %q was not selectable", tt.feature.ID)
+				}
+			case ViewDetail:
+				app.detail = NewDetailModel(tt.feature, t.TempDir())
+				app.detail.width = 80
+				app.detail.height = 24
+			}
+			if tt.focusPanel {
+				app.dashboard.focusPanel = 1
+			}
+
+			result, _ := app.Update(questionMarkKey())
+			got := result.(AppModel)
+			if !got.helpOverlayActive {
+				t.Fatal("helpOverlayActive = false, want true")
+			}
+			if got.helpOverlay.context.Name != tt.wantCtx {
+				t.Fatalf("help context = %q, want %q", got.helpOverlay.context.Name, tt.wantCtx)
+			}
+			view := got.helpOverlay.View()
+			for _, want := range tt.want {
+				if !strings.Contains(view, want) {
+					t.Fatalf("setup help missing %q:\n%s", want, view)
+				}
+			}
+			for _, absent := range tt.absent {
+				if strings.Contains(view, absent) {
+					t.Fatalf("setup help contained %q:\n%s", absent, view)
+				}
+			}
+		})
+	}
+}
+
+func newSetupHelpFeature(id string, status feature.Status, setupStatus feature.SetupStatus, failureType, logPath string) *feature.Feature {
+	now := time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC)
+	f := &feature.Feature{
+		ID:            id,
+		Name:          id,
+		Slug:          id,
+		Status:        status,
+		FailureType:   failureType,
+		CurrentPhase:  feature.PhaseKnowledgeBase,
+		ActiveRun:     1,
+		RunCount:      1,
+		SchemaVersion: feature.SchemaVersionCurrent,
+	}
+	setup := feature.NewActiveSetupState(nil, nil, nil, now)
+	setup.Status = setupStatus
+	setup.LatestLogPath = logPath
+	f.SetRun(&feature.Run{RunNumber: 1, Setup: setup, FailureType: failureType})
+	return f
 }
 
 // TestHelpOverlayCloseRestoresView verifies that closing the help overlay

--- a/internal/tui/orchestrator_api.go
+++ b/internal/tui/orchestrator_api.go
@@ -38,6 +38,8 @@ type orchestratorAPI interface {
 	Done() <-chan struct{}
 
 	// --- Phase lifecycle -----------------------------------------------
+	RunSetup(featureID string) error
+	RetrySetup(featureID string) error
 	StartFeature(featureID string) error
 	HandlePhaseCompletion(featureID string, input orchestrator.PhaseCompletionInput) error
 	HandleReviewDecision(featureID string, d orchestrator.ReviewDecision) error

--- a/internal/tui/orchestrator_bridge_test.go
+++ b/internal/tui/orchestrator_bridge_test.go
@@ -235,6 +235,16 @@ func (f *fakeOrch) StartFeature(featureID string) error {
 	return f.startFeatureErr
 }
 
+func (f *fakeOrch) RunSetup(featureID string) error {
+	f.lifecycleCalls = append(f.lifecycleCalls, "RunSetup:"+featureID)
+	return f.lifecycleErr
+}
+
+func (f *fakeOrch) RetrySetup(featureID string) error {
+	f.lifecycleCalls = append(f.lifecycleCalls, "RetrySetup:"+featureID)
+	return f.lifecycleErr
+}
+
 func (f *fakeOrch) HandlePhaseCompletion(featureID string, input orchestrator.PhaseCompletionInput) error {
 	f.handlePhaseCompletionArgs = append(f.handlePhaseCompletionArgs, struct {
 		FeatureID string
@@ -620,6 +630,10 @@ var allBridgedEventTypes = []ports.EventType{
 	ports.FeatureCompleted,
 	ports.FeatureFailed,
 	ports.FeatureInterrupted,
+	ports.SetupStarted,
+	ports.SetupProgress,
+	ports.SetupCompleted,
+	ports.SetupFailed,
 	ports.PhaseStarted,
 	ports.PhaseCompleted,
 	ports.ReviewRequired,
@@ -649,6 +663,8 @@ func expectedMsgTypeName(et ports.EventType) string {
 		return "OrchFeatureFailedMsg"
 	case ports.FeatureInterrupted:
 		return "OrchFeatureInterruptedMsg"
+	case ports.SetupStarted, ports.SetupProgress, ports.SetupCompleted, ports.SetupFailed:
+		return "OrchSetupLifecycleMsg"
 	case ports.PhaseStarted:
 		return "OrchPhaseStartedMsg"
 	case ports.PhaseCompleted:
@@ -720,6 +736,8 @@ func typeName(v any) string {
 		return "OrchFeatureFailedMsg"
 	case OrchFeatureInterruptedMsg:
 		return "OrchFeatureInterruptedMsg"
+	case OrchSetupLifecycleMsg:
+		return "OrchSetupLifecycleMsg"
 	case OrchPhaseStartedMsg:
 		return "OrchPhaseStartedMsg"
 	case OrchPhaseCompletedMsg:
@@ -923,6 +941,9 @@ func TestTUI_CreateFeatureCmd_DelegatesCompleteWizardResultToOrchestrator(t *tes
 	}
 	if !slices.Equal(opt.Attachments, result.Attachments) {
 		t.Fatalf("Attachments = %v, want %v", opt.Attachments, result.Attachments)
+	}
+	if !opt.QueueSetup {
+		t.Fatal("QueueSetup = false, want true for wizard-created features")
 	}
 }
 

--- a/internal/tui/orchestrator_msgs.go
+++ b/internal/tui/orchestrator_msgs.go
@@ -52,6 +52,15 @@ type OrchFeatureInterruptedMsg struct {
 	FeatureID string
 }
 
+type OrchSetupLifecycleMsg struct {
+	FeatureID string
+	RunNumber int
+	Attempt   int
+	TaskKey   string
+	RepoName  string
+	Error     error
+}
+
 // OrchPhaseStartedMsg is emitted when a phase begins.
 type OrchPhaseStartedMsg struct {
 	FeatureID string

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -118,6 +118,8 @@ func statusIcon(status string) string {
 	switch status {
 	case "Created":
 		return MutedStyle.Render(icons.Created)
+	case "SettingUpWorktrees":
+		return lipgloss.NewStyle().Foreground(colorInfo).Render(icons.Created)
 	case "Researching":
 		return lipgloss.NewStyle().Foreground(colorInfo).Render(icons.Researching)
 	case "Planning":

--- a/test/testutil/mocks/mock_feature_lifecycle.go
+++ b/test/testutil/mocks/mock_feature_lifecycle.go
@@ -32,17 +32,20 @@ type MockFeatureLifecycle struct {
 	CreateFn func(name, description string, repos []string, models config.ModelConfig,
 		exitCriteria, inquireness string, images []string,
 		opts ...feature.CreateOptions) (*feature.Feature, error)
-	GetFn        func(id string) (*feature.Feature, error)
-	ListFn       func() ([]*feature.Feature, error)
-	DeleteFn     func(featureID string) error
-	TransitionFn func(id string, to feature.Status) error
+	GetFn                      func(id string) (*feature.Feature, error)
+	ListFn                     func() ([]*feature.Feature, error)
+	DeleteFn                   func(featureID string) error
+	TransitionFn               func(id string, to feature.Status) error
+	RunSetupFn                 func(featureID string, opts ...feature.SetupRunnerOptions) error
+	RetrySetupFn               func(featureID string, opts ...feature.SetupRunnerOptions) error
+	ReconcileAbandonedSetupsFn func() ([]string, error)
 
 	// Phase-start hooks — tests that need to mimic real lifecycle behavior
 	// (status transitions) can install these. Called after the mock records
 	// the invocation.
 	StartKnowledgeBaseFn  func(featureID string) error
 	StartInquireFn        func(featureID string) error
-	StartDesignFn     func(featureID string) error
+	StartDesignFn         func(featureID string) error
 	StartResearchFn       func(featureID string) error
 	StartPlanningFn       func(featureID string) error
 	StartImplementationFn func(featureID string) error
@@ -52,7 +55,7 @@ type MockFeatureLifecycle struct {
 	CompleteKnowledgeBaseFn  func(featureID string) error
 	CompleteInquireFn        func(featureID string) error
 	CompleteResearchFn       func(featureID string) error
-	CompleteDesignFn     func(featureID string) error
+	CompleteDesignFn         func(featureID string) error
 	CompletePlanningFn       func(featureID string) error
 	CompleteImplementationFn func(featureID string) error
 
@@ -162,6 +165,30 @@ func (m *MockFeatureLifecycle) Transition(id string, to feature.Status) error {
 		return m.TransitionFn(id, to)
 	}
 	return m.DefaultError
+}
+
+func (m *MockFeatureLifecycle) RunSetup(featureID string, opts ...feature.SetupRunnerOptions) error {
+	m.record("RunSetup", featureID, opts)
+	if m.RunSetupFn != nil {
+		return m.RunSetupFn(featureID, opts...)
+	}
+	return m.DefaultError
+}
+
+func (m *MockFeatureLifecycle) RetrySetup(featureID string, opts ...feature.SetupRunnerOptions) error {
+	m.record("RetrySetup", featureID, opts)
+	if m.RetrySetupFn != nil {
+		return m.RetrySetupFn(featureID, opts...)
+	}
+	return m.DefaultError
+}
+
+func (m *MockFeatureLifecycle) ReconcileAbandonedSetups() ([]string, error) {
+	m.record("ReconcileAbandonedSetups")
+	if m.ReconcileAbandonedSetupsFn != nil {
+		return m.ReconcileAbandonedSetupsFn()
+	}
+	return nil, m.DefaultError
 }
 
 // ---------------------------------------------------------------------------

--- a/test/testutil/mocks/mock_git.go
+++ b/test/testutil/mocks/mock_git.go
@@ -417,6 +417,7 @@ func (m *MockReviewCommentOperator) LatestCommitSHA(worktreePath string) (string
 // function overrides and call tracking.
 type MockWorktreeOperator struct {
 	CreateFn                func(repoPath, featureSlug, repoName, startPoint string) (string, error)
+	ExpectedPathFn          func(featureSlug, repoName string) string
 	RemoveFn                func(worktreePath string, deleteBranch bool) error
 	ListFn                  func() ([]git.WorktreeInfo, error)
 	DetectStaleFn           func(activeFeatureIDs []string) ([]git.WorktreeInfo, error)
@@ -438,6 +439,14 @@ func (m *MockWorktreeOperator) Create(repoPath, featureSlug, repoName, startPoin
 		return m.CreateFn(repoPath, featureSlug, repoName, startPoint)
 	}
 	return "", m.DefaultError
+}
+
+func (m *MockWorktreeOperator) ExpectedPath(featureSlug, repoName string) string {
+	m.Calls = append(m.Calls, MockCall{Method: "ExpectedPath", Args: []any{featureSlug, repoName}})
+	if m.ExpectedPathFn != nil {
+		return m.ExpectedPathFn(featureSlug, repoName)
+	}
+	return ""
 }
 
 func (m *MockWorktreeOperator) Remove(worktreePath string, deleteBranch bool) error {


### PR DESCRIPTION
## Summary

Implements the worktree setup UX issue set from `/tmp/worktree-setup-ux-issues/`.

- Adds durable first-run setup state and a setup runner for sequential worktree, image, and attachment setup tasks.
- Persists setup progress, attempt logs, failure diagnostics, retry state, and conservative expected-worktree reuse.
- Wires setup handoff through orchestrator `RunSetup` / `RetrySetup`, then the normal `StartFeature` path only after setup completes.
- Updates TUI dashboard/detail/help/logs behavior for active and failed setup, including setup-specific retry and key gating.
- Adds delete cleanup for setup task worktree paths, startup reconciliation for abandoned setup, and first-class setup lifecycle events/observer docs.

## Verification

- Fast suite: `make test-fast`
- Static analysis: `go vet ./...`
- Build: `go build ./...`
- All packages: `go test ./... -count=1`
- Isolated integration: `go test ./test/integration/... -count=1`
- E2E Go (TUI / teatest): `go test ./test/e2e/... -count=1 -race`
- TUI observability: `go test -tags tui_observe ./internal/tui -run 'Observed|Emits' -count=1`
- Race regression: `go test ./... -count=1 -race`
- Diff whitespace: `git diff --check`

Skipped E2E smoke shell: launch behavior, embedded skills, and release packaging were not touched.
