### PR TITLE
Add artifact preflight validation and attach consumer tracking

### DIFF
--- a/cmd/agentico/main.go
+++ b/cmd/agentico/main.go
@@ -71,6 +71,7 @@ const (
 	launchModeHelp
 	launchModeVersion
 	launchModeUpdate
+	launchModeValidateArtifacts
 )
 
 type launchOptions struct {
@@ -79,9 +80,16 @@ type launchOptions struct {
 	dangerouslySkipPerms bool
 	enabledProviders     []string
 	mode                 launchMode
+	validateArtifacts    validateArtifactsOptions
 	// updateCheck is set when update mode was selected with --check / -n,
 	// requesting a check-only run that never attempts to install.
 	updateCheck bool
+}
+
+type validateArtifactsOptions struct {
+	phase string
+	role  string
+	dir   string
 }
 
 type tuiLauncher func(configPath, stateDir string, dangerouslySkipPerms bool, enabledProviders []string)
@@ -140,6 +148,8 @@ func runArgs(args []string, stdout, stderr io.Writer, launch tuiLauncher, update
 		// The update path never reaches the TUI launcher below, so it takes
 		// no instance lock, builds no fx container, and reconciles no assets.
 		return update(opts.updateCheck, stdout, stderr)
+	case launchModeValidateArtifacts:
+		return runValidateArtifacts(opts.validateArtifacts, stdout, stderr)
 	default:
 		launch(opts.configPath, opts.stateDir, opts.dangerouslySkipPerms, opts.enabledProviders)
 		return 0
@@ -155,6 +165,10 @@ func parseLaunchArgs(args []string) (launchOptions, error) {
 	// command.
 	if len(args) > 0 && args[0] == "update" {
 		return parseUpdateArgs(opts, args[1:])
+	}
+	if len(args) > 0 && args[0] == "validate-artifacts" {
+		opts.mode = launchModeValidateArtifacts
+		return parseValidateArtifactsArgs(opts, args[1:])
 	}
 	for i := 0; i < len(args); i++ {
 		arg := args[i]
@@ -197,15 +211,62 @@ func parseLaunchArgs(args []string) (launchOptions, error) {
 	return opts, nil
 }
 
+func parseValidateArtifactsArgs(opts launchOptions, args []string) (launchOptions, error) {
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		switch arg {
+		case "--phase":
+			if i+1 >= len(args) {
+				return opts, fmt.Errorf("--phase requires a value")
+			}
+			i++
+			opts.validateArtifacts.phase = args[i]
+		case "--role":
+			if i+1 >= len(args) {
+				return opts, fmt.Errorf("--role requires a value")
+			}
+			i++
+			opts.validateArtifacts.role = args[i]
+		case "--dir":
+			if i+1 >= len(args) {
+				return opts, fmt.Errorf("--dir requires a value")
+			}
+			i++
+			opts.validateArtifacts.dir = args[i]
+		case "--help", "-h":
+			opts.mode = launchModeHelp
+			return opts, nil
+		default:
+			if strings.HasPrefix(arg, "-") {
+				return opts, fmt.Errorf("unknown validate-artifacts flag: %s", arg)
+			}
+			return opts, fmt.Errorf("unknown validate-artifacts argument: %s", arg)
+		}
+	}
+	if strings.TrimSpace(opts.validateArtifacts.phase) == "" {
+		return opts, fmt.Errorf("validate-artifacts requires --phase")
+	}
+	if strings.TrimSpace(opts.validateArtifacts.role) == "" {
+		return opts, fmt.Errorf("validate-artifacts requires --role")
+	}
+	if strings.TrimSpace(opts.validateArtifacts.dir) == "" {
+		return opts, fmt.Errorf("validate-artifacts requires --dir")
+	}
+	return opts, nil
+}
+
 func printUsage(w io.Writer) {
 	fmt.Fprintln(w, `Agentic Orchestrator
 
 Usage: agentico [flags]
        agentico update [--check|-n]
+       agentico validate-artifacts --phase <phase> --role <role> --dir <iteration_dir>
 
 Launches the Bubble Tea TUI dashboard.
 Run 'agentico update' to upgrade the binary, or 'agentico update --check'
 (alias -n) to report the latest available release without installing.
+Run 'agentico validate-artifacts' from agent sessions before phase_complete
+to parse and validate role output artifacts without starting the TUI.
 
 Flags:
   --config <path>                  Config file path (default: ~/.agentic-orchestrator/config.yaml)
@@ -219,6 +280,51 @@ Flags:
 
 When no explicit paths are passed, an existing ~/.agentic-workflow/
 runtime parent is used in place so legacy installs remain discoverable.`)
+}
+
+func runValidateArtifacts(opts validateArtifactsOptions, stdout, stderr io.Writer) int {
+	phase, err := parseValidateArtifactsPhase(opts.phase)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	out, violations, err := agent.ValidateArtifactsPreflight(phase, agent.Role(strings.TrimSpace(opts.role)), opts.dir)
+	if err != nil {
+		fmt.Fprintf(stderr, "validating artifacts: %v\n", err)
+		return 1
+	}
+	if !out.OK || len(violations) > 0 {
+		reason := agent.JoinProtocolViolations(violations)
+		if reason == "" {
+			reason = "artifact validation failed"
+		}
+		fmt.Fprintln(stderr, reason)
+		return 1
+	}
+	fmt.Fprintln(stdout, "artifacts OK")
+	return 0
+}
+
+func parseValidateArtifactsPhase(value string) (feature.Phase, error) {
+	normalized := strings.ToLower(strings.TrimSpace(value))
+	for _, phase := range []feature.Phase{
+		feature.PhaseResearch,
+		feature.PhasePlan,
+		feature.PhaseImplement,
+		feature.PhasePublish,
+		feature.PhaseReview,
+		feature.PhaseKnowledgeBase,
+		feature.PhaseInquire,
+		feature.PhaseDesign,
+	} {
+		if normalized == strings.ToLower(phase.DirName()) || normalized == strings.ToLower(phase.String()) {
+			return phase, nil
+		}
+	}
+	if normalized == strings.ToLower(feature.PhaseFinalReview.String()) {
+		return feature.PhaseReview, nil
+	}
+	return 0, fmt.Errorf("unknown validate-artifacts phase: %s", value)
 }
 
 const providerReadinessTimeout = 5 * time.Second

--- a/cmd/agentico/main_test.go
+++ b/cmd/agentico/main_test.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -27,9 +28,35 @@ import (
 	"time"
 
 	"github.com/charmbracelet/colorprofile"
+	"github.com/doordash-oss/agentic-orchestrator/internal/agent"
 	"github.com/doordash-oss/agentic-orchestrator/internal/config"
 	"github.com/doordash-oss/agentic-orchestrator/internal/llm"
 )
+
+func failingLauncher(t *testing.T) tuiLauncher {
+	t.Helper()
+	return func(string, string, bool, []string) {
+		t.Fatal("TUI launcher invoked unexpectedly")
+	}
+}
+
+func writeReviewFeedback(t *testing.T, path, findings, verdict string) {
+	t.Helper()
+	body := strings.Join([]string{
+		"## Findings",
+		findings,
+		"",
+		"## Suggestions",
+		"- (none)",
+		"",
+		"## Verdict",
+		verdict,
+		"",
+	}, "\n")
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write review feedback: %v", err)
+	}
+}
 
 // stubProvider is a minimal LLMProvider for testing checkRequiredProviders.
 type stubProvider struct {
@@ -355,6 +382,74 @@ func TestRunArgsPassesRetainedLaunchFlags(t *testing.T) {
 	}
 	if stdout.Len() != 0 || stderr.Len() != 0 {
 		t.Fatalf("stdout = %q stderr = %q, want both empty", stdout.String(), stderr.String())
+	}
+}
+
+func TestRunArgsValidateArtifactsCatchesMalformedYAML(t *testing.T) {
+	iterDir := t.TempDir()
+	writeReviewFeedback(t, filepath.Join(iterDir, "review-feedback.md"), "- **High**: needs work", "CHANGES_REQUESTED")
+	if err := os.WriteFile(filepath.Join(iterDir, "verification-report.yaml"), []byte(strings.Join([]string{
+		"version: 2",
+		"additional_checks:",
+		"  - name: Source comparison spot-check",
+		"    command: manual: compare translated README against English source",
+		"    mode: manual",
+		"    status: failed",
+	}, "\n")), 0o644); err != nil {
+		t.Fatalf("write malformed report: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	var launchedTUI, updateCalled bool
+	code := runArgs(
+		[]string{"validate-artifacts", "--phase", "review", "--role", string(agent.RoleFinalReviewer), "--dir", iterDir},
+		&stdout,
+		&stderr,
+		func(string, string, bool, []string) {
+			launchedTUI = true
+		},
+		func(bool, io.Writer, io.Writer) int {
+			updateCalled = true
+			return 0
+		},
+	)
+	if code != 1 {
+		t.Fatalf("runArgs() code = %d, want validation failure 1", code)
+	}
+	if launchedTUI || updateCalled {
+		t.Fatalf("validate-artifacts launched unrelated path: tui=%v update=%v", launchedTUI, updateCalled)
+	}
+	if got := stderr.String(); !strings.Contains(got, "verification-report.yaml") || !strings.Contains(got, "unparseable") {
+		t.Fatalf("stderr = %q, want verification-report.yaml unparseable violation", got)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty on validation failure", stdout.String())
+	}
+}
+
+func TestRunArgsValidateArtifactsAcceptsValidArtifacts(t *testing.T) {
+	iterDir := t.TempDir()
+	writeReviewFeedback(t, filepath.Join(iterDir, "review-feedback.md"), "- (none)", "APPROVED")
+	if err := os.WriteFile(filepath.Join(iterDir, "verification-report.yaml"), []byte("version: 1\nrequired_checks: []\n"), 0o644); err != nil {
+		t.Fatalf("write verification report: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := runArgs(
+		[]string{"validate-artifacts", "--phase", "review", "--role", string(agent.RoleFinalReviewer), "--dir", iterDir},
+		&stdout,
+		&stderr,
+		failingLauncher(t),
+		failingUpdater(t),
+	)
+	if code != 0 {
+		t.Fatalf("runArgs() code = %d; stderr = %q", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "artifacts OK") {
+		t.Fatalf("stdout = %q, want OK confirmation", stdout.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
 	}
 }
 

--- a/internal/agent/bounded_helper.go
+++ b/internal/agent/bounded_helper.go
@@ -209,6 +209,10 @@ func (pr *PhaseRunner) runBoundedHelperSession(ctx context.Context, cfg boundedH
 
 	attachCh := sess.AttachCh()
 	statusCh := sess.StatusCh()
+	if registrar, ok := sess.(ports.AttachConsumerRegistrar); ok {
+		unregister := registrar.RegisterAttachConsumer()
+		defer unregister()
+	}
 
 	for {
 		select {

--- a/internal/agent/codex_env_wiring_test.go
+++ b/internal/agent/codex_env_wiring_test.go
@@ -52,9 +52,7 @@ func TestCodexBuildSessionEnvContract(t *testing.T) {
 	if err != nil {
 		t.Fatalf("BuildSession() error: %v", err)
 	}
-	if env != nil {
-		t.Fatalf("BuildSession() env = %v, want nil", env)
-	}
+	requireOnlyAgenticoBinEnv(t, env)
 	wantCmdPrefix := []string{"codex", "app-server"}
 	if len(cmd) < len(wantCmdPrefix) {
 		t.Fatalf("BuildSession() cmd = %v, want prefix %v", cmd, wantCmdPrefix)
@@ -130,9 +128,8 @@ func TestCodexBuildSessionAgentNamesDoNotChangeReconciliation(t *testing.T) {
 	}
 	snapshotNamed := snapshotCodexAgentHome(t, codexHome)
 
-	if envEmpty != nil || envNamed != nil {
-		t.Fatalf("BuildSession() env = %v / %v, want nil / nil", envEmpty, envNamed)
-	}
+	requireOnlyAgenticoBinEnv(t, envEmpty)
+	requireOnlyAgenticoBinEnv(t, envNamed)
 	if !reflect.DeepEqual(cmdEmpty, cmdNamed) {
 		t.Fatalf("BuildSession() command changed with AgentNames: empty=%v named=%v", cmdEmpty, cmdNamed)
 	}

--- a/internal/agent/contract.go
+++ b/internal/agent/contract.go
@@ -145,6 +145,65 @@ func Validate(phase feature.Phase, role Role, iterDir string) (Outcome, []Protoc
 	return out, violations, nil
 }
 
+// ValidateArtifactsPreflight runs cheap artifact checks intended for agents to
+// execute before creating phase_complete. It is intentionally stricter than
+// Validate for YAML syntax so self-checks catch malformed reports even when the
+// harness would tolerate a blocking CHANGES_REQUESTED verdict to route a fix.
+func ValidateArtifactsPreflight(phase feature.Phase, role Role, iterDir string) (Outcome, []ProtocolViolation, error) {
+	contract, ok := Lookup(phase, role)
+	if !ok {
+		return Outcome{}, []ProtocolViolation{{Artifact: string(role), Reason: "no contract registered"}}, nil
+	}
+	if contract.NoOp {
+		return Outcome{OK: true}, nil, nil
+	}
+
+	var violations []ProtocolViolation
+	for _, artifact := range contract.Required {
+		path := artifact.ResolvePath(iterDir)
+		violations = append(violations, validateYAMLArtifactSyntax(artifact.DisplayPath, path, true)...)
+	}
+	for _, artifact := range contract.Optional {
+		path := artifact.ResolvePath(iterDir)
+		violations = append(violations, validateYAMLArtifactSyntax(artifact.DisplayPath, path, false)...)
+	}
+	if len(violations) > 0 {
+		return Outcome{OK: false}, violations, nil
+	}
+	return Validate(phase, role, iterDir)
+}
+
+func validateYAMLArtifactSyntax(displayPath, path string, required bool) []ProtocolViolation {
+	if !isYAMLArtifact(displayPath, path) {
+		return nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			if required {
+				return []ProtocolViolation{{Artifact: displayPath, Reason: missingArtifactReason(displayPath, filepath.Dir(path))}}
+			}
+			return nil
+		}
+		return []ProtocolViolation{{Artifact: displayPath, Reason: fmt.Sprintf("reading %s: %v", displayPath, err)}}
+	}
+	var node yaml.Node
+	if err := yaml.Unmarshal(data, &node); err != nil {
+		return []ProtocolViolation{{Artifact: displayPath, Reason: fmt.Sprintf("%s is unparseable: %v", displayPath, err)}}
+	}
+	return nil
+}
+
+func isYAMLArtifact(displayPath, path string) bool {
+	for _, value := range []string{displayPath, path} {
+		switch strings.ToLower(filepath.Ext(value)) {
+		case ".yaml", ".yml":
+			return true
+		}
+	}
+	return false
+}
+
 func phasePlanArtifactDir(attemptDir string) string {
 	return filepath.Dir(attemptDir)
 }

--- a/internal/agent/phase.go
+++ b/internal/agent/phase.go
@@ -1267,6 +1267,7 @@ func (pr *PhaseRunner) BuildSession(opts BuildSessionOpts) (cmd []string, env []
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("building command for %s: %w", prov.Name(), err)
 	}
+	env = appendAgenticoBinEnv(env)
 
 	contextWindow := 0
 	if cc, ok := prov.(llm.CostCalculator); ok {
@@ -1297,6 +1298,33 @@ func (pr *PhaseRunner) BuildSession(opts BuildSessionOpts) (cmd []string, env []
 		TurnMode:          opts.TurnMode,
 	}
 	return cmd, env, sessOpts, nil
+}
+
+func appendAgenticoBinEnv(env []string) []string {
+	path := currentAgenticoBinPath()
+	if path == "" {
+		return env
+	}
+	entry := "AGENTICO_BIN=" + path
+	out := append([]string(nil), env...)
+	for i, existing := range out {
+		if strings.HasPrefix(existing, "AGENTICO_BIN=") {
+			out[i] = entry
+			return out
+		}
+	}
+	return append(out, entry)
+}
+
+func currentAgenticoBinPath() string {
+	path, err := os.Executable()
+	if err != nil || strings.TrimSpace(path) == "" {
+		path = os.Args[0]
+	}
+	if abs, err := filepath.Abs(path); err == nil {
+		path = abs
+	}
+	return strings.TrimSpace(path)
 }
 
 // AskingClauseForModel returns the asking-questions clause for a given model.

--- a/internal/agent/phase_test.go
+++ b/internal/agent/phase_test.go
@@ -1201,10 +1201,7 @@ func TestBuildSession_Claude(t *testing.T) {
 		t.Errorf("expected claude command, got %v", cmd)
 	}
 
-	// Claude provider returns nil env
-	if env != nil {
-		t.Errorf("expected nil env for claude, got %v", env)
-	}
+	requireOnlyAgenticoBinEnv(t, env)
 
 	// Session opts should have protocol set (registry path)
 	if sessOpts.Protocol == nil {
@@ -1216,6 +1213,29 @@ func TestBuildSession_Claude(t *testing.T) {
 	if sessOpts.InitialPrompt != "research this" {
 		t.Errorf("expected InitialPrompt 'research this', got %q", sessOpts.InitialPrompt)
 	}
+}
+
+func TestBuildSessionInjectsAgenticoBinEnv(t *testing.T) {
+	dir := t.TempDir()
+	eventCh := make(chan any, 100)
+	sm := session.NewManager(eventCh)
+	store := feature.NewStore(dir)
+	pr := NewPhaseRunner(sm, store, dir)
+	pr.Registry = newRegistryWithProviders()
+
+	_, env, _, err := pr.BuildSession(BuildSessionOpts{
+		Model:        "opus",
+		Prompt:       "research this",
+		SystemPrompt: "you are a researcher",
+		PIDDir:       filepath.Join(dir, "pid"),
+		PermHandler:  permHandlerFor(false, nil, ""),
+		WorkDir:      dir,
+	})
+	if err != nil {
+		t.Fatalf("BuildSession() error: %v", err)
+	}
+
+	requireOnlyAgenticoBinEnv(t, env)
 }
 
 // TestBuildSession_PinsPermissionModeForGrillingPhases verifies that
@@ -1633,10 +1653,7 @@ func TestBuildSession_Codex_UsesProviderNilEnv(t *testing.T) {
 		t.Errorf("expected [codex app-server], got %v", cmd)
 	}
 
-	// Codex provider should use the nil-env contract.
-	if env != nil {
-		t.Errorf("expected nil env, got %v", env)
-	}
+	requireOnlyAgenticoBinEnv(t, env)
 
 	// Session opts should have protocol set (registry path).
 	if sessOpts.Protocol == nil {
@@ -1674,9 +1691,7 @@ func TestBuildSession_Codex_IgnoresAgentNamesSelection(t *testing.T) {
 	if got := findArgValue(cmd, "--agents"); got != "" {
 		t.Fatalf("BuildSession() emitted --agents=%q for codex command %v", got, cmd)
 	}
-	if env != nil {
-		t.Fatalf("BuildSession() env = %v, want nil", env)
-	}
+	requireOnlyAgenticoBinEnv(t, env)
 	if sessOpts.ProviderName != "codex" {
 		t.Fatalf("BuildSession() ProviderName = %q, want codex", sessOpts.ProviderName)
 	}

--- a/internal/agent/prompts/templates/system.tmpl
+++ b/internal/agent/prompts/templates/system.tmpl
@@ -31,6 +31,19 @@ When the task is complete, create this marker file as the very last action:
 `{{ .MarkerPath }}`
 
 The file contents do not matter. Its presence is the signal that the harness should parse the role's output files. If you end your turn without creating this file and without asking a properly formatted question, the harness treats the run as a protocol violation.
+{{- if .ArtifactPreflight }}
+
+## Artifact Preflight
+
+`AGENTICO_BIN` is set to the current Agentico executable. To catch malformed output before the harness sees it, run it before creating `phase_complete`:
+
+```bash
+{{ .ArtifactPreflight }}
+```
+
+If validation fails, fix the reported artifact and rerun the command before creating `phase_complete`.
+
+{{ end }}
 
 ## Skill
 

--- a/internal/agent/prompts/types.go
+++ b/internal/agent/prompts/types.go
@@ -72,6 +72,7 @@ type RoleSystemInput struct {
 	OutputRoots          []OutputRootView
 	MarkerPath           string
 	SkillPath            string
+	ArtifactPreflight    string
 	Preflight            PreflightInput
 	ReadOnlyOutsideRoots bool
 

--- a/internal/agent/rolespec_prompt.go
+++ b/internal/agent/rolespec_prompt.go
@@ -15,6 +15,7 @@
 package agent
 
 import (
+	"fmt"
 	"path/filepath"
 
 	"github.com/doordash-oss/agentic-orchestrator/internal/agent/prompts"
@@ -83,8 +84,20 @@ func BuildRoleSystemPrompt(in BuildRoleSystemPromptInput) string {
 		OutputRoots:          rootViews,
 		MarkerPath:           spec.MarkerPath(rt),
 		SkillPath:            skillPath,
+		ArtifactPreflight:    artifactPreflightCommand(spec, in.IterationDir),
 		Preflight:            buildPreflightInput(spec.Phase, in.SkillsDir, in.KBInfos, in.GuidelinesDir),
 		ReadOnlyOutsideRoots: spec.ReadOnlyOutsideRoots,
 		AskingClause:         askingClause,
 	})
+}
+
+func artifactPreflightCommand(spec RoleSpec, iterationDir string) string {
+	if spec.NoOp || spec.Role == "" || iterationDir == "" {
+		return ""
+	}
+	return fmt.Sprintf(`"$AGENTICO_BIN" validate-artifacts --phase %s --role %s --dir %q`,
+		spec.Phase.DirName(),
+		string(spec.Role),
+		iterationDir,
+	)
 }

--- a/internal/agent/rolespec_test.go
+++ b/internal/agent/rolespec_test.go
@@ -174,6 +174,24 @@ func TestRoleSpecCarriesRequiredPhasesAndAskingClauseProvider(t *testing.T) {
 	}
 }
 
+func TestRoleSystemPromptIncludesArtifactPreflightCommand(t *testing.T) {
+	got := BuildRoleSystemPrompt(BuildRoleSystemPromptInput{
+		Spec:         FinalReviewerRoleSpec(),
+		IterationDir: "/state/feat-x/runs/run-001/review/iteration-03",
+		SkillsDir:    "/skills",
+	})
+	for _, want := range []string{
+		"## Artifact Preflight",
+		"`AGENTICO_BIN` is set to the current Agentico executable",
+		`"$AGENTICO_BIN" validate-artifacts --phase review --role final_reviewer --dir "/state/feat-x/runs/run-001/review/iteration-03"`,
+		"run it before creating `phase_complete`",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("BuildRoleSystemPrompt() missing %q in:\n%s", want, got)
+		}
+	}
+}
+
 func TestPlanningRoleSpecsDeriveContractPaths(t *testing.T) {
 	base := t.TempDir()
 	roadmapAttemptDir := filepath.Join(base, "roadmap", "attempt-02")

--- a/internal/agent/test_helpers_test.go
+++ b/internal/agent/test_helpers_test.go
@@ -17,7 +17,9 @@ package agent
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"reflect"
+	"strings"
 	"sync"
 	"testing"
 
@@ -42,6 +44,21 @@ func isReviewHelper(h interface{}) bool {
 		return true
 	}
 	return false
+}
+
+func requireOnlyAgenticoBinEnv(t *testing.T, env []string) string {
+	t.Helper()
+	if len(env) != 1 {
+		t.Fatalf("env = %v, want only AGENTICO_BIN", env)
+	}
+	value, ok := strings.CutPrefix(env[0], "AGENTICO_BIN=")
+	if !ok || value == "" {
+		t.Fatalf("env = %v, want AGENTICO_BIN entry", env)
+	}
+	if !filepath.IsAbs(value) {
+		t.Fatalf("AGENTICO_BIN = %q, want absolute path", value)
+	}
+	return value
 }
 
 // mockBuildSession returns a BuildSession function that returns mock bash

--- a/internal/ports/session.go
+++ b/internal/ports/session.go
@@ -245,6 +245,14 @@ type MessageLog interface {
 	ToolUseBlocks() []llm.ContentBlock
 }
 
+// AttachConsumerRegistrar is an optional interface implemented by session
+// handles that can track whether anything is actively draining AttachCh().
+// Callers that block on AttachCh should register for the lifetime of that read
+// loop and invoke the returned cleanup when the loop exits.
+type AttachConsumerRegistrar interface {
+	RegisterAttachConsumer() func()
+}
+
 // SessionView is the read-oriented interface external packages (TUI, agent)
 // use to observe a session.
 type SessionView interface {

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -52,11 +52,13 @@ const (
 var _ = fmt.Sprintf // keep fmt import used elsewhere in the package
 
 // criticalAttachSendTimeout is the default bound for blocking forward of Result
-// messages onto attachCh. Without it, a stuck consumer would deadlock
-// readMessages indefinitely; with it, the CLI continues reading after
-// the bound. 5s is long enough for any normal TUI event-loop hitch and
-// short enough that a genuine deadlock surfaces quickly. Result drops
-// are recoverable — the next assistant message clears the spinner.
+// messages onto attachCh when an attach consumer is registered. Without it, a
+// stuck consumer would deadlock readMessages indefinitely; with it, the CLI
+// continues reading after the bound. 5s is long enough for any normal TUI
+// event-loop hitch and short enough that a genuine deadlock surfaces quickly.
+// If no consumer is registered, a full attachCh is treated as headless
+// backpressure and the Result is dropped without waiting or logging. Result
+// drops are recoverable — the next assistant message clears the spinner.
 //
 // ControlRequest messages no longer share this path — they take a
 // dedicated controlCh routed through forwardControlRequests, which
@@ -156,6 +158,7 @@ type Session struct {
 	// For attach mode: subscribers receive copies of messages
 	attachCh                  chan llm.SDKMessage
 	criticalAttachSendTimeout time.Duration
+	attachConsumers           atomic.Int64
 
 	// controlCh buffers ControlRequest messages on a dedicated path so a
 	// burst of stream/result traffic on attachCh cannot starve them. The
@@ -518,6 +521,25 @@ func NewSession(id, featureID string, phase feature.Phase) *Session {
 
 func (s *Session) setCriticalAttachSendTimeoutForTest(timeout time.Duration) {
 	s.criticalAttachSendTimeout = timeout
+}
+
+// RegisterAttachConsumer marks a goroutine as actively draining AttachCh. The
+// returned cleanup is idempotent and must be called when the read loop exits.
+func (s *Session) RegisterAttachConsumer() func() {
+	if s == nil {
+		return func() {}
+	}
+	s.attachConsumers.Add(1)
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			s.attachConsumers.Add(-1)
+		})
+	}
+}
+
+func (s *Session) hasAttachConsumer() bool {
+	return s != nil && s.attachConsumers.Load() > 0
 }
 
 func (s *Session) setResultShutdownGraceForTest(grace time.Duration) {
@@ -1071,26 +1093,33 @@ func (s *Session) readMessages(onMessage func(llm.SDKMessage)) {
 				// Session shutting down; drop is fine.
 			}
 		} else if msg.Result != nil {
-			attachTimeout := s.criticalAttachTimeout()
-			criticalSendTimer := time.NewTimer(attachTimeout)
-			select {
-			case s.attachCh <- msg:
-			case <-criticalSendTimer.C:
-				log.Printf("session %s: dropped critical SDK message (type=%s) after %s on full attachCh", s.id, msg.Type, attachTimeout)
-				// Additive metric: surface the drop to observability so
-				// dashboards / watchdogs can alert on a stuck consumer
-				// without having to grep agentic.log. The log line above
-				// is intentionally preserved — the reporter is additive.
-				s.mu.Lock()
-				reporter := s.attachDropReporter
-				featureID := s.featureID
-				phaseName := s.phase.String()
-				s.mu.Unlock()
-				if reporter != nil {
-					reporter.ReportAttachDrop(s.id, featureID, phaseName, msg.Type, attachTimeout)
+			if !s.hasAttachConsumer() {
+				select {
+				case s.attachCh <- msg:
+				default:
 				}
+			} else {
+				attachTimeout := s.criticalAttachTimeout()
+				criticalSendTimer := time.NewTimer(attachTimeout)
+				select {
+				case s.attachCh <- msg:
+				case <-criticalSendTimer.C:
+					log.Printf("session %s: dropped critical SDK message (type=%s) after %s on full attachCh", s.id, msg.Type, attachTimeout)
+					// Additive metric: surface the drop to observability so
+					// dashboards / watchdogs can alert on a stuck consumer
+					// without having to grep agentic.log. The log line above
+					// is intentionally preserved — the reporter is additive.
+					s.mu.Lock()
+					reporter := s.attachDropReporter
+					featureID := s.featureID
+					phaseName := s.phase.String()
+					s.mu.Unlock()
+					if reporter != nil {
+						reporter.ReportAttachDrop(s.id, featureID, phaseName, msg.Type, attachTimeout)
+					}
+				}
+				criticalSendTimer.Stop()
 			}
-			criticalSendTimer.Stop()
 		} else {
 			select {
 			case s.attachCh <- msg:

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -701,6 +701,8 @@ func TestSessionResultDeliveredUnderBackpressure(t *testing.T) {
 	// parallel-candidate: in-process protocol replay with per-test attach buffer.
 	s := NewSession("bp-test", "feat-1", feature.PhaseImplement)
 	s.setCriticalAttachSendTimeoutForTest(time.Second)
+	unregister := registerAttachConsumerForTest(t, s)
+	defer unregister()
 	for i := 0; i < cap(s.attachCh); i++ {
 		s.attachCh <- llm.SDKMessage{Type: "assistant"}
 	}
@@ -740,6 +742,17 @@ func TestSessionResultDeliveredUnderBackpressure(t *testing.T) {
 			t.Fatal("Result SDKMessage was not delivered via AttachCh under backpressure")
 		}
 	}
+}
+
+func registerAttachConsumerForTest(t *testing.T, s *Session) func() {
+	t.Helper()
+	registrar, ok := any(s).(interface {
+		RegisterAttachConsumer() func()
+	})
+	if !ok {
+		t.Fatal("Session does not expose RegisterAttachConsumer")
+	}
+	return registrar.RegisterAttachConsumer()
 }
 
 func TestSession_OnSubagentEventFires(t *testing.T) {
@@ -1729,6 +1742,35 @@ func (r *recordingAttachDropReporter) snapshot() []attachDropCall {
 	return out
 }
 
+func TestSession_NoAttachConsumerSuppressesCriticalDropReport(t *testing.T) {
+	t.Parallel()
+	// parallel-candidate: in-process protocol replay with per-test attach buffer.
+	wantTimeout := 200 * time.Millisecond
+
+	s := NewSession("headless-drop-test", "feat-headless", feature.PhaseImplement)
+	s.setCriticalAttachSendTimeoutForTest(wantTimeout)
+	for i := 0; i < cap(s.attachCh); i++ {
+		s.attachCh <- llm.SDKMessage{Type: "assistant"}
+	}
+
+	reporter := &recordingAttachDropReporter{}
+	s.SetAttachDropReporter(reporter)
+
+	started := time.Now()
+	runMockSession(t, s, []llm.SDKMessage{
+		{Type: "system", Subtype: "init", Init: &llm.SystemInitMessage{SessionID: "s1", Model: "m"}},
+		{Type: "result", Result: &llm.ResultMessage{Type: "result", Subtype: "success", SessionID: "s1", TotalCostUSD: 0.01}},
+	}, func(llm.SDKMessage) {})
+	elapsed := time.Since(started)
+
+	if calls := reporter.snapshot(); len(calls) != 0 {
+		t.Fatalf("expected no AttachDrop reports without an attach consumer; got %d", len(calls))
+	}
+	if elapsed >= wantTimeout/2 {
+		t.Fatalf("headless critical drop waited %s; want it to skip the %s timeout", elapsed, wantTimeout)
+	}
+}
+
 // TestSession_AttachDropReporterFiresOnCriticalDrop simulates a stuck
 // attachCh consumer. The CLI emits a Result message while the attachCh
 // is full — the bounded blocking send at the drop site must time out,
@@ -1741,6 +1783,8 @@ func TestSession_AttachDropReporterFiresOnCriticalDrop(t *testing.T) {
 
 	s := NewSession("drop-test", "feat-9", feature.PhaseImplement)
 	s.setCriticalAttachSendTimeoutForTest(wantTimeout)
+	unregister := registerAttachConsumerForTest(t, s)
+	defer unregister()
 	for i := 0; i < cap(s.attachCh); i++ {
 		s.attachCh <- llm.SDKMessage{Type: "assistant"}
 	}
@@ -1791,6 +1835,8 @@ func TestSession_AttachDropReporterSilentWithoutReporter(t *testing.T) {
 
 	s := NewSession("quiet-test", "feat-9", feature.PhaseImplement)
 	s.setCriticalAttachSendTimeoutForTest(timeout)
+	unregister := registerAttachConsumerForTest(t, s)
+	defer unregister()
 	for i := 0; i < cap(s.attachCh); i++ {
 		s.attachCh <- llm.SDKMessage{Type: "assistant"}
 	}

--- a/internal/tui/artifact_review.go
+++ b/internal/tui/artifact_review.go
@@ -622,6 +622,8 @@ func (m ArtifactReviewModel) handleSessionStarted(sess session.SessionView) (Art
 
 func pollArtifactReviewChCmd(sess session.SessionView) tea.Cmd {
 	return func() tea.Msg {
+		unregister := registerAttachConsumer(sess)
+		defer unregister()
 		ch := sess.AttachCh()
 		msg, ok := <-ch
 		if !ok {

--- a/internal/tui/attach.go
+++ b/internal/tui/attach.go
@@ -3710,12 +3710,21 @@ func (m AttachModel) ActiveRepoName() string {
 	return m.repoTabs[m.activeTabIdx].repoName
 }
 
+func registerAttachConsumer(sess session.SessionView) func() {
+	if registrar, ok := sess.(ports.AttachConsumerRegistrar); ok {
+		return registrar.RegisterAttachConsumer()
+	}
+	return func() {}
+}
+
 // drainAndPollAttachChCmd discards stale messages from the attach channel
 // before blocking for the first fresh message. Use this on initial attach —
 // restoreThinkingLine() already established the correct spinner state from
 // the message log, so stale buffered messages can only corrupt it.
 func drainAndPollAttachChCmd(sess session.SessionView, gen int) tea.Cmd {
 	return func() tea.Msg {
+		unregister := registerAttachConsumer(sess)
+		defer unregister()
 		ch := sess.AttachCh()
 		// Drain stale buffered messages.
 		for len(ch) > 0 {
@@ -3730,6 +3739,8 @@ func drainAndPollAttachChCmd(sess session.SessionView, gen int) tea.Cmd {
 
 func pollAttachChCmd(sess session.SessionView, gen int) tea.Cmd {
 	return func() tea.Msg {
+		unregister := registerAttachConsumer(sess)
+		defer unregister()
 		return pollAttachCh(sess.AttachCh(), gen)
 	}
 }

--- a/internal/tui/chat.go
+++ b/internal/tui/chat.go
@@ -482,6 +482,8 @@ func chatRecoveryTickCmd(sess session.SessionView, baseline *llm.ResultMessage) 
 // pollChatChCmd reads messages from the session's AttachCh in batches.
 func pollChatChCmd(sess session.SessionView) tea.Cmd {
 	return func() tea.Msg {
+		unregister := registerAttachConsumer(sess)
+		defer unregister()
 		ch := sess.AttachCh()
 		msg, ok := <-ch
 		if !ok {


### PR DESCRIPTION
## Summary

Adds an agent-facing artifact validation preflight and fixes attach-channel backpressure handling for detached sessions.

## Changes

- Adds `agentico validate-artifacts --phase --role --dir` so agent sessions can validate role output artifacts without launching the TUI.
- Injects `AGENTICO_BIN` into real provider sessions and renders the preflight command in RoleSpec-backed system prompts.
- Strictly parses YAML artifacts before running the existing role contract validation, catching malformed reports earlier.
- Tracks active `AttachCh` consumers so detached/headless sessions drop full buffers immediately, while attached TUI/helper consumers keep bounded Result delivery and drop reporting.

## Why

Malformed artifacts can otherwise reach the harness and trigger avoidable repair cycles. Separately, a full attach buffer was treated like a stuck active consumer even when no TUI/helper was attached, causing unnecessary waits and noisy drop reports in headless paths.

## Verification

- Fast suite: `make test-fast`
- Static analysis: `go vet ./...`
- Build: `go build ./...`
- E2E smoke shell: `bash test/e2e/smoke.sh`
- Isolated integration: `go test ./test/integration/... -count=1`
- E2E Go (TUI / teatest): `go test ./test/e2e/... -count=1 -race`
- Race regression: `go test ./... -count=1 -race`

Also ran targeted red/green checks for the new CLI, env/prompt wiring, and attach backpressure regressions.