### PR TITLE
Surface codex JSON-RPC error responses to users

### DIFF
--- a/internal/llm/codex/protocol.go
+++ b/internal/llm/codex/protocol.go
@@ -154,7 +154,9 @@ func (p *Protocol) ParseLine(line []byte) ([]llm.SDKMessage, error) {
 
 	// Response to our request (has id but no method)
 	if env.ID != nil && env.Method == "" {
-		p.handleResponse(*env.ID, env.Result, env.Error)
+		if msg, ok := p.handleResponse(*env.ID, env.Result, env.Error); ok {
+			return []llm.SDKMessage{msg}, nil
+		}
 		return nil, nil
 	}
 
@@ -485,10 +487,10 @@ func (p *Protocol) writeJSON(v interface{}) error {
 
 // --- Read methods ---
 
-func (p *Protocol) handleResponse(id int, result, errData json.RawMessage) {
+func (p *Protocol) handleResponse(id int, result, errData json.RawMessage) (llm.SDKMessage, bool) {
 	if len(errData) > 0 && string(errData) != "null" {
 		p.logDebug("[codex] error response for request %d: %s", id, string(errData))
-		return
+		return p.errorResultMessage(errData), true
 	}
 
 	var initResult InitializeResult
@@ -503,7 +505,7 @@ func (p *Protocol) handleResponse(id int, result, errData json.RawMessage) {
 			}
 		}
 		p.mu.Unlock()
-		return
+		return llm.SDKMessage{}, false
 	}
 
 	var threadResult ThreadStartResult
@@ -519,7 +521,7 @@ func (p *Protocol) handleResponse(id int, result, errData json.RawMessage) {
 		}
 		p.mu.Unlock()
 		p.logDebug("[codex] thread started: %s", threadResult.Thread.ID)
-		return
+		return llm.SDKMessage{}, false
 	}
 
 	var turnResult TurnStartResult
@@ -528,10 +530,36 @@ func (p *Protocol) handleResponse(id int, result, errData json.RawMessage) {
 		p.turnID = turnResult.Turn.ID
 		p.mu.Unlock()
 		p.logDebug("[codex] turn started: %s (status=%s)", turnResult.Turn.ID, turnResult.Turn.Status)
-		return
+		return llm.SDKMessage{}, false
 	}
 
 	p.logDebug("[codex] unhandled response for request %d", id)
+	return llm.SDKMessage{}, false
+}
+
+// errorResultMessage converts a JSON-RPC error response into a user-visible
+// result/error so a rejected request fails the session loudly instead of
+// leaving it to hang waiting for output that will never arrive.
+func (p *Protocol) errorResultMessage(errData json.RawMessage) llm.SDKMessage {
+	var rpcErr struct {
+		Code    int    `json:"code"`
+		Message string `json:"message"`
+	}
+	_ = json.Unmarshal(errData, &rpcErr)
+	detail := rpcErr.Message
+	if detail == "" {
+		detail = string(errData)
+	}
+	return llm.SDKMessage{
+		Type:    "result",
+		Subtype: "error",
+		Result: &llm.ResultMessage{
+			Type:    "result",
+			Subtype: "error",
+			Result:  fmt.Sprintf("codex rejected the request (code %d): %s", rpcErr.Code, detail),
+			IsError: true,
+		},
+	}
 }
 
 func (p *Protocol) parseServerRequest(method string, id int, params json.RawMessage) (llm.SDKMessage, bool) {

--- a/internal/llm/codex/protocol_test.go
+++ b/internal/llm/codex/protocol_test.go
@@ -425,6 +425,33 @@ func TestCodexProtocol_StartTurnNetworkAccess(t *testing.T) {
 	}
 }
 
+func TestCodexProtocol_ErrorResponseSurfacesAsResultError(t *testing.T) {
+	p := NewProtocol(llm.ProtocolOpts{WorkDir: "/tmp/test", Model: "codex", DSP: true})
+
+	// A JSON-RPC error response to one of our requests (id, no method). Codex
+	// returns this for turn/start when an MDM policy forbids approval_policy.
+	// It must be surfaced to the user, not silently swallowed.
+	line := []byte("{\"id\":3,\"error\":{\"code\":-32600,\"message\":\"invalid thread settings override: `Never` is not in the allowed set [OnRequest, OnFailure] (set by MDM com.openai.codex:requirements_toml_base64)\"}}")
+
+	msgs, err := p.ParseLine(line)
+	if err != nil {
+		t.Fatalf("ParseLine error: %v", err)
+	}
+	if len(msgs) != 1 {
+		t.Fatalf("got %d messages, want 1 (error must be surfaced, not swallowed)", len(msgs))
+	}
+	msg := msgs[0]
+	if msg.Type != "result" || msg.Subtype != "error" {
+		t.Fatalf("got type=%q subtype=%q, want result/error", msg.Type, msg.Subtype)
+	}
+	if msg.Result == nil || !msg.Result.IsError {
+		t.Fatalf("expected Result with IsError=true, got %+v", msg.Result)
+	}
+	if !strings.Contains(msg.Result.Result, "not in the allowed set") {
+		t.Fatalf("surfaced error should include codex's reason; got %q", msg.Result.Result)
+	}
+}
+
 func TestParseNumberedOptions(t *testing.T) {
 	tests := []struct {
 		name       string


### PR DESCRIPTION
## Summary

A feature running `agentico --dangerously-skip-permissions` with a Codex provider hung indefinitely. Root cause: under DSP, agentico sends `approvalPolicy: "never"`, which is forbidden by the MDM-managed Codex policy on managed Macs (`allowed_approval_policies = ["on-request", "on-failure"]`). Codex **rejects the `turn/start`** with a JSON-RPC error (`-32600: "Never is not in the allowed set"`), but `handleResponse` only logged it to debug and returned. With no watchdog or turn-output timeout for codex sessions, the feature waited forever until manually interrupted.

This PR makes that class of failure **loud and recoverable**: a JSON-RPC error response is converted into a user-visible `result`/`error` message, so it flows through the normal codex failure path — `API_ERROR` status, forwarded to the TUI/events, and bounded by `MaxConsecFails` — instead of hanging.

Scope note: this is the **fail-fast** half. It does not make DSP *succeed* under the MDM policy (that's a follow-up: map DSP → `on-request` + `danger-full-access`). A DSP+codex run now fails fast with a clear error message instead of hanging silently.

### Changes
- `handleResponse` returns `(llm.SDKMessage, bool)`; error responses surface via a new `errorResultMessage` helper that includes codex's own message (e.g. *"codex rejected the request (code -32600): … Never is not in the allowed set …"*).
- `ParseLine` propagates the surfaced message.

## Test plan
- [x] New unit test `TestCodexProtocol_ErrorResponseSurfacesAsResultError` (TDD: verified RED → GREEN) — feeds the real rejection envelope into `ParseLine`, asserts a `result`/`error` with `IsError` and codex's reason.
- [x] `go build ./...`, `go vet ./internal/llm/codex/`, `gofmt` clean.
- [x] Suites pass: `internal/llm/codex`, `internal/session`, `internal/agent`.
- [x] Reproduced the original hang against a live `codex app-server` (deterministic 4/4 under DSP); confirmed the surfaced error now maps to `API_ERROR` via `resultSubtypeToStatus`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)