### PR TITLE
Refresh brew tap before upgrade in agentico update

### DIFF
--- a/cmd/agentico/installmethod.go
+++ b/cmd/agentico/installmethod.go
@@ -319,7 +319,7 @@ func (m installMethod) wouldDoAction() string {
 	case installMethodTarball:
 		return "Would update by downloading the latest release and replacing the binary in place."
 	case installMethodHomebrew:
-		return "Would update via Homebrew by running `brew upgrade agentico`."
+		return "Would update via Homebrew by running `brew update && brew upgrade agentico`."
 	case installMethodDevBuild:
 		return "Would update from source (development builds are not updated automatically)."
 	default:

--- a/cmd/agentico/update.go
+++ b/cmd/agentico/update.go
@@ -395,7 +395,7 @@ func performTarballUpdate(stdout, stderr io.Writer, deps updateDeps, slug, curre
 // failures to a non-zero exit. Reached only in bare mode once the check confirms a
 // newer release; a nil runBrew prints the command as guidance instead.
 func performHomebrewUpdate(stdout, stderr io.Writer, deps updateDeps, latest string) int {
-	cmdline := "brew upgrade " + homebrewFormulaName
+	cmdline := "brew update && brew upgrade " + homebrewFormulaName
 	fmt.Fprintf(stdout, "agentico was installed via Homebrew. Updating with: %s\n", cmdline)
 
 	if deps.runBrew == nil {
@@ -407,6 +407,23 @@ func performHomebrewUpdate(stdout, stderr io.Writer, deps updateDeps, latest str
 	defer cancel()
 
 	fmt.Fprintln(stdout, "(this can take a minute while Homebrew refreshes its taps)")
+
+	// Refresh the tap before upgrading. `brew upgrade` resolves against the local
+	// tap clone, and Homebrew's own auto-update is throttled (HOMEBREW_AUTO_UPDATE_SECS)
+	// or can be disabled (HOMEBREW_NO_AUTO_UPDATE) — so without an explicit refresh the
+	// cached formula stays stale and the upgrade is a no-op that leaves the old version
+	// installed. A missing brew or a timeout won't be fixed by attempting the upgrade, so
+	// those fail fast; any other `brew update` error is transient — warn and still upgrade.
+	if out, err := deps.runBrew(ctx, "brew", []string{"update"}, nil); err != nil {
+		if errors.Is(err, exec.ErrNotFound) || errors.Is(err, context.DeadlineExceeded) || ctx.Err() == context.DeadlineExceeded {
+			return reportBrewFailure(ctx, stderr, err)
+		}
+		fmt.Fprintf(stderr, "Warning: `brew update` failed (%v); the tap may be stale, continuing with the upgrade.\n", err)
+		writeBrewOutput(stderr, out)
+	} else {
+		writeBrewOutput(stdout, out)
+	}
+
 	out, err := deps.runBrew(ctx, "brew", []string{"upgrade", homebrewFormulaName}, nil)
 	writeBrewOutput(stdout, out)
 	if err != nil {

--- a/cmd/agentico/update_test.go
+++ b/cmd/agentico/update_test.go
@@ -758,6 +758,56 @@ func TestRunUpdateWithHomebrewBrewMissing(t *testing.T) {
 	}
 }
 
+// Bare homebrew update refreshes the tap with `brew update` before running
+// `brew upgrade agentico`, so a stale local tap clone cannot leave the old
+// version installed. The two brew invocations must run in that order.
+func TestRunUpdateWithHomebrewRefreshesTapBeforeUpgrade(t *testing.T) {
+	var calls [][]string
+	var stdout, stderr bytes.Buffer
+
+	deps := updateDeps{
+		currentVersion: "1.2.3",
+		method:         fixedMethod(installMethodHomebrew),
+		slug:           okSlug,
+		fetchLatest:    fakeFetch("v2.0.0", nil),
+		runBrew: func(_ context.Context, _ string, args, _ []string) ([]byte, error) {
+			calls = append(calls, append([]string(nil), args...))
+			return nil, nil
+		},
+	}
+
+	code := runUpdateWith(context.Background(), false, &stdout, &stderr, deps)
+	if code != 0 {
+		t.Fatalf("code = %d, want 0\nstderr: %s", code, stderr.String())
+	}
+
+	wantCalls := [][]string{
+		{"update"},
+		{"upgrade", "agentico"},
+	}
+	if len(calls) != len(wantCalls) {
+		t.Fatalf("brew invocations = %v, want %v", calls, wantCalls)
+	}
+	for i := range wantCalls {
+		if !equalArgs(calls[i], wantCalls[i]) {
+			t.Errorf("call[%d] = %v, want %v", i, calls[i], wantCalls[i])
+		}
+	}
+}
+
+// equalArgs reports whether two argument slices are element-wise equal.
+func equalArgs(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
 // A non-zero `brew upgrade` exit is reported as a failure.
 func TestRunUpdateWithHomebrewFailure(t *testing.T) {
 	var rec recordedInstall


### PR DESCRIPTION
## Summary

`agentico update` on a Homebrew install ran only `brew upgrade agentico`. But `brew upgrade` resolves against the **locally-cached tap clone** of `doordash-oss/homebrew-agentic-orchestrator`. Homebrew's own auto-update is throttled (`HOMEBREW_AUTO_UPDATE_SECS`, default 24h) or can be disabled (`HOMEBREW_NO_AUTO_UPDATE=1`), so the cached formula stays stale — the upgrade is a no-op and **the old version remains installed**.

This change refreshes the tap with `brew update` before `brew upgrade agentico`:

- A missing `brew` or a `brew update` timeout fails fast (the upgrade can't succeed anyway), reusing the existing `reportBrewFailure` mapping.
- Any other `brew update` error is treated as transient — a warning is printed and the upgrade is still attempted.
- The user-facing narrative and the `--check` "would do" message now read `brew update && brew upgrade agentico`.

## Test plan

- [x] New `TestRunUpdateWithHomebrewRefreshesTapBeforeUpgrade` asserts the two brew invocations run in order: `[update]` then `[upgrade agentico]` (written test-first; confirmed it failed against the old behavior).
- [x] Existing Homebrew tests still pass (success, brew-missing, failure, `--check` does-not-run-brew).
- [x] `go test ./cmd/agentico/` passes; `go vet ./cmd/agentico/` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)