### PR TITLE
Pre-approve agentico validate-artifacts in default permissions

### DIFF
--- a/internal/permission/defaults.go
+++ b/internal/permission/defaults.go
@@ -37,5 +37,10 @@ func defaultGlobalRules() []Rule {
 		{ToolPattern: "Bash(git diff *)", Effect: "allow"},
 		{ToolPattern: "Bash(git log *)", Effect: "allow"},
 		{ToolPattern: "Bash(git show *)", Effect: "allow"},
+		// agentico's own read-only artifact-validation preflight, which every
+		// agent session runs before phase_complete (see rolespec_prompt.go). The
+		// prompt invokes it as the quoted env var, so the pattern matches that
+		// exact prefix.
+		{ToolPattern: `Bash("$AGENTICO_BIN" validate-artifacts *)`, Effect: "allow"},
 	}
 }

--- a/internal/permission/permission_test.go
+++ b/internal/permission/permission_test.go
@@ -215,6 +215,10 @@ func TestDefaultGlobalRules_MatchReadOnlyCommands(t *testing.T) {
 		{name: "cd then git log piped", command: `{"command":"cd /repo && git log --oneline | head -30"}`},
 		{name: "ls piped", command: `{"command":"ls -la | head -20"}`},
 		{name: "find", command: `{"command":"find src -type f"}`},
+		// agentico's own artifact-validation preflight, run by every agent
+		// session before phase_complete (see rolespec_prompt.go).
+		{name: "validate-artifacts", command: `{"command":"\"$AGENTICO_BIN\" validate-artifacts --phase review --role final_reviewer --dir \"/state/feat-x/runs/run-001/review/iteration-03\""}`},
+		{name: "cd then validate-artifacts", command: `{"command":"cd /repo && \"$AGENTICO_BIN\" validate-artifacts --phase plan --role designer --dir \"/state/feat-x/plan\""}`},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

Every agent session Agentico spawns runs the artifact-validation preflight (`"$AGENTICO_BIN" validate-artifacts --phase … --role … --dir …`, generated in `internal/agent/rolespec_prompt.go`) before `phase_complete`. Because the command wasn't in the shipped allowlist, agents hit a permission prompt for it each time.

This adds the command to `defaultGlobalRules()` in `internal/permission/defaults.go` — the same built-in list that already pre-approves read-only commands like `ls`, `grep`, and `git status`:

```go
{ToolPattern: `Bash("$AGENTICO_BIN" validate-artifacts *)`, Effect: "allow"},
```

### Why this layer

- **Ships to everyone** — it's compiled into the binary, so all Agentico users get it; no per-user config.
- **Reaches existing users** — `EnsureGlobalDefaults` backfills missing defaults into each user's `global.json` on next run, preserving their own rules.
- **Matches the exact invocation** — the permission matcher (`rule.go`/`pattern.go`) does prefix matching on the raw command, preserving the literal quoted `"$AGENTICO_BIN"` and stripping `cd … &&` chains to the last segment, so the pattern matches the exact string the prompt generates.
- **Fits the list's contract** — that allowlist is read-only/inspection-only; `validate-artifacts` only reads and validates artifacts.

## Test plan

- [x] Added two cases to `TestDefaultGlobalRules_MatchReadOnlyCommands` (the exact form and a `cd … &&` chained form agents actually send); confirmed they failed before the rule was added (TDD red → green).
- [x] `go test ./internal/permission/` passes; `go vet ./internal/permission/` and `go build ./...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)