### PR TITLE
[codex] Split planning review gates

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ That is the real "oneshot" value: an engineer can describe a large feature once,
 - **Context is built, not hoped for** — Large and Moonshot features start by building a per-repo knowledge base, then run inquiry, research, and design phases before planning. The implementation agent reads structured artifacts instead of relying on a single overloaded chat history.
 - **Complexity is phased** — Planning produces a roadmap, then each roadmap phase gets its own detailed phase plan. A tracer-bullet phase establishes the path; later TDD fill-in phases retire stubs and expand coverage.
 - **Quality gates happen before the diff gets expensive** — Plan validators review architecture, scope, structure, and, for high-risk work, security, performance, and testing. Implementation and Final Review loops use explicit verification evidence before the feature becomes publishable.
-- **Human attention is reserved for decisions** — Optional gates pause on inquiry, research, design, plan, user-input, and publish decisions. You approve direction, request iteration, or answer targeted questions; the orchestrator keeps the workflow state.
+- **Human attention is reserved for decisions** — Optional gates pause on inquiry review, research review, design review, roadmap review, phase plan review, user-input, and publish decisions. You approve direction, request iteration, or answer targeted questions; the orchestrator keeps the workflow state.
 - **Parallelism is the multiplier, not the premise** — Because every feature gets isolated worktrees, branches, sessions, and artifacts, you can run several complex workflows at once without mixing state or blocking your main checkout.
 - **Provider orchestration is explicit** — One provider is enough to run the whole workflow; add a second to split the work. By default Claude handles context gathering, planning, and implementation while Codex handles independent review, but models can be overridden per phase and swapped at runtime. Use `--providers` to restrict the orchestrator to the CLIs you actually have installed.
 
@@ -112,7 +112,7 @@ When creating a feature, choose a pipeline depth:
 |---------|--------|----------|
 | **Medium** | Roadmap plan → per-phase plan/implement loop → Final Review → Publish | Small, well-understood changes where you already know the approach |
 | **Large** | KB → Inquire → Research → Design → roadmap loop → Final Review → Publish | Most complex features (default) |
-| **Moonshot** | Same phase sequence as Large, with max effort, plan-review defaults, and per-iteration implementation review | High-risk or highly ambiguous changes |
+| **Moonshot** | Same phase sequence as Large, with max effort and per-iteration implementation review | High-risk or highly ambiguous changes |
 
 ### Worktree Isolation
 
@@ -169,8 +169,8 @@ Press `n` from the dashboard to open the wizard:
 
 1. **What** — Name and describe the feature. Supports pasting images (`Ctrl+V`) and attaching files (`@`).
 2. **Where** — Select target repo(s). Browse for new directories or create repos on the fly.
