### PR TITLE
[codex] Track final review runtime

### DIFF
--- a/internal/feature/manager.go
+++ b/internal/feature/manager.go
@@ -653,6 +653,13 @@ func (m *Manager) MarkFinalReviewReady(featureID string) error {
 			return err
 		}
 		f.CurrentPhase = PhaseFinalReview
+		f.accumulateActiveTime()
+		f.ActiveTimingKey = PhaseFinalReview.DirName()
+		now := time.Now()
+		f.ActivePhaseStart = &now
+		if f.StartedAt == nil {
+			f.StartedAt = &now
+		}
 		return nil
 	})
 }

--- a/internal/feature/manager_test.go
+++ b/internal/feature/manager_test.go
@@ -1013,6 +1013,58 @@ func TestManagerPhaseProgression(t *testing.T) {
 	}
 }
 
+func TestMarkFinalReviewReadyTracksReviewRuntime(t *testing.T) {
+	t.Parallel()
+	// parallel-candidate: per-test temp dirs and mocks isolate filesystem and collaborator state.
+	mgr := newTestManager(t)
+	f, err := mgr.Create("Final Review Timing", "test", []string{"test-repo"}, mgr.Config.Defaults.Models, "", "", nil)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if err := mgr.Store.Modify(f.ID, func(ff *feature.Feature) error {
+		ff.Status = feature.StatusReviewPassed
+		ff.CurrentPhase = feature.PhaseImplement
+		return nil
+	}); err != nil {
+		t.Fatalf("seed review passed: %v", err)
+	}
+
+	if err := mgr.MarkFinalReviewReady(f.ID); err != nil {
+		t.Fatalf("MarkFinalReviewReady: %v", err)
+	}
+	got, err := mgr.Get(f.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.ActiveTimingKey != "review" {
+		t.Fatalf("ActiveTimingKey = %q, want review", got.ActiveTimingKey)
+	}
+	if got.ActivePhaseStart == nil {
+		t.Fatal("ActivePhaseStart = nil, want final review timer started")
+	}
+
+	past := time.Now().Add(-4 * time.Minute)
+	if err := mgr.Store.Modify(f.ID, func(ff *feature.Feature) error {
+		ff.ActivePhaseStart = &past
+		return nil
+	}); err != nil {
+		t.Fatalf("backdate ActivePhaseStart: %v", err)
+	}
+	if err := mgr.Transition(f.ID, feature.StatusReviewPassed); err != nil {
+		t.Fatalf("finish final review: %v", err)
+	}
+	got, err = mgr.Get(f.ID)
+	if err != nil {
+		t.Fatalf("Get after finish: %v", err)
+	}
+	if got.ActivePhaseStart != nil {
+		t.Fatal("ActivePhaseStart should be nil after leaving final review")
+	}
+	if d := got.PhaseRuntime("review"); d < 4*time.Minute {
+		t.Fatalf("PhaseRuntime(review) = %v, want at least 4m", d)
+	}
+}
+
 func TestManagerMarkPublished(t *testing.T) {
 	t.Parallel()
 	// parallel-candidate: per-test temp dirs and mocks isolate filesystem and collaborator state.


### PR DESCRIPTION
## Summary

Final Review now starts the same persisted phase timer used by the rest of the lifecycle. Entering `StatusFinalReviewing` sets the active timing key to the shared `review` bucket and starts `ActivePhaseStart`, so leaving Final Review accumulates elapsed time into `PhaseTimings["review"]`.

## Root Cause

Final Review cost was already recorded under `PhaseFinalReview.DirName()` (`review`), but `MarkFinalReviewReady` only changed status/current phase. It did not start an active phase timer, so the TUI phase runtime lookup had no duration to render.

## Impact

The Phase Progress row for Final Review can now show elapsed time consistently with the existing cost display.

## Verification

- Fast suite: `make test-fast`
- Isolated integration: `go test ./test/integration/... -count=1`
- Focused: `go test ./internal/feature -count=1`
- Focused: `go test ./internal/orchestrator -run "FinalReview|MediumRunsDeferredFinalReview" -count=1`
- Focused: `go test ./internal/tui -run "TestRenderPhaseProgress" -count=1`
- Static analysis: `go vet ./...`
- Build: `go build ./...`