### PR TITLE
[codex] Use cheaper defaults for research and KB build

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,12 +208,12 @@ Config lives at `~/.agentic-orchestrator/config.yaml` (auto-created on first lau
 ```yaml
 defaults:
   models:
-    research: "opus[1m]"     # Model for research phase
-    planning: "opus[1m]"     # Model for planning phase
-    implementation: "opus[1m]" # Model for implementation phase
-    review: gpt-5.4          # Model for review phase (Codex)
-    utilities: sonnet        # Model for chat and utility tasks
-    kb_build: "opus[1m]"     # Model for knowledge base builds
+    research: "sonnet[200K]"     # Model for research phase
+    planning: "opus[1M]"         # Model for planning phase
+    implementation: "opus[1M]"   # Model for implementation phase
+    review: "gpt-5.4[272K]"      # Model for review phase (Codex)
+    utilities: "sonnet[200K]"    # Model for chat and utility tasks
+    kb_build: "sonnet[200K]"     # Model for knowledge base builds
   exit_criteria: |
     - Feature fully implemented per plan
     - Unit tests added/updated as needed
@@ -238,7 +238,7 @@ workspace_roots:
 
 ### Model Overrides
 
-Each feature can override default models during creation via the wizard (step 4). Models can be specified with explicit provider prefixes (e.g., `claude:opus`, `codex:gpt-5.4`) or as bare names that are automatically routed to the best-matching provider.
+Each feature can override default models during creation via the wizard (step 4). Models can be specified with explicit provider prefixes (e.g., `claude:opus[1M]`, `codex:gpt-5.4[272K]`) or as bare aliases that are automatically routed to the best-matching provider.
 
 ### Launch Flags
 

--- a/cmd/agentico/main_test.go
+++ b/cmd/agentico/main_test.go
@@ -441,17 +441,17 @@ func TestRemapUnresolvableModels(t *testing.T) {
 
 	t.Run("keeps_resolvable_models", func(t *testing.T) {
 		r := llm.NewRegistry()
-		r.Register(&stubProvider{name: "claude", models: []string{"opus", "sonnet"}, hasCLI: true})
+		r.Register(&stubProvider{name: "claude", models: []string{"opus[1M]", "sonnet[200K]"}, hasCLI: true})
 
 		cfg := config.NewDefault()
 		remapUnresolvableModels(cfg, r)
 
-		// opus and sonnet should stay; gpt-5.4 (review) should become opus (most capable)
-		if cfg.Defaults.Models.Research != "opus" {
-			t.Errorf("research should stay opus, got %q", cfg.Defaults.Models.Research)
+		// canonical Claude defaults should stay; gpt-5.4[272K] (review) should become opus[1M].
+		if cfg.Defaults.Models.Research != "sonnet[200K]" {
+			t.Errorf("research should stay sonnet[200K], got %q", cfg.Defaults.Models.Research)
 		}
-		if cfg.Defaults.Models.Utilities != "sonnet" {
-			t.Errorf("utilities should stay sonnet, got %q", cfg.Defaults.Models.Utilities)
+		if cfg.Defaults.Models.Utilities != "sonnet[200K]" {
+			t.Errorf("utilities should stay sonnet[200K], got %q", cfg.Defaults.Models.Utilities)
 		}
 	})
 }

--- a/internal/agent/phase_test.go
+++ b/internal/agent/phase_test.go
@@ -1161,15 +1161,15 @@ func newRegistryWithProviders() *llm.Registry {
 	reg := llm.NewRegistry()
 	claudeProvider := &claude.Provider{}
 	claudeProvider.SetModelCatalog([]llm.ModelInfo{
-		{ID: "opus", Category: "capable"},
-		{ID: "sonnet", Category: "balanced"},
-		{ID: "haiku", Category: "cheap"},
+		{ID: "opus[1M]", Category: "capable", Aliases: []string{"opus"}},
+		{ID: "sonnet[200K]", Category: "balanced", Aliases: []string{"sonnet"}},
+		{ID: "haiku[200K]", Category: "cheap", Aliases: []string{"haiku"}},
 	})
 	codexProvider := &codex.Provider{}
 	codexProvider.SetModelCatalog([]llm.ModelInfo{
-		{ID: "gpt-5.4", Category: "capable"},
-		{ID: "gpt-5.4-mini", Category: "balanced"},
-		{ID: "codex", Category: "capable"},
+		{ID: "gpt-5.4[272K]", Category: "capable", Aliases: []string{"gpt-5.4"}},
+		{ID: "gpt-5.4-mini[400K]", Category: "balanced", Aliases: []string{"gpt-5.4-mini"}},
+		{ID: "codex[272K]", Category: "capable", Aliases: []string{"codex"}},
 	})
 	reg.Register(claudeProvider)
 	reg.Register(codexProvider)
@@ -2133,7 +2133,7 @@ func stubProviderCLIs(t *testing.T, names ...string) {
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 }
 
-func TestKBBuild_FallsBackToOpus(t *testing.T) {
+func TestKBBuild_FallsBackToCostEfficientDefault(t *testing.T) {
 	stubProviderCLIs(t, "claude", "codex")
 	dir := t.TempDir()
 	eventCh := make(chan any, 10)
@@ -2160,8 +2160,8 @@ func TestKBBuild_FallsBackToOpus(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error from mock BuildSession")
 	}
-	if capturedModel != "claude:opus" {
-		t.Errorf("expected fallback model 'claude:opus', got %q", capturedModel)
+	if capturedModel != "claude:sonnet[200K]" {
+		t.Errorf("expected fallback model 'claude:sonnet[200K]', got %q", capturedModel)
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -25,8 +25,16 @@ import (
 
 func TestNewDefault(t *testing.T) {
 	cfg := NewDefault()
-	if cfg.Defaults.Models.Research != "opus[1m]" {
-		t.Errorf("expected research model opus[1m], got %s", cfg.Defaults.Models.Research)
+	wantModels := ModelConfig{
+		Research:       "sonnet[200K]",
+		Planning:       "opus[1M]",
+		Implementation: "opus[1M]",
+		Review:         "gpt-5.4[272K]",
+		Utilities:      "sonnet[200K]",
+		KBBuild:        "sonnet[200K]",
+	}
+	if cfg.Defaults.Models != wantModels {
+		t.Errorf("default models = %+v, want %+v", cfg.Defaults.Models, wantModels)
 	}
 	if cfg.Defaults.MaxIterations != 10 {
 		t.Errorf("expected max iterations 10, got %d", cfg.Defaults.MaxIterations)
@@ -114,8 +122,8 @@ func TestLoadOrCreate(t *testing.T) {
 		t.Fatalf("load or create: %v", err)
 	}
 
-	if cfg.Defaults.Models.Research != "opus[1m]" {
-		t.Errorf("expected default research model opus[1m], got %s", cfg.Defaults.Models.Research)
+	if cfg.Defaults.Models.Research != "sonnet[200K]" {
+		t.Errorf("expected default research model sonnet[200K], got %s", cfg.Defaults.Models.Research)
 	}
 
 	// File should exist now
@@ -367,11 +375,11 @@ func TestApplyDefaults(t *testing.T) {
 	cfg := &Config{}
 	applyDefaults(cfg)
 
-	if cfg.Defaults.Models.Research != "opus[1m]" {
+	if cfg.Defaults.Models.Research != "sonnet[200K]" {
 		t.Errorf("expected default research model, got %s", cfg.Defaults.Models.Research)
 	}
-	if cfg.Defaults.Models.Utilities != "sonnet" {
-		t.Errorf("expected default utilities model sonnet, got %s", cfg.Defaults.Models.Utilities)
+	if cfg.Defaults.Models.Utilities != "sonnet[200K]" {
+		t.Errorf("expected default utilities model sonnet[200K], got %s", cfg.Defaults.Models.Utilities)
 	}
 	if cfg.Defaults.MaxIterations != 10 {
 		t.Errorf("expected default max iterations, got %d", cfg.Defaults.MaxIterations)
@@ -386,8 +394,8 @@ func TestApplyDefaults(t *testing.T) {
 
 func TestUtilitiesModelDefault(t *testing.T) {
 	cfg := NewDefault()
-	if cfg.Defaults.Models.Utilities != "sonnet" {
-		t.Errorf("expected utilities model sonnet, got %s", cfg.Defaults.Models.Utilities)
+	if cfg.Defaults.Models.Utilities != "sonnet[200K]" {
+		t.Errorf("expected utilities model sonnet[200K], got %s", cfg.Defaults.Models.Utilities)
 	}
 }
 
@@ -473,16 +481,16 @@ ui:
 
 func TestNewDefaultKBBuild(t *testing.T) {
 	cfg := NewDefault()
-	if cfg.Defaults.Models.KBBuild != "opus[1m]" {
-		t.Errorf("expected KBBuild default opus[1m], got %s", cfg.Defaults.Models.KBBuild)
+	if cfg.Defaults.Models.KBBuild != "sonnet[200K]" {
+		t.Errorf("expected KBBuild default sonnet[200K], got %s", cfg.Defaults.Models.KBBuild)
 	}
 }
 
 func TestApplyDefaultsFillsKBBuild(t *testing.T) {
 	cfg := &Config{}
 	applyDefaults(cfg)
-	if cfg.Defaults.Models.KBBuild != "opus[1m]" {
-		t.Errorf("expected KBBuild opus[1m] after applyDefaults, got %s", cfg.Defaults.Models.KBBuild)
+	if cfg.Defaults.Models.KBBuild != "sonnet[200K]" {
+		t.Errorf("expected KBBuild sonnet[200K] after applyDefaults, got %s", cfg.Defaults.Models.KBBuild)
 	}
 }
 
@@ -528,8 +536,8 @@ func TestLoadConfigWithoutKBBuildGetsDefault(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Load: %v", err)
 	}
-	if cfg.Defaults.Models.KBBuild != "opus[1m]" {
-		t.Errorf("expected KBBuild opus[1m] for config without kb_build, got %s", cfg.Defaults.Models.KBBuild)
+	if cfg.Defaults.Models.KBBuild != "sonnet[200K]" {
+		t.Errorf("expected KBBuild sonnet[200K] for config without kb_build, got %s", cfg.Defaults.Models.KBBuild)
 	}
 }
 
@@ -1363,8 +1371,8 @@ func TestDefaultsPipelinePreservesExisting(t *testing.T) {
 
 func TestNewDefault_Utilities(t *testing.T) {
 	cfg := NewDefault()
-	if cfg.Defaults.Models.Utilities != "sonnet" {
-		t.Errorf("expected Utilities default sonnet, got %s", cfg.Defaults.Models.Utilities)
+	if cfg.Defaults.Models.Utilities != "sonnet[200K]" {
+		t.Errorf("expected Utilities default sonnet[200K], got %s", cfg.Defaults.Models.Utilities)
 	}
 }
 
@@ -1420,9 +1428,9 @@ func TestMigrateModelConfig_NeitherSet(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Load: %v", err)
 	}
-	// applyDefaults should fill it with "sonnet"
-	if cfg.Defaults.Models.Utilities != "sonnet" {
-		t.Errorf("expected Utilities=sonnet (from defaults), got %q", cfg.Defaults.Models.Utilities)
+	// applyDefaults should fill it with "sonnet[200K]"
+	if cfg.Defaults.Models.Utilities != "sonnet[200K]" {
+		t.Errorf("expected Utilities=sonnet[200K] (from defaults), got %q", cfg.Defaults.Models.Utilities)
 	}
 }
 

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -25,12 +25,12 @@ func NewDefault() *Config {
 	return &Config{
 		Defaults: DefaultsConfig{
 			Models: ModelConfig{
-				Research:       "opus[1m]",
-				Planning:       "opus[1m]",
-				Implementation: "opus[1m]",
-				Review:         "gpt-5.4",
-				Utilities:      "sonnet",
-				KBBuild:        "opus[1m]",
+				Research:       "sonnet[200K]",
+				Planning:       "opus[1M]",
+				Implementation: "opus[1M]",
+				Review:         "gpt-5.4[272K]",
+				Utilities:      "sonnet[200K]",
+				KBBuild:        "sonnet[200K]",
 			},
 			Checkpoints: Checkpoints{
 				ManualPublish: true,

--- a/internal/llm/registry.go
+++ b/internal/llm/registry.go
@@ -370,17 +370,53 @@ var providerPreference = map[PhaseRole]string{
 	PhaseKBBuild:        "claude",
 }
 
-// categoryForRole maps phase roles to the desired model category.
+// categoryForRole maps phase roles to the default model-selection category.
+// Research and KB build are intentionally cost-efficient defaults: they are
+// token-heavy phases that fan out through sub-agents, so a balanced model is
+// usually a better starting point than the largest context window.
 var categoryForRole = map[PhaseRole]string{
-	PhaseResearch:       "capable",
+	PhaseResearch:       "balanced",
 	PhasePlanning:       "capable",
 	PhaseImplementation: "capable",
 	PhaseReview:         "capable",
 	PhaseChat:           "balanced",
-	PhaseKBBuild:        "capable",
+	PhaseKBBuild:        "balanced",
 }
 
-func selectRoleModel(models []ModelInfo, category string) (ModelInfo, bool) {
+var preferredModelHintsByRoleProvider = map[PhaseRole]map[string][]string{
+	PhaseResearch: {
+		"claude": {"sonnet[200K]", "sonnet"},
+		"codex":  {"gpt-5.4[272K]", "gpt-5.4"},
+	},
+	PhaseKBBuild: {
+		"claude": {"sonnet[200K]", "sonnet"},
+		"codex":  {"gpt-5.4[272K]", "gpt-5.4"},
+	},
+}
+
+func selectHintedModel(models []ModelInfo, hints []string) (ModelInfo, bool) {
+	for _, hint := range hints {
+		for _, model := range models {
+			if strings.EqualFold(model.ID, hint) {
+				return model, true
+			}
+			for _, alias := range model.Aliases {
+				if strings.EqualFold(alias, hint) {
+					return model, true
+				}
+			}
+		}
+	}
+	return ModelInfo{}, false
+}
+
+func selectRoleModel(models []ModelInfo, role PhaseRole, provider string) (ModelInfo, bool) {
+	if providerHints, ok := preferredModelHintsByRoleProvider[role]; ok {
+		if m, ok := selectHintedModel(models, providerHints[provider]); ok {
+			return m, true
+		}
+	}
+	category := categoryForRole[role]
 	if category == "balanced" {
 		return BalancedFrom(models)
 	}
@@ -420,11 +456,10 @@ func (r *Registry) catalogDefaultModelsWithProviderOverride(providerOverride str
 		if providerOverride != "" {
 			preferred = providerOverride
 		}
-		category := categoryForRole[role]
 
 		if preferred != "" {
 			if models := r.ModelsForProvider(preferred); len(models) > 0 {
-				if m, ok := selectRoleModel(models, category); ok {
+				if m, ok := selectRoleModel(models, role, preferred); ok {
 					return formatCatalogDefault(preferred, m, multi)
 				}
 			}
@@ -435,7 +470,7 @@ func (r *Registry) catalogDefaultModelsWithProviderOverride(providerOverride str
 
 		for _, p := range detected {
 			cat := catalogForProvider(p)
-			if m, ok := selectRoleModel(cat, category); ok {
+			if m, ok := selectRoleModel(cat, role, p.Name()); ok {
 				return formatCatalogDefault(p.Name(), m, multi)
 			}
 		}
@@ -469,16 +504,14 @@ func (r *Registry) CatalogDefaultModels() config.ModelConfig {
 }
 
 // eligibleCategoriesForRole maps phase roles to the set of model categories
-// that are appropriate for that phase. Phases requiring deep reasoning only
-// show "capable" models; phases that can use lighter models also include
-// "balanced" or "cheap".
+// that are appropriate for that phase.
 var eligibleCategoriesForRole = map[PhaseRole]map[string]bool{
-	PhaseResearch:       {"capable": true},
+	PhaseResearch:       {"capable": true, "balanced": true},
 	PhasePlanning:       {"capable": true},
 	PhaseImplementation: {"capable": true, "balanced": true},
 	PhaseReview:         {"capable": true, "balanced": true},
 	PhaseChat:           {"balanced": true, "cheap": true},
-	PhaseKBBuild:        {"capable": true},
+	PhaseKBBuild:        {"capable": true, "balanced": true},
 }
 
 // maxModelsPerProvider is the maximum number of models shown per provider
@@ -506,11 +539,43 @@ func (r *Registry) EligibleModelsForPhase(role PhaseRole) map[string][]string {
 			}
 		}
 
-		// Limit to top N by capability rank.
+		// Limit to top N by capability rank, while preserving the role's
+		// default recommendation even when that recommendation is balanced and
+		// would otherwise be crowded out by capable variants.
 		ids := TopModelIDs(filtered, maxModelsPerProvider)
+		if recommended, ok := selectRoleModel(catalog, role, name); ok {
+			ids = includeRecommendedModelID(ids, recommended.ID)
+		}
 		if len(ids) > 0 {
 			result[name] = ids
 		}
 	}
 	return result
+}
+
+func includeRecommendedModelID(ids []string, recommended string) []string {
+	if recommended == "" {
+		return ids
+	}
+	for i, id := range ids {
+		if id != recommended {
+			continue
+		}
+		if i == 0 {
+			return ids
+		}
+		out := make([]string, 0, len(ids))
+		out = append(out, recommended)
+		out = append(out, ids[:i]...)
+		out = append(out, ids[i+1:]...)
+		return out
+	}
+
+	out := make([]string, 0, len(ids)+1)
+	out = append(out, recommended)
+	out = append(out, ids...)
+	if len(out) > maxModelsPerProvider {
+		return out[:maxModelsPerProvider]
+	}
+	return out
 }

--- a/internal/llm/registry_test.go
+++ b/internal/llm/registry_test.go
@@ -414,8 +414,8 @@ func TestRegistry_DefaultModels_UsesCatalogDefaults(t *testing.T) {
 	})
 
 	defaults := r.DefaultModels()
-	if defaults[llm.PhaseResearch] != "claude:opus" {
-		t.Errorf("research: got %q, want %q", defaults[llm.PhaseResearch], "claude:opus")
+	if defaults[llm.PhaseResearch] != "claude:sonnet" {
+		t.Errorf("research: got %q, want %q", defaults[llm.PhaseResearch], "claude:sonnet")
 	}
 	if defaults[llm.PhaseChat] != "claude:sonnet" {
 		t.Errorf("chat: got %q, want %q", defaults[llm.PhaseChat], "claude:sonnet")
@@ -423,8 +423,8 @@ func TestRegistry_DefaultModels_UsesCatalogDefaults(t *testing.T) {
 	if defaults[llm.PhaseReview] != "codex:codex" {
 		t.Errorf("review: got %q, want %q", defaults[llm.PhaseReview], "codex:codex")
 	}
-	if defaults[llm.PhaseKBBuild] != "claude:opus" {
-		t.Errorf("kb_build: got %q, want %q", defaults[llm.PhaseKBBuild], "claude:opus")
+	if defaults[llm.PhaseKBBuild] != "claude:sonnet" {
+		t.Errorf("kb_build: got %q, want %q", defaults[llm.PhaseKBBuild], "claude:sonnet")
 	}
 }
 
@@ -758,10 +758,11 @@ func TestRegistry_CatalogDefaultModels(t *testing.T) {
 
 		mc := r.CatalogDefaultModels()
 
-		// Research/Planning/Implementation prefer claude capable → "claude:opus"
-		if mc.Research != "claude:opus" {
-			t.Errorf("research: got %q, want %q", mc.Research, "claude:opus")
+		// Research and KB build prefer cost-efficient claude defaults → "claude:sonnet"
+		if mc.Research != "claude:sonnet" {
+			t.Errorf("research: got %q, want %q", mc.Research, "claude:sonnet")
 		}
+		// Planning/Implementation prefer claude capable → "claude:opus"
 		if mc.Planning != "claude:opus" {
 			t.Errorf("planning: got %q, want %q", mc.Planning, "claude:opus")
 		}
@@ -776,9 +777,8 @@ func TestRegistry_CatalogDefaultModels(t *testing.T) {
 		if mc.Utilities != "claude:sonnet" {
 			t.Errorf("chat: got %q, want %q", mc.Utilities, "claude:sonnet")
 		}
-		// KBBuild prefers claude capable → "claude:opus"
-		if mc.KBBuild != "claude:opus" {
-			t.Errorf("kb_build: got %q, want %q", mc.KBBuild, "claude:opus")
+		if mc.KBBuild != "claude:sonnet" {
+			t.Errorf("kb_build: got %q, want %q", mc.KBBuild, "claude:sonnet")
 		}
 	})
 
@@ -792,8 +792,8 @@ func TestRegistry_CatalogDefaultModels(t *testing.T) {
 		mc := r.CatalogDefaultModels()
 
 		// Single provider → bare names (no prefix)
-		if mc.Research != "opus" {
-			t.Errorf("research: got %q, want %q", mc.Research, "opus")
+		if mc.Research != "sonnet" {
+			t.Errorf("research: got %q, want %q", mc.Research, "sonnet")
 		}
 		if mc.Planning != "opus" {
 			t.Errorf("planning: got %q, want %q", mc.Planning, "opus")
@@ -808,8 +808,8 @@ func TestRegistry_CatalogDefaultModels(t *testing.T) {
 		if mc.Utilities != "sonnet" {
 			t.Errorf("chat: got %q, want %q", mc.Utilities, "sonnet")
 		}
-		if mc.KBBuild != "opus" {
-			t.Errorf("kb_build: got %q, want %q", mc.KBBuild, "opus")
+		if mc.KBBuild != "sonnet" {
+			t.Errorf("kb_build: got %q, want %q", mc.KBBuild, "sonnet")
 		}
 	})
 
@@ -823,9 +823,9 @@ func TestRegistry_CatalogDefaultModels(t *testing.T) {
 		mc := r.CatalogDefaultModels()
 
 		// Single provider → bare names (no prefix)
-		// Research prefers claude, but claude not available; falls back to codex capable
-		if mc.Research != "codex" {
-			t.Errorf("research: got %q, want %q", mc.Research, "codex")
+		// Research prefers claude, but claude not available; falls back to a balanced codex model
+		if mc.Research != "gpt-5.4-mini" {
+			t.Errorf("research: got %q, want %q", mc.Research, "gpt-5.4-mini")
 		}
 		if mc.Planning != "codex" {
 			t.Errorf("planning: got %q, want %q", mc.Planning, "codex")
@@ -839,8 +839,32 @@ func TestRegistry_CatalogDefaultModels(t *testing.T) {
 		if mc.Utilities != "gpt-5.4-mini" {
 			t.Errorf("chat: got %q, want %q", mc.Utilities, "gpt-5.4-mini")
 		}
-		if mc.KBBuild != "codex" {
-			t.Errorf("kb_build: got %q, want %q", mc.KBBuild, "codex")
+		if mc.KBBuild != "gpt-5.4-mini" {
+			t.Errorf("kb_build: got %q, want %q", mc.KBBuild, "gpt-5.4-mini")
+		}
+	})
+
+	t.Run("codex_cost_efficient_research_and_kb_hint", func(t *testing.T) {
+		r := llm.NewRegistry()
+		r.Register(&stubCatalogProvider{
+			stubProvider: stubProvider{name: "codex", models: []string{"gpt-5.5[272K]", "gpt-5.4[272K]", "gpt-5.4[1M]", "gpt-5.4-mini[400K]"}, hasCLI: true},
+			catalog: []llm.ModelInfo{
+				{ID: "gpt-5.5[272K]", Category: "capable", ContextWindow: 272000, Aliases: []string{"gpt-5.5"}},
+				{ID: "gpt-5.4[272K]", Category: "capable", ContextWindow: 272000, Aliases: []string{"gpt-5.4"}},
+				{ID: "gpt-5.4[1M]", Category: "capable", ContextWindow: 1000000},
+				{ID: "gpt-5.4-mini[400K]", Category: "balanced", ContextWindow: 400000, Aliases: []string{"gpt-5.4-mini"}},
+			},
+		})
+
+		mc := r.CatalogDefaultModels()
+		if mc.Research != "gpt-5.4[272K]" {
+			t.Errorf("research: got %q, want %q", mc.Research, "gpt-5.4[272K]")
+		}
+		if mc.KBBuild != "gpt-5.4[272K]" {
+			t.Errorf("kb_build: got %q, want %q", mc.KBBuild, "gpt-5.4[272K]")
+		}
+		if mc.Planning != "gpt-5.4[1M]" {
+			t.Errorf("planning: got %q, want most-capable %q", mc.Planning, "gpt-5.4[1M]")
 		}
 	})
 
@@ -884,9 +908,9 @@ func TestRegistry_CatalogDefaultModels(t *testing.T) {
 		mc := r.CatalogDefaultModels()
 
 		// Multi-provider detected, so prefixes are used
-		// Research prefers claude capable → "claude:opus"
-		if mc.Research != "claude:opus" {
-			t.Errorf("research: got %q, want %q", mc.Research, "claude:opus")
+		// Research prefers cost-efficient claude defaults → "claude:sonnet"
+		if mc.Research != "claude:sonnet" {
+			t.Errorf("research: got %q, want %q", mc.Research, "claude:sonnet")
 		}
 		// Review prefers codex; codex has no catalog, so synthetic entry for "codex-model"
 		// has no category → MostCapableFrom returns it (rank 0, but still the first/only).
@@ -921,25 +945,22 @@ func TestRegistry_EligibleModelsForPhase(t *testing.T) {
 	r.Register(claude)
 	r.Register(codex)
 
-	t.Run("research only capable top N", func(t *testing.T) {
+	t.Run("research includes cost-efficient default and capable options", func(t *testing.T) {
 		result := r.EligibleModelsForPhase(llm.PhaseResearch)
-		// claude: only opus (capable), no aliases, no balanced/cheap
-		if got := result["claude"]; !slices.Contains(got, "opus") {
-			t.Errorf("claude research: got %v, want opus", got)
+		// claude: sonnet is recommended; opus remains available; cheap models are excluded.
+		if got := result["claude"]; !slices.Contains(got, "sonnet") || !slices.Contains(got, "opus") {
+			t.Errorf("claude research: got %v, want sonnet and opus", got)
 		}
-		if slices.Contains(result["claude"], "sonnet") || slices.Contains(result["claude"], "haiku") {
-			t.Error("claude research should not include sonnet or haiku")
+		if slices.Contains(result["claude"], "haiku") {
+			t.Error("claude research should not include haiku")
 		}
 		// Aliases are no longer included in filtered results
 		if slices.Contains(result["claude"], "opus[1m]") {
 			t.Error("claude research should not include aliases")
 		}
-		// codex: codex and gpt-5.4 (capable), not gpt-5.4-mini (balanced)
-		if got := result["codex"]; !slices.Contains(got, "codex") || !slices.Contains(got, "gpt-5.4") {
-			t.Errorf("codex research: got %v, want codex and gpt-5.4", got)
-		}
-		if slices.Contains(result["codex"], "gpt-5.4-mini") {
-			t.Error("codex research should not include gpt-5.4-mini")
+		// codex: gpt-5.4 is the recommended default; balanced mini remains available.
+		if got := result["codex"]; !slices.Contains(got, "gpt-5.4") || !slices.Contains(got, "gpt-5.4-mini") {
+			t.Errorf("codex research: got %v, want gpt-5.4 and gpt-5.4-mini", got)
 		}
 	})
 

--- a/skills/chat/user-guide/configuration.md
+++ b/skills/chat/user-guide/configuration.md
@@ -21,24 +21,24 @@ The `defaults.models` section assigns a model to each phase role:
 ```yaml
 defaults:
   models:
-    research: opus
-    planning: opus
-    implementation: opus
-    review: gpt-5.4
-    utilities: sonnet
-    kb_build: opus
+    research: "sonnet[200K]"
+    planning: "opus[1M]"
+    implementation: "opus[1M]"
+    review: "gpt-5.4[272K]"
+    utilities: "sonnet[200K]"
+    kb_build: "sonnet[200K]"
 ```
 
 | Role | Default | Used For |
 |------|---------|----------|
-| `research` | `opus` | Research, inquiry, design phases |
-| `planning` | `opus` | Plan creation and roadmap generation |
-| `implementation` | `opus` | Code implementation |
-| `review` | `gpt-5.4` | Final Review loop |
-| `utilities` | `sonnet` | Chat (AMA), utility skills |
-| `kb_build` | `opus` | Knowledge base construction |
+| `research` | `sonnet[200K]` | Research, inquiry, design phases |
+| `planning` | `opus[1M]` | Plan creation and roadmap generation |
+| `implementation` | `opus[1M]` | Code implementation |
+| `review` | `gpt-5.4[272K]` | Final Review loop |
+| `utilities` | `sonnet[200K]` | Chat (AMA), utility skills |
+| `kb_build` | `sonnet[200K]` | Knowledge base construction |
 
-Model names can be bare (e.g., `opus`) or prefixed with a provider (e.g., `claude:opus`, `codex:gpt-5.4`). Bare names are resolved against the registry, which merges each provider's hardcoded catalog (see `internal/llm/claude` and `internal/llm/codex`). Configured model names are canonicalized at startup so the on-disk config reflects the registry's canonical spelling.
+Model names can use canonical context-window IDs (e.g., `opus[1M]`) or provider prefixes (e.g., `claude:opus[1M]`, `codex:gpt-5.4[272K]`). Bare aliases such as `opus` are still accepted and resolved against the registry, which merges each provider's hardcoded catalog (see `internal/llm/claude` and `internal/llm/codex`). Configured model names are canonicalized at startup so the on-disk config reflects the registry's canonical spelling.
 
 ## Pipeline Configuration
 


### PR DESCRIPTION
## Summary

- Default Research and KB Build to cheaper model choices instead of the largest capable context windows.
- Add catalog-selection hints so Research and KB Build recommend Claude Sonnet or Codex GPT-5.4 [272K] while keeping stronger models available in the picker.
- Update model-default tests and user-facing configuration docs.

## Impact

Token-heavy research and knowledge-base construction phases start with lower-cost defaults while preserving explicit user overrides and keeping higher-capability models selectable when needed.

## Verification

- Fast suite: `make test-fast`
- E2E smoke shell: `bash test/e2e/smoke.sh`
- Static analysis: `go vet ./...`
- Build: `go build ./...`