### PR TITLE
Default logs view to active phase, not setup

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -5196,22 +5196,7 @@ func (m AppModel) viewLogsCmd(featureID string, phase feature.Phase, roadmapPhas
 		if loadErr != nil {
 			return RefreshFeaturesMsg{}
 		}
-		if setup := setupState(f); setup != nil && setup.LatestLogPath != "" {
-			data, err := os.ReadFile(setup.LatestLogPath)
-			if err != nil {
-				return LogsContentMsg{
-					FeatureID: featureID,
-					Title:     fmt.Sprintf("Logs: %s (setup)", featureID),
-					Content:   fmt.Sprintf("Setup log not found: %s", setup.LatestLogPath),
-				}
-			}
-			lines := splitLastN(string(data), 100)
-			return LogsContentMsg{
-				FeatureID: featureID,
-				Title:     fmt.Sprintf("Logs: %s (setup \u2014 %s)", featureID, filepath.Base(setup.LatestLogPath)),
-				Content:   strings.Join(lines, "\n"),
-			}
-		}
+
 		var phaseDir string
 		if roadmapPhase > 0 {
 			// Roadmap features store logs under phase-NN/<phase>/
@@ -5219,18 +5204,42 @@ func (m AppModel) viewLogsCmd(featureID string, phase feature.Phase, roadmapPhas
 		} else {
 			phaseDir = filepath.Join(agent.ActiveRunDir(m.featureManager.Store.BaseDir, f), phase.DirName())
 		}
-		logPath := filepath.Join(phaseDir, "output.txt")
-		data, err := os.ReadFile(logPath)
-		if err != nil {
-			// Fallback: find the most recently modified .txt file in
-			// iteration subdirectories (e.g. review/iteration-02/fix-output.txt).
-			data, logPath = findLatestLogFile(phaseDir)
+
+		var setupLogPath string
+		if setup := setupState(f); setup != nil {
+			setupLogPath = setup.LatestLogPath
 		}
-		if data == nil {
+
+		// Prefer the current phase's session output (the active or
+		// most-recently-active phase) over the setup log, which only records
+		// worktree-creation noise. The setup log is used only when the phase
+		// has not produced any output yet.
+		logPath, isSetup := resolveDefaultLogPath(phaseDir, setupLogPath)
+		if logPath == "" {
 			return RefreshFeaturesMsg{}
 		}
+
+		data, err := os.ReadFile(logPath)
+		if err != nil {
+			if isSetup {
+				return LogsContentMsg{
+					FeatureID: featureID,
+					Title:     fmt.Sprintf("Logs: %s (setup)", featureID),
+					Content:   fmt.Sprintf("Setup log not found: %s", logPath),
+				}
+			}
+			return RefreshFeaturesMsg{}
+		}
+
 		// With JSON protocol, output is already clean text
 		lines := splitLastN(string(data), 100)
+		if isSetup {
+			return LogsContentMsg{
+				FeatureID: featureID,
+				Title:     fmt.Sprintf("Logs: %s (setup \u2014 %s)", featureID, filepath.Base(logPath)),
+				Content:   strings.Join(lines, "\n"),
+			}
+		}
 		title := fmt.Sprintf("Logs: %s (%s)", featureID, phase)
 		if base := filepath.Base(logPath); base != "output.txt" {
 			title = fmt.Sprintf("Logs: %s (%s — %s)", featureID, phase, base)
@@ -5242,12 +5251,43 @@ func (m AppModel) viewLogsCmd(featureID string, phase feature.Phase, roadmapPhas
 	}
 }
 
-// findLatestLogFile searches phaseDir for the most recently modified .txt
-// log file inside iteration subdirectories. Returns nil data if nothing found.
-func findLatestLogFile(phaseDir string) ([]byte, string) {
+// resolveDefaultLogPath chooses the most useful log to show by default when the
+// user opens the logs viewer. It prefers the current phase's session output
+// (phaseDir/output.txt), then the most recently modified log inside the phase's
+// iteration subdirectories, and only falls back to the setup log when no phase
+// log exists. isSetup reports whether the returned path is the setup log so the
+// caller can title it and handle a missing file appropriately. An empty path
+// means no log is available.
+func resolveDefaultLogPath(phaseDir, setupLogPath string) (path string, isSetup bool) {
+	if phaseDir != "" {
+		primary := filepath.Join(phaseDir, "output.txt")
+		if fileExists(primary) {
+			return primary, false
+		}
+		// Fallback: the most recently modified .txt file in iteration
+		// subdirectories (e.g. review/iteration-02/fix-output.txt).
+		if latest := latestLogFilePath(phaseDir); latest != "" {
+			return latest, false
+		}
+	}
+	if setupLogPath != "" {
+		return setupLogPath, true
+	}
+	return "", false
+}
+
+// fileExists reports whether path names an existing regular file.
+func fileExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
+}
+
+// latestLogFilePath returns the path of the most recently modified .txt log
+// file inside phaseDir's iteration subdirectories, or "" if none exist.
+func latestLogFilePath(phaseDir string) string {
 	entries, err := os.ReadDir(phaseDir)
 	if err != nil {
-		return nil, ""
+		return ""
 	}
 
 	var bestPath string
@@ -5277,14 +5317,7 @@ func findLatestLogFile(phaseDir string) ([]byte, string) {
 		}
 	}
 
-	if bestPath == "" {
-		return nil, ""
-	}
-	data, err := os.ReadFile(bestPath)
-	if err != nil {
-		return nil, ""
-	}
-	return data, bestPath
+	return bestPath
 }
 
 func (m AppModel) updateLogs(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -779,6 +779,188 @@ func TestViewLogsCmdRoadmapPhase(t *testing.T) {
 	}
 }
 
+func TestResolveDefaultLogPath(t *testing.T) {
+	// Build an isolated phase dir per case so the helper can stat real files.
+	// A case describes which files to create relative to the phase dir; the
+	// setup log lives outside it. "want" is expressed as one of the created
+	// relative keys, or the literal "setup"/"".
+	type file struct {
+		rel string        // path relative to phaseDir; "output.txt" or "iter/foo.txt"
+		age time.Duration // how long ago it was modified (larger = older)
+	}
+	tests := []struct {
+		name        string
+		files       []file
+		hasSetupLog bool
+		emptyPhase  bool // pass "" as phaseDir to model a feature with no active run
+		wantRel     string
+		wantIsSetup bool
+	}{
+		{
+			name:        "prefers phase output over setup log",
+			files:       []file{{rel: "output.txt"}},
+			hasSetupLog: true,
+			wantRel:     "output.txt",
+			wantIsSetup: false,
+		},
+		{
+			name:        "prefers phase output when no setup log",
+			files:       []file{{rel: "output.txt"}},
+			hasSetupLog: false,
+			wantRel:     "output.txt",
+			wantIsSetup: false,
+		},
+		{
+			name:        "falls back to latest iteration log over setup",
+			files:       []file{{rel: "iteration-01/fix-output.txt", age: time.Hour}, {rel: "iteration-02/fix-output.txt"}},
+			hasSetupLog: true,
+			wantRel:     "iteration-02/fix-output.txt",
+			wantIsSetup: false,
+		},
+		{
+			name:        "falls back to setup when phase has no logs",
+			files:       nil,
+			hasSetupLog: true,
+			wantRel:     "setup",
+			wantIsSetup: true,
+		},
+		{
+			name:        "returns empty when nothing exists",
+			files:       nil,
+			hasSetupLog: false,
+			wantRel:     "",
+			wantIsSetup: false,
+		},
+		{
+			name:        "empty phase dir falls back to setup",
+			emptyPhase:  true,
+			hasSetupLog: true,
+			wantRel:     "setup",
+			wantIsSetup: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			base := t.TempDir()
+			phaseDir := filepath.Join(base, "phase")
+			if !tt.emptyPhase {
+				if err := os.MkdirAll(phaseDir, 0o755); err != nil {
+					t.Fatalf("mkdir phase: %v", err)
+				}
+			}
+
+			for _, fl := range tt.files {
+				p := filepath.Join(phaseDir, fl.rel)
+				if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+					t.Fatalf("mkdir %s: %v", fl.rel, err)
+				}
+				if err := os.WriteFile(p, []byte("x"), 0o644); err != nil {
+					t.Fatalf("write %s: %v", fl.rel, err)
+				}
+				if fl.age > 0 {
+					mod := time.Now().Add(-fl.age)
+					if err := os.Chtimes(p, mod, mod); err != nil {
+						t.Fatalf("chtimes %s: %v", fl.rel, err)
+					}
+				}
+			}
+
+			setupLogPath := ""
+			if tt.hasSetupLog {
+				setupLogPath = filepath.Join(base, "setup", "attempt-01-output.txt")
+			}
+
+			passPhaseDir := phaseDir
+			if tt.emptyPhase {
+				passPhaseDir = ""
+			}
+
+			gotPath, gotIsSetup := resolveDefaultLogPath(passPhaseDir, setupLogPath)
+
+			var wantPath string
+			switch tt.wantRel {
+			case "":
+				wantPath = ""
+			case "setup":
+				wantPath = setupLogPath
+			default:
+				wantPath = filepath.Join(phaseDir, tt.wantRel)
+			}
+
+			if gotPath != wantPath {
+				t.Errorf("path = %q, want %q", gotPath, wantPath)
+			}
+			if gotIsSetup != tt.wantIsSetup {
+				t.Errorf("isSetup = %v, want %v", gotIsSetup, tt.wantIsSetup)
+			}
+		})
+	}
+}
+
+// TestViewLogsCmdPrefersActivePhaseOverSetup guards the UX fix: with a setup
+// log present, pressing "l" while a phase is active must show that phase's
+// session output, not the worktree-creation noise in the setup log.
+func TestViewLogsCmdPrefersActivePhaseOverSetup(t *testing.T) {
+	dir := t.TempDir()
+	store := feature.NewStore(dir)
+	cfg := config.NewDefault()
+	fm := feature.NewManager(store, cfg)
+
+	// Setup log exists (as it always does once worktrees are created).
+	setupLog := filepath.Join(dir, "feat-active", "runs", "run-001", "setup", "attempt-01-output.txt")
+	if err := os.MkdirAll(filepath.Dir(setupLog), 0o755); err != nil {
+		t.Fatalf("mkdir setup dir: %v", err)
+	}
+	if err := os.WriteFile(setupLog, []byte("creating worktree\ncreated worktree\n"), 0o644); err != nil {
+		t.Fatalf("write setup log: %v", err)
+	}
+
+	// The active phase (Implement) has real session output.
+	implDir := filepath.Join(dir, "feat-active", "runs", "run-001", "implement")
+	if err := os.MkdirAll(implDir, 0o755); err != nil {
+		t.Fatalf("mkdir implement dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(implDir, "output.txt"), []byte("real agent work here\n"), 0o644); err != nil {
+		t.Fatalf("write implement log: %v", err)
+	}
+
+	now := time.Now()
+	f := &feature.Feature{
+		ID:            "feat-active",
+		Name:          "active",
+		Slug:          "active",
+		Status:        feature.StatusImplementing,
+		CurrentPhase:  feature.PhaseImplement,
+		ActiveRun:     1,
+		RunCount:      1,
+		SchemaVersion: feature.SchemaVersionCurrent,
+	}
+	setup := feature.NewActiveSetupState(nil, nil, nil, now)
+	setup.LatestLogPath = setupLog
+	f.SetRun(&feature.Run{RunNumber: 1, Setup: setup})
+	if err := store.Save(f); err != nil {
+		t.Fatalf("save feature: %v", err)
+	}
+
+	app := AppModel{featureManager: fm}
+	msg := app.viewLogsCmd("feat-active", feature.PhaseImplement, 0)()
+
+	logsMsg, ok := msg.(LogsContentMsg)
+	if !ok {
+		t.Fatalf("expected LogsContentMsg, got %T", msg)
+	}
+	if !strings.Contains(logsMsg.Content, "real agent work here") {
+		t.Fatalf("content = %q, want active phase output", logsMsg.Content)
+	}
+	if strings.Contains(logsMsg.Content, "creating worktree") {
+		t.Fatalf("content = %q, must not show setup log", logsMsg.Content)
+	}
+	if strings.Contains(logsMsg.Title, "setup") {
+		t.Fatalf("title = %q, must not be titled setup", logsMsg.Title)
+	}
+}
+
 func TestHelpInputActivation(t *testing.T) {
 	app, fm := newTestAppModel(t)
 


### PR DESCRIPTION
## Summary

Pressing `l` in the feature-detail view opened the logs viewer on the **setup** log whenever `setup.LatestLogPath` was set, ignoring the current phase entirely. The setup log only records worktree-creation noise, so users never saw the actual agent work.

This change reorders the selection logic so the current phase's session output wins:

- Extract a pure `resolveDefaultLogPath` helper that prefers, in order:
  1. the current phase's session output (`phaseDir/output.txt`) — the active or most-recently-active phase,
  2. the most recently modified iteration log (e.g. `review/iteration-02/fix-output.txt`),
  3. the setup log, only as a last resort when the phase has produced no output yet.
- Split the old `findLatestLogFile` into `latestLogFilePath` (path resolution) and a small `fileExists` helper, keeping the selection logic pure and testable.
- The `isSetup` flag lets the caller title the view and handle a missing file appropriately.

## Test plan

- [x] `go test ./internal/tui/...` — added table-driven tests for `resolveDefaultLogPath` covering phase output, iteration-log fallback, and setup fallback.
- [x] Regression test proving an active phase log now wins over an existing setup log.
- [ ] Manual: press `l` on a running feature and confirm the active phase's log opens instead of the setup log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)