-3. **Pipeline** — Choose Medium, Large, or Moonshot. Toggle individual checkpoints (inquiry review, research review, design review, plan review, manual publish).
-4. **Review** — Adjust risk level, models per phase, exit criteria. Submit to start.
+3. **Pipeline** — Choose Medium, Large, or Moonshot and see the available gate options.
+4. **Review** — Adjust risk level, models per phase, checkpoints (inquiry review, research review, design review, roadmap review, phase plan review, manual publish), exit criteria. Submit to start.
 
 ### Interacting with Agents
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -135,24 +135,48 @@ func (m *ModelConfig) UnmarshalYAML(value *yaml.Node) error {
 
 // Checkpoints controls which phase transitions pause for human review in the config defaults.
 type Checkpoints struct {
-	InquiryReview  bool `yaml:"inquiry_review,omitempty"`
-	ResearchReview bool `yaml:"research_review,omitempty"`
-	DesignReview   bool `yaml:"design_review,omitempty"`
-	PlanReview     bool `yaml:"plan_review,omitempty"`
-	ManualPublish  bool `yaml:"manual_publish"`
+	InquiryReview   bool `yaml:"inquiry_review"`
+	ResearchReview  bool `yaml:"research_review"`
+	DesignReview    bool `yaml:"design_review"`
+	RoadmapReview   bool `yaml:"roadmap_review"`
+	PhasePlanReview bool `yaml:"phase_plan_review"`
+	ManualPublish   bool `yaml:"manual_publish"`
 
 	parsed bool // set by UnmarshalYAML; not serialized
 }
 
-// UnmarshalYAML defaults ManualPublish to true so that configs which include
-// a checkpoints section but omit manual_publish still get manual-publish
-// behaviour (the safe default). An explicit `manual_publish: false` in YAML
-// overrides this during Decode.
+// UnmarshalYAML defaults omitted checkpoint fields to true. The legacy
+// plan_review key is accepted by the decoder but intentionally ignored.
 func (c *Checkpoints) UnmarshalYAML(value *yaml.Node) error {
-	c.ManualPublish = true
+	type checkpointFields struct {
+		InquiryReview   *bool `yaml:"inquiry_review"`
+		ResearchReview  *bool `yaml:"research_review"`
+		DesignReview    *bool `yaml:"design_review"`
+		RoadmapReview   *bool `yaml:"roadmap_review"`
+		PhasePlanReview *bool `yaml:"phase_plan_review"`
+		ManualPublish   *bool `yaml:"manual_publish"`
+	}
+
+	var fields checkpointFields
+	if err := value.Decode(&fields); err != nil {
+		return err
+	}
+
+	c.InquiryReview = boolValueOrDefault(fields.InquiryReview, true)
+	c.ResearchReview = boolValueOrDefault(fields.ResearchReview, true)
+	c.DesignReview = boolValueOrDefault(fields.DesignReview, true)
+	c.RoadmapReview = boolValueOrDefault(fields.RoadmapReview, true)
+	c.PhasePlanReview = boolValueOrDefault(fields.PhasePlanReview, true)
+	c.ManualPublish = boolValueOrDefault(fields.ManualPublish, true)
 	c.parsed = true
-	type plain Checkpoints // avoid infinite recursion
-	return value.Decode((*plain)(c))
+	return nil
+}
+
+func boolValueOrDefault(value *bool, fallback bool) bool {
+	if value == nil {
+		return fallback
+	}
+	return *value
 }
 
 type RepoConfig struct {
@@ -272,10 +296,10 @@ func applyDefaults(cfg *Config) {
 		cfg.Defaults.Inquireness = d.Defaults.Inquireness
 	}
 	// If the YAML had no checkpoints section at all, UnmarshalYAML was never
-	// called, so parsed is false and ManualPublish is the zero value (false).
-	// Apply the default so zero-config and legacy configs get manual-publish.
+	// called, so parsed is false and the fields are zero values. Apply the
+	// complete default checkpoint set.
 	if !cfg.Defaults.Checkpoints.parsed {
-		cfg.Defaults.Checkpoints.ManualPublish = d.Defaults.Checkpoints.ManualPublish
+		cfg.Defaults.Checkpoints = d.Defaults.Checkpoints
 	}
 
 	if cfg.Defaults.Pipeline == "" {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -254,6 +254,136 @@ func TestYAMLIgnoresUnknownAutoPublish(t *testing.T) {
 	}
 }
 
+func TestLoadConfigCheckpointFieldsDefaultOnAndPlanReviewIgnored(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+
+	content := []byte(`defaults:
+  checkpoints:
+    plan_review: false
+`)
+	if err := os.WriteFile(path, content, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	got := cfg.Defaults.Checkpoints
+	if !got.InquiryReview ||
+		!got.ResearchReview ||
+		!got.DesignReview ||
+		!got.RoadmapReview ||
+		!got.PhasePlanReview ||
+		!got.ManualPublish {
+		t.Fatalf("omitted checkpoints should default on and plan_review should be ignored, got %+v", got)
+	}
+}
+
+func TestLoadConfigMalformedLegacyPlanReviewIgnored(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+
+	content := []byte(`defaults:
+  checkpoints:
+    plan_review:
+      - not-a-bool
+    manual_publish: false
+`)
+	if err := os.WriteFile(path, content, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load should ignore malformed legacy plan_review: %v", err)
+	}
+	got := cfg.Defaults.Checkpoints
+	if !got.InquiryReview || !got.ResearchReview || !got.DesignReview || !got.RoadmapReview || !got.PhasePlanReview {
+		t.Fatalf("non-legacy omitted checkpoints should default on, got %+v", got)
+	}
+	if got.ManualPublish {
+		t.Fatalf("explicit manual_publish=false should still win, got %+v", got)
+	}
+}
+
+func TestLoadConfigCheckpointExplicitFalseWins(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+
+	content := []byte(`defaults:
+  checkpoints:
+    inquiry_review: false
+    research_review: false
+    design_review: false
+    roadmap_review: false
+    phase_plan_review: true
+    manual_publish: false
+`)
+	if err := os.WriteFile(path, content, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	got := cfg.Defaults.Checkpoints
+	if got.InquiryReview ||
+		got.ResearchReview ||
+		got.DesignReview ||
+		got.RoadmapReview ||
+		!got.PhasePlanReview ||
+		got.ManualPublish {
+		t.Fatalf("loaded checkpoints did not preserve explicit values: %+v", got)
+	}
+}
+
+func TestSaveWritesCheckpointFieldsExplicitly(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+
+	cfg := NewDefault()
+	cfg.Defaults.Checkpoints = Checkpoints{
+		InquiryReview:   false,
+		ResearchReview:  true,
+		DesignReview:    false,
+		RoadmapReview:   true,
+		PhasePlanReview: false,
+		ManualPublish:   false,
+	}
+
+	if err := Save(path, cfg); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	yamlStr := string(data)
+	for _, needle := range []string{
+		"inquiry_review: false",
+		"research_review: true",
+		"design_review: false",
+		"roadmap_review: true",
+		"phase_plan_review: false",
+		"manual_publish: false",
+	} {
+		if !strings.Contains(yamlStr, needle) {
+			t.Fatalf("saved YAML missing %q:\n%s", needle, yamlStr)
+		}
+	}
+	for _, line := range strings.Split(yamlStr, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "plan_review:") {
+			t.Fatalf("saved YAML should not contain legacy plan_review:\n%s", yamlStr)
+		}
+	}
+}
+
 func TestLoadConfigWithoutManualPublishDefaultsToTrue(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.yaml")
@@ -271,8 +401,11 @@ func TestLoadConfigWithoutManualPublishDefaultsToTrue(t *testing.T) {
 	if !cfg.Defaults.Checkpoints.ManualPublish {
 		t.Error("expected ManualPublish to default to true when omitted from loaded config")
 	}
-	if !cfg.Defaults.Checkpoints.PlanReview {
-		t.Error("expected PlanReview to be parsed as true")
+	if !cfg.Defaults.Checkpoints.RoadmapReview {
+		t.Error("expected RoadmapReview to default to true")
+	}
+	if !cfg.Defaults.Checkpoints.PhasePlanReview {
+		t.Error("expected PhasePlanReview to default to true")
 	}
 }
 
@@ -389,6 +522,30 @@ func TestApplyDefaults(t *testing.T) {
 	}
 	if !cfg.Defaults.Checkpoints.ManualPublish {
 		t.Error("expected ManualPublish to default to true via applyDefaults")
+	}
+}
+
+func TestApplyDefaultsPreservesExplicitFalseCheckpointsOnSecondCall(t *testing.T) {
+	cfg := &Config{
+		Defaults: DefaultsConfig{
+			Checkpoints: Checkpoints{
+				InquiryReview:   false,
+				ResearchReview:  false,
+				DesignReview:    false,
+				RoadmapReview:   false,
+				PhasePlanReview: true,
+				ManualPublish:   false,
+				parsed:          true,
+			},
+		},
+	}
+
+	applyDefaults(cfg)
+	applyDefaults(cfg)
+
+	got := cfg.Defaults.Checkpoints
+	if got.InquiryReview || got.ResearchReview || got.DesignReview || got.RoadmapReview || !got.PhasePlanReview || got.ManualPublish {
+		t.Fatalf("explicit checkpoint values were not preserved after repeated applyDefaults: %+v", got)
 	}
 }
 
@@ -1297,6 +1454,32 @@ func TestRepoConfigPipelineGatesRoundTrip(t *testing.T) {
 	}
 	if medium.ManualPublish {
 		t.Error("expected ManualPublish=false for medium pipeline gate")
+	}
+}
+
+func TestRepoPipelineGatesSparseCheckpointDefaultsOn(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+
+	content := []byte(`repos:
+  my-repo:
+    path: /tmp/my-repo
+    pipeline_gates:
+      medium:
+        manual_publish: false
+`)
+	if err := os.WriteFile(path, content, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	got := cfg.Repos["my-repo"].PipelineGates["medium"]
+	if !got.InquiryReview || !got.ResearchReview || !got.DesignReview || !got.RoadmapReview || !got.PhasePlanReview || got.ManualPublish {
+		t.Fatalf("sparse repo pipeline gate should default omitted checkpoints on and preserve manual_publish=false, got %+v", got)
 	}
 }
 

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -33,7 +33,12 @@ func NewDefault() *Config {
 				KBBuild:        "sonnet[200K]",
 			},
 			Checkpoints: Checkpoints{
-				ManualPublish: true,
+				InquiryReview:   true,
+				ResearchReview:  true,
+				DesignReview:    true,
+				RoadmapReview:   true,
+				PhasePlanReview: true,
+				ManualPublish:   true,
 			},
 			ExitCriteria:             defaultExitCriteria,
 			Inquireness:              "high",

--- a/internal/feature/feature.go
+++ b/internal/feature/feature.go
@@ -479,11 +479,12 @@ func (s *Status) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 // Checkpoints controls which phase transitions pause for human review.
 type Checkpoints struct {
-	InquiryReview  bool `yaml:"inquiry_review,omitempty"`
-	ResearchReview bool `yaml:"research_review,omitempty"`
-	DesignReview   bool `yaml:"design_review,omitempty"`
-	PlanReview     bool `yaml:"plan_review,omitempty"`
-	ManualPublish  bool `yaml:"manual_publish,omitempty"`
+	InquiryReview   bool `yaml:"inquiry_review,omitempty"`
+	ResearchReview  bool `yaml:"research_review,omitempty"`
+	DesignReview    bool `yaml:"design_review,omitempty"`
+	RoadmapReview   bool `yaml:"roadmap_review,omitempty"`
+	PhasePlanReview bool `yaml:"phase_plan_review,omitempty"`
+	ManualPublish   bool `yaml:"manual_publish,omitempty"`
 }
 
 // HasGateForPhase returns true if a review gate is enabled for the given target phase.
@@ -496,7 +497,7 @@ func (c Checkpoints) HasGateForPhase(phase Phase) bool {
 	case PhasePlan:
 		return c.DesignReview
 	case PhaseImplement:
-		return c.PlanReview
+		return c.PhasePlanReview
 	default:
 		return false
 	}

--- a/internal/feature/feature_test.go
+++ b/internal/feature/feature_test.go
@@ -1100,7 +1100,7 @@ func TestCheckpointsHasGateForPhase(t *testing.T) {
 		{"inquiry gate for research", Checkpoints{InquiryReview: true}, PhaseResearch, true},
 		{"research gate for design", Checkpoints{ResearchReview: true}, PhaseDesign, true},
 		{"design gate for plan", Checkpoints{DesignReview: true}, PhasePlan, true},
-		{"plan gate for implement", Checkpoints{PlanReview: true}, PhaseImplement, true},
+		{"phase-plan gate for implement", Checkpoints{PhasePlanReview: true}, PhaseImplement, true},
 		{"no gate for publish", Checkpoints{ManualPublish: true}, PhasePublish, false},
 		{"no gate for KB", Checkpoints{InquiryReview: true}, PhaseKnowledgeBase, false},
 		{"zero value has no gates", Checkpoints{}, PhaseResearch, false},
@@ -1142,11 +1142,12 @@ func TestCheckpointsYAMLRoundTrip(t *testing.T) {
 		ID:   "test",
 		Name: "test",
 		Checkpoints: Checkpoints{
-			InquiryReview:  true,
-			ResearchReview: false,
-			DesignReview:   true,
-			PlanReview:     false,
-			ManualPublish:  true,
+			InquiryReview:   true,
+			ResearchReview:  false,
+			DesignReview:    true,
+			RoadmapReview:   false,
+			PhasePlanReview: true,
+			ManualPublish:   true,
 		},
 	}
 	data, err := yaml.Marshal(f)

--- a/internal/feature/pipeline.go
+++ b/internal/feature/pipeline.go
@@ -168,23 +168,24 @@ func (p PipelineProfile) NextProfile() PipelineProfile {
 func DefaultCheckpointsForProfile(profile PipelineProfile) Checkpoints {
 	switch profile {
 	case PipelineMedium:
-		return Checkpoints{ManualPublish: true}
-	case PipelineLarge:
-		return Checkpoints{DesignReview: true, ManualPublish: true}
-	default: // PipelineMoonshot
-		return Checkpoints{DesignReview: true, PlanReview: true, ManualPublish: true}
+		return Checkpoints{RoadmapReview: true, PhasePlanReview: true, ManualPublish: true}
+	case PipelineLarge, PipelineMoonshot:
+		return Checkpoints{InquiryReview: true, ResearchReview: true, DesignReview: true, RoadmapReview: true, PhasePlanReview: true, ManualPublish: true}
+	default:
+		return Checkpoints{InquiryReview: true, ResearchReview: true, DesignReview: true, RoadmapReview: true, PhasePlanReview: true, ManualPublish: true}
 	}
 }
 
-// GateIndex represents a named gate position in the [5]bool array.
+// GateIndex represents a named gate position in the gate projection.
 type GateIndex int
 
 const (
-	GateInquiryReview  GateIndex = 0
-	GateResearchReview GateIndex = 1
-	GateDesignReview   GateIndex = 2
-	GatePlanReview     GateIndex = 3
-	GateManualPublish  GateIndex = 4
+	GateInquiryReview GateIndex = iota
+	GateResearchReview
+	GateDesignReview
+	GateRoadmapReview
+	GatePhasePlanReview
+	GateManualPublish
 )
 
 // GateProjection is the shared gate contract for a pipeline profile.
@@ -198,11 +199,11 @@ type GateProjection struct {
 func (p PipelineProfile) ApplicableGates() []GateIndex {
 	switch p {
 	case PipelineMedium:
-		return []GateIndex{GatePlanReview, GateManualPublish}
+		return []GateIndex{GateRoadmapReview, GatePhasePlanReview, GateManualPublish}
 	case PipelineLarge, PipelineMoonshot:
-		return []GateIndex{GateInquiryReview, GateResearchReview, GateDesignReview, GatePlanReview, GateManualPublish}
+		return []GateIndex{GateInquiryReview, GateResearchReview, GateDesignReview, GateRoadmapReview, GatePhasePlanReview, GateManualPublish}
 	default:
-		return []GateIndex{GateInquiryReview, GateResearchReview, GateDesignReview, GatePlanReview, GateManualPublish}
+		return []GateIndex{GateInquiryReview, GateResearchReview, GateDesignReview, GateRoadmapReview, GatePhasePlanReview, GateManualPublish}
 	}
 }
 
@@ -221,8 +222,11 @@ func (p PipelineProfile) FilterCheckpoints(cp Checkpoints) Checkpoints {
 	if !applicable[GateDesignReview] {
 		cp.DesignReview = false
 	}
-	if !applicable[GatePlanReview] {
-		cp.PlanReview = false
+	if !applicable[GateRoadmapReview] {
+		cp.RoadmapReview = false
+	}
+	if !applicable[GatePhasePlanReview] {
+		cp.PhasePlanReview = false
 	}
 	if !applicable[GateManualPublish] {
 		cp.ManualPublish = false
@@ -262,7 +266,8 @@ func mergeCheckpoints(checkpoints ...Checkpoints) Checkpoints {
 		merged.InquiryReview = merged.InquiryReview || cp.InquiryReview
 		merged.ResearchReview = merged.ResearchReview || cp.ResearchReview
 		merged.DesignReview = merged.DesignReview || cp.DesignReview
-		merged.PlanReview = merged.PlanReview || cp.PlanReview
+		merged.RoadmapReview = merged.RoadmapReview || cp.RoadmapReview
+		merged.PhasePlanReview = merged.PhasePlanReview || cp.PhasePlanReview
 		merged.ManualPublish = merged.ManualPublish || cp.ManualPublish
 	}
 	return merged
@@ -303,21 +308,23 @@ func ParsePipelineProfile(s string) (PipelineProfile, error) {
 // ConfigCheckpointsToFeature converts config.Checkpoints to feature.Checkpoints.
 func ConfigCheckpointsToFeature(cc config.Checkpoints) Checkpoints {
 	return Checkpoints{
-		InquiryReview:  cc.InquiryReview,
-		ResearchReview: cc.ResearchReview,
-		DesignReview:   cc.DesignReview,
-		PlanReview:     cc.PlanReview,
-		ManualPublish:  cc.ManualPublish,
+		InquiryReview:   cc.InquiryReview,
+		ResearchReview:  cc.ResearchReview,
+		DesignReview:    cc.DesignReview,
+		RoadmapReview:   cc.RoadmapReview,
+		PhasePlanReview: cc.PhasePlanReview,
+		ManualPublish:   cc.ManualPublish,
 	}
 }
 
 // FeatureCheckpointsToConfig converts feature.Checkpoints to config.Checkpoints.
 func FeatureCheckpointsToConfig(fc Checkpoints) config.Checkpoints {
 	return config.Checkpoints{
-		InquiryReview:  fc.InquiryReview,
-		ResearchReview: fc.ResearchReview,
-		DesignReview:   fc.DesignReview,
-		PlanReview:     fc.PlanReview,
-		ManualPublish:  fc.ManualPublish,
+		InquiryReview:   fc.InquiryReview,
+		ResearchReview:  fc.ResearchReview,
+		DesignReview:    fc.DesignReview,
+		RoadmapReview:   fc.RoadmapReview,
+		PhasePlanReview: fc.PhasePlanReview,
+		ManualPublish:   fc.ManualPublish,
 	}
 }

--- a/internal/feature/pipeline_test.go
+++ b/internal/feature/pipeline_test.go
@@ -203,9 +203,9 @@ func TestDefaultCheckpointsForProfile(t *testing.T) {
 		profile PipelineProfile
 		want    Checkpoints
 	}{
-		{"medium: ManualPublish only", PipelineMedium, Checkpoints{ManualPublish: true}},
-		{"large: Design + ManualPublish", PipelineLarge, Checkpoints{DesignReview: true, ManualPublish: true}},
-		{"moonshot: Design + Plan + ManualPublish", PipelineMoonshot, Checkpoints{DesignReview: true, PlanReview: true, ManualPublish: true}},
+		{"medium: roadmap + phase-plan + manual publish", PipelineMedium, Checkpoints{RoadmapReview: true, PhasePlanReview: true, ManualPublish: true}},
+		{"large: every applicable checkpoint", PipelineLarge, Checkpoints{InquiryReview: true, ResearchReview: true, DesignReview: true, RoadmapReview: true, PhasePlanReview: true, ManualPublish: true}},
+		{"moonshot: every applicable checkpoint", PipelineMoonshot, Checkpoints{InquiryReview: true, ResearchReview: true, DesignReview: true, RoadmapReview: true, PhasePlanReview: true, ManualPublish: true}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -237,9 +237,9 @@ func TestPipelineProfileApplicableGates(t *testing.T) {
 		profile PipelineProfile
 		want    []GateIndex
 	}{
-		{"medium", PipelineMedium, []GateIndex{GatePlanReview, GateManualPublish}},
-		{"large", PipelineLarge, []GateIndex{GateInquiryReview, GateResearchReview, GateDesignReview, GatePlanReview, GateManualPublish}},
-		{"moonshot", PipelineMoonshot, []GateIndex{GateInquiryReview, GateResearchReview, GateDesignReview, GatePlanReview, GateManualPublish}},
+		{"medium", PipelineMedium, []GateIndex{GateRoadmapReview, GatePhasePlanReview, GateManualPublish}},
+		{"large", PipelineLarge, []GateIndex{GateInquiryReview, GateResearchReview, GateDesignReview, GateRoadmapReview, GatePhasePlanReview, GateManualPublish}},
+		{"moonshot", PipelineMoonshot, []GateIndex{GateInquiryReview, GateResearchReview, GateDesignReview, GateRoadmapReview, GatePhasePlanReview, GateManualPublish}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -260,20 +260,20 @@ func TestProjectGatesNormalizeCheckpointsForPersistence(t *testing.T) {
 		wantVisible []GateIndex
 	}{
 		{
-			name:        "medium keeps plan and publish gates",
+			name:        "medium keeps planning and publish gates",
 			profile:     PipelineMedium,
-			input:       Checkpoints{InquiryReview: true, DesignReview: true, PlanReview: true, ManualPublish: true},
+			input:       Checkpoints{InquiryReview: true, DesignReview: true, RoadmapReview: true, PhasePlanReview: true, ManualPublish: true},
 			publishable: true,
-			want:        Checkpoints{PlanReview: true, ManualPublish: true},
-			wantVisible: []GateIndex{GatePlanReview, GateManualPublish},
+			want:        Checkpoints{RoadmapReview: true, PhasePlanReview: true, ManualPublish: true},
+			wantVisible: []GateIndex{GateRoadmapReview, GatePhasePlanReview, GateManualPublish},
 		},
 		{
 			name:        "unpublished large forces manual publish while hiding the row",
 			profile:     PipelineLarge,
-			input:       Checkpoints{DesignReview: true, PlanReview: true, ManualPublish: false},
+			input:       Checkpoints{DesignReview: true, RoadmapReview: true, PhasePlanReview: true, ManualPublish: false},
 			publishable: false,
-			want:        Checkpoints{DesignReview: true, PlanReview: true, ManualPublish: true},
-			wantVisible: []GateIndex{GateInquiryReview, GateResearchReview, GateDesignReview, GatePlanReview},
+			want:        Checkpoints{DesignReview: true, RoadmapReview: true, PhasePlanReview: true, ManualPublish: true},
+			wantVisible: []GateIndex{GateInquiryReview, GateResearchReview, GateDesignReview, GateRoadmapReview, GatePhasePlanReview},
 		},
 	}
 
@@ -292,25 +292,27 @@ func TestPipelineProfileFilterCheckpoints(t *testing.T) {
 	t.Parallel()
 	// parallel-candidate: pure value, table-driven, or per-test temp-dir assertions with no shared state.
 	allTrue := Checkpoints{
-		InquiryReview:  true,
-		ResearchReview: true,
-		DesignReview:   true,
-		PlanReview:     true,
-		ManualPublish:  true,
+		InquiryReview:   true,
+		ResearchReview:  true,
+		DesignReview:    true,
+		RoadmapReview:   true,
+		PhasePlanReview: true,
+		ManualPublish:   true,
 	}
 	allGates := Checkpoints{
-		InquiryReview:  true,
-		ResearchReview: true,
-		DesignReview:   true,
-		PlanReview:     true,
-		ManualPublish:  true,
+		InquiryReview:   true,
+		ResearchReview:  true,
+		DesignReview:    true,
+		RoadmapReview:   true,
+		PhasePlanReview: true,
+		ManualPublish:   true,
 	}
 	tests := []struct {
 		name    string
 		profile PipelineProfile
 		want    Checkpoints
 	}{
-		{"medium", PipelineMedium, Checkpoints{PlanReview: true, ManualPublish: true}},
+		{"medium", PipelineMedium, Checkpoints{RoadmapReview: true, PhasePlanReview: true, ManualPublish: true}},
 		{"large", PipelineLarge, allGates},
 		{"moonshot", PipelineMoonshot, allGates},
 	}
@@ -338,18 +340,19 @@ func TestProjectMergedGates(t *testing.T) {
 		wantFromConfig bool
 	}{
 		{
-			name:    "medium keeps plan review overrides",
+			name:    "medium keeps planning gate overrides",
 			profile: PipelineMedium,
 			base:    DefaultCheckpointsForProfile(PipelineMedium),
 			overrides: []Checkpoints{{
-				InquiryReview: true,
-				DesignReview:  true,
-				PlanReview:    true,
-				ManualPublish: true,
+				InquiryReview:   true,
+				DesignReview:    true,
+				RoadmapReview:   true,
+				PhasePlanReview: true,
+				ManualPublish:   true,
 			}},
 			publishable:    true,
-			wantCheckpoint: Checkpoints{PlanReview: true, ManualPublish: true},
-			wantVisible:    []GateIndex{GatePlanReview, GateManualPublish},
+			wantCheckpoint: Checkpoints{RoadmapReview: true, PhasePlanReview: true, ManualPublish: true},
+			wantVisible:    []GateIndex{GateRoadmapReview, GatePhasePlanReview, GateManualPublish},
 			wantFromConfig: true,
 		},
 		{
@@ -358,11 +361,11 @@ func TestProjectMergedGates(t *testing.T) {
 			base:    DefaultCheckpointsForProfile(PipelineLarge),
 			overrides: []Checkpoints{
 				{InquiryReview: true, ManualPublish: true},
-				{ResearchReview: true, DesignReview: true, PlanReview: true},
+				{ResearchReview: true, DesignReview: true, RoadmapReview: true, PhasePlanReview: true},
 			},
 			publishable:    true,
-			wantCheckpoint: Checkpoints{InquiryReview: true, ResearchReview: true, DesignReview: true, PlanReview: true, ManualPublish: true},
-			wantVisible:    []GateIndex{GateInquiryReview, GateResearchReview, GateDesignReview, GatePlanReview, GateManualPublish},
+			wantCheckpoint: Checkpoints{InquiryReview: true, ResearchReview: true, DesignReview: true, RoadmapReview: true, PhasePlanReview: true, ManualPublish: true},
+			wantVisible:    []GateIndex{GateInquiryReview, GateResearchReview, GateDesignReview, GateRoadmapReview, GatePhasePlanReview, GateManualPublish},
 			wantFromConfig: true,
 		},
 		{
@@ -370,8 +373,8 @@ func TestProjectMergedGates(t *testing.T) {
 			profile:        PipelineMedium,
 			base:           DefaultCheckpointsForProfile(PipelineMedium),
 			publishable:    false,
-			wantCheckpoint: Checkpoints{ManualPublish: true},
-			wantVisible:    []GateIndex{GatePlanReview},
+			wantCheckpoint: Checkpoints{RoadmapReview: true, PhasePlanReview: true, ManualPublish: true},
+			wantVisible:    []GateIndex{GateRoadmapReview, GatePhasePlanReview},
 			wantFromConfig: false,
 		},
 	}
@@ -472,19 +475,26 @@ func TestConfigCheckpointsToFeatureCheckpoints(t *testing.T) {
 		{
 			"all true",
 			config.Checkpoints{
-				InquiryReview:  true,
-				ResearchReview: true,
-				DesignReview:   true,
-				PlanReview:     true,
-				ManualPublish:  true,
+				InquiryReview:   true,
+				ResearchReview:  true,
+				DesignReview:    true,
+				RoadmapReview:   true,
+				PhasePlanReview: true,
+				ManualPublish:   true,
 			},
 			Checkpoints{
-				InquiryReview:  true,
-				ResearchReview: true,
-				DesignReview:   true,
-				PlanReview:     true,
-				ManualPublish:  true,
+				InquiryReview:   true,
+				ResearchReview:  true,
+				DesignReview:    true,
+				RoadmapReview:   true,
+				PhasePlanReview: true,
+				ManualPublish:   true,
 			},
+		},
+		{
+			"planning gates",
+			config.Checkpoints{RoadmapReview: true, PhasePlanReview: true},
+			Checkpoints{RoadmapReview: true, PhasePlanReview: true},
 		},
 		{
 			"mixed",
@@ -526,29 +536,36 @@ func TestFeatureCheckpointsToConfigCheckpoints(t *testing.T) {
 		{
 			"all true",
 			Checkpoints{
-				InquiryReview:  true,
-				ResearchReview: true,
-				DesignReview:   true,
-				PlanReview:     true,
-				ManualPublish:  true,
+				InquiryReview:   true,
+				ResearchReview:  true,
+				DesignReview:    true,
+				RoadmapReview:   true,
+				PhasePlanReview: true,
+				ManualPublish:   true,
 			},
 			config.Checkpoints{
-				InquiryReview:  true,
-				ResearchReview: true,
-				DesignReview:   true,
-				PlanReview:     true,
-				ManualPublish:  true,
+				InquiryReview:   true,
+				ResearchReview:  true,
+				DesignReview:    true,
+				RoadmapReview:   true,
+				PhasePlanReview: true,
+				ManualPublish:   true,
 			},
+		},
+		{
+			"planning gates",
+			Checkpoints{RoadmapReview: true, PhasePlanReview: true},
+			config.Checkpoints{RoadmapReview: true, PhasePlanReview: true},
 		},
 		{
 			"mixed",
 			Checkpoints{
-				ResearchReview: true,
-				PlanReview:     true,
+				ResearchReview:  true,
+				PhasePlanReview: true,
 			},
 			config.Checkpoints{
-				ResearchReview: true,
-				PlanReview:     true,
+				ResearchReview:  true,
+				PhasePlanReview: true,
 			},
 		},
 	}
@@ -558,7 +575,8 @@ func TestFeatureCheckpointsToConfigCheckpoints(t *testing.T) {
 			if got.InquiryReview != tt.want.InquiryReview ||
 				got.ResearchReview != tt.want.ResearchReview ||
 				got.DesignReview != tt.want.DesignReview ||
-				got.PlanReview != tt.want.PlanReview ||
+				got.RoadmapReview != tt.want.RoadmapReview ||
+				got.PhasePlanReview != tt.want.PhasePlanReview ||
 				got.ManualPublish != tt.want.ManualPublish {
 				t.Errorf("FeatureCheckpointsToConfig(%+v) = %+v, want %+v", tt.input, got, tt.want)
 			}

--- a/internal/observe/observer.go
+++ b/internal/observe/observer.go
@@ -1109,11 +1109,12 @@ func configSnapshotAttrs(s feature.ConfigSnapshot) map[string]any {
 		},
 		"inquireness": string(s.Inquireness),
 		"checkpoints": map[string]any{
-			"inquiry_review":  s.Checkpoints.InquiryReview,
-			"research_review": s.Checkpoints.ResearchReview,
-			"design_review":   s.Checkpoints.DesignReview,
-			"plan_review":     s.Checkpoints.PlanReview,
-			"manual_publish":  s.Checkpoints.ManualPublish,
+			"inquiry_review":    s.Checkpoints.InquiryReview,
+			"research_review":   s.Checkpoints.ResearchReview,
+			"design_review":     s.Checkpoints.DesignReview,
+			"roadmap_review":    s.Checkpoints.RoadmapReview,
+			"phase_plan_review": s.Checkpoints.PhasePlanReview,
+			"manual_publish":    s.Checkpoints.ManualPublish,
 		},
 	}
 }

--- a/internal/observe/observer_test.go
+++ b/internal/observe/observer_test.go
@@ -1911,7 +1911,7 @@ func TestObserver_ConfigChanged_WritesEventsJSONL(t *testing.T) {
 	before := feature.ConfigSnapshot{
 		Models:      config.ModelConfig{Research: "old-research", Planning: "old-planning"},
 		Inquireness: feature.InquirenessMedium,
-		Checkpoints: feature.Checkpoints{PlanReview: true},
+		Checkpoints: feature.Checkpoints{RoadmapReview: true, PhasePlanReview: true},
 	}
 	after := feature.ConfigSnapshot{
 		Models:      config.ModelConfig{Research: "new-research", Planning: "new-planning"},
@@ -1961,8 +1961,14 @@ func TestObserver_ConfigChanged_WritesEventsJSONL(t *testing.T) {
 	}
 
 	beforeCheckpoints := beforeMap["checkpoints"].(map[string]any)
-	if beforeCheckpoints["plan_review"] != true {
-		t.Errorf("before.checkpoints.plan_review = %v, want true", beforeCheckpoints["plan_review"])
+	if beforeCheckpoints["roadmap_review"] != true {
+		t.Errorf("before.checkpoints.roadmap_review = %v, want true", beforeCheckpoints["roadmap_review"])
+	}
+	if beforeCheckpoints["phase_plan_review"] != true {
+		t.Errorf("before.checkpoints.phase_plan_review = %v, want true", beforeCheckpoints["phase_plan_review"])
+	}
+	if _, ok := beforeCheckpoints["plan_review"]; ok {
+		t.Errorf("before.checkpoints should not include legacy plan_review key, got %v", beforeCheckpoints["plan_review"])
 	}
 	afterCheckpoints := afterMap["checkpoints"].(map[string]any)
 	if afterCheckpoints["inquiry_review"] != true {
@@ -1970,6 +1976,15 @@ func TestObserver_ConfigChanged_WritesEventsJSONL(t *testing.T) {
 	}
 	if afterCheckpoints["manual_publish"] != true {
 		t.Errorf("after.checkpoints.manual_publish = %v, want true", afterCheckpoints["manual_publish"])
+	}
+	if afterCheckpoints["roadmap_review"] != false {
+		t.Errorf("after.checkpoints.roadmap_review = %v, want false", afterCheckpoints["roadmap_review"])
+	}
+	if afterCheckpoints["phase_plan_review"] != false {
+		t.Errorf("after.checkpoints.phase_plan_review = %v, want false", afterCheckpoints["phase_plan_review"])
+	}
+	if _, ok := afterCheckpoints["plan_review"]; ok {
+		t.Errorf("after.checkpoints should not include legacy plan_review key, got %v", afterCheckpoints["plan_review"])
 	}
 }
 

--- a/internal/orchestrator/completion.go
+++ b/internal/orchestrator/completion.go
@@ -670,7 +670,7 @@ func (o *Orchestrator) onPlanApproved(featureID string, f *feature.Feature) erro
 		if getErr != nil {
 			return fmt.Errorf("reload feature: %w", getErr)
 		}
-		if ff.Checkpoints.PlanReview {
+		if ff.Checkpoints.RoadmapReview {
 			// Route through review gate.
 			if err := o.deps.Lifecycle.NeedsPlanReview(featureID); err != nil {
 				return fmt.Errorf("mark needs plan review: %w", err)
@@ -710,11 +710,10 @@ func (o *Orchestrator) onPlanApproved(featureID string, f *feature.Feature) erro
 		return nil
 	}
 
-	// Per-phase plan approval (CurrentRoadmapPhase > 0). If plan review is
-	// enabled, we surface it as a review gate; otherwise we run
-	// StartRoadmapPhaseImplementation → populate execution plan → start
-	// implementation.
-	if f.Checkpoints.PlanReview {
+	// Per-phase plan approval (CurrentRoadmapPhase > 0). If phase-plan review
+	// is enabled, we surface it as a review gate; otherwise we run
+	// StartRoadmapPhaseImplementation and start implementation.
+	if f.Checkpoints.PhasePlanReview {
 		if err := o.deps.Lifecycle.NeedsPlanReview(featureID); err != nil {
 			return fmt.Errorf("mark needs plan review: %w", err)
 		}
@@ -752,8 +751,8 @@ func (o *Orchestrator) onPlanApproved(featureID string, f *feature.Feature) erro
 // This is the validator's escalation path — it fires when the
 // planner ↔ critic loop cannot converge autonomously (max attempts
 // exhausted, or an axis stalled with the planner no longer changing the
-// frozen section). Always raise a review gate regardless of
-// Checkpoints.PlanReview: that checkpoint controls whether to pause for
+// frozen section). Always raise a review gate regardless of configured
+// planning review gates: those checkpoints control whether to pause for
 // routine review after auto-approval, not whether the validator's
 // explicit "I need a human" escalation should be honored. Failing the
 // feature here would discard a working plan over an exception path the

--- a/internal/orchestrator/completion_test.go
+++ b/internal/orchestrator/completion_test.go
@@ -1435,15 +1435,14 @@ func TestOrchestrator_HandlePhaseCompletion_Inquire_Terminal(t *testing.T) {
 // Category C — Plan loop completion
 // ---------------------------------------------------------------------------
 
-// Plan approved with PlanReview checkpoint — raises ReviewRequired gate
-// instead of advancing.
-func TestOrchestrator_HandlePhaseCompletion_Plan_Approved_Gate(t *testing.T) {
+func TestOrchestrator_HandlePhaseCompletion_Plan_RoadmapApproved_RoadmapGate(t *testing.T) {
 	f := &feature.Feature{
-		ID:           "feat-plan-gate",
-		Status:       feature.StatusPlanning,
-		CurrentPhase: feature.PhasePlan,
-		Pipeline:     feature.PipelineMedium,
-		Checkpoints:  feature.Checkpoints{PlanReview: true},
+		ID:                  "feat-roadmap-gate",
+		Status:              feature.StatusPlanning,
+		CurrentPhase:        feature.PhasePlan,
+		Pipeline:            feature.PipelineMedium,
+		CurrentRoadmapPhase: 0,
+		Checkpoints:         feature.Checkpoints{RoadmapReview: true},
 	}
 	lc := lifecycleForFeature(f)
 	lc.NeedsPlanReviewFn = func(id string) error {
@@ -1457,7 +1456,7 @@ func TestOrchestrator_HandlePhaseCompletion_Plan_Approved_Gate(t *testing.T) {
 		OnReviewRequired: func(id string, p feature.Phase) { reviewPhase = p },
 	})
 
-	if err := o.HandlePhaseCompletion("feat-plan-gate", orchestrator.PhaseCompletionInput{
+	if err := o.HandlePhaseCompletion(f.ID, orchestrator.PhaseCompletionInput{
 		Phase:      feature.PhasePlan,
 		PlanResult: &agent.PlanLoopResult{FinalStatus: "approved"},
 	}); err != nil {
@@ -1465,8 +1464,47 @@ func TestOrchestrator_HandlePhaseCompletion_Plan_Approved_Gate(t *testing.T) {
 	}
 
 	assertLifecycleCall(t, lc, "NeedsPlanReview")
-	refuteLifecycleCall(t, lc, "CompletePlanning")
+	refuteLifecycleCall(t, lc, "AdvanceRoadmapPhase")
+	if reviewPhase != feature.PhasePlan {
+		t.Errorf("OnReviewRequired phase = %v, want PhasePlan", reviewPhase)
+	}
+	events := drainEvents(o)
+	if !hasEventType(events, ports.ReviewRequired) {
+		t.Error("expected ReviewRequired event")
+	}
+}
 
+func TestOrchestrator_HandlePhaseCompletion_Plan_PhasePlanApproved_PhasePlanGate(t *testing.T) {
+	f := &feature.Feature{
+		ID:                  "feat-phase-plan-gate",
+		Status:              feature.StatusPlanning,
+		CurrentPhase:        feature.PhasePlan,
+		Pipeline:            feature.PipelineLarge,
+		CurrentRoadmapPhase: 2,
+		TotalRoadmapPhases:  3,
+		Checkpoints:         feature.Checkpoints{PhasePlanReview: true},
+	}
+	lc := lifecycleForFeature(f)
+	lc.NeedsPlanReviewFn = func(id string) error {
+		f.Status = feature.StatusPlanNeedsReview
+		return nil
+	}
+	fs := newFeatureStore(f)
+
+	var reviewPhase feature.Phase
+	o := orchestrator.New(orchestrator.Deps{Lifecycle: lc, Store: fs}, orchestrator.Hooks{
+		OnReviewRequired: func(id string, p feature.Phase) { reviewPhase = p },
+	})
+
+	if err := o.HandlePhaseCompletion(f.ID, orchestrator.PhaseCompletionInput{
+		Phase:      feature.PhasePlan,
+		PlanResult: &agent.PlanLoopResult{FinalStatus: "approved"},
+	}); err != nil {
+		t.Fatalf("HandlePhaseCompletion: %v", err)
+	}
+
+	assertLifecycleCall(t, lc, "NeedsPlanReview")
+	refuteLifecycleCall(t, lc, "StartRoadmapPhaseImplementation")
 	if reviewPhase != feature.PhasePlan {
 		t.Errorf("OnReviewRequired phase = %v, want PhasePlan", reviewPhase)
 	}
@@ -1477,7 +1515,7 @@ func TestOrchestrator_HandlePhaseCompletion_Plan_Approved_Gate(t *testing.T) {
 }
 
 // Plan needs_human_review always raises a review gate, even when
-// Checkpoints.PlanReview is disabled. The validator's escalation is an
+// planning review gates are disabled. The validator's escalation is an
 // exception path — failing the feature would discard a working plan
 // over a question the user can resolve in seconds.
 func TestOrchestrator_HandlePhaseCompletion_Plan_NeedsReview_NoGate_RaisesReview(t *testing.T) {
@@ -1486,7 +1524,7 @@ func TestOrchestrator_HandlePhaseCompletion_Plan_NeedsReview_NoGate_RaisesReview
 		Status:       feature.StatusPlanning,
 		CurrentPhase: feature.PhasePlan,
 		Pipeline:     feature.PipelineMedium,
-		// Checkpoints.PlanReview deliberately left false.
+		// RoadmapReview and PhasePlanReview deliberately left false.
 	}
 	lc := lifecycleForFeature(f)
 	lc.NeedsPlanReviewFn = func(id string) error {

--- a/internal/orchestrator/grill_me_fanout_integration_test.go
+++ b/internal/orchestrator/grill_me_fanout_integration_test.go
@@ -216,10 +216,11 @@ func TestGrillMeFanout_PrimaryBuilders_EndToEnd(t *testing.T) {
 					CurrentPhase: feature.PhaseDesign,
 					Pipeline:     feature.PipelineLarge,
 					Checkpoints: feature.Checkpoints{
-						InquiryReview:  true,
-						ResearchReview: true,
-						DesignReview:   true,
-						PlanReview:     true,
+						InquiryReview:   true,
+						ResearchReview:  true,
+						DesignReview:    true,
+						RoadmapReview:   true,
+						PhasePlanReview: true,
 					},
 				}
 			},
@@ -256,7 +257,7 @@ func TestGrillMeFanout_PrimaryBuilders_EndToEnd(t *testing.T) {
 						InquiryReview:  true,
 						ResearchReview: true,
 						DesignReview:   true,
-						PlanReview:     true,
+						RoadmapReview:  true,
 					},
 				}
 			},
@@ -289,10 +290,10 @@ func TestGrillMeFanout_PrimaryBuilders_EndToEnd(t *testing.T) {
 					CurrentRoadmapPhase: 1,
 					Pipeline:            feature.PipelineLarge,
 					Checkpoints: feature.Checkpoints{
-						InquiryReview:  true,
-						ResearchReview: true,
-						DesignReview:   true,
-						PlanReview:     true,
+						InquiryReview:   true,
+						ResearchReview:  true,
+						DesignReview:    true,
+						PhasePlanReview: true,
 					},
 				}
 			},

--- a/internal/orchestrator/qa_persistence_gate_test.go
+++ b/internal/orchestrator/qa_persistence_gate_test.go
@@ -146,10 +146,11 @@ func TestOrchestrator_OnArtifactPhaseCompleted_QAWritesForInteractivePlanningPha
 				// a checkpoint and short-circuits rather than dispatching a
 				// real downstream phase that would need a model registry.
 				Checkpoints: feature.Checkpoints{
-					InquiryReview:  true,
-					ResearchReview: true,
-					DesignReview:   true,
-					PlanReview:     true,
+					InquiryReview:   true,
+					ResearchReview:  true,
+					DesignReview:    true,
+					RoadmapReview:   true,
+					PhasePlanReview: true,
 				},
 			}
 
@@ -236,10 +237,11 @@ func TestInquirePhase_WritesHarnessOwnedQAFile(t *testing.T) {
 		CurrentPhase: feature.PhaseInquire,
 		Pipeline:     feature.PipelineLarge,
 		Checkpoints: feature.Checkpoints{
-			InquiryReview:  true,
-			ResearchReview: true,
-			DesignReview:   true,
-			PlanReview:     true,
+			InquiryReview:   true,
+			ResearchReview:  true,
+			DesignReview:    true,
+			RoadmapReview:   true,
+			PhasePlanReview: true,
 		},
 	}
 
@@ -308,10 +310,11 @@ func TestInquirePhase_AutoPickAnnotationPreserved(t *testing.T) {
 		CurrentPhase: feature.PhaseInquire,
 		Pipeline:     feature.PipelineLarge,
 		Checkpoints: feature.Checkpoints{
-			InquiryReview:  true,
-			ResearchReview: true,
-			DesignReview:   true,
-			PlanReview:     true,
+			InquiryReview:   true,
+			ResearchReview:  true,
+			DesignReview:    true,
+			RoadmapReview:   true,
+			PhasePlanReview: true,
 		},
 	}
 	phaseDir := filepath.Join(agent.ActiveRunDir(tmpStateDir, f), "inquire")
@@ -373,10 +376,11 @@ func TestInquirePhase_NoExistingQAFile_WritesHarnessOwnedFile(t *testing.T) {
 		CurrentPhase: feature.PhaseInquire,
 		Pipeline:     feature.PipelineLarge,
 		Checkpoints: feature.Checkpoints{
-			InquiryReview:  true,
-			ResearchReview: true,
-			DesignReview:   true,
-			PlanReview:     true,
+			InquiryReview:   true,
+			ResearchReview:  true,
+			DesignReview:    true,
+			RoadmapReview:   true,
+			PhasePlanReview: true,
 		},
 	}
 	phaseDir := filepath.Join(agent.ActiveRunDir(tmpStateDir, f), "inquire")
@@ -432,10 +436,11 @@ func TestInquirePhase_RefPrefix_WritesQAFile(t *testing.T) {
 		// any non-empty prefix exercises the prefixed-path branch.
 		RefactorPrompt: "polish",
 		Checkpoints: feature.Checkpoints{
-			InquiryReview:  true,
-			ResearchReview: true,
-			DesignReview:   true,
-			PlanReview:     true,
+			InquiryReview:   true,
+			ResearchReview:  true,
+			DesignReview:    true,
+			RoadmapReview:   true,
+			PhasePlanReview: true,
 		},
 	}
 	f.SetRefactorCount(1)

--- a/internal/orchestrator/update_feature_config_test.go
+++ b/internal/orchestrator/update_feature_config_test.go
@@ -53,7 +53,7 @@ func TestUpdateFeatureConfig_QuiescentWritesAllThreeAxes(t *testing.T) {
 					Research: "old-research",
 				},
 				Inquireness: feature.InquirenessMedium,
-				Checkpoints: feature.Checkpoints{PlanReview: true},
+				Checkpoints: feature.Checkpoints{RoadmapReview: true, PhasePlanReview: true},
 			}
 			lc := lifecycleForFeature(f)
 			fs := newFeatureStore(f)
@@ -87,8 +87,8 @@ func TestUpdateFeatureConfig_QuiescentWritesAllThreeAxes(t *testing.T) {
 			if !f.Checkpoints.InquiryReview || !f.Checkpoints.ManualPublish {
 				t.Errorf("Checkpoints not updated: %+v", f.Checkpoints)
 			}
-			if f.Checkpoints.PlanReview {
-				t.Errorf("Checkpoints overwritten to zero-valued fields — PlanReview should now be false, got true")
+			if f.Checkpoints.RoadmapReview || f.Checkpoints.PhasePlanReview {
+				t.Errorf("Checkpoints overwritten to zero-valued planning gates — RoadmapReview/PhasePlanReview should now be false, got %+v", f.Checkpoints)
 			}
 
 			if hookCount != 1 {
@@ -258,17 +258,18 @@ func TestUpdateFeatureConfig_NormalizesCheckpointsForPipeline(t *testing.T) {
 
 	input := orchestrator.UpdateFeatureConfigInput{
 		Checkpoints: feature.Checkpoints{
-			InquiryReview: true,
-			DesignReview:  true,
-			PlanReview:    true,
-			ManualPublish: true,
+			InquiryReview:   true,
+			DesignReview:    true,
+			RoadmapReview:   true,
+			PhasePlanReview: true,
+			ManualPublish:   true,
 		},
 	}
 	if err := o.UpdateFeatureConfig("feat-1", input); err != nil {
 		t.Fatalf("UpdateFeatureConfig: %v", err)
 	}
-	if got := f.Checkpoints; got != (feature.Checkpoints{PlanReview: true, ManualPublish: true}) {
-		t.Fatalf("normalized checkpoints = %+v, want PlanReview+ManualPublish", got)
+	if got := f.Checkpoints; got != (feature.Checkpoints{RoadmapReview: true, PhasePlanReview: true, ManualPublish: true}) {
+		t.Fatalf("normalized checkpoints = %+v, want RoadmapReview+PhasePlanReview+ManualPublish", got)
 	}
 }
 

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -3932,9 +3932,9 @@ func TestPlanLoopDone_NeedsHumanReview_RoadmapCase(t *testing.T) {
 		t.Fatalf("create: %v", err)
 	}
 
-	// Enable PlanReview checkpoint so needs_human_review triggers review (not failure)
+	// Enable the roadmap checkpoint so needs_human_review triggers review (not failure).
 	_ = fm.Store.Modify(f.ID, func(feat *feature.Feature) error {
-		feat.Checkpoints.PlanReview = true
+		feat.Checkpoints.RoadmapReview = true
 		return nil
 	})
 
@@ -4097,7 +4097,7 @@ func TestPlanReviewArtifactResolution_RoadmapWithoutTotalPhases(t *testing.T) {
 		t.Fatalf("create: %v", err)
 	}
 
-	// Enable PlanReview checkpoint so needs_human_review triggers review (not failure).
+	// Enable the roadmap checkpoint so needs_human_review triggers review (not failure).
 	// Advance to Planning — do NOT set TotalRoadmapPhases (leave at 0).
 	// Only set Artifacts["roadmap"] to simulate the roadmap artifact being
 	// emitted before TotalRoadmapPhases is populated.
@@ -4105,7 +4105,7 @@ func TestPlanReviewArtifactResolution_RoadmapWithoutTotalPhases(t *testing.T) {
 	_ = fm.Transition(f.ID, feature.StatusPlanReady)
 	_ = fm.Transition(f.ID, feature.StatusPlanning)
 	_ = fm.Store.Modify(f.ID, func(feat *feature.Feature) error {
-		feat.Checkpoints.PlanReview = true
+		feat.Checkpoints.RoadmapReview = true
 		feat.TotalRoadmapPhases = 0
 		feat.CurrentRoadmapPhase = 0
 		if feat.Artifacts == nil {
@@ -8663,10 +8663,11 @@ func TestCreateFeatureCmdNormalizesExpressGatesBeforeSave(t *testing.T) {
 		Repos:       []string{"test-repo"},
 		Pipeline:    feature.PipelineMedium,
 		Checkpoints: feature.Checkpoints{
-			InquiryReview: true,
-			DesignReview:  true,
-			PlanReview:    true,
-			ManualPublish: true,
+			InquiryReview:   true,
+			DesignReview:    true,
+			RoadmapReview:   true,
+			PhasePlanReview: true,
+			ManualPublish:   true,
 		},
 	}
 
@@ -8686,14 +8687,14 @@ func TestCreateFeatureCmdNormalizesExpressGatesBeforeSave(t *testing.T) {
 	if err != nil {
 		t.Fatalf("loading created feature: %v", err)
 	}
-	want := feature.Checkpoints{PlanReview: true, ManualPublish: true}
+	want := feature.Checkpoints{RoadmapReview: true, PhasePlanReview: true, ManualPublish: true}
 	if feat.Checkpoints != want {
 		t.Fatalf("created feature checkpoints = %+v, want %+v", feat.Checkpoints, want)
 	}
 
 	saved := fm.Config.Repos["test-repo"].PipelineGates["medium"]
-	if saved != (config.Checkpoints{PlanReview: true, ManualPublish: true}) {
-		t.Fatalf("saved medium gates = %+v, want PlanReview+ManualPublish", saved)
+	if saved != (config.Checkpoints{RoadmapReview: true, PhasePlanReview: true, ManualPublish: true}) {
+		t.Fatalf("saved medium gates = %+v, want RoadmapReview+PhasePlanReview+ManualPublish", saved)
 	}
 
 	loaded, err := config.Load(configPath)
@@ -8701,8 +8702,8 @@ func TestCreateFeatureCmdNormalizesExpressGatesBeforeSave(t *testing.T) {
 		t.Fatalf("loading saved config: %v", err)
 	}
 	loadedGates := loaded.Repos["test-repo"].PipelineGates["medium"]
-	if loadedGates.InquiryReview || loadedGates.ResearchReview || loadedGates.DesignReview || !loadedGates.PlanReview || !loadedGates.ManualPublish {
-		t.Fatalf("loaded medium gates = %+v, want PlanReview+ManualPublish", loadedGates)
+	if loadedGates.InquiryReview || loadedGates.ResearchReview || loadedGates.DesignReview || !loadedGates.RoadmapReview || !loadedGates.PhasePlanReview || !loadedGates.ManualPublish {
+		t.Fatalf("loaded medium gates = %+v, want RoadmapReview+PhasePlanReview+ManualPublish", loadedGates)
 	}
 }
 
@@ -8740,7 +8741,7 @@ func TestCreateFeatureCmdSavesGatesToAllRepos(t *testing.T) {
 		Description: "test multi-repo gate save",
 		Repos:       []string{"repo-a", "repo-b"},
 		Pipeline:    feature.PipelineLarge,
-		Checkpoints: feature.Checkpoints{DesignReview: true, PlanReview: true, ManualPublish: true},
+		Checkpoints: feature.Checkpoints{DesignReview: true, RoadmapReview: true, PhasePlanReview: true, ManualPublish: true},
 	}
 
 	cmd := app.createFeatureCmd(result)
@@ -8766,8 +8767,8 @@ func TestCreateFeatureCmdSavesGatesToAllRepos(t *testing.T) {
 			t.Errorf("%s: PipelineGates should have 'large' key", repoName)
 			continue
 		}
-		if !gates.DesignReview || !gates.PlanReview || !gates.ManualPublish {
-			t.Errorf("%s: gates should have DesignReview+PlanReview+ManualPublish, got %+v", repoName, gates)
+		if !gates.DesignReview || !gates.RoadmapReview || !gates.PhasePlanReview || !gates.ManualPublish {
+			t.Errorf("%s: gates should have DesignReview+RoadmapReview+PhasePlanReview+ManualPublish, got %+v", repoName, gates)
 		}
 	}
 }
@@ -8790,10 +8791,11 @@ func TestSaveConfigCmdPersistsNormalizedExpressGatesAfterEdit(t *testing.T) {
 		Models:      config.ModelConfig{Implementation: "claude:sonnet"},
 		Inquireness: feature.InquirenessNone,
 		Checkpoints: feature.Checkpoints{
-			InquiryReview: true,
-			DesignReview:  true,
-			PlanReview:    true,
-			ManualPublish: true,
+			InquiryReview:   true,
+			DesignReview:    true,
+			RoadmapReview:   true,
+			PhasePlanReview: true,
+			ManualPublish:   true,
 		},
 	}, []string{"test-repo"}, feature.PipelineMedium, true)()
 	result, ok := msg.(editConfigResultMsg)
@@ -8808,13 +8810,13 @@ func TestSaveConfigCmdPersistsNormalizedExpressGatesAfterEdit(t *testing.T) {
 	if err != nil {
 		t.Fatalf("reloading feature: %v", err)
 	}
-	if got := savedFeature.Checkpoints; got != (feature.Checkpoints{PlanReview: true, ManualPublish: true}) {
-		t.Fatalf("feature checkpoints = %+v, want PlanReview+ManualPublish", got)
+	if got := savedFeature.Checkpoints; got != (feature.Checkpoints{RoadmapReview: true, PhasePlanReview: true, ManualPublish: true}) {
+		t.Fatalf("feature checkpoints = %+v, want RoadmapReview+PhasePlanReview+ManualPublish", got)
 	}
 
 	gates := fm.Config.Repos["test-repo"].PipelineGates["medium"]
-	if gates != (config.Checkpoints{PlanReview: true, ManualPublish: true}) {
-		t.Fatalf("saved medium gates = %+v, want PlanReview+ManualPublish", gates)
+	if gates != (config.Checkpoints{RoadmapReview: true, PhasePlanReview: true, ManualPublish: true}) {
+		t.Fatalf("saved medium gates = %+v, want RoadmapReview+PhasePlanReview+ManualPublish", gates)
 	}
 
 	loaded, err := config.Load(configPath)
@@ -8822,8 +8824,8 @@ func TestSaveConfigCmdPersistsNormalizedExpressGatesAfterEdit(t *testing.T) {
 		t.Fatalf("loading saved config: %v", err)
 	}
 	got := loaded.Repos["test-repo"].PipelineGates["medium"]
-	if got.InquiryReview || got.ResearchReview || got.DesignReview || !got.PlanReview || !got.ManualPublish {
-		t.Fatalf("loaded medium gates = %+v, want PlanReview+ManualPublish", got)
+	if got.InquiryReview || got.ResearchReview || got.DesignReview || !got.RoadmapReview || !got.PhasePlanReview || !got.ManualPublish {
+		t.Fatalf("loaded medium gates = %+v, want RoadmapReview+PhasePlanReview+ManualPublish", got)
 	}
 }
 

--- a/internal/tui/configeditor.go
+++ b/internal/tui/configeditor.go
@@ -42,7 +42,7 @@ type ConfigEditorModel struct {
 	// rowCursor indexes into a flat logical row list:
 	//   0 .. len(catalog.Fields)-1     : Models rows
 	//   modelsCount                    : Inquireness
-	//   modelsCount+1 .. lastRow()     : Checkpoints (4 base + 1 when publishable)
+	//   modelsCount+1 .. lastRow()     : Checkpoints visible for the active pipeline
 	rowCursor int
 }
 
@@ -72,7 +72,8 @@ var checkpointFields = []checkpointField{
 	{Gate: feature.GateInquiryReview, Label: "Inquiry Review", Desc: "Pause after inquiry before research"},
 	{Gate: feature.GateResearchReview, Label: "Research Review", Desc: "Pause after research before design"},
 	{Gate: feature.GateDesignReview, Label: "Design Review", Desc: "Pause after design before planning"},
-	{Gate: feature.GatePlanReview, Label: "Plan Review", Desc: "Pause after planning before implementation"},
+	{Gate: feature.GateRoadmapReview, Label: "Roadmap Review", Desc: "Pause after roadmap before phase planning"},
+	{Gate: feature.GatePhasePlanReview, Label: "Phase Plan Review", Desc: "Pause after each phase plan before implementation"},
 	{Gate: feature.GateManualPublish, Label: "Manual Publish", Desc: "Review diff and PR before publishing"},
 }
 
@@ -243,7 +244,10 @@ func (m ConfigEditorModel) CheckpointsChangeCount() int {
 	if cp.DesignReview != orig.DesignReview {
 		count++
 	}
-	if cp.PlanReview != orig.PlanReview {
+	if cp.RoadmapReview != orig.RoadmapReview {
+		count++
+	}
+	if cp.PhasePlanReview != orig.PhasePlanReview {
 		count++
 	}
 	if cp.ManualPublish != orig.ManualPublish {
@@ -427,6 +431,9 @@ func (m *ConfigEditorModel) toggleCurrentCheckpoint() {
 		return
 	}
 	m.setCheckpointValue(fields[idx].Gate, !m.checkpointValue(fields[idx].Gate))
+	if last := m.lastRow(); m.rowCursor > last {
+		m.rowCursor = last
+	}
 }
 
 func (m ConfigEditorModel) checkpointValue(gate feature.GateIndex) bool {
@@ -437,8 +444,10 @@ func (m ConfigEditorModel) checkpointValue(gate feature.GateIndex) bool {
 		return m.checkpoints.ResearchReview
 	case feature.GateDesignReview:
 		return m.checkpoints.DesignReview
-	case feature.GatePlanReview:
-		return m.checkpoints.PlanReview
+	case feature.GateRoadmapReview:
+		return m.checkpoints.RoadmapReview
+	case feature.GatePhasePlanReview:
+		return m.checkpoints.PhasePlanReview
 	case feature.GateManualPublish:
 		return m.checkpoints.ManualPublish
 	}
@@ -453,8 +462,11 @@ func (m *ConfigEditorModel) setCheckpointValue(gate feature.GateIndex, value boo
 		m.checkpoints.ResearchReview = value
 	case feature.GateDesignReview:
 		m.checkpoints.DesignReview = value
-	case feature.GatePlanReview:
-		m.checkpoints.PlanReview = value
+	case feature.GateRoadmapReview:
+		m.checkpoints.RoadmapReview = value
+		m.checkpoints.PhasePlanReview = value
+	case feature.GatePhasePlanReview:
+		m.checkpoints.PhasePlanReview = value
 	case feature.GateManualPublish:
 		m.checkpoints.ManualPublish = value
 	}
@@ -464,6 +476,9 @@ func (m ConfigEditorModel) visibleCheckpointFields() []checkpointField {
 	projection := m.pipeline.ProjectGates(m.checkpoints, m.provisionalPublishable)
 	fields := make([]checkpointField, 0, len(projection.Visible))
 	for _, gate := range projection.Visible {
+		if gate == feature.GatePhasePlanReview && !m.checkpoints.RoadmapReview && !m.checkpoints.PhasePlanReview {
+			continue
+		}
 		for _, field := range checkpointFields {
 			if field.Gate == gate {
 				fields = append(fields, field)
@@ -660,15 +675,18 @@ func (m ConfigEditorModel) renderCheckpointsBox(_ int) string {
 	title := lipgloss.NewStyle().Bold(true).Render("Gates")
 	lines := []string{title}
 	fields := m.visibleCheckpointFields()
-	for i, cp := range fields {
+	for i, field := range fields {
 		box := "[ ]"
-		if m.checkpointValue(cp.Gate) {
+		if m.checkpointValue(field.Gate) {
 			box = SuccessStyle.Render("[x]")
 		} else {
 			box = MutedStyle.Render("[ ]")
 		}
-		label := cp.Label
-		desc := MutedStyle.Render(cp.Desc)
+		label := field.Label
+		if field.Gate == feature.GatePhasePlanReview {
+			label = "  " + label
+		}
+		desc := MutedStyle.Render(field.Desc)
 		prefix := "  "
 		rendered := fmt.Sprintf("%s %-18s %s", box, label, desc)
 		if m.rowCategory() == rowCatCheckpoints && m.checkpointIndexForRow(m.rowCursor) == i {

--- a/internal/tui/configeditor_test.go
+++ b/internal/tui/configeditor_test.go
@@ -417,6 +417,8 @@ func TestConfigEditor_CheckpointRowsFollowPipelineProfile(t *testing.T) {
 }
 
 func TestConfigEditor_PhasePlanReviewVisibilityFollowsRoadmapReview(t *testing.T) {
+	t.Parallel()
+
 	e := newEditor(&feature.Feature{
 		Pipeline:    feature.PipelineMedium,
 		Checkpoints: feature.Checkpoints{ManualPublish: true},
@@ -442,6 +444,8 @@ func TestConfigEditor_PhasePlanReviewVisibilityFollowsRoadmapReview(t *testing.T
 }
 
 func TestConfigEditor_PhasePlanOnlyManualConfigIsVisible(t *testing.T) {
+	t.Parallel()
+
 	e := newEditor(&feature.Feature{
 		Pipeline: feature.PipelineMedium,
 		Checkpoints: feature.Checkpoints{
@@ -457,6 +461,8 @@ func TestConfigEditor_PhasePlanOnlyManualConfigIsVisible(t *testing.T) {
 }
 
 func TestConfigEditor_PhasePlanOnlyUnpublishedToggleClampsCursor(t *testing.T) {
+	t.Parallel()
+
 	e := newEditor(&feature.Feature{
 		Pipeline: feature.PipelineMedium,
 		Checkpoints: feature.Checkpoints{

--- a/internal/tui/configeditor_test.go
+++ b/internal/tui/configeditor_test.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/charmbracelet/x/ansi"
 	"github.com/doordash-oss/agentic-orchestrator/internal/config"
 	"github.com/doordash-oss/agentic-orchestrator/internal/feature"
 
@@ -71,6 +72,26 @@ func checkpointRowForGate(t *testing.T, e ConfigEditorModel, gate feature.GateIn
 	}
 	t.Fatalf("gate %v not visible in editor", gate)
 	return 0
+}
+
+func checkpointViewContainsLabel(view, label string) bool {
+	for _, line := range strings.Split(ansi.Strip(view), "\n") {
+		row := strings.TrimSpace(line)
+		row = strings.TrimPrefix(row, "▸ ")
+		switch {
+		case strings.HasPrefix(row, "[x] "):
+			row = strings.TrimPrefix(row, "[x] ")
+		case strings.HasPrefix(row, "[ ] "):
+			row = strings.TrimPrefix(row, "[ ] ")
+		default:
+			continue
+		}
+		row = strings.TrimLeft(row, " ")
+		if row == label || strings.HasPrefix(row, label+" ") {
+			return true
+		}
+	}
+	return false
 }
 
 func TestConfigEditor_RowCursor_FlatWalk(t *testing.T) {
@@ -296,7 +317,7 @@ func TestConfigEditor_CheckpointsToggle(t *testing.T) {
 		{"InquiryReview", feature.GateInquiryReview, func(c feature.Checkpoints) bool { return c.InquiryReview }},
 		{"ResearchReview", feature.GateResearchReview, func(c feature.Checkpoints) bool { return c.ResearchReview }},
 		{"DesignReview", feature.GateDesignReview, func(c feature.Checkpoints) bool { return c.DesignReview }},
-		{"PlanReview", feature.GatePlanReview, func(c feature.Checkpoints) bool { return c.PlanReview }},
+		{"RoadmapReview", feature.GateRoadmapReview, func(c feature.Checkpoints) bool { return c.RoadmapReview }},
 	}
 	for _, tc := range toggles {
 		t.Run(tc.name, func(t *testing.T) {
@@ -318,12 +339,12 @@ func TestConfigEditor_CheckpointsToggle(t *testing.T) {
 func TestConfigEditor_CheckpointsToggle_ManualPublishHidden(t *testing.T) {
 	t.Parallel()
 	e := newEditor(&feature.Feature{Pipeline: feature.PipelineMoonshot}, false) // ManualPublish hidden
-	e.rowCursor = checkpointRowForGate(t, e, feature.GatePlanReview)
+	e.rowCursor = checkpointRowForGate(t, e, feature.GateRoadmapReview)
 	before := e.Snapshot().Checkpoints
 	e, _ = e.Update(tea.KeyPressMsg{Code: ' ', Text: " "})
 	after := e.Snapshot().Checkpoints
-	if after.PlanReview == before.PlanReview {
-		t.Errorf("space on last visible row did not toggle PlanReview")
+	if after.RoadmapReview == before.RoadmapReview {
+		t.Errorf("space on last visible row did not toggle RoadmapReview")
 	}
 	// ManualPublish remains forced on regardless of internal state.
 	if !after.ManualPublish {
@@ -342,26 +363,35 @@ func TestConfigEditor_CheckpointRowsFollowPipelineProfile(t *testing.T) {
 		wantCP      feature.Checkpoints
 	}{
 		{
-			name: "medium shows plan and manual publish",
+			name: "medium shows roadmap phase-plan and manual publish",
 			feature: &feature.Feature{
-				Pipeline:    feature.PipelineMedium,
-				Checkpoints: feature.Checkpoints{InquiryReview: true, DesignReview: true, PlanReview: true, ManualPublish: true},
+				Pipeline: feature.PipelineMedium,
+				Checkpoints: feature.Checkpoints{
+					RoadmapReview:   true,
+					PhasePlanReview: true,
+					ManualPublish:   true,
+				},
 			},
 			publishable: true,
-			wantRows:    []string{"Plan Review", "Manual Publish"},
-			wantHidden:  []string{"Inquiry Review", "Research Review", "Design Review"},
-			wantCP:      feature.Checkpoints{PlanReview: true, ManualPublish: true},
+			wantRows:    []string{"Roadmap Review", "Phase Plan Review", "Manual Publish"},
+			wantHidden:  []string{"Inquiry Review", "Research Review", "Design Review", "Plan Review"},
+			wantCP:      feature.Checkpoints{RoadmapReview: true, PhasePlanReview: true, ManualPublish: true},
 		},
 		{
 			name: "unpublished large hides manual publish row but keeps every review gate",
 			feature: &feature.Feature{
-				Pipeline:    feature.PipelineLarge,
-				Checkpoints: feature.Checkpoints{DesignReview: true, PlanReview: true, ManualPublish: false},
+				Pipeline: feature.PipelineLarge,
+				Checkpoints: feature.Checkpoints{
+					DesignReview:    true,
+					RoadmapReview:   true,
+					PhasePlanReview: true,
+					ManualPublish:   false,
+				},
 			},
 			publishable: false,
-			wantRows:    []string{"Inquiry Review", "Research Review", "Design Review", "Plan Review"},
-			wantHidden:  []string{"Manual Publish"},
-			wantCP:      feature.Checkpoints{DesignReview: true, PlanReview: true, ManualPublish: true},
+			wantRows:    []string{"Inquiry Review", "Research Review", "Design Review", "Roadmap Review", "Phase Plan Review"},
+			wantHidden:  []string{"Manual Publish", "Plan Review"},
+			wantCP:      feature.Checkpoints{DesignReview: true, RoadmapReview: true, PhasePlanReview: true, ManualPublish: true},
 		},
 	}
 
@@ -370,12 +400,12 @@ func TestConfigEditor_CheckpointRowsFollowPipelineProfile(t *testing.T) {
 			e := newEditor(tt.feature, tt.publishable)
 			view := e.renderCheckpointsBox(120)
 			for _, label := range tt.wantRows {
-				if !strings.Contains(view, label) {
+				if !checkpointViewContainsLabel(view, label) {
 					t.Fatalf("renderCheckpointsBox missing %q\n%s", label, view)
 				}
 			}
 			for _, label := range tt.wantHidden {
-				if strings.Contains(view, label) {
+				if checkpointViewContainsLabel(view, label) {
 					t.Fatalf("renderCheckpointsBox unexpectedly contained %q\n%s", label, view)
 				}
 			}
@@ -383,6 +413,65 @@ func TestConfigEditor_CheckpointRowsFollowPipelineProfile(t *testing.T) {
 				t.Fatalf("Snapshot checkpoints = %+v, want %+v", got, tt.wantCP)
 			}
 		})
+	}
+}
+
+func TestConfigEditor_PhasePlanReviewVisibilityFollowsRoadmapReview(t *testing.T) {
+	e := newEditor(&feature.Feature{
+		Pipeline:    feature.PipelineMedium,
+		Checkpoints: feature.Checkpoints{ManualPublish: true},
+	}, true)
+
+	view := e.renderCheckpointsBox(120)
+	if strings.Contains(view, "Phase Plan Review") {
+		t.Fatalf("phase plan review should be hidden when both planning gates are off:\n%s", view)
+	}
+
+	e.rowCursor = checkpointRowForGate(t, e, feature.GateRoadmapReview)
+	e, _ = e.Update(tea.KeyPressMsg{Code: ' ', Text: " "})
+	cp := e.Snapshot().Checkpoints
+	if !cp.RoadmapReview || !cp.PhasePlanReview {
+		t.Fatalf("turning roadmap review on should restore phase plan review on, got %+v", cp)
+	}
+
+	e, _ = e.Update(tea.KeyPressMsg{Code: ' ', Text: " "})
+	cp = e.Snapshot().Checkpoints
+	if cp.RoadmapReview || cp.PhasePlanReview {
+		t.Fatalf("turning roadmap review off should turn phase plan review off, got %+v", cp)
+	}
+}
+
+func TestConfigEditor_PhasePlanOnlyManualConfigIsVisible(t *testing.T) {
+	e := newEditor(&feature.Feature{
+		Pipeline: feature.PipelineMedium,
+		Checkpoints: feature.Checkpoints{
+			PhasePlanReview: true,
+			ManualPublish:   true,
+		},
+	}, true)
+
+	view := e.renderCheckpointsBox(120)
+	if !strings.Contains(view, "Phase Plan Review") {
+		t.Fatalf("manual phase-plan-only config should be visible:\n%s", view)
+	}
+}
+
+func TestConfigEditor_PhasePlanOnlyUnpublishedToggleClampsCursor(t *testing.T) {
+	e := newEditor(&feature.Feature{
+		Pipeline: feature.PipelineMedium,
+		Checkpoints: feature.Checkpoints{
+			PhasePlanReview: true,
+		},
+	}, false)
+
+	e.rowCursor = checkpointRowForGate(t, e, feature.GatePhasePlanReview)
+	e, _ = e.Update(tea.KeyPressMsg{Code: ' ', Text: " "})
+
+	if e.rowCursor > e.lastRow() {
+		t.Fatalf("rowCursor should be clamped after hiding phase plan review: got rowCursor=%d lastRow=%d", e.rowCursor, e.lastRow())
+	}
+	if want := checkpointRowForGate(t, e, feature.GateRoadmapReview); e.rowCursor != want {
+		t.Fatalf("rowCursor should land on roadmap review after phase plan row hides: got %d, want %d", e.rowCursor, want)
 	}
 }
 

--- a/internal/tui/editconfig_test.go
+++ b/internal/tui/editconfig_test.go
@@ -268,7 +268,8 @@ func TestEditConfig_EnterDispatchesSaveWithAllAxes(t *testing.T) {
 	// Dirty all three axes.
 	app.editConfig.editor.inquireness = feature.InquirenessHigh
 	app.editConfig.editor.models.Research = "new-research"
-	app.editConfig.editor.checkpoints.PlanReview = true
+	app.editConfig.editor.checkpoints.RoadmapReview = true
+	app.editConfig.editor.checkpoints.PhasePlanReview = true
 
 	updated, cmd := app.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
 	got := updated.(AppModel)
@@ -293,8 +294,11 @@ func TestEditConfig_EnterDispatchesSaveWithAllAxes(t *testing.T) {
 	if call.Input.Models.Research != "new-research" {
 		t.Errorf("Models.Research = %q, want new-research", call.Input.Models.Research)
 	}
-	if !call.Input.Checkpoints.PlanReview {
-		t.Error("Checkpoints.PlanReview should be true")
+	if !call.Input.Checkpoints.RoadmapReview {
+		t.Error("Checkpoints.RoadmapReview should be true")
+	}
+	if !call.Input.Checkpoints.PhasePlanReview {
+		t.Error("Checkpoints.PhasePlanReview should be true")
 	}
 }
 
@@ -359,10 +363,11 @@ func TestEditConfig_DiffSummaryFooter(t *testing.T) {
 			mutate: func(m *EditConfigModel) {
 				m.editor.models.Research = "r2"
 				m.editor.models.Planning = "p2"
-				m.editor.checkpoints.PlanReview = true
+				m.editor.checkpoints.RoadmapReview = true
+				m.editor.checkpoints.PhasePlanReview = true
 				m.editor.inquireness = feature.InquirenessNone
 			},
-			want: []string{"Models: 2 changes", "Gates: 1 change", "Inquiry: changed"},
+			want: []string{"Models: 2 changes", "Gates: 2 changes", "Inquiry: changed"},
 		},
 	}
 	for _, tc := range cases {

--- a/internal/tui/grill_me_smoke_test.go
+++ b/internal/tui/grill_me_smoke_test.go
@@ -95,10 +95,11 @@ func TestInquirePhase_GrillMe_SmokeEndToEnd(t *testing.T) {
 				// touch a real PhaseRunner / model registry once the inquire
 				// gate lands.
 				ff.Checkpoints = feature.Checkpoints{
-					InquiryReview:  true,
-					ResearchReview: true,
-					DesignReview:   true,
-					PlanReview:     true,
+					InquiryReview:   true,
+					ResearchReview:  true,
+					DesignReview:    true,
+					RoadmapReview:   true,
+					PhasePlanReview: true,
 				}
 				return nil
 			})

--- a/internal/tui/orchestrator_bridge_test.go
+++ b/internal/tui/orchestrator_bridge_test.go
@@ -889,9 +889,10 @@ func TestTUI_CreateFeatureCmd_DelegatesCompleteWizardResultToOrchestrator(t *tes
 		Pipeline:         feature.PipelineMedium,
 		UseCurrentBranch: true,
 		Checkpoints: feature.Checkpoints{
-			InquiryReview: true,
-			PlanReview:    true,
-			ManualPublish: true,
+			InquiryReview:   true,
+			RoadmapReview:   true,
+			PhasePlanReview: true,
+			ManualPublish:   true,
 		},
 	}
 

--- a/internal/tui/qa_persistence_gate_test.go
+++ b/internal/tui/qa_persistence_gate_test.go
@@ -112,10 +112,11 @@ func TestTUI_HandleSessionDone_QAWritesForInteractivePlanningPhases(t *testing.T
 				ff.Status = statusForPhase(tc.phase)
 				ff.CurrentPhase = tc.phase
 				ff.Checkpoints = feature.Checkpoints{
-					InquiryReview:  true,
-					ResearchReview: true,
-					DesignReview:   true,
-					PlanReview:     true,
+					InquiryReview:   true,
+					ResearchReview:  true,
+					DesignReview:    true,
+					RoadmapReview:   true,
+					PhasePlanReview: true,
 				}
 				return nil
 			})

--- a/internal/tui/wizard.go
+++ b/internal/tui/wizard.go
@@ -171,6 +171,7 @@ type WizardModel struct {
 	showBranchWarning       bool             // true when the dedicated branch-selection screen replaces the Where panel
 	checkpointsCursor       int              // which checkpoint row is focused
 	checkpoints             [checkpointCount]bool
+	checkpointDefaults      feature.Checkpoints
 	result                  *WizardResult
 	cancelled               bool
 	width, height           int
@@ -317,13 +318,14 @@ func NewWizardModel(availRepos []string, repoPaths map[string]string, repoConfig
 	crni.CharLimit = 100
 
 	// Initialize checkpoint toggles from config defaults.
+	checkpointDefaults := feature.ConfigCheckpointsToFeature(defaults.Checkpoints)
 	var initCheckpoints [checkpointCount]bool
-	initCheckpoints[checkpointInquiryReview] = defaults.Checkpoints.InquiryReview
-	initCheckpoints[checkpointResearchReview] = defaults.Checkpoints.ResearchReview
-	initCheckpoints[checkpointDesignReview] = defaults.Checkpoints.DesignReview
-	initCheckpoints[checkpointRoadmapReview] = defaults.Checkpoints.RoadmapReview
-	initCheckpoints[checkpointPhasePlanReview] = defaults.Checkpoints.PhasePlanReview
-	initCheckpoints[checkpointManualPublish] = defaults.Checkpoints.ManualPublish
+	initCheckpoints[checkpointInquiryReview] = checkpointDefaults.InquiryReview
+	initCheckpoints[checkpointResearchReview] = checkpointDefaults.ResearchReview
+	initCheckpoints[checkpointDesignReview] = checkpointDefaults.DesignReview
+	initCheckpoints[checkpointRoadmapReview] = checkpointDefaults.RoadmapReview
+	initCheckpoints[checkpointPhasePlanReview] = checkpointDefaults.PhasePlanReview
+	initCheckpoints[checkpointManualPublish] = checkpointDefaults.ManualPublish
 
 	pipelineOptions := []string{
 		feature.PipelineMedium.ConfigKey(),
@@ -388,6 +390,7 @@ func NewWizardModel(availRepos []string, repoPaths map[string]string, repoConfig
 		inquirenessOptions:     []string{"none", "medium", "high"},
 		inquirenessCursor:      inquirenessCursor,
 		checkpoints:            initCheckpoints,
+		checkpointDefaults:     checkpointDefaults,
 		riskOptions:            []string{"low", "medium", "high"},
 		riskCursor:             1, // default to medium
 		pipelineOptions:        pipelineOptions,
@@ -551,7 +554,7 @@ func (m *WizardModel) pipelineCheckpointOverrides(opt string) []feature.Checkpoi
 func (m *WizardModel) mergedPipelineCheckpoints(opt string) (feature.Checkpoints, bool) {
 	profile := pipelineProfileFromKey(opt)
 	projection := profile.ProjectMergedGates(
-		feature.DefaultCheckpointsForProfile(profile),
+		m.checkpointDefaults,
 		m.pipelineCheckpointOverrides(opt),
 		m.provisionalPublishable,
 	)
@@ -581,7 +584,7 @@ func (m *WizardModel) setCheckpointState(cp feature.Checkpoints) {
 func (m *WizardModel) projectedPipelineCheckpoints(opt string) feature.GateProjection {
 	profile := pipelineProfileFromKey(opt)
 	return profile.ProjectMergedGates(
-		feature.DefaultCheckpointsForProfile(profile),
+		m.checkpointDefaults,
 		m.pipelineCheckpointOverrides(opt),
 		m.provisionalPublishable,
 	)
@@ -649,7 +652,7 @@ func availableGateLabels(projection feature.GateProjection) []string {
 }
 
 // applyPipelineDefaults updates checkpoints to match the selected pipeline profile.
-// It first applies the profile defaults, then checks for per-repo pipeline_gates
+// It first applies the configured defaults, then checks for per-repo pipeline_gates
 // config overrides (matching the logic used for card rendering in step 3).
 func (m *WizardModel) applyPipelineDefaults() {
 	opt := m.pipelineOptions[m.pipelineCursor]

--- a/internal/tui/wizard.go
+++ b/internal/tui/wizard.go
@@ -84,6 +84,16 @@ const (
 	summaryFieldExitCriteria
 )
 
+const (
+	checkpointInquiryReview = iota
+	checkpointResearchReview
+	checkpointDesignReview
+	checkpointRoadmapReview
+	checkpointPhasePlanReview
+	checkpointManualPublish
+	checkpointCount
+)
+
 type modelProviderGroup struct {
 	Name   string
 	Models []string
@@ -159,8 +169,8 @@ type WizardModel struct {
 	branchOptionCursor      int              // 0 = start from default branch (recommended), 1 = start from current branch
 	branchChoices           map[string]bool  // repo name -> useCurrentBranch (true = start from current HEAD)
 	showBranchWarning       bool             // true when the dedicated branch-selection screen replaces the Where panel
-	checkpointsCursor       int              // which row is focused (0-4)
-	checkpoints             [5]bool          // toggle state for each checkpoint item
+	checkpointsCursor       int              // which checkpoint row is focused
+	checkpoints             [checkpointCount]bool
 	result                  *WizardResult
 	cancelled               bool
 	width, height           int
@@ -307,12 +317,13 @@ func NewWizardModel(availRepos []string, repoPaths map[string]string, repoConfig
 	crni.CharLimit = 100
 
 	// Initialize checkpoint toggles from config defaults.
-	var initCheckpoints [5]bool
-	initCheckpoints[0] = defaults.Checkpoints.InquiryReview
-	initCheckpoints[1] = defaults.Checkpoints.ResearchReview
-	initCheckpoints[2] = defaults.Checkpoints.DesignReview
-	initCheckpoints[3] = defaults.Checkpoints.PlanReview
-	initCheckpoints[4] = defaults.Checkpoints.ManualPublish
+	var initCheckpoints [checkpointCount]bool
+	initCheckpoints[checkpointInquiryReview] = defaults.Checkpoints.InquiryReview
+	initCheckpoints[checkpointResearchReview] = defaults.Checkpoints.ResearchReview
+	initCheckpoints[checkpointDesignReview] = defaults.Checkpoints.DesignReview
+	initCheckpoints[checkpointRoadmapReview] = defaults.Checkpoints.RoadmapReview
+	initCheckpoints[checkpointPhasePlanReview] = defaults.Checkpoints.PhasePlanReview
+	initCheckpoints[checkpointManualPublish] = defaults.Checkpoints.ManualPublish
 
 	pipelineOptions := []string{
 		feature.PipelineMedium.ConfigKey(),
@@ -549,20 +560,22 @@ func (m *WizardModel) mergedPipelineCheckpoints(opt string) (feature.Checkpoints
 
 func (m *WizardModel) checkpointState() feature.Checkpoints {
 	return feature.Checkpoints{
-		InquiryReview:  m.checkpoints[0],
-		ResearchReview: m.checkpoints[1],
-		DesignReview:   m.checkpoints[2],
-		PlanReview:     m.checkpoints[3],
-		ManualPublish:  m.checkpoints[4],
+		InquiryReview:   m.checkpoints[checkpointInquiryReview],
+		ResearchReview:  m.checkpoints[checkpointResearchReview],
+		DesignReview:    m.checkpoints[checkpointDesignReview],
+		RoadmapReview:   m.checkpoints[checkpointRoadmapReview],
+		PhasePlanReview: m.checkpoints[checkpointPhasePlanReview],
+		ManualPublish:   m.checkpoints[checkpointManualPublish],
 	}
 }
 
 func (m *WizardModel) setCheckpointState(cp feature.Checkpoints) {
-	m.checkpoints[0] = cp.InquiryReview
-	m.checkpoints[1] = cp.ResearchReview
-	m.checkpoints[2] = cp.DesignReview
-	m.checkpoints[3] = cp.PlanReview
-	m.checkpoints[4] = cp.ManualPublish
+	m.checkpoints[checkpointInquiryReview] = cp.InquiryReview
+	m.checkpoints[checkpointResearchReview] = cp.ResearchReview
+	m.checkpoints[checkpointDesignReview] = cp.DesignReview
+	m.checkpoints[checkpointRoadmapReview] = cp.RoadmapReview
+	m.checkpoints[checkpointPhasePlanReview] = cp.PhasePlanReview
+	m.checkpoints[checkpointManualPublish] = cp.ManualPublish
 }
 
 func (m *WizardModel) projectedPipelineCheckpoints(opt string) feature.GateProjection {
@@ -597,9 +610,13 @@ func gateLabels(projection feature.GateProjection) []string {
 			if projection.Checkpoints.DesignReview {
 				gates = append(gates, "Design review")
 			}
-		case feature.GatePlanReview:
-			if projection.Checkpoints.PlanReview {
-				gates = append(gates, "Plan review")
+		case feature.GateRoadmapReview:
+			if projection.Checkpoints.RoadmapReview {
+				gates = append(gates, "Roadmap review")
+			}
+		case feature.GatePhasePlanReview:
+			if projection.Checkpoints.PhasePlanReview {
+				gates = append(gates, "Phase plan review")
 			}
 		case feature.GateManualPublish:
 			if projection.Checkpoints.ManualPublish {
@@ -620,8 +637,10 @@ func availableGateLabels(projection feature.GateProjection) []string {
 			gates = append(gates, "Research review")
 		case feature.GateDesignReview:
 			gates = append(gates, "Design review")
-		case feature.GatePlanReview:
-			gates = append(gates, "Plan review")
+		case feature.GateRoadmapReview:
+			gates = append(gates, "Roadmap review")
+		case feature.GatePhasePlanReview:
+			gates = append(gates, "Phase plan review")
 		case feature.GateManualPublish:
 			gates = append(gates, "Publish review")
 		}
@@ -637,7 +656,7 @@ func (m *WizardModel) applyPipelineDefaults() {
 	projection := m.projectedPipelineCheckpoints(opt)
 	m.setCheckpointState(projection.Checkpoints)
 	if !m.provisionalPublishable {
-		m.checkpoints[4] = true // force ManualPublish when unpublished
+		m.checkpoints[checkpointManualPublish] = true // force ManualPublish when unpublished
 	}
 }
 
@@ -722,13 +741,7 @@ func (m *WizardModel) virtualConfigFeature() *feature.Feature {
 		Pipeline:    pipelineProfileFromKey(m.currentPipelineKey()),
 		Models:      m.models,
 		Inquireness: inq,
-		Checkpoints: feature.Checkpoints{
-			InquiryReview:  m.checkpoints[0],
-			ResearchReview: m.checkpoints[1],
-			DesignReview:   m.checkpoints[2],
-			PlanReview:     m.checkpoints[3],
-			ManualPublish:  m.checkpoints[4],
-		},
+		Checkpoints: m.checkpointState(),
 	}
 }
 
@@ -784,8 +797,8 @@ func (m *WizardModel) syncConfigEditorFromWizard() {
 // syncWizardFromConfigEditor copies the editor's post-Update internal state
 // back into wizard fields. Uses the editor's raw internal `checkpoints`
 // field — NOT `Snapshot()` — so the wizard's pre-Phase-3 semantics where
-// m.checkpoints[4] retains its init value when !provisionalPublishable are
-// preserved (Snapshot() forces ManualPublish=true).
+// m.checkpoints[checkpointManualPublish] retains its init value when
+// !provisionalPublishable are preserved (Snapshot() forces ManualPublish=true).
 func (m *WizardModel) syncWizardFromConfigEditor() {
 	m.models = m.configEditor.models
 	m.inquirenessCursor = indexOfInquireness(m.configEditor.inquireness, m.inquirenessOptions)

--- a/internal/tui/wizard_delegation_test.go
+++ b/internal/tui/wizard_delegation_test.go
@@ -202,16 +202,16 @@ func TestWizardReviewDelegation_CheckpointsSpaceToggles(t *testing.T) {
 	m.summaryCursor = summaryFieldCheckpoints
 	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
 
-	orig := m.checkpoints[0]
+	orig := m.checkpoints[checkpointInquiryReview]
 	m, _ = m.Update(tea.KeyPressMsg{Code: ' ', Text: " "})
-	if m.checkpoints[0] == orig {
-		t.Error("Space did not toggle checkpoint[0]")
+	if m.checkpoints[checkpointInquiryReview] == orig {
+		t.Error("Space did not toggle InquiryReview checkpoint")
 	}
 	if !m.checkpointsManuallySet {
 		t.Error("expected checkpointsManuallySet=true after Space")
 	}
 	m, _ = m.Update(tea.KeyPressMsg{Code: ' ', Text: " "})
-	if m.checkpoints[0] != orig {
+	if m.checkpoints[checkpointInquiryReview] != orig {
 		t.Error("second Space did not toggle back")
 	}
 }
@@ -221,10 +221,10 @@ func TestWizardReviewDelegation_CheckpointsTabTogglesNotJumps(t *testing.T) {
 	m.summaryCursor = summaryFieldCheckpoints
 	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
 
-	orig := m.checkpoints[0]
+	orig := m.checkpoints[checkpointInquiryReview]
 	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyTab})
-	if m.checkpoints[0] == orig {
-		t.Error("Tab on Checkpoints did not toggle checkpoint[0] (wizard reshape failed)")
+	if m.checkpoints[checkpointInquiryReview] == orig {
+		t.Error("Tab on Checkpoints did not toggle InquiryReview checkpoint (wizard reshape failed)")
 	}
 	if m.checkpointsCursor != 0 {
 		t.Errorf("Tab on Checkpoints moved sub-cursor: got %d, want 0", m.checkpointsCursor)
@@ -246,23 +246,23 @@ func TestWizardReviewDelegation_CheckpointsUpDownClampedAtBounds(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
 	}
-	if m.checkpointsCursor != 4 {
-		t.Errorf("Down × 10 (publishable=true): got %d, want 4 (clamped)", m.checkpointsCursor)
+	if m.checkpointsCursor != checkpointManualPublish {
+		t.Errorf("Down × 10 (publishable=true): got %d, want %d (clamped)", m.checkpointsCursor, checkpointManualPublish)
 	}
 }
 
 func TestWizardReviewDelegation_CheckpointsManualPublishHidden_Parity(t *testing.T) {
 	m := newWizardAtReviewForDelegation(t, nil, nil, nil)
 	m.provisionalPublishable = false
-	initManualPublish := m.checkpoints[4]
+	initManualPublish := m.checkpoints[checkpointManualPublish]
 	m.summaryCursor = summaryFieldCheckpoints
 	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
 
 	for i := 0; i < 10; i++ {
 		m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
 	}
-	if m.checkpointsCursor != 3 {
-		t.Errorf("Down × 10 (publishable=false): got %d, want 3 (row 4 hidden)", m.checkpointsCursor)
+	if m.checkpointsCursor != checkpointPhasePlanReview {
+		t.Errorf("Down × 10 (publishable=false): got %d, want %d (manual publish row hidden)", m.checkpointsCursor, checkpointPhasePlanReview)
 	}
 
 	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEnter}) // collapse
@@ -312,8 +312,8 @@ func TestWizardReviewDelegation_GateRoundTripAllThreeAxes(t *testing.T) {
 	if r.Inquireness != inquirenessVal {
 		t.Errorf("Inquireness = %q, want %q", r.Inquireness, inquirenessVal)
 	}
-	if !r.Checkpoints.InquiryReview {
-		t.Errorf("Checkpoints.InquiryReview = %v, want true after toggling the visible thorough gate", r.Checkpoints.InquiryReview)
+	if r.Checkpoints.InquiryReview {
+		t.Errorf("Checkpoints.InquiryReview = %v, want false after toggling the visible thorough gate", r.Checkpoints.InquiryReview)
 	}
 }
 
@@ -433,7 +433,7 @@ func TestWizardReviewDelegation_CheckpointsEditorRendersGates(t *testing.T) {
 	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
 
 	view := m.View()
-	for _, needle := range []string{"Gates", "Inquiry Review", "Research Review", "Design Review", "Plan Review"} {
+	for _, needle := range []string{"Gates", "Inquiry Review", "Research Review", "Design Review", "Roadmap Review", "Phase Plan Review"} {
 		if !strings.Contains(view, needle) {
 			t.Errorf("rendered Checkpoints editor missing %q", needle)
 		}

--- a/internal/tui/wizard_delegation_test.go
+++ b/internal/tui/wizard_delegation_test.go
@@ -32,15 +32,15 @@ import (
 
 func newWizardAtReviewForDelegation(t *testing.T, providerModels map[string][]string, providerOrder []string, phaseModels map[string]map[string][]string) WizardModel {
 	t.Helper()
-	defaults := config.DefaultsConfig{
-		Models: config.ModelConfig{
-			Research:       "opus",
-			Planning:       "opus",
-			Implementation: "opus",
-			Review:         "opus",
-			KBBuild:        "opus",
-		},
+	defaults := config.NewDefault().Defaults
+	defaults.Models = config.ModelConfig{
+		Research:       "opus",
+		Planning:       "opus",
+		Implementation: "opus",
+		Review:         "opus",
+		KBBuild:        "opus",
 	}
+	defaults.Inquireness = "medium"
 	m := NewWizardModel(nil, nil, nil, defaults, "", providerModels, providerOrder, nil, phaseModels, nil, nil)
 	m.nameInput.SetValue("feat")
 	m, _ = m.advance() // What → Where

--- a/internal/tui/wizard_test.go
+++ b/internal/tui/wizard_test.go
@@ -36,6 +36,19 @@ func advanceWizardToWhereViaUI(m WizardModel, name string) WizardModel {
 	return m
 }
 
+func normalizedWizardViewText(view string) string {
+	return strings.Join(strings.Fields(ansiRegex.ReplaceAllString(view, "")), " ")
+}
+
+func requireWizardViewContainsAll(t *testing.T, view string, needles ...string) {
+	t.Helper()
+	for _, needle := range needles {
+		if !strings.Contains(view, needle) {
+			t.Fatalf("wizard view missing %q:\n%s", needle, view)
+		}
+	}
+}
+
 func TestWizardSteps(t *testing.T) {
 	repos := []string{"repo-a", "repo-b"}
 	defaults := config.DefaultsConfig{
@@ -2925,10 +2938,18 @@ func TestWizardSummaryCheckpointsUpDownNavigation(t *testing.T) {
 		t.Errorf("expected 4, got %d", m.checkpointsCursor)
 	}
 	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
-	if m.checkpointsCursor != 4 {
-		t.Errorf("expected 4 (clamped), got %d", m.checkpointsCursor)
+	if m.checkpointsCursor != 5 {
+		t.Errorf("expected 5, got %d", m.checkpointsCursor)
+	}
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	if m.checkpointsCursor != 5 {
+		t.Errorf("expected 5 (clamped), got %d", m.checkpointsCursor)
 	}
 
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyUp})
+	if m.checkpointsCursor != 4 {
+		t.Errorf("expected 4, got %d", m.checkpointsCursor)
+	}
 	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyUp})
 	if m.checkpointsCursor != 3 {
 		t.Errorf("expected 3, got %d", m.checkpointsCursor)
@@ -2964,10 +2985,10 @@ func TestWizardSummaryCheckpointsSpaceToggles(t *testing.T) {
 	m.summaryCursor = summaryFieldCheckpoints
 	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
 
-	orig := m.checkpoints[0]
+	orig := m.checkpoints[checkpointInquiryReview]
 	m, _ = m.Update(tea.KeyPressMsg{Code: ' ', Text: " "})
-	if m.checkpoints[0] == orig {
-		t.Error("expected checkpoint[0] to toggle after Space")
+	if m.checkpoints[checkpointInquiryReview] == orig {
+		t.Error("expected InquiryReview checkpoint to toggle after Space")
 	}
 	if !m.checkpointsManuallySet {
 		t.Error("expected checkpointsManuallySet=true after Space")
@@ -2975,8 +2996,8 @@ func TestWizardSummaryCheckpointsSpaceToggles(t *testing.T) {
 
 	// Toggle back
 	m, _ = m.Update(tea.KeyPressMsg{Code: ' ', Text: " "})
-	if m.checkpoints[0] != orig {
-		t.Error("expected checkpoint[0] to toggle back after second Space")
+	if m.checkpoints[checkpointInquiryReview] != orig {
+		t.Error("expected InquiryReview checkpoint to toggle back after second Space")
 	}
 }
 
@@ -2993,10 +3014,10 @@ func TestWizardSummaryCheckpointsTabToggles(t *testing.T) {
 	m.summaryCursor = summaryFieldCheckpoints
 	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
 
-	orig := m.checkpoints[0]
+	orig := m.checkpoints[checkpointInquiryReview]
 	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyTab})
-	if m.checkpoints[0] == orig {
-		t.Error("expected checkpoint[0] to toggle after Tab")
+	if m.checkpoints[checkpointInquiryReview] == orig {
+		t.Error("expected InquiryReview checkpoint to toggle after Tab")
 	}
 	if !m.checkpointsManuallySet {
 		t.Error("expected checkpointsManuallySet=true after Tab")
@@ -3017,7 +3038,7 @@ func TestWizardSummaryCheckpointsEnterCollapses(t *testing.T) {
 	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
 
 	// Toggle
-	orig := m.checkpoints[0]
+	orig := m.checkpoints[checkpointInquiryReview]
 	m, _ = m.Update(tea.KeyPressMsg{Code: ' ', Text: " "})
 
 	// Collapse
@@ -3025,7 +3046,7 @@ func TestWizardSummaryCheckpointsEnterCollapses(t *testing.T) {
 	if m.summaryEditing {
 		t.Error("expected summaryEditing=false after Enter (collapse)")
 	}
-	if m.checkpoints[0] == orig {
+	if m.checkpoints[checkpointInquiryReview] == orig {
 		t.Error("expected toggled value to be preserved after collapse")
 	}
 }
@@ -3043,13 +3064,13 @@ func TestWizardSummaryCheckpointsEscCollapses(t *testing.T) {
 
 	// Toggle
 	m, _ = m.Update(tea.KeyPressMsg{Code: ' ', Text: " "})
-	toggled := m.checkpoints[0]
+	toggled := m.checkpoints[checkpointInquiryReview]
 
 	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
 	if m.summaryEditing {
 		t.Error("expected summaryEditing=false after Esc")
 	}
-	if m.checkpoints[0] != toggled {
+	if m.checkpoints[checkpointInquiryReview] != toggled {
 		t.Error("expected toggled value to be preserved after Esc")
 	}
 }
@@ -3439,14 +3460,17 @@ func TestWizardSummaryEditedCheckpointsInResult(t *testing.T) {
 	if r == nil {
 		t.Fatal("expected non-nil Result")
 	}
-	if !r.Checkpoints.InquiryReview {
-		t.Error("expected InquiryReview to be true after toggling the first visible moonshot gate")
+	if r.Checkpoints.InquiryReview {
+		t.Error("expected InquiryReview to be false after toggling the first visible moonshot gate")
 	}
-	if r.Checkpoints.ResearchReview {
-		t.Error("expected ResearchReview to be false (unchanged)")
+	if !r.Checkpoints.ResearchReview {
+		t.Error("expected ResearchReview to remain true (moonshot pipeline default)")
 	}
-	if !r.Checkpoints.PlanReview {
-		t.Error("expected PlanReview to remain true (moonshot pipeline default)")
+	if !r.Checkpoints.RoadmapReview {
+		t.Error("expected RoadmapReview to remain true (moonshot pipeline default)")
+	}
+	if !r.Checkpoints.PhasePlanReview {
+		t.Error("expected PhasePlanReview to remain true (moonshot pipeline default)")
 	}
 	if !r.Checkpoints.DesignReview {
 		t.Error("expected DesignReview to remain true (moonshot pipeline default)")
@@ -4718,7 +4742,7 @@ func TestWizardCheckpointHidingManualPublishForcedTrue(t *testing.T) {
 
 	m.applyPipelineDefaults()
 
-	if !m.checkpoints[4] {
+	if !m.checkpoints[checkpointManualPublish] {
 		t.Error("ManualPublish should be forced true when provisionalPublishable=false")
 	}
 }
@@ -4731,12 +4755,12 @@ func TestWizardCheckpointHidingCursorBound(t *testing.T) {
 	m.step = wizardStepReview
 	m.summaryEditing = true
 	m.summaryCursor = summaryFieldCheckpoints
-	m.checkpointsCursor = 3 // at the max for unpublished
+	m.checkpointsCursor = checkpointPhasePlanReview // at the max for unpublished
 
-	// Try to go down — should not go to 4
+	// Try to go down — should not move to the hidden Manual Publish row.
 	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
-	if m.checkpointsCursor != 3 {
-		t.Errorf("checkpointsCursor = %d, want 3 (max for unpublished)", m.checkpointsCursor)
+	if m.checkpointsCursor != checkpointPhasePlanReview {
+		t.Errorf("checkpointsCursor = %d, want %d (max for unpublished)", m.checkpointsCursor, checkpointPhasePlanReview)
 	}
 }
 
@@ -4772,16 +4796,16 @@ func TestWizardMergedPipelineCheckpointsNormalizeToSelectedProfile(t *testing.T)
 		want        feature.Checkpoints
 	}{
 		{
-			name:    "medium keeps plan and manual publish",
+			name:    "medium keeps roadmap, phase plan, and manual publish",
 			profile: "medium",
 			repoConfigs: map[string]config.RepoConfig{
 				"alpha": {
 					PipelineGates: map[string]config.Checkpoints{
-						"medium": {InquiryReview: true, DesignReview: true, PlanReview: true, ManualPublish: true},
+						"medium": {InquiryReview: true, DesignReview: true, RoadmapReview: true, PhasePlanReview: true, ManualPublish: true},
 					},
 				},
 			},
-			want: feature.Checkpoints{PlanReview: true, ManualPublish: true},
+			want: feature.Checkpoints{RoadmapReview: true, PhasePlanReview: true, ManualPublish: true},
 		},
 		{
 			name:    "large keeps only supported merged gates",
@@ -4794,16 +4818,17 @@ func TestWizardMergedPipelineCheckpointsNormalizeToSelectedProfile(t *testing.T)
 				},
 				"bravo": {
 					PipelineGates: map[string]config.Checkpoints{
-						"large": {ResearchReview: true, DesignReview: true, PlanReview: true},
+						"large": {ResearchReview: true, DesignReview: true, RoadmapReview: true, PhasePlanReview: true},
 					},
 				},
 			},
 			want: feature.Checkpoints{
-				InquiryReview:  true,
-				ResearchReview: true,
-				DesignReview:   true,
-				PlanReview:     true,
-				ManualPublish:  true,
+				InquiryReview:   true,
+				ResearchReview:  true,
+				DesignReview:    true,
+				RoadmapReview:   true,
+				PhasePlanReview: true,
+				ManualPublish:   true,
 			},
 		},
 		{
@@ -4817,16 +4842,17 @@ func TestWizardMergedPipelineCheckpointsNormalizeToSelectedProfile(t *testing.T)
 				},
 				"bravo": {
 					PipelineGates: map[string]config.Checkpoints{
-						"moonshot": {ResearchReview: true, PlanReview: true, ManualPublish: true},
+						"moonshot": {ResearchReview: true, RoadmapReview: true, PhasePlanReview: true, ManualPublish: true},
 					},
 				},
 			},
 			want: feature.Checkpoints{
-				InquiryReview:  true,
-				ResearchReview: true,
-				DesignReview:   true,
-				PlanReview:     true,
-				ManualPublish:  true,
+				InquiryReview:   true,
+				ResearchReview:  true,
+				DesignReview:    true,
+				RoadmapReview:   true,
+				PhasePlanReview: true,
+				ManualPublish:   true,
 			},
 		},
 	}
@@ -4860,8 +4886,8 @@ func TestWizardPipelineCardAndReviewGatesTrackSelectedProfile(t *testing.T) {
 		"alpha": {
 			PipelineGates: map[string]config.Checkpoints{
 				"medium":   {InquiryReview: true, ManualPublish: true},
-				"large":    {InquiryReview: true, DesignReview: true, PlanReview: true, ManualPublish: true},
-				"moonshot": {InquiryReview: true, ResearchReview: true, DesignReview: true, PlanReview: true, ManualPublish: true},
+				"large":    {InquiryReview: true, DesignReview: true, RoadmapReview: true, PhasePlanReview: true, ManualPublish: true},
+				"moonshot": {InquiryReview: true, ResearchReview: true, DesignReview: true, RoadmapReview: true, PhasePlanReview: true, ManualPublish: true},
 			},
 		},
 	}
@@ -4875,28 +4901,25 @@ func TestWizardPipelineCardAndReviewGatesTrackSelectedProfile(t *testing.T) {
 	m.height = 40
 
 	largeView := m.View()
-	if !strings.Contains(largeView, "Gate options: Inquiry review, Research review, Design review, Plan") ||
-		!strings.Contains(largeView, "review, Publish review") {
-		t.Fatalf("large card lost its profile-specific gates:\n%s", m.View())
-	}
+	requireWizardViewContainsAll(t, largeView,
+		"Gate options:", "Inquiry review", "Research review", "Design review",
+		"Roadmap review", "Phase plan review", "Publish review")
 
 	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyUp})
-	if !strings.Contains(m.View(), "Gate options: Plan review, Publish review") {
-		t.Fatalf("medium card lost its profile-specific gates:\n%s", m.View())
-	}
+	requireWizardViewContainsAll(t, m.View(),
+		"Gate options:", "Roadmap review", "Phase plan review", "Publish review")
 
 	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
 	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
 	moonshotView := m.View()
-	if !strings.Contains(moonshotView, "Gate options: Inquiry review, Research review, Design review, Plan") ||
-		!strings.Contains(moonshotView, "review, Publish review") {
-		t.Fatalf("moonshot card lost its profile-specific gates:\n%s", m.View())
-	}
+	requireWizardViewContainsAll(t, moonshotView,
+		"Gate options:", "Inquiry review", "Research review", "Design review",
+		"Roadmap review", "Phase plan review", "Publish review")
 
 	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
 	review := m.View()
-	if !strings.Contains(review, "Inquiry review, Research review, Design review, Plan review,") ||
-		!strings.Contains(review, "Publish review") {
+	if !strings.Contains(review, "Inquiry review, Research review, Design review, Roadmap review,") ||
+		!strings.Contains(review, "Phase plan review, Publish review") {
 		t.Fatalf("review summary leaked the wrong gate set after profile switching:\n%s", review)
 	}
 }
@@ -4906,10 +4929,11 @@ func TestWizardExpressProjectionFiltersNonApplicableConfigGates(t *testing.T) {
 		"alpha": {
 			PipelineGates: map[string]config.Checkpoints{
 				"medium": {
-					InquiryReview: true,
-					DesignReview:  true,
-					PlanReview:    true,
-					ManualPublish: true,
+					InquiryReview:   true,
+					DesignReview:    true,
+					RoadmapReview:   true,
+					PhasePlanReview: true,
+					ManualPublish:   true,
 				},
 			},
 		},
@@ -4920,14 +4944,14 @@ func TestWizardExpressProjectionFiltersNonApplicableConfigGates(t *testing.T) {
 	m.provisionalPublishable = true
 
 	projection := m.projectedPipelineCheckpoints("medium")
-	if projection.Checkpoints != (feature.Checkpoints{PlanReview: true, ManualPublish: true}) {
-		t.Fatalf("projectedPipelineCheckpoints(medium).Checkpoints = %+v, want PlanReview+ManualPublish", projection.Checkpoints)
+	if projection.Checkpoints != (feature.Checkpoints{RoadmapReview: true, PhasePlanReview: true, ManualPublish: true}) {
+		t.Fatalf("projectedPipelineCheckpoints(medium).Checkpoints = %+v, want RoadmapReview+PhasePlanReview+ManualPublish", projection.Checkpoints)
 	}
 	if !projection.FromConfig {
 		t.Fatal("expected medium repo override to be detected")
 	}
-	if !slices.Equal(projection.Visible, []feature.GateIndex{feature.GatePlanReview, feature.GateManualPublish}) {
-		t.Fatalf("projectedPipelineCheckpoints(medium).Visible = %v, want PlanReview+ManualPublish", projection.Visible)
+	if !slices.Equal(projection.Visible, []feature.GateIndex{feature.GateRoadmapReview, feature.GatePhasePlanReview, feature.GateManualPublish}) {
+		t.Fatalf("projectedPipelineCheckpoints(medium).Visible = %v, want RoadmapReview+PhasePlanReview+ManualPublish", projection.Visible)
 	}
 }
 
@@ -4936,10 +4960,11 @@ func TestWizardExpressPipelineCardAndResultUseProjectedGates(t *testing.T) {
 		"alpha": {
 			PipelineGates: map[string]config.Checkpoints{
 				"medium": {
-					InquiryReview: true,
-					DesignReview:  true,
-					PlanReview:    true,
-					ManualPublish: true,
+					InquiryReview:   true,
+					DesignReview:    true,
+					RoadmapReview:   true,
+					PhasePlanReview: true,
+					ManualPublish:   true,
 				},
 			},
 		},
@@ -4950,6 +4975,8 @@ func TestWizardExpressPipelineCardAndResultUseProjectedGates(t *testing.T) {
 	m.descInput.SetValue("projection smoke")
 	m.selectedRepos = map[string]bool{"alpha": true}
 	m.provisionalPublishable = true
+	m.width = 200
+	m.height = 40
 
 	m, _ = m.advance()
 	m, _ = m.advance()
@@ -4962,8 +4989,8 @@ func TestWizardExpressPipelineCardAndResultUseProjectedGates(t *testing.T) {
 	}
 
 	view := m.View()
-	if !strings.Contains(view, "Gate options: Plan review, Publish review") {
-		t.Fatalf("expected medium pipeline card to contain plan and publish options; got:\n%s", view)
+	if !strings.Contains(normalizedWizardViewText(view), "Gate options: Roadmap review, Phase plan review, Publish review") {
+		t.Fatalf("expected medium pipeline card to contain roadmap, phase plan, and publish options; got:\n%s", view)
 	}
 
 	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
@@ -4979,8 +5006,8 @@ func TestWizardExpressPipelineCardAndResultUseProjectedGates(t *testing.T) {
 	if result == nil {
 		t.Fatal("expected result to be populated")
 	}
-	if result.Checkpoints != (feature.Checkpoints{PlanReview: true, ManualPublish: true}) {
-		t.Fatalf("WizardResult.Checkpoints = %+v, want PlanReview+ManualPublish", result.Checkpoints)
+	if result.Checkpoints != (feature.Checkpoints{RoadmapReview: true, PhasePlanReview: true, ManualPublish: true}) {
+		t.Fatalf("WizardResult.Checkpoints = %+v, want RoadmapReview+PhasePlanReview+ManualPublish", result.Checkpoints)
 	}
 }
 
@@ -4989,10 +5016,11 @@ func TestWizardReviewCheckpointEditorUsesProjectedGateRows(t *testing.T) {
 		"alpha": {
 			PipelineGates: map[string]config.Checkpoints{
 				"medium": {
-					InquiryReview: true,
-					DesignReview:  true,
-					PlanReview:    true,
-					ManualPublish: true,
+					InquiryReview:   true,
+					DesignReview:    true,
+					RoadmapReview:   true,
+					PhasePlanReview: true,
+					ManualPublish:   true,
 				},
 			},
 		},
@@ -5020,8 +5048,11 @@ func TestWizardReviewCheckpointEditorUsesProjectedGateRows(t *testing.T) {
 	if !strings.Contains(view, "Manual Publish") {
 		t.Fatalf("review checkpoint editor missing Manual Publish:\n%s", view)
 	}
-	if !strings.Contains(view, "Plan Review") {
-		t.Fatalf("review checkpoint editor missing Plan Review:\n%s", view)
+	if !strings.Contains(view, "Roadmap Review") {
+		t.Fatalf("review checkpoint editor missing Roadmap Review:\n%s", view)
+	}
+	if !strings.Contains(view, "Phase Plan Review") {
+		t.Fatalf("review checkpoint editor missing Phase Plan Review:\n%s", view)
 	}
 	for _, hidden := range []string{"Inquiry Review", "Research Review", "Design Review"} {
 		if strings.Contains(view, hidden) {

--- a/internal/tui/wizard_test.go
+++ b/internal/tui/wizard_test.go
@@ -139,11 +139,8 @@ func TestWizardZeroConfigDefaultsToManualPublish(t *testing.T) {
 
 func TestWizardPipelineDefaultsApplyCheckpoints(t *testing.T) {
 	// Config with explicit checkpoints that disable ManualPublish.
-	defaults := config.DefaultsConfig{
-		Checkpoints: config.Checkpoints{
-			ManualPublish: false,
-		},
-	}
+	defaults := config.NewDefault().Defaults
+	defaults.Checkpoints.ManualPublish = false
 	m := NewWizardModel(nil, nil, nil, defaults, "", nil, nil, nil, nil, nil, nil)
 
 	m.nameInput.SetValue("test")
@@ -157,12 +154,12 @@ func TestWizardPipelineDefaultsApplyCheckpoints(t *testing.T) {
 		t.Fatal("expected wizard to be done")
 	}
 	result := m.Result()
-	// Large pipeline defaults: DesignReview=true, ManualPublish=true
+	// Large applies compatible configured defaults and preserves explicit false.
 	if !result.Checkpoints.DesignReview {
-		t.Error("expected DesignReview to be true (large pipeline default)")
+		t.Error("expected DesignReview to be true (configured default)")
 	}
-	if !result.Checkpoints.ManualPublish {
-		t.Error("expected ManualPublish to be true (large pipeline default)")
+	if result.Checkpoints.ManualPublish {
+		t.Error("expected ManualPublish to remain false from configured default")
 	}
 }
 
@@ -2906,7 +2903,7 @@ func TestWizardSummaryCheckpointsEnterExpands(t *testing.T) {
 }
 
 func TestWizardSummaryCheckpointsUpDownNavigation(t *testing.T) {
-	m := NewWizardModel(nil, nil, nil, config.DefaultsConfig{}, "", nil, nil, nil, nil, nil, nil)
+	m := NewWizardModel(nil, nil, nil, config.NewDefault().Defaults, "", nil, nil, nil, nil, nil, nil)
 	m.nameInput.SetValue("test")
 	m, _ = m.advance()
 	m.selectedRepos["test-repo"] = true
@@ -3437,7 +3434,7 @@ func TestWizardSummaryEditedModelsInResult(t *testing.T) {
 
 func TestWizardSummaryEditedCheckpointsInResult(t *testing.T) {
 	// applyPipelineDefaults seeds the selected moonshot profile before review.
-	m := NewWizardModel(nil, nil, nil, config.DefaultsConfig{}, "", nil, nil, nil, nil, nil, nil)
+	m := NewWizardModel(nil, nil, nil, config.NewDefault().Defaults, "", nil, nil, nil, nil, nil, nil)
 	m.nameInput.SetValue("test")
 	m, _ = m.advance()
 	m.selectedRepos["test-repo"] = true
@@ -4748,7 +4745,7 @@ func TestWizardCheckpointHidingManualPublishForcedTrue(t *testing.T) {
 }
 
 func TestWizardCheckpointHidingCursorBound(t *testing.T) {
-	m := NewWizardModel(nil, nil, nil, config.DefaultsConfig{}, "", nil, nil, nil, nil, nil, nil)
+	m := NewWizardModel(nil, nil, nil, config.NewDefault().Defaults, "", nil, nil, nil, nil, nil, nil)
 	m.provisionalPublishable = false
 	m.pipelineCursor = 2
 	m.applyPipelineDefaults()
@@ -4761,6 +4758,31 @@ func TestWizardCheckpointHidingCursorBound(t *testing.T) {
 	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
 	if m.checkpointsCursor != checkpointPhasePlanReview {
 		t.Errorf("checkpointsCursor = %d, want %d (max for unpublished)", m.checkpointsCursor, checkpointPhasePlanReview)
+	}
+}
+
+func TestWizardApplyPipelineDefaultsUsesConfiguredCheckpointDefaults(t *testing.T) {
+	defaults := config.NewDefault().Defaults
+	defaults.Checkpoints.RoadmapReview = false
+	defaults.Checkpoints.PhasePlanReview = false
+
+	m := NewWizardModel(nil, nil, nil, defaults, "", nil, nil, nil, nil, nil, nil)
+	m.pipelineCursor = 0 // medium
+	m.provisionalPublishable = true
+
+	projection := m.projectedPipelineCheckpoints(feature.PipelineMedium.ConfigKey())
+	if projection.Checkpoints.RoadmapReview || projection.Checkpoints.PhasePlanReview {
+		t.Fatalf("projected medium checkpoints = %+v, want planning reviews disabled by configured defaults", projection.Checkpoints)
+	}
+
+	m.applyPipelineDefaults()
+
+	got := m.checkpointState()
+	if got.RoadmapReview || got.PhasePlanReview {
+		t.Fatalf("applied medium checkpoints = %+v, want planning reviews disabled by configured defaults", got)
+	}
+	if !got.ManualPublish {
+		t.Fatalf("applied medium checkpoints = %+v, want ManualPublish preserved from configured defaults", got)
 	}
 }
 

--- a/skills/chat/user-guide/configuration.md
+++ b/skills/chat/user-guide/configuration.md
@@ -51,22 +51,28 @@ Checkpoints are review gates that pause the pipeline between phases for human re
 ```yaml
 defaults:
   checkpoints:
-    inquiry_review: false
-    research_review: false
-    design_review: false
-    plan_review: false
+    inquiry_review: true
+    research_review: true
+    design_review: true
+    roadmap_review: true
+    phase_plan_review: true
     manual_publish: true
 ```
 
 | Checkpoint | Gates Before | Default |
 |------------|-------------|---------|
-| `inquiry_review` | Research phase | `false` |
-| `research_review` | Design phase | `false` |
-| `design_review` | Plan phase | `false` |
-| `plan_review` | Implementation phase | `false` |
+| `inquiry_review` | Research phase | `true` |
+| `research_review` | Design phase | `true` |
+| `design_review` | Plan phase | `true` |
+| `roadmap_review` | Phase planning | `true` |
+| `phase_plan_review` | Implementation phase | `true` |
 | `manual_publish` | Publish step | `true` |
 
-When a feature is created, these defaults are combined with the pipeline profile's defaults (see [Feature Lifecycle — Checkpoints](feature-lifecycle.md#checkpoints-review-gates)). Individual checkpoints can be toggled per-feature in the creation wizard.
+When a feature is created, these defaults are projected through the selected pipeline profile (see [Feature Lifecycle — Checkpoints](feature-lifecycle.md#checkpoints-review-gates)). Individual checkpoints can be toggled per-feature in the creation wizard.
+
+Omitted checkpoint fields in `defaults.checkpoints` or repo `pipeline_gates` default to `true` when the checkpoint is compatible with the selected pipeline. Config saves write all checkpoint fields explicitly. The legacy `plan_review` key is ignored by new config handling; replace it with `roadmap_review` and `phase_plan_review`.
+
+In the TUI, Roadmap Review controls the planning review group and Phase Plan Review appears beneath it. Turning Roadmap Review off also turns Phase Plan Review off; turning it back on enables Phase Plan Review by default. Advanced YAML can still set `phase_plan_review: true` with `roadmap_review: false`, and that runtime combination is honored.
 
 ## Iteration Limits
 
@@ -116,8 +122,11 @@ repos:
     path: /Users/you/Projects/my-project
     pipeline_gates:
       moonshot:
+        inquiry_review: true
+        research_review: true
         design_review: true
-        plan_review: true
+        roadmap_review: true
+        phase_plan_review: true
         manual_publish: true
 ```
 

--- a/skills/chat/user-guide/feature-lifecycle.md
+++ b/skills/chat/user-guide/feature-lifecycle.md
@@ -92,6 +92,8 @@ When checkpoints are enabled, features pause at these states for human review:
 | `DesignNeedsReview` | Plan phase |
 | `PlanNeedsReview` | Implementation phase |
 
+`PlanNeedsReview` remains the runtime review state name for planning pauses. Checkpoint configuration uses the split `roadmap_review` and `phase_plan_review` keys instead of a single plan-review key.
+
 ### Error States
 
 | State | Description |
@@ -105,13 +107,14 @@ Checkpoints pause the pipeline between phases so you can review artifacts before
 
 | Checkpoint | Gates Before | Medium | Large | Moonshot |
 |------------|-------------|---------|----------|----------|
-| Inquiry Review | Research | Off | Off | Off |
-| Research Review | Design | Off | Off | Off |
+| Inquiry Review | Research | Off | On | On |
+| Research Review | Design | Off | On | On |
 | Design Review | Plan | Off | On | On |
-| Plan Review | Implementation | Off | Off | On |
+| Roadmap Review | Phase planning | On | On | On |
+| Phase Plan Review | Implementation | On | On | On |
 | Manual Publish | (publish step) | On | On | On |
 
-You can toggle any applicable checkpoint in the feature creation wizard (Step 4) or in `config.yaml`.
+You can toggle any applicable checkpoint in the feature creation wizard (Step 4) or in `config.yaml`. In normal TUI use, Roadmap Review controls the planning review group and Phase Plan Review is the subordinate option.
 
 ## Rewind and Retry
 

--- a/test/e2e/tui_test.go
+++ b/test/e2e/tui_test.go
@@ -237,10 +237,11 @@ func TestMediumWizardGateProjectionSmoke(t *testing.T) {
 		Path: repoPath,
 		PipelineGates: map[string]config.Checkpoints{
 			"medium": {
-				InquiryReview: true,
-				DesignReview:  true,
-				PlanReview:    true,
-				ManualPublish: true,
+				InquiryReview:   true,
+				DesignReview:    true,
+				RoadmapReview:   true,
+				PhasePlanReview: true,
+				ManualPublish:   true,
 			},
 		},
 	}
@@ -278,15 +279,15 @@ func TestMediumWizardGateProjectionSmoke(t *testing.T) {
 	)
 
 	tm.Send(tea.KeyPressMsg{Text: "medium wizard smoke"})
-	tm.Send(tea.KeyPressMsg{Code: tea.KeyEnter})                  // name -> description
-	tm.Send(tea.KeyPressMsg{Code: tea.KeyEnter})                  // description -> Where
-	tm.Send(tea.KeyPressMsg{Code: tea.KeyEnter})                  // add focused repo to chips
-	tm.Send(tea.KeyPressMsg{Code: 'd', Mod: tea.ModCtrl})         // Ctrl+D advances Where -> Pipeline
-	tm.Send(tea.KeyPressMsg{Code: tea.KeyUp})                     // pipeline cursor up -> medium
+	tm.Send(tea.KeyPressMsg{Code: tea.KeyEnter})          // name -> description
+	tm.Send(tea.KeyPressMsg{Code: tea.KeyEnter})          // description -> Where
+	tm.Send(tea.KeyPressMsg{Code: tea.KeyEnter})          // add focused repo to chips
+	tm.Send(tea.KeyPressMsg{Code: 'd', Mod: tea.ModCtrl}) // Ctrl+D advances Where -> Pipeline
+	tm.Send(tea.KeyPressMsg{Code: tea.KeyUp})             // pipeline cursor up -> medium
 
 	teatest.WaitFor(t, tm.Output(),
 		func(bts []byte) bool {
-			return bytes.Contains(bts, []byte("Gate options: Plan review, Publish review"))
+			return bytes.Contains(bts, []byte("Gate options: Roadmap review, Phase plan review, Publish review"))
 		},
 		teatest.WithDuration(3*time.Second),
 	)
@@ -308,13 +309,13 @@ func TestMediumWizardGateProjectionSmoke(t *testing.T) {
 	if len(features) != 1 {
 		t.Fatalf("feature count = %d, want 1", len(features))
 	}
-	if features[0].Checkpoints != (feature.Checkpoints{PlanReview: true, ManualPublish: true}) {
-		t.Fatalf("created feature checkpoints = %+v, want PlanReview+ManualPublish", features[0].Checkpoints)
+	if features[0].Checkpoints != (feature.Checkpoints{RoadmapReview: true, PhasePlanReview: true, ManualPublish: true}) {
+		t.Fatalf("created feature checkpoints = %+v, want RoadmapReview+PhasePlanReview+ManualPublish", features[0].Checkpoints)
 	}
 
 	saved := fm.Config.Repos["test-repo"].PipelineGates["medium"]
-	if saved != (config.Checkpoints{PlanReview: true, ManualPublish: true}) {
-		t.Fatalf("saved medium gates = %+v, want PlanReview+ManualPublish", saved)
+	if saved != (config.Checkpoints{RoadmapReview: true, PhasePlanReview: true, ManualPublish: true}) {
+		t.Fatalf("saved medium gates = %+v, want RoadmapReview+PhasePlanReview+ManualPublish", saved)
 	}
 }
 

--- a/test/e2e/tui_test.go
+++ b/test/e2e/tui_test.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/x/ansi"
 	teatest "github.com/charmbracelet/x/exp/teatest/v2"
 
 	"github.com/doordash-oss/agentic-orchestrator/internal/agent"
@@ -287,7 +288,7 @@ func TestMediumWizardGateProjectionSmoke(t *testing.T) {
 
 	teatest.WaitFor(t, tm.Output(),
 		func(bts []byte) bool {
-			return bytes.Contains(bts, []byte("Gate options: Roadmap review, Phase plan review, Publish review"))
+			return strings.Contains(ansi.Strip(string(bts)), "Gate options: Roadmap review, Phase plan review, Publish review")
 		},
 		teatest.WithDuration(3*time.Second),
 	)


### PR DESCRIPTION
## Summary

Splits the planning human-review checkpoint into separate Roadmap Review and Phase Plan Review gates.

- Adds `roadmap_review` and `phase_plan_review` config fields, with omitted checkpoint fields defaulting on and saved configs writing explicit booleans.
- Ignores legacy `plan_review` moving forward and removes it from saved config/observability output.
- Gates roadmap completion on `RoadmapReview` and per-phase plan completion on `PhasePlanReview`, while preserving `needs_human_review` behavior.
- Updates feature gate projection, TUI config editor, wizard/app persistence, observability, e2e coverage, and user docs.
- Keeps the simplified UX rule: Phase Plan Review is subordinate to Roadmap Review in normal UI, while manually configured phase-plan-only YAML remains supported at runtime.

## Verification

- Fast suite: `make test-fast`
- Static/build: `go vet ./...`, `go build ./...`
- E2E Go (TUI / teatest): `go test ./test/e2e/... -count=1 -race`
- Isolated integration: `go test ./test/integration/... -count=1`
- E2E smoke shell: `bash test/e2e/smoke.sh`
- Race regression: `go test ./... -count=1 -race`
