### PR TITLE
[codex] Prevent final review from reopening planning

### DIFF
--- a/internal/agent/final_review_loop.go
+++ b/internal/agent/final_review_loop.go
@@ -52,9 +52,6 @@ import (
 //     repo's RepoState records the failure.
 //   - "protocol_violation": the fix agent ended its turn without satisfying
 //     the completion contract. Every staged repo's RepoState records the failure.
-//   - "plan_revision_required": reviewer found missing visual or behavioral
-//     implementation evidence coverage that must be repaired by revising the
-//     relevant phase plan. No failure stamp is written.
 //   - "interrupted":     graceful shutdown / feature stopped while
 //     running. No atomic stamp written; persisted state preserved.
 //   - "failed":          dispatch error before iteration began.
@@ -183,13 +180,6 @@ func RunFeatureFinalReviewLoop(cfg OrchestratorConfig, sm ports.SessionManager) 
 	case "interrupted":
 		// No atomic stamp on interrupt; persisted state is left
 		// untouched so the next start picks up the loop.
-		result.Repos = stagedRepos
-		return result, nil
-
-	case "plan_revision_required":
-		// Missing evidence is a plan-repair path, not a failed final review.
-		// The orchestrator will invalidate the relevant phase-plan attempt
-		// and dispatch planning again.
 		result.Repos = stagedRepos
 		return result, nil
 
@@ -408,14 +398,6 @@ func (s *featureFinalReviewLoopState) run() (*FeatureFinalReviewResult, error) {
 			return &FeatureFinalReviewResult{FinalStatus: "review_passed", Iterations: i}, nil
 
 		case ReviewChangesRequested:
-			if reqs := MissingEvidenceRequirements(feedback); len(reqs) > 0 {
-				s.writeIterationMeta(iterDir, i, "changes_requested")
-				return &FeatureFinalReviewResult{
-					FinalStatus:          "plan_revision_required",
-					Iterations:           i,
-					PlanRevisionFeedback: MissingEvidencePlanRevisionFeedback(reqs),
-				}, nil
-			}
 			s.setReviewFixing(true)
 			fixStatus, fixErr := s.runFix(i, iterDir, feedback)
 

--- a/internal/agent/final_review_loop_test.go
+++ b/internal/agent/final_review_loop_test.go
@@ -723,25 +723,76 @@ func TestRunFeatureFinalReviewLoop_ConsecutiveFailuresSafetyRail(t *testing.T) {
 	}
 }
 
-func TestRunFeatureFinalReviewLoop_MissingEvidenceRoutesPlanRevision(t *testing.T) {
+func TestRunFeatureFinalReviewLoop_MissingEvidenceRunsFixAgent(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
 	}
-	result := runFinalReviewWithReviewScript(t, func(artDir string) string {
-		return testutil.WriteFinalReviewChangesRequested(artDir, "- **Critical**: MISSING_EVIDENCE_REQUIREMENT behavioral: Record the create-project CLI journey.")
-	})
+	env := newFRLoopEnv(t)
+	store, f, _ := newFRTestFeature(t, env.stateDir, "fr-missing-evidence-fix", []string{"api", "web"})
 
-	if result.FinalStatus != "plan_revision_required" {
-		t.Fatalf("FinalStatus = %q, want plan_revision_required", result.FinalStatus)
+	artDir := frArtifactDir(env.stateDir, f)
+	if err := os.MkdirAll(artDir, 0o755); err != nil {
+		t.Fatalf("mkdir artifact: %v", err)
 	}
-	for _, want := range []string{
-		"MISSING_EVIDENCE_REQUIREMENT behavioral: Record the create-project CLI journey.",
-		"### Behavioral Evidence",
-		"Do not add verification-report.yaml rows directly",
-	} {
-		if !strings.Contains(result.PlanRevisionFeedback, want) {
-			t.Errorf("PlanRevisionFeedback missing %q:\n%s", want, result.PlanRevisionFeedback)
-		}
+
+	reviewScript := testutil.WriteScript(t, env.scriptsDir, "review.sh",
+		fmt.Sprintf(`if [ -d "%s/iteration-02" ]; then
+%s
+%s
+%s
+else
+%s
+%s
+%s
+fi`,
+			artDir,
+			testutil.JSONLInit,
+			testutil.WriteFinalReviewApproved(artDir),
+			testutil.JSONLSuccess,
+			testutil.JSONLInit,
+			testutil.WriteFinalReviewChangesRequested(artDir, "- **Critical**: MISSING_EVIDENCE_REQUIREMENT behavioral: Record the create-project CLI journey."),
+			testutil.JSONLSuccess))
+	fixScript := testutil.WriteScript(t, env.scriptsDir, "fix.sh",
+		testutil.JSONLInit+"\n"+
+			testutil.WriteFinalReviewFixSuccessArtifacts(artDir)+"\n"+
+			testutil.JSONLSuccess+"\n")
+
+	eventCh := make(chan any, 100)
+	sm := session.NewManager(eventCh)
+	defer sm.Shutdown()
+
+	cfg := OrchestratorConfig{
+		Feature:        f,
+		FeatureStore:   store,
+		StateDir:       env.stateDir,
+		Model:          "agent",
+		ReviewModel:    "reviewer",
+		MaxIterations:  3,
+		MaxConsecFails: 3,
+		BuildSession: mockBuildSessionByModel(map[string]string{
+			"reviewer": reviewScript,
+			"agent":    fixScript,
+		}),
+	}
+
+	result, err := RunFeatureFinalReviewLoop(cfg, sm)
+	if err != nil {
+		t.Fatalf("RunFeatureFinalReviewLoop() error = %v", err)
+	}
+	if result.FinalStatus != "review_passed" {
+		t.Fatalf("FinalStatus = %q, want review_passed", result.FinalStatus)
+	}
+	if result.PlanRevisionFeedback != "" {
+		t.Fatalf("PlanRevisionFeedback = %q, want empty", result.PlanRevisionFeedback)
+	}
+	if result.Iterations != 2 {
+		t.Fatalf("Iterations = %d, want 2 after fix-agent iteration", result.Iterations)
+	}
+	if _, err := os.Stat(filepath.Join(artDir, "iteration-01", "phase_complete")); err != nil {
+		t.Fatalf("iteration-01 phase_complete missing: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(artDir, "iteration-02", "phase_complete")); err != nil {
+		t.Fatalf("iteration-02 phase_complete missing: %v", err)
 	}
 }
 

--- a/internal/agent/missing_evidence.go
+++ b/internal/agent/missing_evidence.go
@@ -96,25 +96,6 @@ func parseMissingEvidenceMarkerHead(head string) (int, string, bool) {
 	}
 }
 
-// MissingEvidenceTargetPhase returns the earliest roadmap phase explicitly
-// named by phase-qualified markers, or fallback when the feedback only uses
-// the current-phase marker form.
-func MissingEvidenceTargetPhase(feedback string, fallback int) int {
-	target := 0
-	for _, req := range MissingEvidenceRequirements(feedback) {
-		if req.Phase <= 0 {
-			continue
-		}
-		if target == 0 || req.Phase < target {
-			target = req.Phase
-		}
-	}
-	if target > 0 {
-		return target
-	}
-	return fallback
-}
-
 // MissingEvidencePlanRevisionFeedback renders the phase-plan critic feedback
 // used when review discovers a user-facing surface without contract-backed
 // visual or behavioral evidence coverage.

--- a/internal/agent/missing_evidence_test.go
+++ b/internal/agent/missing_evidence_test.go
@@ -67,10 +67,9 @@ func TestMissingEvidenceRequirements_ParsePhaseQualifiedMarkers(t *testing.T) {
 
 func TestMissingEvidenceReviewerSkillsShareSafetyNetRule(t *testing.T) {
 	repoRoot := filepath.Join("..", "..")
-	for _, path := range []string{
-		filepath.Join(repoRoot, "skills", "review-implementation", "SKILL.md"),
-		filepath.Join(repoRoot, "skills", "final-review", "SKILL.md"),
-	} {
+	implementationReviewPath := filepath.Join(repoRoot, "skills", "review-implementation", "SKILL.md")
+	finalReviewPath := filepath.Join(repoRoot, "skills", "final-review", "SKILL.md")
+	for _, path := range []string{implementationReviewPath, finalReviewPath} {
 		data, err := os.ReadFile(path)
 		if err != nil {
 			t.Fatalf("ReadFile(%s) error = %v", path, err)
@@ -80,14 +79,39 @@ func TestMissingEvidenceReviewerSkillsShareSafetyNetRule(t *testing.T) {
 			"Missing Visual / Behavioral Evidence Safety Net",
 			"rendered UI, TUI screens, web/mobile/native views, CLI output",
 			"Existing",
-			"MISSING_EVIDENCE_REQUIREMENT visual: <reviewer-authored requirement>",
-			"MISSING_EVIDENCE_REQUIREMENT behavioral: <reviewer-authored requirement>",
 			"Do not",
-			"phase-plan revision",
 		} {
 			if !strings.Contains(body, want) {
 				t.Errorf("%s missing %q", path, want)
 			}
+		}
+	}
+
+	implementationReview, err := os.ReadFile(implementationReviewPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%s) error = %v", implementationReviewPath, err)
+	}
+	for _, want := range []string{
+		"MISSING_EVIDENCE_REQUIREMENT visual: <reviewer-authored requirement>",
+		"MISSING_EVIDENCE_REQUIREMENT behavioral: <reviewer-authored requirement>",
+		"phase-plan revision",
+	} {
+		if !strings.Contains(string(implementationReview), want) {
+			t.Errorf("%s missing %q", implementationReviewPath, want)
+		}
+	}
+
+	finalReview, err := os.ReadFile(finalReviewPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%s) error = %v", finalReviewPath, err)
+	}
+	for _, want := range []string{
+		"Final Review never reopens planning",
+		"Do not emit `MISSING_EVIDENCE_REQUIREMENT` markers in Final Review feedback",
+		"fix agent should capture the missing evidence artifacts",
+	} {
+		if !strings.Contains(string(finalReview), want) {
+			t.Errorf("%s missing %q", finalReviewPath, want)
 		}
 	}
 }

--- a/internal/agent/orchestrator.go
+++ b/internal/agent/orchestrator.go
@@ -122,8 +122,9 @@ type OrchestratorResult struct {
 	// can read the questionnaire and answers.
 	NeedUserInputPath string
 	LastError         string
-	// PlanRevisionFeedback carries reviewer-authored missing-evidence
-	// requirements when FinalStatus == "plan_revision_required".
+	// PlanRevisionFeedback carries implementation-review missing-evidence
+	// requirements when FinalStatus == "plan_revision_required". Final Review
+	// must run its fix leg instead of returning this status.
 	PlanRevisionFeedback string
 }
 
@@ -225,10 +226,14 @@ func RunMultiRepoFinalReview(cfg OrchestratorConfig, sm ports.SessionManager) (*
 	case "interrupted":
 		return &OrchestratorResult{FinalStatus: "interrupted"}, nil
 	case "plan_revision_required":
+		// Final Review must keep fixes inside the final-review loop. Older
+		// injected/fake review runners may still return this status; surface
+		// it as a failure instead of reopening planning.
 		return &OrchestratorResult{
-			FinalStatus:          "plan_revision_required",
-			RepoStatuses:         finalReviewRepoStatuses(frResult),
-			PlanRevisionFeedback: frResult.PlanRevisionFeedback,
+			FinalStatus:  "failed",
+			RepoStatuses: finalReviewRepoStatuses(frResult),
+			FailedRepos:  append([]string(nil), frResultRepos(frResult)...),
+			LastError:    "final review requested unsupported phase-plan revision",
 		}, nil
 	default:
 		return &OrchestratorResult{

--- a/internal/orchestrator/completion.go
+++ b/internal/orchestrator/completion.go
@@ -920,7 +920,7 @@ func (o *Orchestrator) routeMissingEvidencePlanRevision(featureID string, f *fea
 	if strings.TrimSpace(feedback) == "" {
 		feedback = agent.MissingEvidencePlanRevisionFeedback(nil)
 	}
-	targetRoadmapPhase := agent.MissingEvidenceTargetPhase(feedback, f.CurrentRoadmapPhase)
+	targetRoadmapPhase := f.CurrentRoadmapPhase
 	if f.TotalRoadmapPhases > 0 && targetRoadmapPhase > f.TotalRoadmapPhases {
 		targetRoadmapPhase = f.CurrentRoadmapPhase
 	}
@@ -1380,11 +1380,9 @@ func (o *Orchestrator) runDeferredFinalReview(featureID string) error {
 		o.emitPhaseCompleted(featureID, feature.PhaseFinalReview, nil)
 		return errFinalReviewInterrupted
 	case "plan_revision_required":
-		if err := o.routeMissingEvidencePlanRevision(featureID, f, res.PlanRevisionFeedback); err != nil {
-			return err
-		}
-		o.emitPhaseCompleted(featureID, feature.PhaseFinalReview, errors.New("missing evidence requires phase-plan revision"))
-		return errPlanRevisionDispatched
+		errMsg := "final review requested unsupported phase-plan revision"
+		o.emitPhaseCompleted(featureID, feature.PhaseFinalReview, errors.New(errMsg))
+		return o.markFinalReviewFailedWithEvent(featureID, feature.FailureInfrastructure, errMsg)
 	case "failed":
 		errMsg := res.LastError
 		if errMsg == "" {

--- a/internal/orchestrator/completion_unified_fr_test.go
+++ b/internal/orchestrator/completion_unified_fr_test.go
@@ -195,7 +195,7 @@ func TestOrchestrator_OnMultiReposPassed_MediumRunsDeferredFinalReview(t *testin
 	}
 }
 
-func TestOrchestrator_OnMultiReposPassed_MissingEvidenceFinalReviewRoutesPhasePlanRevision(t *testing.T) {
+func TestOrchestrator_OnMultiReposPassed_FinalReviewPlanRevisionResultFailsWithoutPlanning(t *testing.T) {
 	tests := []struct {
 		name     string
 		pipeline feature.PipelineProfile
@@ -206,9 +206,6 @@ func TestOrchestrator_OnMultiReposPassed_MissingEvidenceFinalReviewRoutesPhasePl
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cpr := newCapturingPhaseRunner(t)
-			cpr.sm.StartSessionFn = func(id, featureID string, phase feature.Phase, command []string, workdir string, env []string, opts ...*session.SessionOpts) (ports.SessionHandle, error) {
-				return nil, session.ErrShuttingDown
-			}
 
 			featureID := "feat-fr-missing-evidence-" + tt.name
 			roadmapPath := filepath.Join(cpr.stateDir, "roadmap.md")
@@ -244,7 +241,19 @@ func TestOrchestrator_OnMultiReposPassed_MissingEvidenceFinalReviewRoutesPhasePl
 			lc.CompleteImplementationFn = func(id string) error { f.Status = feature.StatusReviewPassed; return nil }
 			lc.MarkFinalReviewReadyFn = func(id string) error { f.Status = feature.StatusFinalReviewing; return nil }
 			lc.MarkCodeReadyFn = func(id string) error {
-				t.Fatalf("MarkCodeReady called after final-review missing-evidence rejection")
+				t.Fatalf("MarkCodeReady called after unsupported final-review plan revision")
+				return nil
+			}
+			lc.MarkFailedFn = func(id, failureType, lastError string) error {
+				if failureType != feature.FailureInfrastructure {
+					t.Fatalf("failureType = %q, want %q", failureType, feature.FailureInfrastructure)
+				}
+				if !strings.Contains(lastError, "final review requested unsupported phase-plan revision") {
+					t.Fatalf("lastError = %q, want unsupported phase-plan revision", lastError)
+				}
+				f.Status = feature.StatusFailed
+				f.FailureType = failureType
+				f.LastError = lastError
 				return nil
 			}
 			fs := newFeatureStore(f)
@@ -271,37 +280,33 @@ func TestOrchestrator_OnMultiReposPassed_MissingEvidenceFinalReviewRoutesPhasePl
 			if err := o.HandlePhaseCompletion(featureID, orchestrator.PhaseCompletionInput{
 				Phase:           feature.PhaseImplement,
 				MultiRepoResult: &agent.OrchestratorResult{FinalStatus: "awaiting_final_review"},
-			}); err != nil {
-				t.Fatalf("HandlePhaseCompletion() error = %v", err)
+			}); err == nil || !strings.Contains(err.Error(), "final review requested unsupported phase-plan revision") {
+				t.Fatalf("HandlePhaseCompletion() error = %v, want unsupported phase-plan revision", err)
 			}
 
-			if f.Status != feature.StatusPlanning {
-				t.Fatalf("feature status = %v, want Planning after final-review evidence repair dispatch", f.Status)
+			if f.Status != feature.StatusFailed {
+				t.Fatalf("feature status = %v, want Failed after unsupported final-review plan revision", f.Status)
 			}
-			if captured := waitForCapturedPhase(t, cpr, feature.PhasePlan, 3*time.Second); len(captured) == 0 {
-				t.Fatalf("no phase-plan revision session captured; captures: %+v", cpr.capturedOpts)
+			if captured := cpr.capturedOpts; len(captured) != 0 {
+				t.Fatalf("unexpected phase-plan revision session captured: %+v", captured)
 			}
-			data, err := os.ReadFile(filepath.Join(phasePlanDir, "attempt-01", "validation-feedback.md"))
-			if err != nil {
-				t.Fatalf("read validation feedback: %v", err)
+			if _, err := os.Stat(filepath.Join(phasePlanDir, "attempt-01", "validation-feedback.md")); !os.IsNotExist(err) {
+				t.Fatalf("final review must not write phase-plan validation feedback, stat err = %v", err)
 			}
-			if got := string(data); !strings.Contains(got, "MISSING_EVIDENCE_REQUIREMENT behavioral: Record the create-project CLI journey.") {
-				t.Fatalf("validation feedback missing reviewer-authored requirement:\n%s", got)
-			}
-			if latest := agent.LatestCompletedPlanAttempt(phasePlanDir); latest != 0 {
-				t.Fatalf("LatestCompletedPlanAttempt() = %d, want 0 after invalidating approved phase plan", latest)
+			if latest := agent.LatestCompletedPlanAttempt(phasePlanDir); latest != 1 {
+				t.Fatalf("LatestCompletedPlanAttempt() = %d, want approved attempt to remain intact", latest)
 			}
 		})
 	}
 }
 
-func TestOrchestrator_OnMultiReposPassed_FinalReviewMissingEvidenceTargetsEarlierRoadmapPhase(t *testing.T) {
+func TestOrchestrator_HandlePhaseCompletion_Implement_MissingEvidenceStaysOnCurrentRoadmapPhase(t *testing.T) {
 	cpr := newCapturingPhaseRunner(t)
 	cpr.sm.StartSessionFn = func(id, featureID string, phase feature.Phase, command []string, workdir string, env []string, opts ...*session.SessionOpts) (ports.SessionHandle, error) {
 		return nil, session.ErrShuttingDown
 	}
 
-	featureID := "feat-fr-missing-evidence-earlier-phase"
+	featureID := "feat-impl-missing-evidence-current-phase"
 	roadmapPath := filepath.Join(cpr.stateDir, "roadmap.md")
 	writeRoadmap(t, roadmapPath)
 	unpub := false
@@ -339,12 +344,6 @@ func TestOrchestrator_OnMultiReposPassed_FinalReviewMissingEvidenceTargetsEarlie
 	}
 
 	lc := lifecycleForFeature(f)
-	lc.CompleteImplementationFn = func(id string) error { f.Status = feature.StatusReviewPassed; return nil }
-	lc.MarkFinalReviewReadyFn = func(id string) error { f.Status = feature.StatusFinalReviewing; return nil }
-	lc.MarkCodeReadyFn = func(id string) error {
-		t.Fatalf("MarkCodeReady called after final-review missing-evidence rejection")
-		return nil
-	}
 	lc.StartPlanningFn = func(id string) error {
 		f.Status = feature.StatusPlanning
 		return nil
@@ -358,37 +357,31 @@ func TestOrchestrator_OnMultiReposPassed_FinalReviewMissingEvidenceTargetsEarlie
 		PhaseRunner: cpr.pr,
 		CmdRunner:   cpr.cmd,
 	}, orchestrator.Hooks{})
-	o.SetRunMultiRepoFinalReviewFn(func(ff *feature.Feature, _ ...agent.KBInfo) (chan *agent.OrchestratorResult, error) {
-		ch := make(chan *agent.OrchestratorResult, 1)
-		ch <- &agent.OrchestratorResult{
+	if err := o.HandlePhaseCompletion(featureID, orchestrator.PhaseCompletionInput{
+		Phase: feature.PhaseImplement,
+		MultiRepoResult: &agent.OrchestratorResult{
 			FinalStatus:          "plan_revision_required",
 			PlanRevisionFeedback: "MISSING_EVIDENCE_REQUIREMENT phase 1 behavioral: Record the phase-one create-project CLI journey.",
-		}
-		return ch, nil
-	})
-
-	if err := o.HandlePhaseCompletion(featureID, orchestrator.PhaseCompletionInput{
-		Phase:           feature.PhaseImplement,
-		MultiRepoResult: &agent.OrchestratorResult{FinalStatus: "awaiting_final_review"},
+		},
 	}); err != nil {
 		t.Fatalf("HandlePhaseCompletion() error = %v", err)
 	}
 
-	if f.CurrentRoadmapPhase != 1 {
-		t.Fatalf("CurrentRoadmapPhase = %d, want targeted phase 1", f.CurrentRoadmapPhase)
+	if f.CurrentRoadmapPhase != 2 {
+		t.Fatalf("CurrentRoadmapPhase = %d, want current phase 2", f.CurrentRoadmapPhase)
 	}
 	if captured := waitForCapturedPhase(t, cpr, feature.PhasePlan, 3*time.Second); len(captured) == 0 {
 		t.Fatalf("no phase-plan revision session captured; captures: %+v", cpr.capturedOpts)
 	}
-	data, err := os.ReadFile(filepath.Join(phase1PlanDir, "attempt-01", "validation-feedback.md"))
+	data, err := os.ReadFile(filepath.Join(phase2PlanDir, "attempt-01", "validation-feedback.md"))
 	if err != nil {
-		t.Fatalf("read phase 1 validation feedback: %v", err)
+		t.Fatalf("read phase 2 validation feedback: %v", err)
 	}
 	if got := string(data); !strings.Contains(got, "MISSING_EVIDENCE_REQUIREMENT phase 1 behavioral: Record the phase-one create-project CLI journey.") {
-		t.Fatalf("phase 1 validation feedback missing targeted reviewer requirement:\n%s", got)
+		t.Fatalf("phase 2 validation feedback missing reviewer requirement:\n%s", got)
 	}
-	if _, err := os.Stat(filepath.Join(phase2PlanDir, "attempt-01", "validation-feedback.md")); !os.IsNotExist(err) {
-		t.Fatalf("phase 2 validation feedback should not be overwritten for a phase 1 repair, stat err = %v", err)
+	if _, err := os.Stat(filepath.Join(phase1PlanDir, "attempt-01", "validation-feedback.md")); !os.IsNotExist(err) {
+		t.Fatalf("phase 1 validation feedback should not be overwritten for a current-phase repair, stat err = %v", err)
 	}
 }
 

--- a/skills/final-review/SKILL.md
+++ b/skills/final-review/SKILL.md
@@ -66,23 +66,9 @@ Before approving, compare the cumulative diff against prior implementation visua
 
 Existing prior implementation visual or behavioral rows with valid verification evidence files count as coverage. Audit those rows and evidence artifacts before requesting a new row. Do not add visual or behavioral rows to the final-review PlanLess testing contract.
 
-When coverage is missing, add a blocking finding that includes exactly one structured marker per absent requirement:
+Final Review never reopens planning. When coverage is missing during Final Review, write a normal blocking finding that explains the missing visual or behavioral evidence, and route it through `CHANGES_REQUESTED` so the fix agent should capture the missing evidence artifacts.
 
-`MISSING_EVIDENCE_REQUIREMENT visual: <reviewer-authored requirement>`
-
-or
-
-`MISSING_EVIDENCE_REQUIREMENT behavioral: <reviewer-authored requirement>`
-
-For roadmap features, include the target roadmap phase when the missing evidence belongs to a prior implementation phase:
-
-`MISSING_EVIDENCE_REQUIREMENT phase <number> visual: <reviewer-authored requirement>`
-
-or
-
-`MISSING_EVIDENCE_REQUIREMENT phase <number> behavioral: <reviewer-authored requirement>`
-
-The requirement text must describe the evidence the phase plan should add. Do not tell the fix agent to add rows directly to `verification-report.yaml`, and do not ask for ad hoc `testing-contract.yaml` Changes entries to create new rows. Missing evidence is repaired by phase-plan revision so the next implementation attempt receives normal compiled contract rows.
+Do not emit `MISSING_EVIDENCE_REQUIREMENT` markers in Final Review feedback. Those markers are reserved for implementation review, where the orchestrator may revise the current phase plan.
 
 ## Severity Classification
 


### PR DESCRIPTION
## Summary

Prevent Final Review from reopening planning when it requests changes, including missing visual or behavioral evidence findings. Final Review feedback now routes through the fix-agent loop, while implementation-review missing-evidence markers may only revise the current roadmap phase.

## Root Cause

The final-review loop had a special missing-evidence path that could return `plan_revision_required`. That allowed a feature-level final review to reopen planning and, when phase-qualified markers referenced earlier roadmap phases, send orchestration back to an already implemented and approved phase.

## Changes

- Route Final Review `CHANGES_REQUESTED` outcomes through the fix-agent path instead of plan revision.
- Treat unexpected Final Review `plan_revision_required` outcomes as unsupported failures defensively.
- Limit implementation-side missing-evidence plan repair to the current roadmap phase.
- Update the Final Review skill to forbid `MISSING_EVIDENCE_REQUIREMENT` markers and require normal blocking review feedback for the fix agent.
- Add regression coverage for Final Review routing, defensive orchestration, and current-phase-only missing-evidence repair.

## Verification

- Fast suite: `make test-fast`
- Static analysis: `go vet ./...`
- Build: `go build ./...`

Skipped E2E smoke shell, isolated integration, E2E Go, TUI observability, race regression, and eval: this change is limited to final-review orchestration routing, unit-level regression coverage, and skill text; it does not touch launch behavior, lifecycle session execution, TUI behavior, concurrency-sensitive code, or live LLM evaluation paths.
