### PR TITLE
Account review sessions in feature costs

### DIFF
--- a/internal/agent/bounded_helper.go
+++ b/internal/agent/bounded_helper.go
@@ -202,7 +202,11 @@ func (pr *PhaseRunner) runBoundedHelperSession(ctx context.Context, cfg boundedH
 
 	defer func() {
 		cost := ExtractSessionCost(sess)
-		_ = accumulateSessionCostToFeature(pr.FeatureStore, cfg.featureID, observerPhase, cost)
+		_ = accumulateSessionCostToFeature(pr.FeatureStore, cfg.featureID, observerPhase, cost, SessionCostMetadata{
+			SessionID:     cfg.sessionID,
+			ObserverPhase: observerPhase,
+			RepoName:      cfg.repoName,
+		})
 		if pr.Observer != nil {
 			pr.Observer.SessionEnded(sessionCtx, observerPhase, cfg.sessionID, cfg.repoName, toSessionUsage(cost), time.Since(sessionStart), sessionErrFromStatus(sess))
 		}

--- a/internal/agent/bounded_helper_test.go
+++ b/internal/agent/bounded_helper_test.go
@@ -83,6 +83,84 @@ func TestRunBoundedHelper_SuccessWithoutPhaseComplete(t *testing.T) {
 	}
 }
 
+func TestRunBoundedHelperRecordsIndividualSessionCost(t *testing.T) {
+	workDir := t.TempDir()
+	pr, cleanup := newMockBoundedHelperRunner(t, []llm.SDKMessage{
+		mocks.InitMessage(),
+		mocks.AssistantTextMessage("Review complete"),
+		{
+			Type: "result",
+			Result: &llm.ResultMessage{
+				Type:         "result",
+				Subtype:      "success",
+				Result:       "success",
+				StopReason:   "end_turn",
+				TotalCostUSD: 0.12,
+			},
+		},
+	})
+	defer cleanup()
+
+	store := feature.NewStore(t.TempDir())
+	f := &feature.Feature{
+		ID:              "feature-1",
+		Name:            "feature-1",
+		Status:          feature.StatusPlanning,
+		ActiveTimingKey: "phase-1-plan",
+		SchemaVersion:   feature.SchemaVersionCurrent,
+	}
+	if err := store.Save(f); err != nil {
+		t.Fatal(err)
+	}
+	pr.FeatureStore = store
+
+	_, err := pr.RunBoundedHelper(context.Background(), BoundedHelperConfig{
+		SessionID:     "feature-1-planreview-architecture-01",
+		FeatureID:     "feature-1",
+		Phase:         feature.PhasePlan,
+		Label:         "review helper",
+		ObserverPhase: "review",
+		Model:         "test-model",
+		Prompt:        "Review the plan.",
+		SystemPrompt:  "You are a bounded plan reviewer.",
+		WorkDir:       workDir,
+		RepoName:      "repo-a",
+		Timeout:       2 * time.Second,
+		EffortLevel:   llm.EffortMedium,
+		PermHandler:   &permission.ReadOnlyHandler{},
+	})
+	if err != nil {
+		t.Fatalf("RunBoundedHelper() error = %v", err)
+	}
+
+	updated, err := store.Load("feature-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := updated.PhaseCost("phase-1-plan"); got != 0.12 {
+		t.Errorf("PhaseCost(phase-1-plan) = %v, want 0.12", got)
+	}
+	if len(updated.SessionCosts) != 1 {
+		t.Fatalf("len(SessionCosts) = %d, want 1", len(updated.SessionCosts))
+	}
+	got := updated.SessionCosts[0]
+	if got.SessionID != "feature-1-planreview-architecture-01" {
+		t.Errorf("SessionID = %q, want feature-1-planreview-architecture-01", got.SessionID)
+	}
+	if got.PhaseKey != "phase-1-plan" {
+		t.Errorf("PhaseKey = %q, want phase-1-plan", got.PhaseKey)
+	}
+	if got.ObserverPhase != "review" {
+		t.Errorf("ObserverPhase = %q, want review", got.ObserverPhase)
+	}
+	if got.RepoName != "repo-a" {
+		t.Errorf("RepoName = %q, want repo-a", got.RepoName)
+	}
+	if got.CostUSD != 0.12 {
+		t.Errorf("CostUSD = %v, want 0.12", got.CostUSD)
+	}
+}
+
 func TestRunBoundedHelper_FailsOnPendingAskUserQuestion(t *testing.T) {
 	workDir := t.TempDir()
 	pr, cleanup := newMockBoundedHelperRunner(t, []llm.SDKMessage{

--- a/internal/agent/cost.go
+++ b/internal/agent/cost.go
@@ -30,6 +30,13 @@ type SessionCost struct {
 	Usage        llm.Usage
 }
 
+// SessionCostMetadata identifies the single session behind an accounted cost.
+type SessionCostMetadata struct {
+	SessionID     string
+	ObserverPhase string
+	RepoName      string
+}
+
 // ExtractSessionCost reads cost and accumulated usage from the session.
 // Returns zero values if no data is available.
 func ExtractSessionCost(sess ports.SessionView) SessionCost {
@@ -59,18 +66,25 @@ func toSessionUsage(cost SessionCost) observe.SessionUsage {
 // accumulateSessionCostToFeature adds a session's cost to the latest active
 // timing key on the feature, falling back to fallbackKey when no active key is
 // recorded.
-func accumulateSessionCostToFeature(store ports.FeatureStore, featureID, fallbackKey string, cost SessionCost) error {
-	return accumulateSessionCost(store, featureID, fallbackKey, cost, true)
+func accumulateSessionCostToFeature(store ports.FeatureStore, featureID, fallbackKey string, cost SessionCost, metadata ...SessionCostMetadata) error {
+	return accumulateSessionCost(store, featureID, fallbackKey, cost, true, firstSessionCostMetadata(metadata))
 }
 
 // accumulateSessionCostToFeatureKey adds a session's cost to key regardless of
 // ActiveTimingKey. Use this for phases such as Final Review where the lifecycle
 // phase can advance while the old timing key remains preserved for resume UI.
-func accumulateSessionCostToFeatureKey(store ports.FeatureStore, featureID, key string, cost SessionCost) error {
-	return accumulateSessionCost(store, featureID, key, cost, false)
+func accumulateSessionCostToFeatureKey(store ports.FeatureStore, featureID, key string, cost SessionCost, metadata ...SessionCostMetadata) error {
+	return accumulateSessionCost(store, featureID, key, cost, false, firstSessionCostMetadata(metadata))
 }
 
-func accumulateSessionCost(store ports.FeatureStore, featureID, fallbackKey string, cost SessionCost, preferActiveKey bool) error {
+func firstSessionCostMetadata(metadata []SessionCostMetadata) SessionCostMetadata {
+	if len(metadata) == 0 {
+		return SessionCostMetadata{}
+	}
+	return metadata[0]
+}
+
+func accumulateSessionCost(store ports.FeatureStore, featureID, fallbackKey string, cost SessionCost, preferActiveKey bool, metadata SessionCostMetadata) error {
 	if store == nil || strings.TrimSpace(featureID) == "" || cost.TotalCostUSD <= 0 {
 		return nil
 	}
@@ -85,7 +99,13 @@ func accumulateSessionCost(store ports.FeatureStore, featureID, fallbackKey stri
 		if costKey == "" {
 			return nil
 		}
-		f.AddPhaseCost(costKey, cost.TotalCostUSD)
+		f.RecordSessionCost(feature.SessionCostRecord{
+			SessionID:     metadata.SessionID,
+			PhaseKey:      costKey,
+			ObserverPhase: metadata.ObserverPhase,
+			RepoName:      metadata.RepoName,
+			CostUSD:       cost.TotalCostUSD,
+		})
 		return nil
 	})
 }

--- a/internal/agent/cost_test.go
+++ b/internal/agent/cost_test.go
@@ -127,6 +127,58 @@ func TestAccumulateSessionCostToFeatureUsesActiveTimingKey(t *testing.T) {
 	}
 }
 
+func TestAccumulateSessionCostToFeatureRecordsIndividualSession(t *testing.T) {
+	dir := t.TempDir()
+	store := feature.NewStore(dir)
+
+	f := &feature.Feature{
+		ID:              "test-helper-session-cost",
+		Name:            "test-helper-session-cost",
+		Status:          feature.StatusImplementing,
+		ActiveTimingKey: "phase-2-impl",
+		SchemaVersion:   feature.SchemaVersionCurrent,
+	}
+	if err := store.Save(f); err != nil {
+		t.Fatal(err)
+	}
+
+	err := accumulateSessionCostToFeature(store, f.ID, "review", SessionCost{TotalCostUSD: 0.42}, SessionCostMetadata{
+		SessionID:     "feat-phase-02-review-01",
+		ObserverPhase: "review",
+		RepoName:      "repo-a",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	updated, err := store.Load(f.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := updated.PhaseCost("phase-2-impl"); got != 0.42 {
+		t.Errorf("PhaseCost(phase-2-impl) = %v, want 0.42", got)
+	}
+	if len(updated.SessionCosts) != 1 {
+		t.Fatalf("len(SessionCosts) = %d, want 1", len(updated.SessionCosts))
+	}
+	got := updated.SessionCosts[0]
+	if got.SessionID != "feat-phase-02-review-01" {
+		t.Errorf("SessionID = %q, want feat-phase-02-review-01", got.SessionID)
+	}
+	if got.PhaseKey != "phase-2-impl" {
+		t.Errorf("PhaseKey = %q, want phase-2-impl", got.PhaseKey)
+	}
+	if got.ObserverPhase != "review" {
+		t.Errorf("ObserverPhase = %q, want review", got.ObserverPhase)
+	}
+	if got.RepoName != "repo-a" {
+		t.Errorf("RepoName = %q, want repo-a", got.RepoName)
+	}
+	if got.CostUSD != 0.42 {
+		t.Errorf("CostUSD = %v, want 0.42", got.CostUSD)
+	}
+}
+
 func TestAccumulateSessionCostToFeatureUsesFallbackKey(t *testing.T) {
 	dir := t.TempDir()
 	store := feature.NewStore(dir)

--- a/internal/agent/final_review_loop.go
+++ b/internal/agent/final_review_loop.go
@@ -583,7 +583,10 @@ func (s *featureFinalReviewLoopState) runReview(iteration int, iterDir string) (
 	sessionCtx, sessionStart, observed := s.observeFinalReviewSession(sess, sessionID, providerName, cfg.ReviewModel)
 	defer func() {
 		cost := ExtractSessionCost(sess)
-		_ = accumulateSessionCostToFeatureKey(cfg.FeatureStore, cfg.Feature.ID, feature.PhaseFinalReview.DirName(), cost)
+		_ = accumulateSessionCostToFeatureKey(cfg.FeatureStore, cfg.Feature.ID, feature.PhaseFinalReview.DirName(), cost, SessionCostMetadata{
+			SessionID:     sessionID,
+			ObserverPhase: feature.PhaseFinalReview.String(),
+		})
 		if observed {
 			cfg.Observer.SessionEnded(sessionCtx, feature.PhaseFinalReview.String(), sessionID, "", toSessionUsage(cost), time.Since(sessionStart), sessionErrFromStatus(sess))
 		}
@@ -709,7 +712,10 @@ func (s *featureFinalReviewLoopState) runFix(iteration int, iterDir, feedback st
 	sessionCtx, sessionStart, observed := s.observeFinalReviewSession(sess, sessionID, providerName, cfg.Model)
 	defer func() {
 		cost := ExtractSessionCost(sess)
-		_ = accumulateSessionCostToFeatureKey(cfg.FeatureStore, cfg.Feature.ID, feature.PhaseFinalReview.DirName(), cost)
+		_ = accumulateSessionCostToFeatureKey(cfg.FeatureStore, cfg.Feature.ID, feature.PhaseFinalReview.DirName(), cost, SessionCostMetadata{
+			SessionID:     sessionID,
+			ObserverPhase: feature.PhaseFinalReview.String(),
+		})
 		if observed {
 			cfg.Observer.SessionEnded(sessionCtx, feature.PhaseFinalReview.String(), sessionID, "", toSessionUsage(cost), time.Since(sessionStart), sessionErrFromStatus(sess))
 		}

--- a/internal/agent/implement.go
+++ b/internal/agent/implement.go
@@ -262,6 +262,7 @@ func RunImplementationLoop(cfg ImplementConfig, sm ports.SessionManager) (result
 
 		var (
 			iterDir      string
+			sessionID    string
 			agentStatus  string
 			duration     time.Duration
 			cost         SessionCost
@@ -400,7 +401,6 @@ func RunImplementationLoop(cfg ImplementConfig, sm ports.SessionManager) (result
 			sessOpts.PermCacheScope = permRepoName
 
 			// Start session in interactive mode
-			var sessionID string
 			if cfg.Feature.CurrentRoadmapPhase > 0 {
 				sessionID = fmt.Sprintf("%s-phase-%02d-impl", cfg.Feature.ID, cfg.Feature.CurrentRoadmapPhase)
 			} else {
@@ -543,7 +543,11 @@ func RunImplementationLoop(cfg ImplementConfig, sm ports.SessionManager) (result
 		// Accumulate iteration cost into the latest active timing key rather
 		// than the initial config snapshot, which may be stale after phase
 		// transitions such as plan -> implement.
-		_ = accumulateSessionCostToFeature(cfg.FeatureStore, cfg.Feature.ID, "implement", cost)
+		_ = accumulateSessionCostToFeature(cfg.FeatureStore, cfg.Feature.ID, "implement", cost, SessionCostMetadata{
+			SessionID:     sessionID,
+			ObserverPhase: "implement",
+			RepoName:      cfg.RepoName,
+		})
 
 		// Handle based on agent status
 		if agentStatus == agentStatusMissingMarker {
@@ -1031,6 +1035,7 @@ func runReviewGate(cfg ImplementConfig, sm ports.SessionManager, iteration int, 
 	reviewID += fmt.Sprintf("-%02d", iteration)
 	helper := &PhaseRunner{
 		SessionManager: sm,
+		FeatureStore:   cfg.FeatureStore,
 		StateDir:       cfg.StateDir,
 		SkillsDir:      cfg.SkillsDir,
 		GuidelinesDir:  cfg.GuidelinesDir,

--- a/internal/agent/implement_test.go
+++ b/internal/agent/implement_test.go
@@ -2118,12 +2118,13 @@ func TestImplementLoopNoSkipIterationReview(t *testing.T) {
 	_ = os.WriteFile(planPath, []byte("# Plan\nImplement something"), 0o644)
 
 	f := &feature.Feature{
-		ID:           "test-noskip-001",
-		Name:         "Test No Skip Review",
-		Slug:         "test-no-skip-review",
-		Description:  "No skip iteration review test",
-		Status:       feature.StatusImplementing,
-		CurrentPhase: feature.PhaseImplement,
+		ID:              "test-noskip-001",
+		Name:            "Test No Skip Review",
+		Slug:            "test-no-skip-review",
+		Description:     "No skip iteration review test",
+		Status:          feature.StatusImplementing,
+		CurrentPhase:    feature.PhaseImplement,
+		ActiveTimingKey: "implement",
 		Repos: []feature.FeatureRepo{
 			{Name: "test-repo", Path: workDir},
 		},
@@ -2167,6 +2168,25 @@ func TestImplementLoopNoSkipIterationReview(t *testing.T) {
 	}
 	assertExplicitEmptyAgentNames(t, (*captured)[0].AgentNames)
 	assertExplorationAgentNames(t, (*captured)[1].AgentNames)
+
+	updated, err := store.Load(f.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := updated.PhaseCost("implement"); got != 0.002 {
+		t.Errorf("PhaseCost(implement) = %v, want 0.002", got)
+	}
+	if len(updated.SessionCosts) != 2 {
+		t.Fatalf("len(SessionCosts) = %d, want 2", len(updated.SessionCosts))
+	}
+	implCost := updated.SessionCosts[0]
+	if implCost.SessionID != "test-noskip-001-impl-01" || implCost.PhaseKey != "implement" || implCost.ObserverPhase != "implement" || implCost.CostUSD != 0.001 {
+		t.Errorf("SessionCosts[0] = %+v, want implementation session cost under implement", implCost)
+	}
+	reviewCost := updated.SessionCosts[1]
+	if reviewCost.SessionID != "test-noskip-001-review-01" || reviewCost.PhaseKey != "implement" || reviewCost.ObserverPhase != "review" || reviewCost.CostUSD != 0.001 {
+		t.Errorf("SessionCosts[1] = %+v, want review helper session cost under implement", reviewCost)
+	}
 }
 
 func TestImplementLoopReviewHelperUsesChildDirAndMarker(t *testing.T) {

--- a/internal/agent/phase.go
+++ b/internal/agent/phase.go
@@ -224,6 +224,10 @@ func (pr *PhaseRunner) runInteractivePhase(f *feature.Feature, cfg interactivePh
 		cost := ExtractSessionCost(sess)
 		usage := toSessionUsage(cost)
 		duration := time.Since(sessionStart)
+		_ = accumulateSessionCostToFeatureKey(pr.FeatureStore, f.ID, cfg.Phase.DirName(), cost, SessionCostMetadata{
+			SessionID:     sessionID,
+			ObserverPhase: cfg.Phase.String(),
+		})
 		pr.Observer.SessionEnded(sessionCtx, cfg.Phase.String(), sessionID, "", usage, duration, sessionErrFromStatus(sess))
 	})
 
@@ -382,7 +386,12 @@ func (pr *PhaseRunner) RunTweakSession(f *feature.Feature, cfgs ...TweakSessionC
 				if key == "" {
 					key = "implement"
 				}
-				feat.AddPhaseCost(key, cost.TotalCostUSD)
+				feat.RecordSessionCost(feature.SessionCostRecord{
+					SessionID:     sessionID,
+					PhaseKey:      key,
+					ObserverPhase: feature.PhaseImplement.String(),
+					CostUSD:       cost.TotalCostUSD,
+				})
 				return nil
 			})
 		}
@@ -629,6 +638,11 @@ func (pr *PhaseRunner) RunKnowledgeBaseForRepo(f *feature.Feature, repo feature.
 	sessionStart := time.Now()
 	sess.AddCleanupFunc(func() {
 		cost := ExtractSessionCost(sess)
+		_ = accumulateSessionCostToFeatureKey(pr.FeatureStore, f.ID, feature.PhaseKnowledgeBase.DirName(), cost, SessionCostMetadata{
+			SessionID:     sessionID,
+			ObserverPhase: feature.PhaseKnowledgeBase.String(),
+			RepoName:      repo.Name,
+		})
 		pr.Observer.SessionEnded(sessionCtx, feature.PhaseKnowledgeBase.String(), sessionID, repo.Name, toSessionUsage(cost), time.Since(sessionStart), sessionErrFromStatus(sess))
 	})
 

--- a/internal/agent/plan_validation.go
+++ b/internal/agent/plan_validation.go
@@ -45,11 +45,12 @@ import (
 // reconstruct its state after a session restart — without them, the
 // on-stack counter resets and a drifting critic can escape the stall cap.
 type PlanAttemptMeta struct {
-	Attempt      int               `yaml:"attempt"`
-	AgentStatus  string            `yaml:"agent_status"`            // SUCCESS or FAILED
-	ReviewStatus string            `yaml:"review_status"`           // APPROVED, CHANGES_REQUESTED, or empty
-	AxisVerdicts map[string]string `yaml:"axis_verdicts,omitempty"` // axis (lowercase) -> "APPROVED"|"CHANGES_REQUESTED"|"ERROR"
-	AxisDigests  map[string]string `yaml:"axis_digests,omitempty"`  // axis (lowercase) -> sha256 of the frozen section at this attempt
+	Attempt        int               `yaml:"attempt"`
+	SessionAttempt int               `yaml:"session_attempt,omitempty"` // provider-session retry within this logical attempt
+	AgentStatus    string            `yaml:"agent_status"`              // SUCCESS or FAILED
+	ReviewStatus   string            `yaml:"review_status"`             // APPROVED, CHANGES_REQUESTED, or empty
+	AxisVerdicts   map[string]string `yaml:"axis_verdicts,omitempty"`   // axis (lowercase) -> "APPROVED"|"CHANGES_REQUESTED"|"ERROR"
+	AxisDigests    map[string]string `yaml:"axis_digests,omitempty"`    // axis (lowercase) -> sha256 of the frozen section at this attempt
 }
 
 // WritePlanAttemptMeta persists a PlanAttemptMeta to the attempt subdirectory.
@@ -185,6 +186,24 @@ func latestPlanRevisionFeedbackAttempt(artifactDir string) (int, string) {
 		bestFeedback = strings.TrimSpace(string(data))
 	}
 	return best, bestFeedback
+}
+
+func nextPlanSessionAttempt(artifactDir string, attempt int) int {
+	meta, err := readPlanAttemptMeta(artifactDir, attempt)
+	if err != nil || meta.AgentStatus != "FAILED" {
+		return 1
+	}
+	if meta.SessionAttempt < 1 {
+		return 2
+	}
+	return meta.SessionAttempt + 1
+}
+
+func planAttemptSessionID(base string, sessionAttempt int) string {
+	if sessionAttempt <= 1 {
+		return base
+	}
+	return fmt.Sprintf("%s-retry-%02d", base, sessionAttempt)
 }
 
 // AxisApproval is a sticky approval recovered from a prior validation attempt.
@@ -1488,7 +1507,8 @@ func RunRoadmapPlanningLoop(cfg PlanLoopConfig, sm ports.SessionManager) (result
 			WriteDebugPrompts(attemptDir, sessOpts.DebugSystemPrompt, prompt)
 			sessOpts.PermCacheScope = cfg.RepoName
 
-			sessionID := fmt.Sprintf("%s-roadmap-%02d", cfg.Feature.ID, attempt)
+			sessionAttempt := nextPlanSessionAttempt(artifactDir, attempt)
+			sessionID := planAttemptSessionID(fmt.Sprintf("%s-roadmap-%02d", cfg.Feature.ID, attempt), sessionAttempt)
 			planSessionCtx := cfg.PhaseSpanCtx.Child()
 			if attempt == 1 {
 				sessOpts.AskUserAutoPick = askUserAutoPickConfig(
@@ -1585,7 +1605,11 @@ func RunRoadmapPlanningLoop(cfg PlanLoopConfig, sm ports.SessionManager) (result
 					}
 					continue
 				}
-				_ = WritePlanAttemptMeta(artifactDir, PlanAttemptMeta{Attempt: attempt, AgentStatus: "FAILED"})
+				_ = WritePlanAttemptMeta(artifactDir, PlanAttemptMeta{
+					Attempt:        attempt,
+					SessionAttempt: sessionAttempt,
+					AgentStatus:    "FAILED",
+				})
 				return &PlanLoopResult{FinalStatus: "failed", Iterations: attempt, LastError: "roadmap session did not complete successfully"}, nil
 			}
 			if attempt == 1 {
@@ -1876,7 +1900,8 @@ func RunPhasePlanningLoop(cfg PhasePlanLoopConfig, sm ports.SessionManager) (res
 			WriteDebugPrompts(attemptDir, sessOpts.DebugSystemPrompt, prompt)
 			sessOpts.PermCacheScope = cfg.RepoName
 
-			sessionID := fmt.Sprintf("%s-phase-%02d-plan-%02d", cfg.Feature.ID, cfg.Phase.Number, attempt)
+			sessionAttempt := nextPlanSessionAttempt(artifactDir, attempt)
+			sessionID := planAttemptSessionID(fmt.Sprintf("%s-phase-%02d-plan-%02d", cfg.Feature.ID, cfg.Phase.Number, attempt), sessionAttempt)
 			planSessionCtx := cfg.PlanLoopConfig.PhaseSpanCtx.Child()
 			if attempt == 1 {
 				sessOpts.AskUserAutoPick = askUserAutoPickConfig(
@@ -1974,7 +1999,11 @@ func RunPhasePlanningLoop(cfg PhasePlanLoopConfig, sm ports.SessionManager) (res
 					}
 					continue
 				}
-				_ = WritePlanAttemptMeta(artifactDir, PlanAttemptMeta{Attempt: attempt, AgentStatus: "FAILED"})
+				_ = WritePlanAttemptMeta(artifactDir, PlanAttemptMeta{
+					Attempt:        attempt,
+					SessionAttempt: sessionAttempt,
+					AgentStatus:    "FAILED",
+				})
 				return &PlanLoopResult{FinalStatus: "failed", Iterations: attempt, LastError: "phase plan session did not complete"}, nil
 			}
 			if attempt == 1 {

--- a/internal/agent/plan_validation.go
+++ b/internal/agent/plan_validation.go
@@ -637,6 +637,7 @@ func runSpecializedPlanValidationForArtifact(cfg PlanLoopConfig, sm ports.Sessio
 	reviewID := fmt.Sprintf("%s-planreview-%s-%02d", cfg.Feature.ID, domainLower, attempt)
 	helper := &PhaseRunner{
 		SessionManager: sm,
+		FeatureStore:   cfg.FeatureStore,
 		StateDir:       cfg.StateDir,
 		SkillsDir:      cfg.SkillsDir,
 		GuidelinesDir:  cfg.GuidelinesDir,
@@ -1547,7 +1548,13 @@ func RunRoadmapPlanningLoop(cfg PlanLoopConfig, sm ports.SessionManager) (result
 			cost := ExtractSessionCost(sess)
 			if cfg.FeatureStore != nil && cost.TotalCostUSD > 0 {
 				_ = cfg.FeatureStore.Modify(cfg.Feature.ID, func(f *feature.Feature) error {
-					f.AddPhaseCost("plan", cost.TotalCostUSD)
+					f.RecordSessionCost(feature.SessionCostRecord{
+						SessionID:     sessionID,
+						PhaseKey:      "plan",
+						ObserverPhase: "plan",
+						RepoName:      cfg.RepoName,
+						CostUSD:       cost.TotalCostUSD,
+					})
 					return nil
 				})
 			}
@@ -1930,7 +1937,13 @@ func RunPhasePlanningLoop(cfg PhasePlanLoopConfig, sm ports.SessionManager) (res
 			if cfg.FeatureStore != nil && cost.TotalCostUSD > 0 {
 				costKey := fmt.Sprintf("phase-%d-plan", cfg.Phase.Number)
 				_ = cfg.FeatureStore.Modify(cfg.Feature.ID, func(f *feature.Feature) error {
-					f.AddPhaseCost(costKey, cost.TotalCostUSD)
+					f.RecordSessionCost(feature.SessionCostRecord{
+						SessionID:     sessionID,
+						PhaseKey:      costKey,
+						ObserverPhase: "plan",
+						RepoName:      cfg.RepoName,
+						CostUSD:       cost.TotalCostUSD,
+					})
 					return nil
 				})
 			}

--- a/internal/agent/plan_validation_test.go
+++ b/internal/agent/plan_validation_test.go
@@ -1176,6 +1176,110 @@ func TestLatestCompletedPlanAttempt(t *testing.T) {
 	})
 }
 
+func TestRunPhasePlanningLoopRetriesFailedAttemptWithFreshSessionID(t *testing.T) {
+	tmpDir := t.TempDir()
+	workDir := filepath.Join(tmpDir, "work")
+	phasePlanDir := filepath.Join(tmpDir, "test-plan-001", "runs", "run-001", "phase-01", "plan")
+	for _, dir := range []string{workDir, phasePlanDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("MkdirAll(%q): %v", dir, err)
+		}
+	}
+	if err := WritePlanAttemptMeta(phasePlanDir, PlanAttemptMeta{
+		Attempt:      1,
+		AgentStatus:  "SUCCESS",
+		ReviewStatus: "CHANGES_REQUESTED",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(phasePlanDir, "attempt-01", "validation-feedback.md"), []byte("revise this plan"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := WritePlanAttemptMeta(phasePlanDir, PlanAttemptMeta{
+		Attempt:     2,
+		AgentStatus: "FAILED",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	store := feature.NewStore(tmpDir)
+	f := newTestPlanFeature(t, workDir)
+	if err := store.Save(f); err != nil {
+		t.Fatal(err)
+	}
+
+	var gotSessionID string
+	result, err := RunPhasePlanningLoop(PhasePlanLoopConfig{
+		PlanLoopConfig: PlanLoopConfig{
+			Feature:      f,
+			FeatureStore: store,
+			StateDir:     tmpDir,
+			WorkDir:      workDir,
+			MaxAttempts:  3,
+			BuildSession: func(opts BuildSessionOpts) ([]string, []string, *ports.SessionOpts, error) {
+				return []string{"echo", "unused"}, nil, &ports.SessionOpts{PIDDir: opts.PIDDir}, nil
+			},
+			SessionStartFunc: func(id, featureID string, phase feature.Phase, command []string, workdir string, env []string, opts ...*ports.SessionOpts) (ports.SessionHandle, error) {
+				gotSessionID = id
+				return nil, session.ErrShuttingDown
+			},
+		},
+		Phase: RoadmapPhase{
+			Number: 1,
+			Name:   "Restarted plan",
+			Type:   "tdd-fill-in",
+			Goal:   "Retry failed provider sessions without changing the plan attempt",
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("RunPhasePlanningLoop() error = %v", err)
+	}
+	if result.FinalStatus != "interrupted" {
+		t.Fatalf("FinalStatus = %q, want interrupted", result.FinalStatus)
+	}
+	if gotSessionID != "test-plan-001-phase-01-plan-02-retry-02" {
+		t.Fatalf("sessionID = %q, want test-plan-001-phase-01-plan-02-retry-02", gotSessionID)
+	}
+	updated, err := store.Load(f.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.PlanIteration != 2 {
+		t.Fatalf("PlanIteration = %d, want 2", updated.PlanIteration)
+	}
+}
+
+func TestPlanRetrySessionAttempt(t *testing.T) {
+	dir := t.TempDir()
+	if got := nextPlanSessionAttempt(dir, 2); got != 1 {
+		t.Fatalf("nextPlanSessionAttempt(no meta) = %d, want 1", got)
+	}
+	if got := planAttemptSessionID("feature-phase-01-plan-02", 1); got != "feature-phase-01-plan-02" {
+		t.Fatalf("planAttemptSessionID(first) = %q", got)
+	}
+	if err := WritePlanAttemptMeta(dir, PlanAttemptMeta{Attempt: 2, AgentStatus: "FAILED"}); err != nil {
+		t.Fatal(err)
+	}
+	if got := nextPlanSessionAttempt(dir, 2); got != 2 {
+		t.Fatalf("nextPlanSessionAttempt(legacy failed) = %d, want 2", got)
+	}
+	if got := planAttemptSessionID("feature-phase-01-plan-02", 2); got != "feature-phase-01-plan-02-retry-02" {
+		t.Fatalf("planAttemptSessionID(retry) = %q", got)
+	}
+	if err := WritePlanAttemptMeta(dir, PlanAttemptMeta{Attempt: 2, SessionAttempt: 2, AgentStatus: "FAILED"}); err != nil {
+		t.Fatal(err)
+	}
+	if got := nextPlanSessionAttempt(dir, 2); got != 3 {
+		t.Fatalf("nextPlanSessionAttempt(recorded failed retry) = %d, want 3", got)
+	}
+	if err := WritePlanAttemptMeta(dir, PlanAttemptMeta{Attempt: 2, AgentStatus: "SUCCESS", ReviewStatus: "CHANGES_REQUESTED"}); err != nil {
+		t.Fatal(err)
+	}
+	if got := nextPlanSessionAttempt(dir, 2); got != 1 {
+		t.Fatalf("nextPlanSessionAttempt(success) = %d, want 1", got)
+	}
+}
+
 func TestLoadPriorAxisApprovals(t *testing.T) {
 	t.Run("latest wins per axis", func(t *testing.T) {
 		dir := t.TempDir()
@@ -1437,9 +1541,10 @@ func TestFrozenSectionsDigest(t *testing.T) {
 func TestPlanAttemptMetaRoundTrip(t *testing.T) {
 	dir := t.TempDir()
 	meta := PlanAttemptMeta{
-		Attempt:      2,
-		AgentStatus:  "SUCCESS",
-		ReviewStatus: "CHANGES_REQUESTED",
+		Attempt:        2,
+		SessionAttempt: 3,
+		AgentStatus:    "SUCCESS",
+		ReviewStatus:   "CHANGES_REQUESTED",
 	}
 	if err := WritePlanAttemptMeta(dir, meta); err != nil {
 		t.Fatalf("write error: %v", err)
@@ -1449,7 +1554,7 @@ func TestPlanAttemptMetaRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read error: %v", err)
 	}
-	if got.Attempt != 2 || got.AgentStatus != "SUCCESS" || got.ReviewStatus != "CHANGES_REQUESTED" {
+	if got.Attempt != 2 || got.SessionAttempt != 3 || got.AgentStatus != "SUCCESS" || got.ReviewStatus != "CHANGES_REQUESTED" {
 		t.Errorf("round-trip mismatch: %+v", got)
 	}
 }

--- a/internal/agent/plan_validation_test.go
+++ b/internal/agent/plan_validation_test.go
@@ -917,15 +917,23 @@ done
 	sm := session.NewManager(eventCh)
 	defer sm.Shutdown()
 
+	store := feature.NewStore(filepath.Join(tmpDir, "store"))
+	f := &feature.Feature{
+		ID:              "test-plan-001",
+		Name:            "Test Plan Feature",
+		RiskLevel:       feature.RiskMedium,
+		Status:          feature.StatusPlanning,
+		ActiveTimingKey: "phase-1-plan",
+		SchemaVersion:   feature.SchemaVersionCurrent,
+	}
+	if err := store.Save(f); err != nil {
+		t.Fatal(err)
+	}
 	cfg := PlanLoopConfig{
-		Feature: &feature.Feature{
-			ID:            "test-plan-001",
-			Name:          "Test Plan Feature",
-			RiskLevel:     feature.RiskMedium,
-			SchemaVersion: feature.SchemaVersionCurrent,
-		},
-		StateDir: tmpDir,
-		WorkDir:  workDir,
+		Feature:      f,
+		FeatureStore: store,
+		StateDir:     tmpDir,
+		WorkDir:      workDir,
 		BuildSession: func(opts BuildSessionOpts) ([]string, []string, *session.SessionOpts, error) {
 			got = opts
 			return []string{"bash", criticScript}, nil, &session.SessionOpts{
@@ -969,6 +977,29 @@ done
 	}
 	if !permissionHandlerIncludesBoundedArtifacts(got.PermHandler) {
 		t.Fatalf("PermHandler = %T, want bounded artifact handler", got.PermHandler)
+	}
+	updated, err := store.Load(f.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := updated.PhaseCost("phase-1-plan"); got != 0.001 {
+		t.Errorf("PhaseCost(phase-1-plan) = %v, want 0.001", got)
+	}
+	if len(updated.SessionCosts) != 1 {
+		t.Fatalf("len(SessionCosts) = %d, want 1", len(updated.SessionCosts))
+	}
+	cost := updated.SessionCosts[0]
+	if cost.SessionID != "test-plan-001-planreview-scope-01" {
+		t.Errorf("SessionID = %q, want test-plan-001-planreview-scope-01", cost.SessionID)
+	}
+	if cost.PhaseKey != "phase-1-plan" {
+		t.Errorf("PhaseKey = %q, want phase-1-plan", cost.PhaseKey)
+	}
+	if cost.ObserverPhase != "review" {
+		t.Errorf("ObserverPhase = %q, want review", cost.ObserverPhase)
+	}
+	if cost.CostUSD != 0.001 {
+		t.Errorf("CostUSD = %v, want 0.001", cost.CostUSD)
 	}
 }
 

--- a/internal/feature/feature.go
+++ b/internal/feature/feature.go
@@ -634,6 +634,7 @@ type Feature struct {
 	ActivePhaseStart                *time.Time                 `yaml:"-"`
 	ActiveTimingKey                 string                     `yaml:"-"`
 	PhaseCosts                      map[string]float64         `yaml:"-"`
+	SessionCosts                    []SessionCostRecord        `yaml:"-"`
 	PendingReviewPhase              *Phase                     `yaml:"-"`
 	PendingRewindReviewRoadmapPhase *int                       `yaml:"-"`
 	IsRewind                        bool                       `yaml:"-"`
@@ -710,6 +711,7 @@ func (f *Feature) syncShadowsToRun() {
 	r.ActivePhaseStart = f.ActivePhaseStart
 	r.ActiveTimingKey = f.ActiveTimingKey
 	r.PhaseCosts = f.PhaseCosts
+	r.SessionCosts = f.SessionCosts
 	r.ActiveCycle = f.ActiveCycle
 	r.PendingReviewPhase = f.PendingReviewPhase
 	r.PendingRewindReviewRoadmapPhase = f.PendingRewindReviewRoadmapPhase
@@ -751,6 +753,7 @@ func (f *Feature) syncRunToShadows() {
 	f.ActivePhaseStart = r.ActivePhaseStart
 	f.ActiveTimingKey = r.ActiveTimingKey
 	f.PhaseCosts = r.PhaseCosts
+	f.SessionCosts = r.SessionCosts
 	f.ActiveCycle = r.ActiveCycle
 	f.PendingReviewPhase = r.PendingReviewPhase
 	f.PendingRewindReviewRoadmapPhase = r.PendingRewindReviewRoadmapPhase
@@ -1124,6 +1127,20 @@ func (f *Feature) AddPhaseCost(key string, cost float64) {
 		f.PhaseCosts = make(map[string]float64)
 	}
 	f.PhaseCosts[key] += cost
+}
+
+// RecordSessionCost appends one session-level ledger row and updates the
+// phase-level aggregate used by existing dashboard and summary readers.
+func (f *Feature) RecordSessionCost(record SessionCostRecord) {
+	record.PhaseKey = strings.TrimSpace(record.PhaseKey)
+	if record.CostUSD <= 0 || record.PhaseKey == "" {
+		return
+	}
+	record.SessionID = strings.TrimSpace(record.SessionID)
+	record.ObserverPhase = strings.TrimSpace(record.ObserverPhase)
+	record.RepoName = strings.TrimSpace(record.RepoName)
+	f.AddPhaseCost(record.PhaseKey, record.CostUSD)
+	f.SessionCosts = append(f.SessionCosts, record)
 }
 
 func (f *Feature) Transition(to Status) error {

--- a/internal/feature/feature_test.go
+++ b/internal/feature/feature_test.go
@@ -797,6 +797,58 @@ func TestAddPhaseCostAccumulates(t *testing.T) {
 	}
 }
 
+func TestRecordSessionCostPersistsAndAggregates(t *testing.T) {
+	t.Parallel()
+	// parallel-candidate: per-test temp-dir, no shared fixtures.
+	store := NewStore(t.TempDir())
+	f := &Feature{
+		ID:            "test-session-costs",
+		Status:        StatusCreated,
+		ActiveRun:     1,
+		RunCount:      1,
+		SchemaVersion: SchemaVersionCurrent,
+	}
+	f.RecordSessionCost(SessionCostRecord{
+		SessionID:     "sess-plan-1",
+		PhaseKey:      "phase-1-plan",
+		ObserverPhase: "review",
+		RepoName:      "repo-a",
+		CostUSD:       0.12,
+	})
+	f.RecordSessionCost(SessionCostRecord{
+		SessionID:     "sess-plan-2",
+		PhaseKey:      "phase-1-plan",
+		ObserverPhase: "plan",
+		RepoName:      "repo-a",
+		CostUSD:       0.34,
+	})
+	if err := store.Save(f); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	got, err := store.Load(f.ID)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got.PhaseCost("phase-1-plan") != 0.46 {
+		t.Errorf("PhaseCost(phase-1-plan) = %v, want 0.46", got.PhaseCost("phase-1-plan"))
+	}
+	if got.TotalCost() != 0.46 {
+		t.Errorf("TotalCost() = %v, want 0.46", got.TotalCost())
+	}
+	if len(got.SessionCosts) != 2 {
+		t.Fatalf("len(SessionCosts) = %d, want 2", len(got.SessionCosts))
+	}
+	first := got.SessionCosts[0]
+	if first.SessionID != "sess-plan-1" || first.PhaseKey != "phase-1-plan" || first.ObserverPhase != "review" || first.RepoName != "repo-a" || first.CostUSD != 0.12 {
+		t.Errorf("SessionCosts[0] = %+v, want sess-plan-1 phase-1-plan review repo-a 0.12", first)
+	}
+	second := got.SessionCosts[1]
+	if second.SessionID != "sess-plan-2" || second.PhaseKey != "phase-1-plan" || second.ObserverPhase != "plan" || second.RepoName != "repo-a" || second.CostUSD != 0.34 {
+		t.Errorf("SessionCosts[1] = %+v, want sess-plan-2 phase-1-plan plan repo-a 0.34", second)
+	}
+}
+
 func TestAddPhaseCostZeroNegativeNoop(t *testing.T) {
 	t.Parallel()
 	// parallel-candidate: pure value, table-driven, or per-test temp-dir assertions with no shared state.

--- a/internal/feature/run.go
+++ b/internal/feature/run.go
@@ -76,6 +76,7 @@ type Run struct {
 	// Timings/costs (moved from Feature).
 	PhaseTimings     map[string]time.Duration `yaml:"phase_timings,omitempty"`
 	PhaseCosts       map[string]float64       `yaml:"phase_costs,omitempty"`
+	SessionCosts     []SessionCostRecord      `yaml:"session_costs,omitempty"`
 	ActivePhaseStart *time.Time               `yaml:"active_phase_start,omitempty"`
 	ActiveTimingKey  string                   `yaml:"active_timing_key,omitempty"`
 
@@ -174,6 +175,17 @@ type Run struct {
 	// single-repo NEED_USER_INPUT gate. Empty when no gate is open. Multi-repo
 	// runs persist the per-repo gate path on RepoImplState instead.
 	PendingNeedUserInputPath string `yaml:"pending_need_user_input_path,omitempty"`
+}
+
+// SessionCostRecord is one accounted LLM session within a run. PhaseCosts is
+// the phase-level aggregate used by dashboards; this slice preserves the
+// session-level ledger behind that aggregate.
+type SessionCostRecord struct {
+	SessionID     string  `yaml:"session_id"`
+	PhaseKey      string  `yaml:"phase_key"`
+	ObserverPhase string  `yaml:"observer_phase,omitempty"`
+	RepoName      string  `yaml:"repo_name,omitempty"`
+	CostUSD       float64 `yaml:"cost_usd"`
 }
 
 // IsSealed reports whether this run has been sealed (rewound past).

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -2422,27 +2422,7 @@ func (m AppModel) handleSDKEvent(msg SDKSessionEventMsg) (tea.Model, tea.Cmd) {
 				}
 
 				if registryOwnedSingleShotPhase(phase) {
-					if sess != nil {
-						cost := agent.ExtractSessionCost(sess)
-						if cost.TotalCostUSD > 0 {
-							_ = m.featureManager.Store.Modify(fid, func(f *feature.Feature) error {
-								f.AddPhaseCost(phase.DirName(), cost.TotalCostUSD)
-								return nil
-							})
-						}
-					}
 					return m.completeRegistryOwnedSingleShotPhase(fid, phase, evt.SessionID, sess)
-				}
-
-				// Capture cost from session's ResultMessage
-				if sess != nil {
-					cost := agent.ExtractSessionCost(sess)
-					if cost.TotalCostUSD > 0 {
-						_ = m.featureManager.Store.Modify(fid, func(f *feature.Feature) error {
-							f.AddPhaseCost(phase.DirName(), cost.TotalCostUSD)
-							return nil
-						})
-					}
 				}
 
 				// Stop session gracefully in background
@@ -2704,18 +2684,6 @@ func (m AppModel) handleSessionDone(msg SessionDoneTUIMsg) (tea.Model, tea.Cmd) 
 	for key := range m.lastNotifyTime {
 		if key.featureID == fid {
 			delete(m.lastNotifyTime, key)
-		}
-	}
-
-	// Capture cost from session's ResultMessage.
-	if sess != nil && (phase == feature.PhaseResearch || phase == feature.PhaseKnowledgeBase ||
-		phase == feature.PhaseInquire || phase == feature.PhaseDesign) {
-		cost := agent.ExtractSessionCost(sess)
-		if cost.TotalCostUSD > 0 {
-			_ = m.featureManager.Store.Modify(fid, func(f *feature.Feature) error {
-				f.AddPhaseCost(phase.DirName(), cost.TotalCostUSD)
-				return nil
-			})
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Record every review/helper/planner/implementation session as an independent session-cost ledger row while preserving aggregate phase totals.
- Attribute plan critics, validators, implementation review gates, final reviews, and other helper sessions to their owning phase so final feature cost includes them.
- Fix failed planning restarts so they keep the same logical attempt/progress directory while using a fresh provider session ID after a failed invocation.

## Verification
- Fast suite: `make test-fast`
- Static analysis: `go vet ./...`
- Build: `go build ./...`
- Isolated integration: `go test ./test/integration/... -count=1`
- E2E Go (TUI / teatest): `go test ./test/e2e/... -count=1 -race`

Skipped TUI observability: no observer wiring or emitted observability event schema changes.
Skipped Race regression: covered the touched session lifecycle path with the targeted E2E race gate; full all-package race sweep was not run.