### PR TITLE
[codex] account for OpenCode child session costs

### DIFF
--- a/internal/agent/cost.go
+++ b/internal/agent/cost.go
@@ -15,8 +15,11 @@
 package agent
 
 import (
+	"context"
 	"fmt"
+	"log"
 	"strings"
+	"time"
 
 	"github.com/doordash-oss/agentic-orchestrator/internal/feature"
 	"github.com/doordash-oss/agentic-orchestrator/internal/llm"
@@ -24,10 +27,16 @@ import (
 	"github.com/doordash-oss/agentic-orchestrator/internal/ports"
 )
 
+const additionalSessionCostTimeout = 2 * time.Second
+
 // SessionCost holds cost and usage data extracted from a session.
 type SessionCost struct {
 	TotalCostUSD float64
 	Usage        llm.Usage
+}
+
+type additionalSessionCostProvider interface {
+	AdditionalSessionCost(context.Context) (llm.SessionCostAdjustment, error)
 }
 
 // SessionCostMetadata identifies the single session behind an accounted cost.
@@ -49,7 +58,28 @@ func ExtractSessionCost(sess ports.SessionView) SessionCost {
 	if sess.Cost() != nil {
 		sc.TotalCostUSD = sess.Cost().TotalCostUSD
 	}
+	if provider, ok := sess.(additionalSessionCostProvider); ok {
+		ctx, cancel := context.WithTimeout(context.Background(), additionalSessionCostTimeout)
+		defer cancel()
+		adjustment, err := provider.AdditionalSessionCost(ctx)
+		if err != nil {
+			log.Printf("session cost: additional provider cost unavailable for %s: %v", sess.ID(), err)
+		} else {
+			applySessionCostAdjustment(&sc, adjustment)
+		}
+	}
 	return sc
+}
+
+func applySessionCostAdjustment(cost *SessionCost, adjustment llm.SessionCostAdjustment) {
+	if cost == nil {
+		return
+	}
+	cost.TotalCostUSD += adjustment.TotalCostUSD
+	cost.Usage.InputTokens += adjustment.Usage.InputTokens
+	cost.Usage.OutputTokens += adjustment.Usage.OutputTokens
+	cost.Usage.CacheReadInputTokens += adjustment.Usage.CacheReadInputTokens
+	cost.Usage.CacheCreationInputTokens += adjustment.Usage.CacheCreationInputTokens
 }
 
 // toSessionUsage converts a SessionCost to an observe.SessionUsage.

--- a/internal/agent/cost_test.go
+++ b/internal/agent/cost_test.go
@@ -15,6 +15,7 @@
 package agent
 
 import (
+	"context"
 	"testing"
 
 	"github.com/doordash-oss/agentic-orchestrator/internal/feature"
@@ -45,6 +46,57 @@ func TestExtractSessionCostFromResult(t *testing.T) {
 	if cost.TotalCostUSD != 2.75 {
 		t.Errorf("TotalCostUSD = %v, want 2.75", cost.TotalCostUSD)
 	}
+}
+
+func TestExtractSessionCostIncludesProviderAdditionalSessionCost(t *testing.T) {
+	base := mocks.NewMockSessionView("sess-parent", "feat-1")
+	base.CostVal = &llm.ResultMessage{TotalCostUSD: 2.00}
+	base.AccumulatedUsageVal = llm.Usage{
+		InputTokens:              100,
+		OutputTokens:             20,
+		CacheReadInputTokens:     300,
+		CacheCreationInputTokens: 4,
+	}
+	sess := &additionalCostSession{
+		MockSessionView: base,
+		adjustment: llm.SessionCostAdjustment{
+			TotalCostUSD: 0.75,
+			Usage: llm.Usage{
+				InputTokens:              10,
+				OutputTokens:             2,
+				CacheReadInputTokens:     30,
+				CacheCreationInputTokens: 1,
+			},
+		},
+	}
+
+	cost := ExtractSessionCost(sess)
+
+	if cost.TotalCostUSD != 2.75 {
+		t.Errorf("TotalCostUSD = %v, want 2.75", cost.TotalCostUSD)
+	}
+	if cost.Usage.InputTokens != 110 {
+		t.Errorf("Usage.InputTokens = %d, want 110", cost.Usage.InputTokens)
+	}
+	if cost.Usage.OutputTokens != 22 {
+		t.Errorf("Usage.OutputTokens = %d, want 22", cost.Usage.OutputTokens)
+	}
+	if cost.Usage.CacheReadInputTokens != 330 {
+		t.Errorf("Usage.CacheReadInputTokens = %d, want 330", cost.Usage.CacheReadInputTokens)
+	}
+	if cost.Usage.CacheCreationInputTokens != 5 {
+		t.Errorf("Usage.CacheCreationInputTokens = %d, want 5", cost.Usage.CacheCreationInputTokens)
+	}
+}
+
+type additionalCostSession struct {
+	*mocks.MockSessionView
+	adjustment llm.SessionCostAdjustment
+	err        error
+}
+
+func (s *additionalCostSession) AdditionalSessionCost(context.Context) (llm.SessionCostAdjustment, error) {
+	return s.adjustment, s.err
 }
 
 func TestImplementCostAttributionUsesStoreKey(t *testing.T) {

--- a/internal/agent/implement_test.go
+++ b/internal/agent/implement_test.go
@@ -1030,7 +1030,7 @@ type captureSink struct {
 }
 
 func newCaptureSink() *captureSink {
-	return &captureSink{done: make(chan struct{})}
+	return &captureSink{done: make(chan struct{}, 1)}
 }
 
 func (c *captureSink) Write(p []byte) (int, error) {
@@ -1054,9 +1054,9 @@ func (c *captureSink) contents() string {
 	return c.buf.String()
 }
 
-// waitForWrite blocks until the sink sees another write or the timeout
-// elapses. Drains any queued notifications up front so callers can issue
-// an action and then wait for the resulting write without racing.
+// waitForWrite blocks until the sink sees a write or the timeout elapses. The
+// sink retains one pending notification so callers do not race when the write
+// lands immediately after the triggering action.
 func (c *captureSink) waitForWrite(t *testing.T, timeout time.Duration) {
 	t.Helper()
 	select {
@@ -1064,6 +1064,15 @@ func (c *captureSink) waitForWrite(t *testing.T, timeout time.Duration) {
 	case <-time.After(timeout):
 		t.Fatalf("timed out waiting for stdin write")
 	}
+}
+
+func TestCaptureSinkWaitForWriteObservesAlreadyCompletedWrite(t *testing.T) {
+	sink := newCaptureSink()
+	if _, err := sink.Write([]byte("already written")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	sink.waitForWrite(t, 10*time.Millisecond)
 }
 
 // attachCaptureSink installs a captureSink as the session's stdin. Returns

--- a/internal/llm/opencode/session_cost.go
+++ b/internal/llm/opencode/session_cost.go
@@ -1,0 +1,192 @@
+// Copyright 2026 DoorDash, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package opencode
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/doordash-oss/agentic-orchestrator/internal/llm"
+)
+
+var (
+	openCodeSessionIDPattern = regexp.MustCompile(`^[A-Za-z0-9_-]+$`)
+	errSQLiteUnavailable     = errors.New("sqlite3 is not available")
+)
+
+type sqliteRunner interface {
+	RunSQLite(ctx context.Context, dbPath, query string) ([]byte, error)
+}
+
+type sqliteCLIRunner struct{}
+
+func (sqliteCLIRunner) RunSQLite(ctx context.Context, dbPath, query string) ([]byte, error) {
+	sqlitePath, err := exec.LookPath("sqlite3")
+	if err != nil {
+		return nil, errSQLiteUnavailable
+	}
+	cmd := exec.CommandContext(ctx, sqlitePath, "-readonly", "-batch", "-noheader", "-separator", "\t", dbPath, query)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("sqlite3 query failed: %w: %s", err, strings.TrimSpace(string(out)))
+	}
+	return out, nil
+}
+
+type openCodeChildSessionCostLookup struct {
+	dbPath string
+	runner sqliteRunner
+}
+
+// AdditionalSessionCost returns costs for OpenCode-managed child sessions, such
+// as Task subagents. OpenCode reports the parent ACP session cost separately
+// from those rows, so Agentico has to add descendants explicitly.
+func (p *Protocol) AdditionalSessionCost(ctx context.Context) (llm.SessionCostAdjustment, error) {
+	sessionID := p.SessionID()
+	return openCodeChildSessionCostLookup{}.Lookup(ctx, sessionID)
+}
+
+func (l openCodeChildSessionCostLookup) Lookup(ctx context.Context, parentSessionID string) (llm.SessionCostAdjustment, error) {
+	parentSessionID = strings.TrimSpace(parentSessionID)
+	if parentSessionID == "" || !openCodeSessionIDPattern.MatchString(parentSessionID) {
+		return llm.SessionCostAdjustment{}, nil
+	}
+	if l.dbPath == "" {
+		l.dbPath = defaultOpenCodeDBPath()
+	}
+	if l.dbPath == "" {
+		return llm.SessionCostAdjustment{}, nil
+	}
+	if l.runner == nil {
+		if _, err := os.Stat(l.dbPath); err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				return llm.SessionCostAdjustment{}, nil
+			}
+			return llm.SessionCostAdjustment{}, fmt.Errorf("stat OpenCode session database: %w", err)
+		}
+		l.runner = sqliteCLIRunner{}
+	}
+
+	out, err := l.runner.RunSQLite(ctx, l.dbPath, openCodeChildSessionCostQuery(parentSessionID))
+	if err != nil {
+		if errors.Is(err, errSQLiteUnavailable) {
+			return llm.SessionCostAdjustment{}, nil
+		}
+		return llm.SessionCostAdjustment{}, err
+	}
+	return parseOpenCodeChildSessionCostOutput(out)
+}
+
+func defaultOpenCodeDBPath() string {
+	if dataDir := strings.TrimSpace(os.Getenv("OPENCODE_DATA_DIR")); dataDir != "" {
+		return filepath.Join(dataDir, "opencode.db")
+	}
+	if xdgData := strings.TrimSpace(os.Getenv("XDG_DATA_HOME")); xdgData != "" {
+		return filepath.Join(xdgData, "opencode", "opencode.db")
+	}
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return ""
+	}
+	return filepath.Join(home, ".local", "share", "opencode", "opencode.db")
+}
+
+func openCodeChildSessionCostQuery(parentSessionID string) string {
+	parent := sqlStringLiteral(parentSessionID)
+	return fmt.Sprintf(`WITH RECURSIVE descendants(id) AS (
+  SELECT id FROM session WHERE parent_id = %s
+  UNION ALL
+  SELECT s.id FROM session s JOIN descendants d ON s.parent_id = d.id
+)
+SELECT
+  COALESCE(SUM(s.cost), 0),
+  COALESCE(SUM(s.tokens_input), 0),
+  COALESCE(SUM(s.tokens_output), 0),
+  COALESCE(SUM(s.tokens_cache_read), 0),
+  COALESCE(SUM(s.tokens_cache_write), 0),
+  COALESCE(group_concat(s.id, ','), '')
+FROM session s
+WHERE s.id IN (SELECT id FROM descendants);`, parent)
+}
+
+func sqlStringLiteral(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "''") + "'"
+}
+
+func parseOpenCodeChildSessionCostOutput(out []byte) (llm.SessionCostAdjustment, error) {
+	line := strings.TrimSpace(string(out))
+	if line == "" {
+		return llm.SessionCostAdjustment{}, nil
+	}
+	fields := strings.Split(line, "\t")
+	if len(fields) != 6 {
+		return llm.SessionCostAdjustment{}, fmt.Errorf("unexpected OpenCode child cost output %q", line)
+	}
+
+	cost, err := strconv.ParseFloat(strings.TrimSpace(fields[0]), 64)
+	if err != nil {
+		return llm.SessionCostAdjustment{}, fmt.Errorf("parse child cost: %w", err)
+	}
+	input, err := parseSQLiteIntField(fields[1], "input tokens")
+	if err != nil {
+		return llm.SessionCostAdjustment{}, err
+	}
+	output, err := parseSQLiteIntField(fields[2], "output tokens")
+	if err != nil {
+		return llm.SessionCostAdjustment{}, err
+	}
+	cacheRead, err := parseSQLiteIntField(fields[3], "cache read tokens")
+	if err != nil {
+		return llm.SessionCostAdjustment{}, err
+	}
+	cacheWrite, err := parseSQLiteIntField(fields[4], "cache write tokens")
+	if err != nil {
+		return llm.SessionCostAdjustment{}, err
+	}
+
+	var sessionIDs []string
+	for _, id := range strings.Split(strings.TrimSpace(fields[5]), ",") {
+		id = strings.TrimSpace(id)
+		if id != "" {
+			sessionIDs = append(sessionIDs, id)
+		}
+	}
+
+	return llm.SessionCostAdjustment{
+		TotalCostUSD: cost,
+		Usage: llm.Usage{
+			InputTokens:              input,
+			OutputTokens:             output,
+			CacheReadInputTokens:     cacheRead,
+			CacheCreationInputTokens: cacheWrite,
+		},
+		SessionIDs: sessionIDs,
+	}, nil
+}
+
+func parseSQLiteIntField(value, label string) (int, error) {
+	parsed, err := strconv.ParseInt(strings.TrimSpace(value), 10, 0)
+	if err != nil {
+		return 0, fmt.Errorf("parse child %s: %w", label, err)
+	}
+	return int(parsed), nil
+}

