### PR TITLE
[codex] split inquiry and research models

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ Config lives at `~/.agentic-orchestrator/config.yaml` (auto-created on first lau
 ```yaml
 defaults:
   models:
+    inquiry: "sonnet[200K]"      # Model for Clarify/Inquire phase
     research: "sonnet[200K]"     # Model for research phase
     planning: "opus[1M]"         # Model for planning phase
     implementation: "opus[1M]"   # Model for implementation phase
@@ -241,7 +242,7 @@ workspace_roots:
 
 ### Model Overrides
 
-Each feature can override default models during creation via the wizard (step 4). Models can be specified with explicit provider prefixes (e.g., `claude:opus[1M]`, `codex:gpt-5.4[272K]`, `opencode:anthropic/claude-sonnet-4-5`) or as bare ids resolved against the provider registry. There are three ways a selection reaches OpenCode, and they are distinct:
+Each feature can override default models during creation via the wizard (step 4). The model editor shows the Inquire phase as **Clarify**, separately from **Research**, so requirement clarification and codebase research can use different models. Models can be specified with explicit provider prefixes (e.g., `claude:opus[1M]`, `codex:gpt-5.4[272K]`, `opencode:anthropic/claude-sonnet-4-5`) or as bare ids resolved against the provider registry. There are three ways a selection reaches OpenCode, and they are distinct:
 
 - A **plain alias** such as `opus`, `sonnet`, or `gpt-5.4` (no slash) resolves to its owning native provider (Claude or Codex) and **never** to OpenCode — OpenCode contributes only slash-form backend ids.
 - The explicit **`opencode:<provider>/<model>` prefix** always routes to OpenCode, passing the backend id straight through (it works even for a backend OpenCode discovers but Agentico does not pre-list).

--- a/cmd/agentico/main.go
+++ b/cmd/agentico/main.go
@@ -1037,6 +1037,7 @@ func remapUnresolvableModels(cfg *config.Config, registry *llm.Registry) {
 		}
 	}
 
+	remap(&m.Inquiry)
 	remap(&m.Research)
 	remap(&m.Planning)
 	remap(&m.Implementation)
@@ -1117,7 +1118,8 @@ func providerFxModules(enabled []string) []fx.Option {
 }
 
 func hasAnyModelConfig(m config.ModelConfig) bool {
-	return m.Research != "" ||
+	return m.Inquiry != "" ||
+		m.Research != "" ||
 		m.Planning != "" ||
 		m.Implementation != "" ||
 		m.Review != "" ||
@@ -1127,6 +1129,7 @@ func hasAnyModelConfig(m config.ModelConfig) bool {
 
 func modelConfigDefaultsMap(m config.ModelConfig) map[string]string {
 	return map[string]string{
+		"inquiry":        m.Inquiry,
 		"research":       m.Research,
 		"planning":       m.Planning,
 		"implementation": m.Implementation,
@@ -1153,6 +1156,7 @@ func canonicalizeModel(registry *llm.Registry, model string) string {
 
 func canonicalizeModelConfig(registry *llm.Registry, models config.ModelConfig) (config.ModelConfig, bool) {
 	updated := models
+	updated.Inquiry = canonicalizeModel(registry, models.Inquiry)
 	updated.Research = canonicalizeModel(registry, models.Research)
 	updated.Planning = canonicalizeModel(registry, models.Planning)
 	updated.Implementation = canonicalizeModel(registry, models.Implementation)

--- a/cmd/agentico/main_test.go
+++ b/cmd/agentico/main_test.go
@@ -1042,7 +1042,7 @@ func TestApplyCatalogModelDefaultsToConfig_OpenCodeOnlyPersistsBareBackendIDs(t 
 	const want = "anthropic/claude-sonnet-4-5[200K]"
 	got := cfg.Defaults.Models
 	for field, val := range map[string]string{
-		"research": got.Research, "planning": got.Planning, "implementation": got.Implementation,
+		"inquiry": got.Inquiry, "research": got.Research, "planning": got.Planning, "implementation": got.Implementation,
 		"review": got.Review, "chat": got.Utilities, "kb_build": got.KBBuild,
 	} {
 		if val != want {
@@ -1091,6 +1091,7 @@ func TestApplyCatalogModelDefaultsToConfig_ExistingConfigCanonicalizesAndFills(t
 
 	cfg := config.NewDefault()
 	cfg.Defaults.Models = config.ModelConfig{
+		Inquiry:  "claude:SONNET", // explicit prefix + non-canonical case
 		Research: "claude:SONNET", // explicit prefix + non-canonical case
 		Review:   "gpt-5.4",       // bare codex name
 		// Planning/Implementation/Utilities/KBBuild left empty → filled from defaults.
@@ -1099,6 +1100,9 @@ func TestApplyCatalogModelDefaultsToConfig_ExistingConfigCanonicalizesAndFills(t
 	changed := applyCatalogModelDefaultsToConfig(cfg, reg, false)
 	if !changed {
 		t.Fatal("expected changed=true (canonicalization + filled empties)")
+	}
+	if got := cfg.Defaults.Models.Inquiry; got != "claude:sonnet" {
+		t.Errorf("inquiry canonicalized = %q, want claude:sonnet (user choice preserved, canonicalized)", got)
 	}
 	if got := cfg.Defaults.Models.Research; got != "claude:sonnet" {
 		t.Errorf("research canonicalized = %q, want claude:sonnet (user choice preserved, canonicalized)", got)
@@ -1121,7 +1125,7 @@ func TestRemapUnresolvableModels(t *testing.T) {
 
 		// All fields should now be "gpt-5.4" since codex is the only provider
 		m := cfg.Defaults.Models
-		for _, field := range []string{m.Research, m.Planning, m.Implementation, m.Review, m.Utilities, m.KBBuild} {
+		for _, field := range []string{m.Inquiry, m.Research, m.Planning, m.Implementation, m.Review, m.Utilities, m.KBBuild} {
 			if field != "gpt-5.4" {
 				t.Errorf("expected gpt-5.4, got %q", field)
 			}
@@ -1136,6 +1140,9 @@ func TestRemapUnresolvableModels(t *testing.T) {
 		remapUnresolvableModels(cfg, r)
 
 		// canonical Claude defaults should stay; gpt-5.4[272K] (review) should become opus[1M].
+		if cfg.Defaults.Models.Inquiry != "sonnet[200K]" {
+			t.Errorf("inquiry should stay sonnet[200K], got %q", cfg.Defaults.Models.Inquiry)
+		}
 		if cfg.Defaults.Models.Research != "sonnet[200K]" {
 			t.Errorf("research should stay sonnet[200K], got %q", cfg.Defaults.Models.Research)
 		}

--- a/internal/agent/phase.go
+++ b/internal/agent/phase.go
@@ -87,6 +87,8 @@ func (pr *PhaseRunner) defaultModelForRole(role llm.PhaseRole) string {
 	}
 	defaults := pr.Registry.CatalogDefaultModels()
 	switch role {
+	case llm.PhaseInquiry:
+		return defaults.Inquiry
 	case llm.PhaseResearch:
 		return defaults.Research
 	case llm.PhasePlanning:
@@ -129,15 +131,17 @@ func (pr *PhaseRunner) resolvePhaseArtifactDir(f *feature.Feature, phaseName str
 // RoleSpec system prompt that owns skill discovery, useful resources, output
 // roots, and completion.
 type interactivePhaseConfig struct {
-	Prompt        string
-	Spec          RoleSpec
-	DirName       string        // artifact subdirectory: "inquire", "research", "design"
-	SkillName     string        // skill name (used for error messages and session naming)
-	SessionSuffix string        // appended to feature ID: "-inquire", "-research", "-design"
-	Phase         feature.Phase // feature.PhaseInquire, etc.
-	AgentNames    []string
-	GuidelinesDir string
-	KBInfos       []KBInfo
+	Prompt          string
+	Spec            RoleSpec
+	DirName         string        // artifact subdirectory: "inquire", "research", "design"
+	SkillName       string        // skill name (used for error messages and session naming)
+	SessionSuffix   string        // appended to feature ID: "-inquire", "-research", "-design"
+	Phase           feature.Phase // feature.PhaseInquire, etc.
+	ConfiguredModel string
+	ModelRole       llm.PhaseRole
+	AgentNames      []string
+	GuidelinesDir   string
+	KBInfos         []KBInfo
 }
 
 // runInteractivePhase contains the shared boilerplate for launching an async
@@ -147,7 +151,7 @@ func (pr *PhaseRunner) runInteractivePhase(f *feature.Feature, cfg interactivePh
 	artifactDir := pr.resolvePhaseArtifactDir(f, cfg.DirName)
 	_ = os.MkdirAll(artifactDir, 0o755)
 	RemovePhaseComplete(artifactDir)
-	researchModel := pr.modelForRole(f.Models.Research, llm.PhaseResearch)
+	phaseModel := pr.modelForRole(cfg.ConfiguredModel, cfg.ModelRole)
 
 	systemPrompt := BuildRoleSystemPrompt(BuildRoleSystemPromptInput{
 		Spec:          cfg.Spec,
@@ -155,7 +159,7 @@ func (pr *PhaseRunner) runInteractivePhase(f *feature.Feature, cfg interactivePh
 		SkillsDir:     pr.SkillsDir,
 		GuidelinesDir: cfg.GuidelinesDir,
 		KBInfos:       cfg.KBInfos,
-		AskingClause:  pr.askingQuestionsClauseForModel(researchModel),
+		AskingClause:  pr.askingQuestionsClauseForModel(phaseModel),
 	})
 	sessionID := fmt.Sprintf("%s%s", f.ID, cfg.SessionSuffix)
 
@@ -167,7 +171,7 @@ func (pr *PhaseRunner) runInteractivePhase(f *feature.Feature, cfg interactivePh
 	pr.Observer.PhaseStarted(phaseCtx, cfg.Phase.String())
 
 	cmd, env, sessOpts, err := pr.BuildSession(BuildSessionOpts{
-		Model:                          researchModel,
+		Model:                          phaseModel,
 		Prompt:                         cfg.Prompt,
 		SystemPrompt:                   systemPrompt,
 		AdditionalDirs:                 additionalDirs,
@@ -209,7 +213,7 @@ func (pr *PhaseRunner) runInteractivePhase(f *feature.Feature, cfg interactivePh
 	if sessOpts != nil {
 		providerName = sessOpts.ProviderName
 	}
-	pr.Observer.SessionStarted(sessionCtx, cfg.Phase.String(), sessionID, providerName, f.Models.Research, "")
+	pr.Observer.SessionStarted(sessionCtx, cfg.Phase.String(), sessionID, providerName, phaseModel, "")
 
 	// Track reads of KB/skill/guideline files for observability.
 	pr.installContextReadTracker(sess, sessionCtx, cfg.Phase.String(), sessionID, pr.StateDir)
@@ -397,15 +401,21 @@ func (pr *PhaseRunner) RunTweakSession(f *feature.Feature, cfgs ...TweakSessionC
 // RunInquire starts an inquire session for a feature.
 // Returns the session ID. The session runs asynchronously.
 func (pr *PhaseRunner) RunInquire(f *feature.Feature, kbInfos ...KBInfo) (string, error) {
+	inquiryModel := f.Models.Inquiry
+	if inquiryModel == "" {
+		inquiryModel = f.Models.Research
+	}
 	return pr.runInteractivePhase(f, interactivePhaseConfig{
-		Prompt:        BuildInquirePrompt(f, pr.SkillsDir, kbInfos...),
-		Spec:          InquirerRoleSpec(),
-		DirName:       "inquire",
-		SkillName:     "inquire",
-		SessionSuffix: "-inquire",
-		Phase:         feature.PhaseInquire,
-		AgentNames:    []string{},
-		KBInfos:       kbInfos,
+		Prompt:          BuildInquirePrompt(f, pr.SkillsDir, kbInfos...),
+		Spec:            InquirerRoleSpec(),
+		DirName:         "inquire",
+		SkillName:       "inquire",
+		SessionSuffix:   "-inquire",
+		Phase:           feature.PhaseInquire,
+		ConfiguredModel: inquiryModel,
+		ModelRole:       llm.PhaseInquiry,
+		AgentNames:      []string{},
+		KBInfos:         kbInfos,
 	})
 }
 
@@ -413,14 +423,16 @@ func (pr *PhaseRunner) RunInquire(f *feature.Feature, kbInfos ...KBInfo) (string
 // Returns the session ID. The session runs asynchronously.
 func (pr *PhaseRunner) RunResearchFromQuestions(f *feature.Feature, questionsPath string, kbInfos ...KBInfo) (string, error) {
 	return pr.runInteractivePhase(f, interactivePhaseConfig{
-		Prompt:        BuildResearchFromQuestionsPrompt(f, pr.SkillsDir, questionsPath, kbInfos...),
-		Spec:          ResearcherRoleSpec(),
-		DirName:       "research",
-		SkillName:     "research-codebase",
-		SessionSuffix: "-research",
-		Phase:         feature.PhaseResearch,
-		AgentNames:    explorationAgentNames(),
-		KBInfos:       kbInfos,
+		Prompt:          BuildResearchFromQuestionsPrompt(f, pr.SkillsDir, questionsPath, kbInfos...),
+		Spec:            ResearcherRoleSpec(),
+		DirName:         "research",
+		SkillName:       "research-codebase",
+		SessionSuffix:   "-research",
+		Phase:           feature.PhaseResearch,
+		ConfiguredModel: f.Models.Research,
+		ModelRole:       llm.PhaseResearch,
+		AgentNames:      explorationAgentNames(),
+		KBInfos:         kbInfos,
 	})
 }
 
@@ -441,15 +453,17 @@ func explorationAgentNames() []string {
 // place; the session identity, skill, and prompt template are Design-facing.
 func (pr *PhaseRunner) RunDesign(f *feature.Feature, researchOutput string, qaFilePaths []string, kbInfos ...KBInfo) (string, error) {
 	return pr.runInteractivePhase(f, interactivePhaseConfig{
-		Prompt:        BuildDesignPrompt(f, pr.SkillsDir, pr.GuidelinesDir, researchOutput, qaFilePaths, kbInfos...),
-		Spec:          DesignerRoleSpec(),
-		DirName:       feature.PhaseDesign.DirName(),
-		SkillName:     "design",
-		SessionSuffix: "-design",
-		Phase:         feature.PhaseDesign,
-		AgentNames:    []string{},
-		GuidelinesDir: pr.GuidelinesDir,
-		KBInfos:       kbInfos,
+		Prompt:          BuildDesignPrompt(f, pr.SkillsDir, pr.GuidelinesDir, researchOutput, qaFilePaths, kbInfos...),
+		Spec:            DesignerRoleSpec(),
+		DirName:         feature.PhaseDesign.DirName(),
+		SkillName:       "design",
+		SessionSuffix:   "-design",
+		Phase:           feature.PhaseDesign,
+		ConfiguredModel: f.Models.Research,
+		ModelRole:       llm.PhaseResearch,
+		AgentNames:      []string{},
+		GuidelinesDir:   pr.GuidelinesDir,
+		KBInfos:         kbInfos,
 	})
 }
 

--- a/internal/agent/phase_test.go
+++ b/internal/agent/phase_test.go
@@ -115,6 +115,49 @@ func TestPhaseRunnerRunResearchBuildPrompt(t *testing.T) {
 	}
 }
 
+func TestRunInteractivePhase_UsesPhaseSpecificModel(t *testing.T) {
+	dir := t.TempDir()
+	eventCh := make(chan any, 10)
+	sm := session.NewManager(eventCh)
+	defer sm.Shutdown()
+
+	store := feature.NewStore(filepath.Join(dir, "state"))
+	pr := NewPhaseRunner(sm, store, filepath.Join(dir, "state"))
+
+	captured := map[feature.Phase]string{}
+	pr.BuildSessionFn = func(opts BuildSessionOpts) ([]string, []string, *session.SessionOpts, error) {
+		captured[opts.Phase] = opts.Model
+		return nil, nil, nil, fmt.Errorf("stop after capturing model")
+	}
+
+	f := &feature.Feature{
+		ID:          "feat-model-routing",
+		Name:        "Model Routing",
+		Description: "Verify phase-specific model routing",
+		Repos: []feature.FeatureRepo{
+			{Name: "repo", Path: dir},
+		},
+		Models: config.ModelConfig{
+			Inquiry:  "inquiry-model",
+			Research: "research-model",
+		},
+	}
+
+	if _, err := pr.RunInquire(f); err == nil {
+		t.Fatal("RunInquire error = nil, want injected BuildSession error")
+	}
+	if got := captured[feature.PhaseInquire]; got != "inquiry-model" {
+		t.Errorf("RunInquire model = %q, want inquiry-model", got)
+	}
+
+	if _, err := pr.RunResearchFromQuestions(f, filepath.Join(dir, "questions.md")); err == nil {
+		t.Fatal("RunResearchFromQuestions error = nil, want injected BuildSession error")
+	}
+	if got := captured[feature.PhaseResearch]; got != "research-model" {
+		t.Errorf("RunResearchFromQuestions model = %q, want research-model", got)
+	}
+}
+
 func TestBuildResearchPhaseSession_ClaudeProvider(t *testing.T) {
 	dir := t.TempDir()
 	eventCh := make(chan any, 100)

--- a/internal/agent/startup_test.go
+++ b/internal/agent/startup_test.go
@@ -91,6 +91,7 @@ func TestFormatNoCLIMessage_SingleProvider(t *testing.T) {
 func TestApplyStartupDefaults_FillsEmptyConfig(t *testing.T) {
 	cfg := &config.Config{}
 	defaults := map[string]string{
+		"inquiry":        "sonnet",
 		"research":       "opus",
 		"planning":       "opus",
 		"implementation": "opus",
@@ -102,6 +103,9 @@ func TestApplyStartupDefaults_FillsEmptyConfig(t *testing.T) {
 	if !changed {
 		t.Error("expected changed=true when filling empty config")
 	}
+	if cfg.Defaults.Models.Inquiry != "sonnet" {
+		t.Errorf("expected Inquiry='sonnet', got %q", cfg.Defaults.Models.Inquiry)
+	}
 	if cfg.Defaults.Models.Research != "opus" {
 		t.Errorf("expected Research='opus', got %q", cfg.Defaults.Models.Research)
 	}
@@ -112,8 +116,10 @@ func TestApplyStartupDefaults_FillsEmptyConfig(t *testing.T) {
 
 func TestApplyStartupDefaults_PreservesUserValues(t *testing.T) {
 	cfg := &config.Config{}
+	cfg.Defaults.Models.Inquiry = "haiku"
 	cfg.Defaults.Models.Research = "haiku"
 	defaults := map[string]string{
+		"inquiry":        "sonnet",
 		"research":       "opus",
 		"planning":       "opus",
 		"implementation": "opus",
@@ -124,6 +130,9 @@ func TestApplyStartupDefaults_PreservesUserValues(t *testing.T) {
 	changed := ApplyStartupDefaults(cfg, defaults)
 	if !changed {
 		t.Error("expected changed=true since other fields were empty")
+	}
+	if cfg.Defaults.Models.Inquiry != "haiku" {
+		t.Errorf("expected Inquiry='haiku' preserved, got %q", cfg.Defaults.Models.Inquiry)
 	}
 	if cfg.Defaults.Models.Research != "haiku" {
 		t.Errorf("expected Research='haiku' preserved, got %q", cfg.Defaults.Models.Research)
@@ -180,6 +189,7 @@ func TestCheckRequiredTools_ContainsInstallHints(t *testing.T) {
 
 func TestApplyStartupDefaults_NoChange(t *testing.T) {
 	cfg := &config.Config{}
+	cfg.Defaults.Models.Inquiry = "z"
 	cfg.Defaults.Models.Research = "a"
 	cfg.Defaults.Models.Planning = "b"
 	cfg.Defaults.Models.Implementation = "c"
@@ -188,6 +198,7 @@ func TestApplyStartupDefaults_NoChange(t *testing.T) {
 	cfg.Defaults.Models.KBBuild = "f"
 
 	defaults := map[string]string{
+		"inquiry":        "sonnet",
 		"research":       "opus",
 		"planning":       "opus",
 		"implementation": "opus",

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -97,6 +97,7 @@ type PipelinePreference struct {
 }
 
 type ModelConfig struct {
+	Inquiry        string `yaml:"inquiry"`
 	Research       string `yaml:"research"`
 	Planning       string `yaml:"planning"`
 	Implementation string `yaml:"implementation"`
@@ -109,6 +110,7 @@ type ModelConfig struct {
 // If both keys are present, "utilities" takes precedence.
 func (m *ModelConfig) UnmarshalYAML(value *yaml.Node) error {
 	type aux struct {
+		Inquiry        string `yaml:"inquiry"`
 		Research       string `yaml:"research"`
 		Planning       string `yaml:"planning"`
 		Implementation string `yaml:"implementation"`
@@ -121,6 +123,7 @@ func (m *ModelConfig) UnmarshalYAML(value *yaml.Node) error {
 	if err := value.Decode(&a); err != nil {
 		return err
 	}
+	m.Inquiry = a.Inquiry
 	m.Research = a.Research
 	m.Planning = a.Planning
 	m.Implementation = a.Implementation
@@ -129,6 +132,9 @@ func (m *ModelConfig) UnmarshalYAML(value *yaml.Node) error {
 	m.KBBuild = a.KBBuild
 	if m.Utilities == "" && a.Chat != "" {
 		m.Utilities = a.Chat
+	}
+	if m.Inquiry == "" {
+		m.Inquiry = m.Research
 	}
 	return nil
 }
@@ -259,6 +265,13 @@ func DiscoverRepos(cfg *Config, baseDir string) int {
 
 func applyDefaults(cfg *Config) {
 	d := NewDefault()
+	if cfg.Defaults.Models.Inquiry == "" {
+		if cfg.Defaults.Models.Research != "" {
+			cfg.Defaults.Models.Inquiry = cfg.Defaults.Models.Research
+		} else {
+			cfg.Defaults.Models.Inquiry = d.Defaults.Models.Inquiry
+		}
+	}
 	if cfg.Defaults.Models.Research == "" {
 		cfg.Defaults.Models.Research = d.Defaults.Models.Research
 	}
@@ -546,6 +559,12 @@ func ApplyProviderDefaults(cfg *Config, defaults map[string]string) {
 		return
 	}
 	m := &cfg.Defaults.Models
+	if m.Inquiry == "" {
+		m.Inquiry = defaults["inquiry"]
+		if m.Inquiry == "" {
+			m.Inquiry = defaults["research"]
+		}
+	}
 	if m.Research == "" {
 		m.Research = defaults["research"]
 	}
@@ -588,6 +607,9 @@ func (d DefaultsConfig) PreferenceForPipeline(profile string) PipelinePreference
 }
 
 func overlayModelConfig(base, override ModelConfig) ModelConfig {
+	if override.Inquiry != "" {
+		base.Inquiry = override.Inquiry
+	}
 	if override.Research != "" {
 		base.Research = override.Research
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -26,6 +26,7 @@ import (
 func TestNewDefault(t *testing.T) {
 	cfg := NewDefault()
 	wantModels := ModelConfig{
+		Inquiry:        "sonnet[200K]",
 		Research:       "sonnet[200K]",
 		Planning:       "sonnet[200K]",
 		Implementation: "sonnet[200K]",
@@ -65,6 +66,7 @@ func TestSaveAndLoad(t *testing.T) {
 	original.Defaults.PipelinePreferences = map[string]PipelinePreference{
 		"medium": {
 			Models: ModelConfig{
+				Inquiry:        "claude:haiku",
 				Research:       "claude:haiku",
 				Planning:       "claude:haiku",
 				Implementation: "claude:sonnet",
@@ -89,6 +91,9 @@ func TestSaveAndLoad(t *testing.T) {
 
 	if loaded.Defaults.Models.Research != original.Defaults.Models.Research {
 		t.Errorf("models mismatch: got %s, want %s", loaded.Defaults.Models.Research, original.Defaults.Models.Research)
+	}
+	if loaded.Defaults.Models.Inquiry != original.Defaults.Models.Inquiry {
+		t.Errorf("inquiry model mismatch: got %s, want %s", loaded.Defaults.Models.Inquiry, original.Defaults.Models.Inquiry)
 	}
 	if loaded.Defaults.MaxIterations != original.Defaults.MaxIterations {
 		t.Errorf("max iterations mismatch: got %d, want %d", loaded.Defaults.MaxIterations, original.Defaults.MaxIterations)
@@ -159,6 +164,7 @@ func TestDefaultsConfigPreferenceForPipelineOverlaysRememberedValues(t *testing.
 	defaults.PipelinePreferences = map[string]PipelinePreference{
 		"moonshot": {
 			Models: ModelConfig{
+				Inquiry:        "claude:haiku",
 				Implementation: "claude:sonnet",
 				Review:         "codex:gpt-5.4-mini",
 			},
@@ -171,6 +177,9 @@ func TestDefaultsConfigPreferenceForPipelineOverlaysRememberedValues(t *testing.
 	if pref.Models.Research != defaults.Models.Research {
 		t.Errorf("research = %q, want fallback %q", pref.Models.Research, defaults.Models.Research)
 	}
+	if pref.Models.Inquiry != "claude:haiku" {
+		t.Errorf("inquiry = %q, want %q", pref.Models.Inquiry, "claude:haiku")
+	}
 	if pref.Models.Implementation != "claude:sonnet" {
 		t.Errorf("implementation = %q, want %q", pref.Models.Implementation, "claude:sonnet")
 	}
@@ -179,6 +188,27 @@ func TestDefaultsConfigPreferenceForPipelineOverlaysRememberedValues(t *testing.
 	}
 	if pref.Inquireness != "high" {
 		t.Errorf("inquireness = %q, want %q", pref.Inquireness, "high")
+	}
+}
+
+func TestLoadModelConfigMigratesMissingInquiryFromResearch(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	content := []byte("defaults:\n  models:\n    research: claude:custom-research\n")
+	if err := os.WriteFile(path, content, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	if cfg.Defaults.Models.Inquiry != "claude:custom-research" {
+		t.Errorf("inquiry = %q, want migrated research model", cfg.Defaults.Models.Inquiry)
+	}
+	if cfg.Defaults.Models.Research != "claude:custom-research" {
+		t.Errorf("research = %q, want configured research model", cfg.Defaults.Models.Research)
 	}
 }
 

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -25,6 +25,7 @@ func NewDefault() *Config {
 	return &Config{
 		Defaults: DefaultsConfig{
 			Models: ModelConfig{
+				Inquiry:        "sonnet[200K]",
 				Research:       "sonnet[200K]",
 				Planning:       "sonnet[200K]",
 				Implementation: "sonnet[200K]",

--- a/internal/llm/provider.go
+++ b/internal/llm/provider.go
@@ -263,6 +263,7 @@ var ErrNotSupported = fmt.Errorf("operation not supported by this provider")
 type PhaseRole string
 
 const (
+	PhaseInquiry        PhaseRole = "inquiry"
 	PhaseResearch       PhaseRole = "research"
 	PhasePlanning       PhaseRole = "planning"
 	PhaseImplementation PhaseRole = "implementation"

--- a/internal/llm/registry.go
+++ b/internal/llm/registry.go
@@ -257,7 +257,10 @@ func canonicalModelForProvider(p LLMProvider, model string) (string, bool) {
 // bare names are used.
 func (r *Registry) DefaultModels() map[PhaseRole]string {
 	mc := r.CatalogDefaultModels()
-	result := make(map[PhaseRole]string, 6)
+	result := make(map[PhaseRole]string, 7)
+	if mc.Inquiry != "" {
+		result[PhaseInquiry] = mc.Inquiry
+	}
 	if mc.Research != "" {
 		result[PhaseResearch] = mc.Research
 	}
@@ -384,6 +387,7 @@ func (r *Registry) LargestContextModel() string {
 // remain selectable for phases that benefit from them, but balanced defaults
 // are the cost/performance starting point for new features.
 var categoryForRole = map[PhaseRole]string{
+	PhaseInquiry:        "balanced",
 	PhaseResearch:       "balanced",
 	PhasePlanning:       "balanced",
 	PhaseImplementation: "balanced",
@@ -393,6 +397,10 @@ var categoryForRole = map[PhaseRole]string{
 }
 
 var preferredModelHintsByRoleProvider = map[PhaseRole]map[string][]string{
+	PhaseInquiry: {
+		"claude": {"sonnet[200K]", "sonnet"},
+		"codex":  {"gpt-5.4[272K]", "gpt-5.4"},
+	},
 	PhaseResearch: {
 		"claude": {"sonnet[200K]", "sonnet"},
 		"codex":  {"gpt-5.4[272K]", "gpt-5.4"},
@@ -526,6 +534,7 @@ func (r *Registry) CatalogDefaultModels() config.ModelConfig {
 	}
 
 	return config.ModelConfig{
+		Inquiry:        selectModel(PhaseInquiry),
 		Research:       selectModel(PhaseResearch),
 		Planning:       selectModel(PhasePlanning),
 		Implementation: selectModel(PhaseImplementation),
@@ -538,6 +547,7 @@ func (r *Registry) CatalogDefaultModels() config.ModelConfig {
 // eligibleCategoriesForRole maps phase roles to the set of model categories
 // that are appropriate for that phase.
 var eligibleCategoriesForRole = map[PhaseRole]map[string]bool{
+	PhaseInquiry:        {"capable": true, "balanced": true},
 	PhaseResearch:       {"capable": true, "balanced": true},
 	PhasePlanning:       {"capable": true, "balanced": true},
 	PhaseImplementation: {"capable": true, "balanced": true},

--- a/internal/llm/registry_test.go
+++ b/internal/llm/registry_test.go
@@ -482,6 +482,9 @@ func TestRegistry_DefaultModels_UsesCatalogDefaults(t *testing.T) {
 	})
 
 	defaults := r.DefaultModels()
+	if defaults[llm.PhaseInquiry] != "claude:sonnet" {
+		t.Errorf("inquiry: got %q, want %q", defaults[llm.PhaseInquiry], "claude:sonnet")
+	}
 	if defaults[llm.PhaseResearch] != "claude:sonnet" {
 		t.Errorf("research: got %q, want %q", defaults[llm.PhaseResearch], "claude:sonnet")
 	}
@@ -837,6 +840,9 @@ func TestRegistry_CatalogDefaultModels(t *testing.T) {
 		mc := r.CatalogDefaultModels()
 
 		// Feature phases prefer balanced defaults where available.
+		if mc.Inquiry != "claude:sonnet" {
+			t.Errorf("inquiry: got %q, want %q", mc.Inquiry, "claude:sonnet")
+		}
 		if mc.Research != "claude:sonnet" {
 			t.Errorf("research: got %q, want %q", mc.Research, "claude:sonnet")
 		}
@@ -870,6 +876,9 @@ func TestRegistry_CatalogDefaultModels(t *testing.T) {
 		mc := r.CatalogDefaultModels()
 
 		// Single provider → bare names (no prefix)
+		if mc.Inquiry != "sonnet" {
+			t.Errorf("inquiry: got %q, want %q", mc.Inquiry, "sonnet")
+		}
 		if mc.Research != "sonnet" {
 			t.Errorf("research: got %q, want %q", mc.Research, "sonnet")
 		}
@@ -902,6 +911,9 @@ func TestRegistry_CatalogDefaultModels(t *testing.T) {
 
 		// Single provider → bare names (no prefix)
 		// Research prefers claude, but claude not available; falls back to a balanced codex model
+		if mc.Inquiry != "gpt-5.4" {
+			t.Errorf("inquiry: got %q, want %q", mc.Inquiry, "gpt-5.4")
+		}
 		if mc.Research != "gpt-5.4" {
 			t.Errorf("research: got %q, want %q", mc.Research, "gpt-5.4")
 		}
@@ -1042,6 +1054,19 @@ func TestRegistry_EligibleModelsForPhase(t *testing.T) {
 		// codex: gpt-5.4 is the recommended default; balanced mini remains available.
 		if got := result["codex"]; !slices.Contains(got, "gpt-5.4") || !slices.Contains(got, "gpt-5.4-mini") {
 			t.Errorf("codex research: got %v, want gpt-5.4 and gpt-5.4-mini", got)
+		}
+	})
+
+	t.Run("inquiry includes same capable and balanced options as research", func(t *testing.T) {
+		result := r.EligibleModelsForPhase(llm.PhaseInquiry)
+		if got := result["claude"]; !slices.Contains(got, "sonnet") || !slices.Contains(got, "opus") {
+			t.Errorf("claude inquiry: got %v, want sonnet and opus", got)
+		}
+		if slices.Contains(result["claude"], "haiku") {
+			t.Error("claude inquiry should not include haiku")
+		}
+		if got := result["codex"]; !slices.Contains(got, "gpt-5.4") || !slices.Contains(got, "gpt-5.4-mini") {
+			t.Errorf("codex inquiry: got %v, want gpt-5.4 and gpt-5.4-mini", got)
 		}
 	})
 

--- a/internal/observe/observer.go
+++ b/internal/observe/observer.go
@@ -1100,6 +1100,7 @@ func (o *Observer) ConfigChanged(sc SpanContext, before, after feature.ConfigSna
 func configSnapshotAttrs(s feature.ConfigSnapshot) map[string]any {
 	return map[string]any{
 		"models": map[string]any{
+			"inquiry":        s.Models.Inquiry,
 			"research":       s.Models.Research,
 			"planning":       s.Models.Planning,
 			"implementation": s.Models.Implementation,

--- a/internal/tui/configeditor.go
+++ b/internal/tui/configeditor.go
@@ -262,6 +262,9 @@ func (m ConfigEditorModel) ModelsChangeCount() int {
 	orig := m.original.Models
 	cur := m.models
 	count := 0
+	if cur.Inquiry != orig.Inquiry {
+		count++
+	}
 	if cur.Research != orig.Research {
 		count++
 	}
@@ -404,6 +407,8 @@ func (m ConfigEditorModel) currentModelField() string {
 
 func (m ConfigEditorModel) modelValueForField(field string) string {
 	switch field {
+	case "Clarify":
+		return m.models.Inquiry
 	case "Research":
 		return m.models.Research
 	case "Planning":
@@ -420,6 +425,8 @@ func (m ConfigEditorModel) modelValueForField(field string) string {
 
 func (m *ConfigEditorModel) setModelValueForField(field, value string) {
 	switch field {
+	case "Clarify":
+		m.models.Inquiry = value
 	case "Research":
 		m.models.Research = value
 	case "Planning":
@@ -691,7 +698,8 @@ func compactModelIDLabel(id string) string {
 }
 
 func compactModelSummary(models config.ModelConfig, separator string) string {
-	return fmt.Sprintf("R:%s%sP:%s%sI:%s%sRev:%s%sKB:%s",
+	return fmt.Sprintf("C:%s%sR:%s%sP:%s%sI:%s%sRev:%s%sKB:%s",
+		compactModelValueLabel(models.Inquiry), separator,
 		compactModelValueLabel(models.Research), separator,
 		compactModelValueLabel(models.Planning), separator,
 		compactModelValueLabel(models.Implementation), separator,

--- a/internal/tui/configeditor_test.go
+++ b/internal/tui/configeditor_test.go
@@ -31,13 +31,14 @@ import (
 // consume this catalog instead of a live *llm.Registry.
 func testCatalog() PhaseModelCatalog {
 	cat := PhaseModelCatalog{
-		Fields:        []string{"Research", "Planning", "Implementation", "Review", "KB Build"},
+		Fields:        []string{"Clarify", "Research", "Planning", "Implementation", "Review", "KB Build"},
 		ProviderOrder: []string{"claude", "codex"},
 		ProviderModels: map[string][]string{
 			"claude": {"claude/sonnet-4-6", "claude/opus-4-7"},
 			"codex":  {"codex/gpt-5-codex"},
 		},
 		PhaseDefaults: map[string]string{
+			"Clarify":        "claude/sonnet-4-6",
 			"Research":       "claude/sonnet-4-6",
 			"Planning":       "claude/opus-4-7",
 			"Implementation": "claude/sonnet-4-6",
@@ -45,6 +46,7 @@ func testCatalog() PhaseModelCatalog {
 			"KB Build":       "claude/sonnet-4-6",
 		},
 		PhaseProviderModels: map[string]map[string][]string{
+			"Clarify":        {"claude": {"claude/sonnet-4-6", "claude/opus-4-7"}, "codex": {"codex/gpt-5-codex"}},
 			"Research":       {"claude": {"claude/sonnet-4-6", "claude/opus-4-7"}, "codex": {"codex/gpt-5-codex"}},
 			"Planning":       {"claude": {"claude/sonnet-4-6", "claude/opus-4-7"}, "codex": {"codex/gpt-5-codex"}},
 			"Implementation": {"claude": {"claude/sonnet-4-6", "claude/opus-4-7"}, "codex": {"codex/gpt-5-codex"}},
@@ -97,45 +99,45 @@ func checkpointViewContainsLabel(view, label string) bool {
 
 func TestConfigEditor_RowCursor_FlatWalk(t *testing.T) {
 	t.Parallel()
-	e := newEditor(nil, true) // 5 Models + 1 Inquireness + 5 Checkpoints = rows 0..10
+	e := newEditor(nil, true) // 6 Models + 1 Inquireness + 5 Checkpoints = rows 0..11
 	if e.rowCursor != 0 {
 		t.Fatalf("initial rowCursor = %d, want 0", e.rowCursor)
 	}
-	for i := 0; i < 10; i++ {
+	for i := 0; i < 11; i++ {
 		e, _ = e.Update(tea.KeyPressMsg{Code: tea.KeyDown})
 	}
-	if e.rowCursor != 10 {
-		t.Errorf("after 10 downs: rowCursor = %d, want 10", e.rowCursor)
+	if e.rowCursor != 11 {
+		t.Errorf("after 11 downs: rowCursor = %d, want 11", e.rowCursor)
 	}
 	// One more down wraps to 0.
 	e, _ = e.Update(tea.KeyPressMsg{Code: tea.KeyDown})
 	if e.rowCursor != 0 {
 		t.Errorf("after wrap-around down: rowCursor = %d, want 0", e.rowCursor)
 	}
-	// Up from 0 wraps to 10.
+	// Up from 0 wraps to 11.
 	e, _ = e.Update(tea.KeyPressMsg{Code: tea.KeyUp})
-	if e.rowCursor != 10 {
-		t.Errorf("up from 0 should wrap to 10, got %d", e.rowCursor)
+	if e.rowCursor != 11 {
+		t.Errorf("up from 0 should wrap to 11, got %d", e.rowCursor)
 	}
-	for i := 0; i < 10; i++ {
+	for i := 0; i < 11; i++ {
 		e, _ = e.Update(tea.KeyPressMsg{Code: tea.KeyUp})
 	}
 	if e.rowCursor != 0 {
-		t.Errorf("after 10 ups from 10: rowCursor = %d, want 0", e.rowCursor)
+		t.Errorf("after 11 ups from 11: rowCursor = %d, want 0", e.rowCursor)
 	}
 }
 
 func TestConfigEditor_RowCursor_FlatWalk_4Checkpoints(t *testing.T) {
 	t.Parallel()
-	e := newEditor(nil, false) // ManualPublish hidden → 5 + 1 + 4 = rows 0..9
-	if e.lastRow() != 9 {
-		t.Fatalf("lastRow = %d, want 9", e.lastRow())
+	e := newEditor(nil, false) // ManualPublish hidden → 6 + 1 + 4 = rows 0..10
+	if e.lastRow() != 10 {
+		t.Fatalf("lastRow = %d, want 10", e.lastRow())
 	}
-	for i := 0; i < 9; i++ {
+	for i := 0; i < 10; i++ {
 		e, _ = e.Update(tea.KeyPressMsg{Code: tea.KeyDown})
 	}
-	if e.rowCursor != 9 {
-		t.Errorf("after 9 downs: rowCursor = %d, want 9", e.rowCursor)
+	if e.rowCursor != 10 {
+		t.Errorf("after 10 downs: rowCursor = %d, want 10", e.rowCursor)
 	}
 	e, _ = e.Update(tea.KeyPressMsg{Code: tea.KeyDown})
 	if e.rowCursor != 0 {
@@ -149,15 +151,17 @@ func TestConfigEditor_Tab_SelectsModelCellOnModelsRow(t *testing.T) {
 		row    int
 		getter func(feature.ConfigSnapshot) string
 	}{
-		{0, func(s feature.ConfigSnapshot) string { return s.Models.Research }},
-		{1, func(s feature.ConfigSnapshot) string { return s.Models.Planning }},
-		{2, func(s feature.ConfigSnapshot) string { return s.Models.Implementation }},
-		{3, func(s feature.ConfigSnapshot) string { return s.Models.Review }},
-		{4, func(s feature.ConfigSnapshot) string { return s.Models.KBBuild }},
+		{0, func(s feature.ConfigSnapshot) string { return s.Models.Inquiry }},
+		{1, func(s feature.ConfigSnapshot) string { return s.Models.Research }},
+		{2, func(s feature.ConfigSnapshot) string { return s.Models.Planning }},
+		{3, func(s feature.ConfigSnapshot) string { return s.Models.Implementation }},
+		{4, func(s feature.ConfigSnapshot) string { return s.Models.Review }},
+		{5, func(s feature.ConfigSnapshot) string { return s.Models.KBBuild }},
 	}
 	// Seed each Models field to a known valid value so the reversibility
 	// assertion exercises normal cycling (not stale-model preservation).
 	seed := config.ModelConfig{
+		Inquiry:        "claude/sonnet-4-6",
 		Research:       "claude/sonnet-4-6",
 		Planning:       "claude/sonnet-4-6",
 		Implementation: "claude/sonnet-4-6",
@@ -213,7 +217,7 @@ func TestConfigEditor_ChangingAgentSelectsRecommendedModel(t *testing.T) {
 	t.Parallel()
 	cat := BuildPhaseModelCatalog(gatewayWinningRegistry(), config.DefaultsConfig{})
 	e := NewConfigEditorModel(&feature.Feature{Models: config.ModelConfig{Research: "claude:sonnet[200K]"}}, cat, true)
-	e.rowCursor = 0
+	e.rowCursor = 1
 	e.activeModelCell = modelCellAgent
 
 	e, _ = e.Update(tea.KeyPressMsg{Code: tea.KeyRight})
@@ -236,7 +240,7 @@ func TestConfigEditor_BlankModelValueInheritsDefaultAgent(t *testing.T) {
 		t.Fatalf("agentValueForField(Research) = %q, want gateway from phase default", got)
 	}
 
-	e.rowCursor = 0
+	e.rowCursor = 1
 	e.activeModelCell = modelCellModel
 	e, _ = e.Update(tea.KeyPressMsg{Code: tea.KeyRight})
 	if got := e.agentValueForField("Research"); got != "gateway" {
@@ -267,7 +271,7 @@ func TestConfigEditor_ModelFilteringIsScopedToSelectedAgent(t *testing.T) {
 	})
 	cat := BuildPhaseModelCatalog(reg, config.DefaultsConfig{})
 	e := NewConfigEditorModel(&feature.Feature{Models: config.ModelConfig{Planning: "gateway:ollama/gemma4:31b-256k"}}, cat, true)
-	e.rowCursor = 1
+	e.rowCursor = 2
 	e.activeModelCell = modelCellModel
 
 	e, _ = e.Update(tea.KeyPressMsg{Code: '/', Text: "/"})
@@ -297,7 +301,7 @@ func TestConfigEditor_ModelFilterConsumesNavigationAndCellKeys(t *testing.T) {
 	}
 	for _, keyMsg := range keys {
 		e := newEditor(&feature.Feature{Models: config.ModelConfig{Research: "claude/sonnet-4-6"}}, true)
-		e.rowCursor = 0
+		e.rowCursor = 1
 		e.activeModelCell = modelCellModel
 		e, _ = e.Update(tea.KeyPressMsg{Code: '/', Text: "/"})
 		e, _ = e.Update(tea.KeyPressMsg{Code: 'o', Text: "o"})
@@ -330,7 +334,7 @@ func TestConfigEditor_ModelFilterConsumesNavigationAndCellKeys(t *testing.T) {
 func TestConfigEditor_EmptyFilterEnterPreservesCurrentModel(t *testing.T) {
 	t.Parallel()
 	e := newEditor(&feature.Feature{Models: config.ModelConfig{Research: "claude/opus-4-7"}}, true)
-	e.rowCursor = 0
+	e.rowCursor = 1
 	e.activeModelCell = modelCellModel
 
 	e, _ = e.Update(tea.KeyPressMsg{Code: '/', Text: "/"})
@@ -357,7 +361,7 @@ func TestConfigEditor_SingleAgentCyclePreservesValidNonDefaultModel(t *testing.T
 	})
 	cat := BuildPhaseModelCatalog(reg, config.DefaultsConfig{})
 	e := NewConfigEditorModel(&feature.Feature{Models: config.ModelConfig{Research: "opus"}}, cat, true)
-	e.rowCursor = 0
+	e.rowCursor = 1
 	e.activeModelCell = modelCellAgent
 
 	e, _ = e.Update(tea.KeyPressMsg{Code: tea.KeyRight})
@@ -383,7 +387,7 @@ func TestConfigEditor_SingleAgentCyclePreservesBlankDefaultModel(t *testing.T) {
 	})
 	cat := BuildPhaseModelCatalog(reg, config.DefaultsConfig{})
 	e := NewConfigEditorModel(&feature.Feature{}, cat, true)
-	e.rowCursor = 0
+	e.rowCursor = 1
 	e.activeModelCell = modelCellAgent
 
 	e, _ = e.Update(tea.KeyPressMsg{Code: tea.KeyRight})
@@ -444,7 +448,7 @@ func TestConfigEditor_ModelsCycleForward(t *testing.T) {
 	if len(entries) < 2 {
 		t.Fatalf("catalog has too few claude Research entries: %+v", entries)
 	}
-	e.rowCursor = 0
+	e.rowCursor = 1
 	e.activeModelCell = modelCellModel
 	// Seed to the first option.
 	e.models.Research = e.catalog.SelectionValue(entries[0])
@@ -464,7 +468,7 @@ func TestConfigEditor_ModelsCycleBackward(t *testing.T) {
 	t.Parallel()
 	e := newEditor(nil, true)
 	entries := e.catalog.EntriesForFieldAndAgent("Research", "claude")
-	e.rowCursor = 0
+	e.rowCursor = 1
 	e.activeModelCell = modelCellModel
 	e.models.Research = e.catalog.SelectionValue(entries[0])
 	e, _ = e.Update(tea.KeyPressMsg{Code: tea.KeyLeft})
@@ -716,7 +720,7 @@ func TestConfigEditor_StaleModelPreservation(t *testing.T) {
 		t.Errorf("renderer missing (unavailable) marker; view:\n%s", view)
 	}
 	// Forward cycle lands on the first eligible, dropping the stale value.
-	e.rowCursor = 0
+	e.rowCursor = 1
 	e.activeModelCell = modelCellModel
 	e, _ = e.Update(tea.KeyPressMsg{Code: tea.KeyRight})
 	entries := e.catalog.EntriesForFieldAndAgent("Research", "claude")
@@ -760,7 +764,7 @@ func TestConfigEditor_ProviderSelectionPersistsRoutedSlashForm(t *testing.T) {
 	cat := BuildPhaseModelCatalog(gatewayWinningRegistry(), config.DefaultsConfig{})
 	e := NewConfigEditorModel(&feature.Feature{}, cat, true)
 
-	e.rowCursor = 0
+	e.rowCursor = 1
 	e.activeModelCell = modelCellModel
 	e, _ = e.Update(tea.KeyPressMsg{Code: tea.KeyRight})
 	target := "vendor/sonnet[200K]"
@@ -805,9 +809,9 @@ func TestConfigEditor_ChangeCounters(t *testing.T) {
 	t.Parallel()
 	e := newEditor(&feature.Feature{Inquireness: feature.InquirenessMedium}, true)
 	// Cycle Research and Planning rows forward.
-	e.rowCursor = 0
-	e, _ = e.Update(tea.KeyPressMsg{Code: tea.KeyRight})
 	e.rowCursor = 1
+	e, _ = e.Update(tea.KeyPressMsg{Code: tea.KeyRight})
+	e.rowCursor = 2
 	e, _ = e.Update(tea.KeyPressMsg{Code: tea.KeyRight})
 	if got := e.ModelsChangeCount(); got != 2 {
 		t.Errorf("ModelsChangeCount = %d, want 2", got)
@@ -867,7 +871,7 @@ func TestConfigEditor_CycleFromPrefixedDefaultAdvances(t *testing.T) {
 	const prefixed = "gateway:vendor/sonnet[200K]"
 	e := NewConfigEditorModel(&feature.Feature{Models: config.ModelConfig{Research: prefixed}}, cat, true)
 
-	e.rowCursor = 0
+	e.rowCursor = 1
 	e.activeModelCell = modelCellModel
 	e.cycleModelForward()
 	entries := cat.EntriesForFieldAndAgent("Research", "gateway")

--- a/internal/tui/editconfig_test.go
+++ b/internal/tui/editconfig_test.go
@@ -437,6 +437,7 @@ func TestAppModel_EditConfigModelFilterEnterLeavesOverlayOpen(t *testing.T) {
 	app.editConfig = NewEditConfigModel(f, cat, true)
 	app.editConfigActive = true
 	app.editConfig.activeTab = tabModels
+	app.editConfig.editor.rowCursor = 1
 	app.editConfig.editor.activeModelCell = modelCellModel
 	app.editConfig.focus = configFocusModelList
 
@@ -665,6 +666,7 @@ func TestEditConfig_ModelWorkspaceAlwaysShowsThreePanelsAndOneFocusCursor(t *tes
 		t.Run(tc.name, func(t *testing.T) {
 			m := NewEditConfigModel(f, cat, true)
 			m.focus = tc.focus
+			m.editor.rowCursor = 1
 			view := m.View()
 			for _, want := range []string{"Phases", "Agents", "Models for gateway"} {
 				if !strings.Contains(view, want) {
@@ -862,8 +864,8 @@ func TestEditConfig_CatalogBuiltAtModalOpen(t *testing.T) {
 	if !got.editConfigActive {
 		t.Fatal("right-panel `e` should open the overlay for a quiescent feature")
 	}
-	if n := len(got.editConfig.editor.catalog.Fields); n != 5 {
-		t.Errorf("catalog.Fields = %d entries, want 5", n)
+	if n := len(got.editConfig.editor.catalog.Fields); n != 6 {
+		t.Errorf("catalog.Fields = %d entries, want 6", n)
 	}
 
 	// Detail-view dispatch path.
@@ -879,7 +881,7 @@ func TestEditConfig_CatalogBuiltAtModalOpen(t *testing.T) {
 	if !got2.editConfigActive {
 		t.Fatal("detail-view `e` should open the overlay for a quiescent feature")
 	}
-	if n := len(got2.editConfig.editor.catalog.Fields); n != 5 {
-		t.Errorf("catalog.Fields = %d entries, want 5", n)
+	if n := len(got2.editConfig.editor.catalog.Fields); n != 6 {
+		t.Errorf("catalog.Fields = %d entries, want 6", n)
 	}
 }

--- a/internal/tui/live_preview.go
+++ b/internal/tui/live_preview.go
@@ -500,7 +500,12 @@ func livePreviewConfiguredPhaseModel(f *feature.Feature, phase feature.Phase) st
 	switch phase {
 	case feature.PhaseKnowledgeBase:
 		return f.Models.KBBuild
-	case feature.PhaseInquire, feature.PhaseResearch, feature.PhaseDesign:
+	case feature.PhaseInquire:
+		if f.Models.Inquiry != "" {
+			return f.Models.Inquiry
+		}
+		return f.Models.Research
+	case feature.PhaseResearch, feature.PhaseDesign:
 		return f.Models.Research
 	case feature.PhasePlan, feature.PhasePublish:
 		return f.Models.Planning

--- a/internal/tui/live_preview_test.go
+++ b/internal/tui/live_preview_test.go
@@ -753,6 +753,23 @@ func TestLivePreviewUpperMetadataUsesShortPhaseModelName(t *testing.T) {
 	}
 }
 
+func TestLivePreviewConfiguredPhaseModelUsesInquiryForInquire(t *testing.T) {
+	t.Parallel()
+	f := &feature.Feature{
+		Models: config.ModelConfig{
+			Inquiry:  "claude:clarify-model",
+			Research: "claude:research-model",
+		},
+	}
+
+	if got := livePreviewConfiguredPhaseModel(f, feature.PhaseInquire); got != "claude:clarify-model" {
+		t.Errorf("PhaseInquire model = %q, want inquiry model", got)
+	}
+	if got := livePreviewConfiguredPhaseModel(f, feature.PhaseResearch); got != "claude:research-model" {
+		t.Errorf("PhaseResearch model = %q, want research model", got)
+	}
+}
+
 func TestLivePreviewUpperMetadataKeepsConfiguredProviderForBackendSessionModel(t *testing.T) {
 	t.Parallel()
 	const routedModel = "opencode:portkey/@fireworks/accounts/fireworks/models/glm-5p2[1.04M]"

--- a/internal/tui/phase_catalog.go
+++ b/internal/tui/phase_catalog.go
@@ -23,12 +23,12 @@ import (
 
 // phaseCatalogFields is the canonical ordered list of phase-role field names
 // consumed by both the wizard's inline catalog block and BuildPhaseModelCatalog.
-var phaseCatalogFields = []string{"Research", "Planning", "Implementation", "Review", "KB Build"}
+var phaseCatalogFields = []string{"Clarify", "Research", "Planning", "Implementation", "Review", "KB Build"}
 
-// phaseCatalogRoleToField maps llm.PhaseRole to catalog field name. The ground
-// truth for this mapping lives in AppModel.transitionToWizard (app.go); the
-// helper mirrors it while the wizard and edit-config overlay share the catalog.
+// phaseCatalogRoleToField maps llm.PhaseRole to catalog field name. The wizard
+// and edit-config overlay both consume this shared catalog mapping.
 var phaseCatalogRoleToField = map[llm.PhaseRole]string{
+	llm.PhaseInquiry:        "Clarify",
 	llm.PhaseResearch:       "Research",
 	llm.PhasePlanning:       "Planning",
 	llm.PhaseImplementation: "Implementation",
@@ -58,7 +58,7 @@ type PhaseModelCatalog struct {
 	ProviderModelInfos map[string][]llm.ModelInfo
 	// ProviderOrder is the display order of provider names.
 	ProviderOrder []string
-	// PhaseDefaults maps field name ("Research", "Planning",
+	// PhaseDefaults maps field name ("Clarify", "Research", "Planning",
 	// "Implementation", "Review", "KB Build") → recommended model ID.
 	PhaseDefaults map[string]string
 	// PhaseProviderModels maps field name → provider → eligible model IDs
@@ -68,14 +68,13 @@ type PhaseModelCatalog struct {
 	// metadata entries filtered by role category.
 	PhaseProviderModelInfos map[string]map[string][]llm.ModelInfo
 	// Fields is the canonical ordered list of phase-role field names. Always
-	// {"Research", "Planning", "Implementation", "Review", "KB Build"}.
+	// {"Clarify", "Research", "Planning", "Implementation", "Review", "KB Build"}.
 	Fields []string
 }
 
 // BuildPhaseModelCatalog builds a PhaseModelCatalog from the current
-// registry state. Mirrors the block currently inlined in
-// AppModel.transitionToWizard; both stay in shape-parity (guarded by
-// phase_catalog_test.go).
+// registry state. The wizard and edit-config overlay share this immutable
+// view of model availability and per-phase eligibility.
 //
 // The `defaults` parameter is accepted for forward compatibility.
 //
@@ -122,6 +121,7 @@ func BuildPhaseModelCatalog(reg *llm.Registry, _ config.DefaultsConfig) PhaseMod
 		}
 	}
 	catalogDefaults := reg.CatalogDefaultModels()
+	cat.PhaseDefaults["Clarify"] = catalogDefaults.Inquiry
 	cat.PhaseDefaults["Research"] = catalogDefaults.Research
 	cat.PhaseDefaults["Planning"] = catalogDefaults.Planning
 	cat.PhaseDefaults["Implementation"] = catalogDefaults.Implementation

--- a/internal/tui/phase_catalog_test.go
+++ b/internal/tui/phase_catalog_test.go
@@ -86,7 +86,7 @@ func TestBuildPhaseModelCatalog_SurfacesProviderGroup(t *testing.T) {
 	if got := cat.ProviderModels["gateway"]; !slices.Contains(got, "vendor/sonnet[200K]") {
 		t.Errorf("gateway ProviderModels = %v, want the slash-form backend id", got)
 	}
-	for _, field := range []string{"Research", "Planning", "Implementation", "Review", "KB Build"} {
+	for _, field := range []string{"Clarify", "Research", "Planning", "Implementation", "Review", "KB Build"} {
 		if _, ok := cat.PhaseProviderModels[field]["gateway"]; !ok {
 			t.Errorf("PhaseProviderModels[%q] missing gateway group", field)
 		}
@@ -104,7 +104,7 @@ func TestBuildPhaseModelCatalog_Shape(t *testing.T) {
 	reg := llm.NewRegistry()
 	cat := BuildPhaseModelCatalog(reg, config.DefaultsConfig{})
 
-	wantFields := []string{"Research", "Planning", "Implementation", "Review", "KB Build"}
+	wantFields := []string{"Clarify", "Research", "Planning", "Implementation", "Review", "KB Build"}
 	if !reflect.DeepEqual(cat.Fields, wantFields) {
 		t.Errorf("Fields = %v, want %v", cat.Fields, wantFields)
 	}
@@ -149,8 +149,8 @@ func TestBuildPhaseModelCatalog_Shape(t *testing.T) {
 func TestBuildPhaseModelCatalog_NilRegistry(t *testing.T) {
 	t.Parallel()
 	cat := BuildPhaseModelCatalog(nil, config.DefaultsConfig{})
-	if len(cat.Fields) != 5 {
-		t.Errorf("Fields = %d entries, want 5", len(cat.Fields))
+	if len(cat.Fields) != 6 {
+		t.Errorf("Fields = %d entries, want 6", len(cat.Fields))
 	}
 	if len(cat.ProviderOrder) != 0 {
 		t.Errorf("ProviderOrder should be empty for nil registry, got %v", cat.ProviderOrder)
@@ -173,7 +173,7 @@ func TestBuildPhaseModelCatalog_NilRegistry(t *testing.T) {
 func TestPhaseModelCatalog_ModelOptionsForField(t *testing.T) {
 	t.Parallel()
 	cat := PhaseModelCatalog{
-		Fields:        []string{"Research", "Planning", "Implementation", "Review", "KB Build"},
+		Fields:        []string{"Clarify", "Research", "Planning", "Implementation", "Review", "KB Build"},
 		ProviderOrder: []string{"claude", "codex"},
 		ProviderModels: map[string][]string{
 			"claude": {"claude/sonnet-4-6", "claude/opus-4-7"},

--- a/internal/tui/wizard.go
+++ b/internal/tui/wizard.go
@@ -322,6 +322,7 @@ func NewWizardModel(availRepos []string, repoPaths map[string]string, repoConfig
 	pipelinePrefs := make(map[string]config.PipelinePreference, len(pipelineOptions))
 	for _, profile := range pipelineOptions {
 		pref := defaults.PreferenceForPipeline(profile)
+		pref.Models.Inquiry = configCatalog.ClampModelValue("Clarify", pref.Models.Inquiry)
 		pref.Models.Research = configCatalog.ClampModelValue("Research", pref.Models.Research)
 		pref.Models.Planning = configCatalog.ClampModelValue("Planning", pref.Models.Planning)
 		pref.Models.Implementation = configCatalog.ClampModelValue("Implementation", pref.Models.Implementation)
@@ -358,7 +359,7 @@ func NewWizardModel(availRepos []string, repoPaths map[string]string, repoConfig
 		selectedRepos:          make(map[string]bool),
 		repos:                  repoConfigs,
 		models:                 models,
-		modelFields:            []string{"Research", "Planning", "Implementation", "Review", "KB Build"},
+		modelFields:            append([]string(nil), phaseCatalogFields...),
 		providerModels:         providerModels,
 		providerOrder:          providerOrder,
 		phaseDefaults:          phaseDefaults,
@@ -667,6 +668,7 @@ func (m *WizardModel) applyPipelinePreference(profile string) {
 	if !ok {
 		return
 	}
+	pref.Models.Inquiry = m.configCatalog.ClampModelValue("Clarify", pref.Models.Inquiry)
 	pref.Models.Research = m.configCatalog.ClampModelValue("Research", pref.Models.Research)
 	pref.Models.Planning = m.configCatalog.ClampModelValue("Planning", pref.Models.Planning)
 	pref.Models.Implementation = m.configCatalog.ClampModelValue("Implementation", pref.Models.Implementation)
@@ -2523,6 +2525,8 @@ func (m *WizardModel) cycleModelReverse() {
 
 func (m *WizardModel) getModelField(field string) string {
 	switch field {
+	case "Clarify":
+		return m.models.Inquiry
 	case "Research":
 		return m.models.Research
 	case "Planning":
@@ -2539,6 +2543,8 @@ func (m *WizardModel) getModelField(field string) string {
 
 func (m *WizardModel) setModelField(field, value string) {
 	switch field {
+	case "Clarify":
+		m.models.Inquiry = value
 	case "Research":
 		m.models.Research = value
 	case "Planning":

--- a/internal/tui/wizard_delegation_test.go
+++ b/internal/tui/wizard_delegation_test.go
@@ -35,6 +35,7 @@ func newWizardAtReviewForDelegation(t *testing.T, providerModels map[string][]st
 	t.Helper()
 	defaults := config.NewDefault().Defaults
 	defaults.Models = config.ModelConfig{
+		Inquiry:        "opus",
 		Research:       "opus",
 		Planning:       "opus",
 		Implementation: "opus",
@@ -64,6 +65,7 @@ func TestWizardReviewDelegation_ModelsCycleRoundTrip(t *testing.T) {
 
 	m.summaryCursor = summaryFieldModels
 	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown}) // Clarify -> Research
 	if !m.summaryEditing {
 		t.Fatal("expected summaryEditing=true after Enter on Models")
 	}
@@ -136,12 +138,12 @@ func TestWizardReviewDelegation_ModelsUpDownClampedAtBounds(t *testing.T) {
 		t.Errorf("Up at modelCursor=0: got %d, want 0", m.modelCursor)
 	}
 
-	// Walk down to 4 and beyond: stays at 4
+	// Walk down to 5 and beyond: stays at 5
 	for i := 0; i < 10; i++ {
 		m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
 	}
-	if m.modelCursor != 4 {
-		t.Errorf("Down × 10 at top: got modelCursor=%d, want 4 (clamped)", m.modelCursor)
+	if m.modelCursor != 5 {
+		t.Errorf("Down × 10 at top: got modelCursor=%d, want 5 (clamped)", m.modelCursor)
 	}
 }
 
@@ -153,11 +155,12 @@ func TestWizardReviewDelegation_ModelsSubRowCycle(t *testing.T) {
 	m.summaryCursor = summaryFieldModels
 	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
 
-	// Navigate to Implementation (row 2)
+	// Navigate to Implementation (row 3)
 	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
 	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
-	if m.modelCursor != 2 {
-		t.Fatalf("modelCursor = %d, want 2", m.modelCursor)
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	if m.modelCursor != 3 {
+		t.Fatalf("modelCursor = %d, want 3", m.modelCursor)
 	}
 	origImpl := m.models.Implementation
 	origResearch := m.models.Research
@@ -183,6 +186,7 @@ func TestWizardReviewDelegation_ModelSelectionPanelsUseVerticalSelection(t *test
 	m := newWizardAtReviewForDelegation(t, providerModels, []string{"claude", "gateway"}, nil)
 	m.summaryCursor = summaryFieldModels
 	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown}) // Clarify -> Research
 
 	if got := m.wizardModelFocus(); got != configFocusPhaseList {
 		t.Fatalf("initial model editor focus = %v, want phase list", got)
@@ -618,8 +622,9 @@ func TestWizardReviewDelegation_ModelFilterEnterDoesNotCloseEditing(t *testing.T
 	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
 
 	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
-	if m.modelCursor != 1 {
-		t.Fatalf("modelCursor = %d, want Planning row 1", m.modelCursor)
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	if m.modelCursor != 2 {
+		t.Fatalf("modelCursor = %d, want Planning row 2", m.modelCursor)
 	}
 	beforePlanning := m.models.Planning
 

--- a/internal/tui/wizard_test.go
+++ b/internal/tui/wizard_test.go
@@ -53,6 +53,7 @@ func TestWizardSteps(t *testing.T) {
 	repos := []string{"repo-a", "repo-b"}
 	defaults := config.DefaultsConfig{
 		Models: config.ModelConfig{
+			Inquiry:        "opus",
 			Research:       "opus",
 			Planning:       "opus",
 			Implementation: "opus",
@@ -786,6 +787,7 @@ func TestWizardRepoFilter(t *testing.T) {
 	repos := []string{"alpha", "beta", "gamma", "geo-intel", "geo-proxy"}
 	defaults := config.DefaultsConfig{
 		Models: config.ModelConfig{
+			Inquiry:        "opus",
 			Research:       "opus",
 			Planning:       "opus",
 			Implementation: "opus",
@@ -2732,10 +2734,18 @@ func TestWizardSummaryModelsUpDownNavigation(t *testing.T) {
 		t.Errorf("expected modelCursor=4 after Down, got %d", m.modelCursor)
 	}
 	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
-	if m.modelCursor != 4 {
-		t.Errorf("expected modelCursor=4 (clamped) after Down, got %d", m.modelCursor)
+	if m.modelCursor != 5 {
+		t.Errorf("expected modelCursor=5 after Down, got %d", m.modelCursor)
+	}
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	if m.modelCursor != 5 {
+		t.Errorf("expected modelCursor=5 (clamped) after Down, got %d", m.modelCursor)
 	}
 
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyUp})
+	if m.modelCursor != 4 {
+		t.Errorf("expected modelCursor=4 after Up, got %d", m.modelCursor)
+	}
 	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyUp})
 	if m.modelCursor != 3 {
 		t.Errorf("expected modelCursor=3 after Up, got %d", m.modelCursor)
@@ -2769,6 +2779,7 @@ func TestWizardSummaryModelsTabCycles(t *testing.T) {
 
 	m.summaryCursor = summaryFieldModels
 	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown}) // Clarify -> Research
 
 	origModel := m.models.Research
 	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyTab})
@@ -2800,6 +2811,7 @@ func TestWizardSummaryModelsVerticalSelectionCycles(t *testing.T) {
 
 	m.summaryCursor = summaryFieldModels
 	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown}) // Clarify -> Research
 
 	origModel := m.models.Research
 	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyRight})
@@ -2882,11 +2894,12 @@ func TestWizardSummaryModelsSubRowNavAndCycle(t *testing.T) {
 	m.summaryCursor = summaryFieldModels
 	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
 
-	// Navigate down to Implementation (index 2)
+	// Navigate down to Implementation (index 3)
 	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
 	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
-	if m.modelCursor != 2 {
-		t.Fatalf("expected modelCursor=2, got %d", m.modelCursor)
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	if m.modelCursor != 3 {
+		t.Fatalf("expected modelCursor=3, got %d", m.modelCursor)
 	}
 
 	origImpl := m.models.Implementation
@@ -3431,6 +3444,7 @@ func TestWizardSummaryEditedModelsInResult(t *testing.T) {
 	// cycle it to "sonnet".
 	m.summaryCursor = summaryFieldModels
 	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown})  // Clarify -> Research
 	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyRight}) // focus Agent panel
 	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyRight}) // focus Model panel
 	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown})  // cycle Research: opus -> sonnet
@@ -4025,11 +4039,14 @@ func TestWizardSummaryModelsIncludesKBBuild(t *testing.T) {
 	providerOrder := []string{"test"}
 	m := navigateToModelEditing(t, defaults, providerModels, providerOrder, nil)
 
-	if len(m.modelFields) != 5 {
-		t.Errorf("expected 5 model fields, got %d", len(m.modelFields))
+	if len(m.modelFields) != 6 {
+		t.Errorf("expected 6 model fields, got %d", len(m.modelFields))
 	}
-	if m.modelFields[4] != "KB Build" {
-		t.Errorf("expected modelFields[4] = %q, got %q", "KB Build", m.modelFields[4])
+	if m.modelFields[0] != "Clarify" {
+		t.Errorf("expected modelFields[0] = %q, got %q", "Clarify", m.modelFields[0])
+	}
+	if m.modelFields[5] != "KB Build" {
+		t.Errorf("expected modelFields[5] = %q, got %q", "KB Build", m.modelFields[5])
 	}
 }
 
@@ -4047,14 +4064,15 @@ func TestWizardSummaryModelsKBBuildCycles(t *testing.T) {
 	providerOrder := []string{"test"}
 	m := navigateToModelEditing(t, defaults, providerModels, providerOrder, nil)
 
-	// Navigate down to KB Build row (index 4)
+	// Navigate down to KB Build row (index 5)
 	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown}) // 0 -> 1
 	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown}) // 1 -> 2
 	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown}) // 2 -> 3
 	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown}) // 3 -> 4
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown}) // 4 -> 5
 
-	if m.modelCursor != 4 {
-		t.Fatalf("expected modelCursor = 4, got %d", m.modelCursor)
+	if m.modelCursor != 5 {
+		t.Fatalf("expected modelCursor = 5, got %d", m.modelCursor)
 	}
 
 	// Cycle KB Build model from the Model panel.
@@ -4075,6 +4093,7 @@ func TestWizardSummaryModelsKBBuildCycles(t *testing.T) {
 func TestWizardSummaryEditedKBBuildInResult(t *testing.T) {
 	defaults := config.DefaultsConfig{
 		Models: config.ModelConfig{
+			Inquiry:        "opus",
 			Research:       "opus",
 			Planning:       "opus",
 			Implementation: "opus",
@@ -4091,6 +4110,7 @@ func TestWizardSummaryEditedKBBuildInResult(t *testing.T) {
 	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown})  // 1 -> 2
 	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown})  // 2 -> 3
 	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown})  // 3 -> 4
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown})  // 4 -> 5
 	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyRight}) // focus Agent panel
 	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyRight}) // focus Model panel
 	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown})  // cycle KB Build
@@ -4109,9 +4129,10 @@ func TestWizardSummaryEditedKBBuildInResult(t *testing.T) {
 	}
 }
 
-func TestWizardSummaryModelsUpDownNavigation_FiveRows(t *testing.T) {
+func TestWizardSummaryModelsUpDownNavigation_SixRows(t *testing.T) {
 	defaults := config.DefaultsConfig{
 		Models: config.ModelConfig{
+			Inquiry:        "opus",
 			Research:       "opus",
 			Planning:       "opus",
 			Implementation: "opus",
@@ -4123,26 +4144,28 @@ func TestWizardSummaryModelsUpDownNavigation_FiveRows(t *testing.T) {
 	providerOrder := []string{"test"}
 	m := navigateToModelEditing(t, defaults, providerModels, providerOrder, nil)
 
-	// Navigate down to index 4 (KB Build)
+	// Navigate down to index 5 (KB Build)
 	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown}) // 0 -> 1
 	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown}) // 1 -> 2
 	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown}) // 2 -> 3
 	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown}) // 3 -> 4
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown}) // 4 -> 5
 
-	if m.modelCursor != 4 {
-		t.Errorf("expected modelCursor = 4, got %d", m.modelCursor)
+	if m.modelCursor != 5 {
+		t.Errorf("expected modelCursor = 5, got %d", m.modelCursor)
 	}
 
-	// Down again: should stay at 4 (clamped)
+	// Down again: should stay at 5 (clamped)
 	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
-	if m.modelCursor != 4 {
-		t.Errorf("expected modelCursor to stay at 4 (clamped), got %d", m.modelCursor)
+	if m.modelCursor != 5 {
+		t.Errorf("expected modelCursor to stay at 5 (clamped), got %d", m.modelCursor)
 	}
 }
 
 func TestWizardSummaryModelsPrefixedModelsCycle(t *testing.T) {
 	defaults := config.DefaultsConfig{
 		Models: config.ModelConfig{
+			Inquiry:        "claude:opus",
 			Research:       "claude:opus",
 			Planning:       "claude:opus",
 			Implementation: "claude:opus",
@@ -4162,6 +4185,7 @@ func TestWizardSummaryModelsPrefixedModelsCycle(t *testing.T) {
 	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown}) // 1 -> 2
 	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown}) // 2 -> 3
 	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown}) // 3 -> 4
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown}) // 4 -> 5
 
 	// Cycle through prefixed KB Build models scoped to the selected agent.
 	if m.models.KBBuild != "claude:opus" {
@@ -4195,6 +4219,7 @@ func TestWizardSummaryModelsPrefixedModelsCycle(t *testing.T) {
 func TestWizardSummaryModelsReviewShowsKBBuild(t *testing.T) {
 	defaults := config.DefaultsConfig{
 		Models: config.ModelConfig{
+			Inquiry:        "opus",
 			Research:       "opus",
 			Planning:       "opus",
 			Implementation: "opus",
@@ -4270,7 +4295,7 @@ func TestWizardModelPickerEmptyProviders(t *testing.T) {
 		t.Errorf("expected empty allModels, got %v", m.allModels)
 	}
 	// cycleModel should be a no-op
-	m.modelCursor = 0
+	m.modelCursor = 1
 	m.cycleModel()
 	// Should not panic
 }
@@ -4342,7 +4367,7 @@ func TestWizardClampKeepsPrefixedProviderDefault(t *testing.T) {
 	}
 	providerOrder := []string{"claude", "gateway"}
 	phaseModels := map[string]map[string][]string{}
-	for _, f := range []string{"Research", "Planning", "Implementation", "Review", "KB Build"} {
+	for _, f := range []string{"Clarify", "Research", "Planning", "Implementation", "Review", "KB Build"} {
 		phaseModels[f] = map[string][]string{
 			"claude":  {"sonnet[200K]", "opus[200K]"},
 			"gateway": {"vendor/sonnet[200K]", "vendor/gpt-5"},
@@ -4374,7 +4399,7 @@ func TestWizardModelCyclingForwardAndWrap(t *testing.T) {
 	m := NewWizardModel(nil, nil, nil, defaults, "", providerModels, providerOrder, nil, nil, nil, nil)
 
 	// Forward: opus → sonnet
-	m.modelCursor = 0
+	m.modelCursor = 1
 	m.cycleModel()
 	if m.models.Research != "sonnet" {
 		t.Errorf("after cycle forward: Research = %q, want sonnet", m.models.Research)
@@ -4400,7 +4425,7 @@ func TestWizardModelCyclingReverseAndWrap(t *testing.T) {
 	m := NewWizardModel(nil, nil, nil, defaults, "", providerModels, providerOrder, nil, nil, nil, nil)
 
 	// Reverse from opus → wraps to gpt-5.4
-	m.modelCursor = 0
+	m.modelCursor = 1
 	m.cycleModelReverse()
 	if m.models.Research != "gpt-5.4" {
 		t.Errorf("after reverse wrap: Research = %q, want gpt-5.4", m.models.Research)


### PR DESCRIPTION
## Summary

- Add a separate `models.inquiry` setting with defaulting and migration from existing `research` configs.
- Route the Inquire phase through the inquiry model while keeping Research and Design on the research model.
- Show the Inquire model selector as **Clarify** in wizard/edit-config UX and update live preview, docs, and tests.

## Impact

Users can choose a cheaper or faster model for requirement clarification without changing the model used for codebase research. Existing configs keep their current behavior because missing `inquiry` values inherit `research`.

## Verification

- Fast suite: `make test-fast`
- E2E Go (TUI / teatest): `go test ./test/e2e/... -count=1 -race`
- Static analysis: `go vet ./...`
- Build: `go build ./...`
- Focused TUI catalog check: `go test ./internal/tui -run PhaseModelCatalog -count=1`

Skipped TUI observability: no TUI observer wiring, emitted event flow, or feature-span propagation behavior changed.