### PR TITLE
Account Codex cached input costs

### DIFF
--- a/internal/llm/codex/protocol.go
+++ b/internal/llm/codex/protocol.go
@@ -59,6 +59,7 @@ type Protocol struct {
 	model              string
 	approvalPolicy     string
 	inputTokens        int
+	cachedInputTokens  int
 	outputTokens       int
 	modelContextWindow int
 	deltaBuf           map[string]string
@@ -732,6 +733,7 @@ func (p *Protocol) parseNotification(method string, params json.RawMessage) (llm
 			p.mu.Lock()
 			model := p.model
 			inTok := p.inputTokens
+			cachedInTok := p.cachedInputTokens
 			outTok := p.outputTokens
 			hadToolUse := p.turnHadToolUse
 			lastText := p.lastAssistantText
@@ -782,7 +784,7 @@ func (p *Protocol) parseNotification(method string, params json.RawMessage) (llm
 			p.formatRetryCount = 0
 			p.mu.Unlock()
 
-			costUSD := computeCost(model, inTok, outTok)
+			costUSD := computeCost(model, inTok, cachedInTok, outTok)
 			msg := llm.SDKMessage{
 				Type:    "result",
 				Subtype: "success",
@@ -793,7 +795,11 @@ func (p *Protocol) parseNotification(method string, params json.RawMessage) (llm
 				},
 			}
 			if inTok > 0 || outTok > 0 {
-				msg.Result.Usage = &llm.Usage{InputTokens: inTok, OutputTokens: outTok}
+				msg.Result.Usage = &llm.Usage{
+					InputTokens:          inTok,
+					CacheReadInputTokens: cachedInTok,
+					OutputTokens:         outTok,
+				}
 			}
 			return msg, true
 
@@ -801,10 +807,11 @@ func (p *Protocol) parseNotification(method string, params json.RawMessage) (llm
 			p.mu.Lock()
 			model := p.model
 			inTok := p.inputTokens
+			cachedInTok := p.cachedInputTokens
 			outTok := p.outputTokens
 			p.mu.Unlock()
 
-			costUSD := computeCost(model, inTok, outTok)
+			costUSD := computeCost(model, inTok, cachedInTok, outTok)
 			errMsg := fmt.Sprintf("codex turn failed: %s", completed.Turn.ID)
 			if completed.Turn.Error != nil {
 				errMsg = completed.Turn.Error.Message
@@ -832,7 +839,11 @@ func (p *Protocol) parseNotification(method string, params json.RawMessage) (llm
 				},
 			}
 			if inTok > 0 || outTok > 0 {
-				msg.Result.Usage = &llm.Usage{InputTokens: inTok, OutputTokens: outTok}
+				msg.Result.Usage = &llm.Usage{
+					InputTokens:          inTok,
+					CacheReadInputTokens: cachedInTok,
+					OutputTokens:         outTok,
+				}
 			}
 			return msg, true
 
@@ -840,10 +851,11 @@ func (p *Protocol) parseNotification(method string, params json.RawMessage) (llm
 			p.mu.Lock()
 			model := p.model
 			inTok := p.inputTokens
+			cachedInTok := p.cachedInputTokens
 			outTok := p.outputTokens
 			p.mu.Unlock()
 
-			costUSD := computeCost(model, inTok, outTok)
+			costUSD := computeCost(model, inTok, cachedInTok, outTok)
 			msg := llm.SDKMessage{
 				Type:    "result",
 				Subtype: "error",
@@ -856,7 +868,11 @@ func (p *Protocol) parseNotification(method string, params json.RawMessage) (llm
 				},
 			}
 			if inTok > 0 || outTok > 0 {
-				msg.Result.Usage = &llm.Usage{InputTokens: inTok, OutputTokens: outTok}
+				msg.Result.Usage = &llm.Usage{
+					InputTokens:          inTok,
+					CacheReadInputTokens: cachedInTok,
+					OutputTokens:         outTok,
+				}
 			}
 			return msg, true
 
@@ -874,6 +890,7 @@ func (p *Protocol) parseNotification(method string, params json.RawMessage) (llm
 		// Last = current context fill (resets on compaction; use for context %).
 		p.mu.Lock()
 		p.inputTokens = usage.TokenUsage.Total.InputTokens
+		p.cachedInputTokens = usage.TokenUsage.Total.CachedInputTokens
 		p.outputTokens = usage.TokenUsage.Total.OutputTokens
 		if usage.TokenUsage.ModelContextWindow != nil {
 			p.modelContextWindow = *usage.TokenUsage.ModelContextWindow
@@ -891,12 +908,13 @@ func (p *Protocol) parseNotification(method string, params json.RawMessage) (llm
 		return llm.SDKMessage{
 			Type: "usage_update",
 			UsageUpdate: &llm.Usage{
-				InputTokens:        usage.TokenUsage.Total.InputTokens,
-				OutputTokens:       usage.TokenUsage.Total.OutputTokens,
-				ContextInputTokens: usage.TokenUsage.Last.InputTokens,
-				ContextTotalTokens: usage.TokenUsage.Last.TotalTokens,
-				ContextBaseline:    codexContextBaselineTokens,
-				ContextWindow:      ctxWindow,
+				InputTokens:          usage.TokenUsage.Total.InputTokens,
+				CacheReadInputTokens: usage.TokenUsage.Total.CachedInputTokens,
+				OutputTokens:         usage.TokenUsage.Total.OutputTokens,
+				ContextInputTokens:   usage.TokenUsage.Last.InputTokens,
+				ContextTotalTokens:   usage.TokenUsage.Last.TotalTokens,
+				ContextBaseline:      codexContextBaselineTokens,
+				ContextWindow:        ctxWindow,
 			},
 		}, true
 
@@ -1500,11 +1518,19 @@ func (p *Protocol) SystemPromptForTest() string {
 	return p.opts.SystemPrompt
 }
 
-func computeCost(model string, inputTokens, outputTokens int) float64 {
+func computeCost(model string, inputTokens, cachedInputTokens, outputTokens int) float64 {
 	r, ok := lookupRate(model)
 	if !ok {
 		return 0
 	}
-	return (float64(inputTokens)/1_000_000)*r.inputPerMToken +
+	if cachedInputTokens < 0 {
+		cachedInputTokens = 0
+	}
+	if cachedInputTokens > inputTokens {
+		cachedInputTokens = inputTokens
+	}
+	uncachedInputTokens := inputTokens - cachedInputTokens
+	return (float64(uncachedInputTokens)/1_000_000)*r.inputPerMToken +
+		(float64(cachedInputTokens)/1_000_000)*r.cachedInputPerMToken +
 		(float64(outputTokens)/1_000_000)*r.outputPerMToken
 }

--- a/internal/llm/codex/protocol_test.go
+++ b/internal/llm/codex/protocol_test.go
@@ -58,14 +58,16 @@ func TestCodexProtocol_TokenUsageUpdated(t *testing.T) {
 			"turnId":   "turn1",
 			"tokenUsage": map[string]interface{}{
 				"total": map[string]interface{}{
-					"inputTokens":  150000,
-					"outputTokens": 5000,
-					"totalTokens":  155000,
+					"inputTokens":       150000,
+					"cachedInputTokens": 20000,
+					"outputTokens":      5000,
+					"totalTokens":       155000,
 				},
 				"last": map[string]interface{}{
-					"inputTokens":  80000,
-					"outputTokens": 2000,
-					"totalTokens":  82000,
+					"inputTokens":       80000,
+					"cachedInputTokens": 10000,
+					"outputTokens":      2000,
+					"totalTokens":       82000,
 				},
 				"modelContextWindow": ctxWindow,
 			},
@@ -96,6 +98,12 @@ func TestCodexProtocol_TokenUsageUpdated(t *testing.T) {
 	if u.OutputTokens != 5000 {
 		t.Errorf("OutputTokens = %d, want 5000 (Total.OutputTokens)", u.OutputTokens)
 	}
+	if u.CacheReadInputTokens != 20000 {
+		t.Errorf("CacheReadInputTokens = %d, want 20000 (Total.CachedInputTokens)", u.CacheReadInputTokens)
+	}
+	if u.CacheCreationInputTokens != 0 {
+		t.Errorf("CacheCreationInputTokens = %d, want 0", u.CacheCreationInputTokens)
+	}
 	// ContextInputTokens carries Last.InputTokens (informational)
 	if u.ContextInputTokens != 80000 {
 		t.Errorf("ContextInputTokens = %d, want 80000 (Last.InputTokens)", u.ContextInputTokens)
@@ -119,6 +127,9 @@ func TestCodexProtocol_TokenUsageUpdated(t *testing.T) {
 	}
 	if p.outputTokens != 5000 {
 		t.Errorf("p.outputTokens = %d, want 5000 (Total.OutputTokens)", p.outputTokens)
+	}
+	if p.cachedInputTokens != 20000 {
+		t.Errorf("p.cachedInputTokens = %d, want 20000 (Total.CachedInputTokens)", p.cachedInputTokens)
 	}
 	if p.modelContextWindow != ctxWindow {
 		t.Errorf("p.modelContextWindow = %d, want %d", p.modelContextWindow, ctxWindow)
@@ -709,6 +720,54 @@ func completedTurnParams(t *testing.T, threadID string) json.RawMessage {
 		t.Fatalf("marshal turn/completed: %v", err)
 	}
 	return raw
+}
+
+func TestTurnCompletedComputesCostWithCachedInputTokens(t *testing.T) {
+	p := NewProtocol(llm.ProtocolOpts{WorkDir: "/tmp/test", Model: "gpt-5.5"})
+
+	usage := map[string]interface{}{
+		"threadId": "thread-1",
+		"turnId":   "turn-1",
+		"tokenUsage": map[string]interface{}{
+			"total": map[string]interface{}{
+				"inputTokens":       1_000_000,
+				"cachedInputTokens": 400_000,
+				"outputTokens":      100_000,
+				"totalTokens":       1_100_000,
+			},
+			"last": map[string]interface{}{
+				"inputTokens":       1_000_000,
+				"cachedInputTokens": 400_000,
+				"outputTokens":      100_000,
+				"totalTokens":       1_100_000,
+			},
+		},
+	}
+	params, err := json.Marshal(usage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := p.parseNotification("thread/tokenUsage/updated", params); !ok {
+		t.Fatal("token usage notification ok = false, want true")
+	}
+
+	msg, ok := p.parseNotification("turn/completed", completedTurnParams(t, "thread-1"))
+	if !ok {
+		t.Fatal("turn completed ok = false, want true")
+	}
+	if msg.Result == nil {
+		t.Fatal("Result = nil")
+	}
+	const want = 6.20 // 600K full input at $5/M + 400K cached at $0.50/M + 100K output at $30/M
+	if diff := msg.Result.TotalCostUSD - want; diff < -0.001 || diff > 0.001 {
+		t.Fatalf("TotalCostUSD = %.6f, want %.2f", msg.Result.TotalCostUSD, want)
+	}
+	if msg.Result.Usage == nil {
+		t.Fatal("Result.Usage = nil")
+	}
+	if msg.Result.Usage.CacheReadInputTokens != 400_000 {
+		t.Fatalf("Result.Usage.CacheReadInputTokens = %d, want 400000", msg.Result.Usage.CacheReadInputTokens)
+	}
 }
 
 func TestTurnCompleted_WellFormedQuestionSurfacesOptions(t *testing.T) {

--- a/internal/llm/codex/provider.go
+++ b/internal/llm/codex/provider.go
@@ -153,12 +153,7 @@ Self-check before sending every question. If any answer is "no" and the free-for
 }
 
 func (p *Provider) ComputeCost(model string, inputTokens, outputTokens int64) float64 {
-	r, ok := lookupRate(model)
-	if !ok {
-		return 0
-	}
-	return (float64(inputTokens)/1_000_000)*r.inputPerMToken +
-		(float64(outputTokens)/1_000_000)*r.outputPerMToken
+	return computeCost(model, int(inputTokens), 0, int(outputTokens))
 }
 
 func (p *Provider) ContextWindowForModel(model string) int {

--- a/internal/llm/codex/rates.go
+++ b/internal/llm/codex/rates.go
@@ -22,16 +22,18 @@ import (
 
 // tokenRate holds per-million-token pricing for a model.
 type tokenRate struct {
-	inputPerMToken  float64
-	outputPerMToken float64
+	inputPerMToken       float64
+	cachedInputPerMToken float64
+	outputPerMToken      float64
 }
 
 // modelRates maps canonical model names to their token pricing.
-// Source: https://developers.openai.com/api/docs/pricing (March 2026)
+// Source: https://developers.openai.com/api/docs/pricing (June 2026)
 var modelRates = map[string]tokenRate{
-	"gpt-5.4":       {inputPerMToken: 2.50, outputPerMToken: 15.00},
-	"gpt-5.4-mini":  {inputPerMToken: 0.75, outputPerMToken: 4.50},
-	"gpt-5.3-codex": {inputPerMToken: 1.75, outputPerMToken: 14.00},
+	"gpt-5.5":       {inputPerMToken: 5.00, cachedInputPerMToken: 0.50, outputPerMToken: 30.00},
+	"gpt-5.4":       {inputPerMToken: 2.50, cachedInputPerMToken: 0.25, outputPerMToken: 15.00},
+	"gpt-5.4-mini":  {inputPerMToken: 0.75, cachedInputPerMToken: 0.075, outputPerMToken: 4.50},
+	"gpt-5.3-codex": {inputPerMToken: 1.75, cachedInputPerMToken: 0.175, outputPerMToken: 14.00},
 }
 
 // defaultModel is the fallback when a model string doesn't match any rate entry.

--- a/internal/llm/codex/rates_test.go
+++ b/internal/llm/codex/rates_test.go
@@ -21,32 +21,34 @@ import (
 
 func TestLookupRate(t *testing.T) {
 	tests := []struct {
-		model   string
-		wantOK  bool
-		wantIn  float64
-		wantOut float64
+		model      string
+		wantOK     bool
+		wantIn     float64
+		wantCached float64
+		wantOut    float64
 	}{
 		// Direct matches
-		{"gpt-5.4", true, 2.50, 15.00},
-		{"gpt-5.4[1M]", true, 2.50, 15.00},
-		{"gpt-5.4-mini", true, 0.75, 4.50},
-		{"gpt-5.4-mini[1M]", true, 0.75, 4.50},
-		{"gpt-5.3-codex", true, 1.75, 14.00},
+		{"gpt-5.5", true, 5.00, 0.50, 30.00},
+		{"gpt-5.5[1M]", true, 5.00, 0.50, 30.00},
+		{"gpt-5.4", true, 2.50, 0.25, 15.00},
+		{"gpt-5.4[1M]", true, 2.50, 0.25, 15.00},
+		{"gpt-5.4-mini", true, 0.75, 0.075, 4.50},
+		{"gpt-5.4-mini[1M]", true, 0.75, 0.075, 4.50},
+		{"gpt-5.3-codex", true, 1.75, 0.175, 14.00},
 
 		// Empty model uses the default model rate.
-		{"", true, 2.50, 15.00},
+		{"", true, 2.50, 0.25, 15.00},
 
 		// Unknown gpt-* variants fall back to default
-		{"gpt-5.5", true, 2.50, 15.00},
-		{"gpt-future-model", true, 2.50, 15.00},
+		{"gpt-future-model", true, 2.50, 0.25, 15.00},
 
 		// Case insensitive
-		{"GPT-5.4", true, 2.50, 15.00},
+		{"GPT-5.4", true, 2.50, 0.25, 15.00},
 		// Non-matching models
-		{"codex", false, 0, 0},
-		{"opus", false, 0, 0},
-		{"sonnet", false, 0, 0},
-		{"unknown", false, 0, 0},
+		{"codex", false, 0, 0, 0},
+		{"opus", false, 0, 0, 0},
+		{"sonnet", false, 0, 0, 0},
+		{"unknown", false, 0, 0, 0},
 	}
 
 	for _, tt := range tests {
@@ -61,6 +63,9 @@ func TestLookupRate(t *testing.T) {
 			if math.Abs(r.inputPerMToken-tt.wantIn) > 0.001 {
 				t.Errorf("inputPerMToken = %f, want %f", r.inputPerMToken, tt.wantIn)
 			}
+			if math.Abs(r.cachedInputPerMToken-tt.wantCached) > 0.001 {
+				t.Errorf("cachedInputPerMToken = %f, want %f", r.cachedInputPerMToken, tt.wantCached)
+			}
 			if math.Abs(r.outputPerMToken-tt.wantOut) > 0.001 {
 				t.Errorf("outputPerMToken = %f, want %f", r.outputPerMToken, tt.wantOut)
 			}
@@ -70,19 +75,33 @@ func TestLookupRate(t *testing.T) {
 
 func TestComputeCost(t *testing.T) {
 	// 1M input + 1M output tokens at gpt-5.4 rates = $2.50 + $15.00 = $17.50
-	cost := computeCost("gpt-5.4", 1_000_000, 1_000_000)
+	cost := computeCost("gpt-5.4", 1_000_000, 0, 1_000_000)
 	if math.Abs(cost-17.50) > 0.001 {
 		t.Errorf("computeCost(gpt-5.4, 1M, 1M) = %f, want 17.50", cost)
 	}
 
+	// 600K uncached input + 400K cached input + 100K output at gpt-5.5 rates =
+	// $3.00 + $0.20 + $3.00 = $6.20.
+	costCached := computeCost("gpt-5.5", 1_000_000, 400_000, 100_000)
+	if math.Abs(costCached-6.20) > 0.001 {
+		t.Errorf("computeCost(gpt-5.5, 1M, 400K, 100K) = %f, want 6.20", costCached)
+	}
+
+	// Cached input is bounded by total input, matching the billing model that
+	// treats cached tokens as a discounted subset of input tokens.
+	costClamped := computeCost("gpt-5.5", 100_000, 200_000, 0)
+	if math.Abs(costClamped-0.05) > 0.001 {
+		t.Errorf("computeCost(gpt-5.5, 100K, 200K, 0) = %f, want 0.05", costClamped)
+	}
+
 	// Empty model should also work (default)
-	costEmpty := computeCost("", 1_000_000, 1_000_000)
+	costEmpty := computeCost("", 1_000_000, 0, 1_000_000)
 	if math.Abs(costEmpty-17.50) > 0.001 {
 		t.Errorf("computeCost('', 1M, 1M) = %f, want 17.50", costEmpty)
 	}
 
 	// Unknown non-gpt model returns 0
-	costUnknown := computeCost("opus", 1_000_000, 1_000_000)
+	costUnknown := computeCost("opus", 1_000_000, 0, 1_000_000)
 	if costUnknown != 0 {
 		t.Errorf("computeCost(opus, 1M, 1M) = %f, want 0", costUnknown)
 	}


### PR DESCRIPTION
## Summary
- Track Codex `cachedInputTokens` from app-server usage events and surface them as `CacheReadInputTokens`.
- Price cached Codex input separately from uncached input when computing turn result cost.
- Refresh the Codex standard rate table from the June 2026 OpenAI pricing table, including `gpt-5.5` and cached-input rates.

## Verification
- Targeted Codex provider: `go test ./internal/llm/codex -count=1`
- Fast suite: `make test-fast`
- Static analysis: `go vet ./...`
- Build: `go build ./...`

Skipped Isolated integration: Codex provider accounting only; lifecycle, state-machine, runs layout, and protocol-violation behavior were not changed.
Skipped E2E Go (TUI / teatest): no TUI, Bubble Tea model behavior, or session lifecycle changes.
Skipped TUI observability: no observer wiring, emitted observability events, or feature-span propagation changes.
Skipped Race regression: provider accounting change has no new concurrency path; covered by targeted provider tests plus fast/static/build gates.