--- a/internal/llm/opencode/session_cost_test.go
+++ b/internal/llm/opencode/session_cost_test.go
@@ -1,0 +1,72 @@
+// Copyright 2026 DoorDash, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package opencode
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/doordash-oss/agentic-orchestrator/internal/llm"
+)
+
+func TestChildSessionCostLookupSumsRecursiveDescendants(t *testing.T) {
+	t.Parallel()
+	runner := &fakeSQLiteRunner{
+		output: "0.75\t100\t20\t300\t4\tchild-a,child-b\n",
+	}
+	lookup := openCodeChildSessionCostLookup{
+		dbPath: "/tmp/opencode.db",
+		runner: runner,
+	}
+
+	got, err := lookup.Lookup(context.Background(), "ses_parent")
+	if err != nil {
+		t.Fatalf("Lookup: %v", err)
+	}
+
+	if got.TotalCostUSD != 0.75 {
+		t.Errorf("TotalCostUSD = %v, want 0.75", got.TotalCostUSD)
+	}
+	if got.Usage != (llm.Usage{
+		InputTokens:              100,
+		OutputTokens:             20,
+		CacheReadInputTokens:     300,
+		CacheCreationInputTokens: 4,
+	}) {
+		t.Errorf("Usage = %+v, want recursive child token totals", got.Usage)
+	}
+	if strings.Join(got.SessionIDs, ",") != "child-a,child-b" {
+		t.Errorf("SessionIDs = %v, want [child-a child-b]", got.SessionIDs)
+	}
+	if !strings.Contains(runner.query, "WITH RECURSIVE descendants") {
+		t.Errorf("query = %q, want recursive descendant CTE", runner.query)
+	}
+	if !strings.Contains(runner.query, "parent_id = 'ses_parent'") {
+		t.Errorf("query = %q, want parent_id filter for parent session", runner.query)
+	}
+}
+
+type fakeSQLiteRunner struct {
+	output string
+	dbPath string
+	query  string
+}
+
+func (r *fakeSQLiteRunner) RunSQLite(_ context.Context, dbPath, query string) ([]byte, error) {
+	r.dbPath = dbPath
+	r.query = query
+	return []byte(r.output), nil
+}

