### PR TITLE
Extend welcome art to spell AGENTICO

### DIFF
--- a/internal/tui/welcome.go
+++ b/internal/tui/welcome.go
@@ -177,8 +177,8 @@ func (m WelcomeModel) View() string {
 
 func (m WelcomeModel) viewIntro() string {
 	artLines := []string{
-		" ▄▀█ █▀▀ █▀▀ █▄░█ ▀█▀ █ █▀▀",
-		" █▀█ █▄█ ██▄ █░▀█ ░█░ █ █▄▄",
+		" ▄▀█ █▀▀ █▀▀ █▄░█ ▀█▀ █ █▀▀ █▀█",
+		" █▀█ █▄█ ██▄ █░▀█ ░█░ █ █▄▄ █▄█",
 	}
 
 	brandStyle := lipgloss.NewStyle().

--- a/internal/tui/welcome_test.go
+++ b/internal/tui/welcome_test.go
@@ -42,6 +42,17 @@ func TestWelcomeModelInitialView(t *testing.T) {
 	}
 }
 
+func TestWelcomeIntroArtSpellsAgentico(t *testing.T) {
+	m := newTestWelcomeModel(t)
+	view := m.View()
+	if !strings.Contains(view, " ▄▀█ █▀▀ █▀▀ █▄░█ ▀█▀ █ █▀▀ █▀█") {
+		t.Errorf("welcome intro art missing AGENTICO top row:\n%s", view)
+	}
+	if !strings.Contains(view, " █▀█ █▄█ ██▄ █░▀█ ░█░ █ █▄▄ █▄█") {
+		t.Errorf("welcome intro art missing AGENTICO bottom row:\n%s", view)
+	}
+}
+
 func TestWelcomeModelEnterGoesToPicker(t *testing.T) {
 	m := newTestWelcomeModel(t)
 	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})


### PR DESCRIPTION
## Summary

Extends the TUI welcome screen ASCII art from "AGENTIC" to "AGENTICO" by adding the `O` glyph to both rows of the brand banner.

## Changes

- `internal/tui/welcome.go`: append the `O` block (`█▀█` / `█▄█`) to both art lines in `viewIntro()`.
- `internal/tui/welcome_test.go`: add `TestWelcomeIntroArtSpellsAgentico` asserting both rows render the full AGENTICO art.

## Test plan

- [x] `go test ./internal/tui/...` passes
- [x] Welcome screen visually renders "AGENTICO"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