--- a/internal/llm/provider.go
+++ b/internal/llm/provider.go
@@ -111,6 +111,22 @@ type CostCalculator interface {
 	ContextWindowForModel(model string) int
 }
 
+// SessionCostAdjustment is provider-specific cost and usage that is not carried
+// by the primary session result. For example, OpenCode stores Task subagents as
+// child sessions outside the parent ACP usage_update total.
+type SessionCostAdjustment struct {
+	TotalCostUSD float64
+	Usage        Usage
+	SessionIDs   []string
+}
+
+// SessionCostAugmenter is an optional Protocol capability for providers that
+// need to account for provider-managed child sessions in addition to the parent
+// session's terminal result.
+type SessionCostAugmenter interface {
+	AdditionalSessionCost(ctx context.Context) (SessionCostAdjustment, error)
+}
+
 // CatalogProvider exposes the model catalog populated by discovery.
 // Providers implementing this interface allow the Registry to perform
 // category-based model selection from the live catalog.

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -16,6 +16,7 @@ package session
 
 import (
 	"bufio"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -345,6 +346,20 @@ func estimateInitialPromptContextTokens(prompt string) int {
 func (s *Session) MessageLog() ports.MessageLog { return s.messageLog }
 func (s *Session) Cost() *llm.ResultMessage     { return s.cost }
 func (s *Session) StatusCh() <-chan string      { return s.statusCh }
+
+// AdditionalSessionCost returns provider-specific child-session cost that is
+// not included in the primary result cost. Providers without this optional
+// capability return a zero adjustment.
+func (s *Session) AdditionalSessionCost(ctx context.Context) (llm.SessionCostAdjustment, error) {
+	if s == nil || s.protocol == nil {
+		return llm.SessionCostAdjustment{}, nil
+	}
+	augmenter, ok := s.protocol.(llm.SessionCostAugmenter)
+	if !ok {
+		return llm.SessionCostAdjustment{}, nil
+	}
+	return augmenter.AdditionalSessionCost(ctx)
+}
 
 // LastControlRequest returns the most recently arrived pending
 // control_request, or nil if none are outstanding. Preserves the historical


### PR DESCRIPTION
## Summary

Agentico previously recorded only the top-level session cost returned by a provider session. For OpenCode, Task/subagent work is persisted as child sessions in the OpenCode SQLite session store, so those child costs were missing from Agentico session, phase, and feature totals.

This change adds an optional provider cost augmentation hook and implements it for OpenCode by recursively summing descendant session rows from the OpenCode database. The extracted session cost now includes both the parent ACP result cost and provider-managed child session costs/tokens.

A CI flake surfaced in the wait-status tests while validating this PR. The capture sink used by those tests dropped a write notification if the nudge write completed before the assertion started waiting, so the test could time out despite the write succeeding. The PR now buffers one pending write notification and covers that path with a regression test.

## Changes

- Add `llm.SessionCostAdjustment` and optional `llm.SessionCostAugmenter` capability.
- Expose `Session.AdditionalSessionCost(ctx)` for providers that can account for out-of-band child sessions.
- Merge provider additional cost and token usage in `agent.ExtractSessionCost`.
- Add OpenCode child-session lookup using a recursive SQLite query over `session.parent_id`.
- Add unit coverage for cost merging and recursive OpenCode child-session parsing.
- Stabilize the wait-status test capture sink so already-completed writes are observable.

## Verification

- Fast suite: `make test-fast`
- CI-equivalent short suite: `go test ./... -short -count=1`
- Focused wait-status tests: `go test ./internal/agent -run 'TestCaptureSinkWaitForWriteObservesAlreadyCompletedWrite|TestWaitForStatus_EndedAfterText_ReturnsMissingMarker|TestWaitForStatus_EndedAfterText_NudgesThenSucceeds' -short -count=1 -v`
- Flake stress loop: 50x `go test ./internal/agent -run 'TestWaitForStatus' -short -count=1`
- Static analysis: `go vet ./...`
- Build: `go build ./...`