### PR TITLE
[codex] Prevent tweak push when auto-publish is off

### DIFF
--- a/internal/agent/tweak_session.go
+++ b/internal/agent/tweak_session.go
@@ -25,10 +25,10 @@
 //  2. CommitAll — after the user ends the session, iterate every
 //     Feature.Repos and commit any worktree with uncommitted changes (the
 //     skill prompt forbids the agent from committing).
-//  3. PushAll — pull-rebase + push every modified repo's branch. A
-//     PullRebaseConflict surfaces a structured FeatureTweakPushError carrying
-//     the per-repo conflict so the orchestrator can route the affected repo
-//     into a rebase cycle.
+//  3. PushAll — when the orchestrator elects to publish, pull-rebase + push
+//     every modified repo's branch. A PullRebaseConflict surfaces a structured
+//     FeatureTweakPushError carrying the per-repo conflict so the orchestrator
+//     can route the affected repo into a rebase cycle.
 //  4. Mark transitions on Feature.ActiveCycle: Status: running while the
 //     session is alive; cleared on success; transitioned to Status: interrupted
 //     on session-die-mid-tweak (crash recovery).

--- a/internal/orchestrator/cycles_test.go
+++ b/internal/orchestrator/cycles_test.go
@@ -709,6 +709,95 @@ func TestCompleteTweakFinish_PullRebaseConflict_SurfacesPublishConflictError(t *
 	}
 }
 
+func TestCompleteTweakCommitFinish_AutoPublishOff_CommitsWithoutPush(t *testing.T) {
+	const featureID = "feat-tweak-manual"
+	const repoName = "repo-a"
+	const branch = "feature/tweak-manual"
+
+	for _, tc := range []struct {
+		name        string
+		publishable bool
+	}{
+		{name: "publishable manual feature", publishable: true},
+		{name: "local only manual feature", publishable: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			publishable := tc.publishable
+			f := &feature.Feature{
+				ID:          featureID,
+				Slug:        "tweak-manual",
+				Status:      feature.StatusCodeReady,
+				ActiveRun:   1,
+				RunCount:    1,
+				Checkpoints: feature.Checkpoints{ManualPublish: true},
+				Repos: []feature.FeatureRepo{{
+					Name:         repoName,
+					Path:         "/tmp/repo-a",
+					WorktreePath: "/tmp/worktrees/repo-a",
+					Branch:       branch,
+					Publishable:  &publishable,
+				}},
+				RepoCycles: map[string]*feature.RepoCycleState{
+					repoName: {Type: feature.CycleTweak, Status: feature.RepoCycleRunning, Count: 1},
+				},
+				ActiveCycle: &feature.CycleState{
+					Type:   feature.CycleTweak,
+					Status: feature.RepoCycleRunning,
+					Count:  1,
+				},
+			}
+			lc := lifecycleForFeature(f)
+			fs := newFeatureStore(f)
+
+			dirtyChecks := 0
+			pub := mocks.NewMockPublisher()
+			pub.HasUncommittedChangesFn = func(string) (bool, error) {
+				dirtyChecks++
+				return dirtyChecks == 1, nil
+			}
+			reb := mocks.NewMockRebaseOperator()
+			reb.PullRebaseFn = func(string, string) git.PullRebaseResult {
+				return git.PullRebaseResult{Outcome: git.PullRebaseSuccess}
+			}
+
+			o := orchestrator.New(orchestrator.Deps{
+				Lifecycle: lc,
+				Store:     fs,
+				Publisher: pub,
+				Rebaser:   reb,
+			}, orchestrator.Hooks{})
+
+			hadChanges, err := o.CompleteTweakCommit(featureID)
+			if err != nil {
+				t.Fatalf("CompleteTweakCommit: %v", err)
+			}
+			if !hadChanges {
+				t.Fatal("CompleteTweakCommit hadChanges = false, want true")
+			}
+
+			if err := o.CompleteTweakFinish(featureID, hadChanges); err != nil {
+				t.Fatalf("CompleteTweakFinish: %v", err)
+			}
+
+			if got := countPublisherCalls(pub, "CommitAll"); got != 1 {
+				t.Errorf("Publisher.CommitAll calls = %d, want 1 (post-tweak flow must still commit local changes)", got)
+			}
+			if got := countRebaseCalls(reb, "PullRebase"); got != 0 {
+				t.Errorf("Rebaser.PullRebase calls = %d, want 0 when auto-publish is off", got)
+			}
+			if got := countPublisherCalls(pub, "Push"); got != 0 {
+				t.Errorf("Publisher.Push calls = %d, want 0 when auto-publish is off", got)
+			}
+			if got := countLifecycleCalls(lc, "CompleteRepoCycle"); got != 1 {
+				t.Errorf("Lifecycle.CompleteRepoCycle calls = %d, want 1", got)
+			}
+			if f.ActiveCycle != nil {
+				t.Errorf("ActiveCycle = %+v, want cleared", f.ActiveCycle)
+			}
+		})
+	}
+}
+
 // TestCompleteTweakFinish_CompleteRepoCycleError_PropagatesAndFails asserts
 // that a post-push CompleteRepoCycle store-write failure surfaces an error
 // (so the user does not see a successful tweak completion) and marks the

--- a/internal/orchestrator/tweak.go
+++ b/internal/orchestrator/tweak.go
@@ -14,10 +14,11 @@
 
 // Package orchestrator wires the feature-level interactive tweak cycle. One
 // Claude session is opened with --add-dir for every Feature.Repos worktree,
-// the agent does not commit, and the orchestrator commits and pushes every
-// modified repo at session end. Pull-rebase conflicts on any repo surface a
-// structured PublishConflictError so the TUI can route the affected repo into
-// a rebase cycle.
+// the agent does not commit, and the orchestrator commits every modified repo
+// at session end. Auto-publish publishable features also pull-rebase and push;
+// manual-publish or local-only features stop after local commits. Pull-rebase
+// conflicts on any repo surface a structured PublishConflictError so the TUI
+// can route the affected repo into a rebase cycle.
 //
 // Lifecycle:
 //
@@ -26,10 +27,11 @@
 //     via PhaseRunner.RunTweakSession with the feature-level workspace.
 //   - CompleteTweakCommit(featureID) — iterates every Feature.Repos and
 //     commits any worktree with uncommitted changes.
-//   - CompleteTweakFinish(featureID, hadChanges) — iterates every
-//     Feature.Repos, pull-rebases each modified branch, pushes. A
-//     PullRebaseConflict in any repo surfaces a *PublishConflictError
-//     for that repo and routes to a rebase cycle.
+//   - CompleteTweakFinish(featureID, hadChanges) — commits any review-fix
+//     leftovers, then either completes locally (manual/local-only) or
+//     pull-rebases and pushes each modified branch (auto-publish). A
+//     PullRebaseConflict in any repo surfaces a *PublishConflictError for
+//     that repo and routes to a rebase cycle.
 //   - FailTweakSession(featureID) — marks the cycle failed (session-die
 //     mid-tweak path).
 //   - RestoreTweakFromReview(featureID) — Esc on the post-commit Final
@@ -179,8 +181,9 @@ func (o *Orchestrator) CompleteTweakCommit(featureID string) (bool, error) {
 
 // CompleteTweakFinish finalizes a feature-level tweak. When hadChanges
 // is true (CompleteTweakCommit recorded at least one modified repo),
-// iterates every Feature.Repos that has uncommitted-or-just-committed
-// work and runs the pull-rebase + push chain.
+// commits any review-fix leftovers. Manual-publish or local-only features
+// then complete locally; auto-publish publishable features continue through
+// the pull-rebase + push chain.
 //
 // A PullRebase conflict in any repo surfaces a *PublishConflictError for
 // the FIRST conflicted repo (in alphabetical order), so the TUI's
@@ -237,6 +240,10 @@ func (o *Orchestrator) CompleteTweakFinish(featureID string, hadChanges bool) er
 		}
 	}
 
+	if !f.Checkpoints.AutoPublish() || !f.IsPublishable() {
+		return o.completeTweakCycle(featureID, f, ts)
+	}
+
 	// Step 2: pull-rebase + push every modified repo. A pull-rebase
 	// conflict on any repo surfaces a *PublishConflictError so the TUI
 	// can route that repo into a fresh CycleRebase. Non-conflict failures
@@ -282,6 +289,10 @@ func (o *Orchestrator) CompleteTweakFinish(featureID string, hadChanges bool) er
 
 	// Step 3: every modified repo pushed cleanly. Clear ActiveCycle and
 	// per-repo cycle entries so the feature returns to its steady state.
+	return o.completeTweakCycle(featureID, f, ts)
+}
+
+func (o *Orchestrator) completeTweakCycle(featureID string, f *feature.Feature, ts *agent.TweakSession) error {
 	for i := range f.Repos {
 		if err := o.deps.Lifecycle.CompleteRepoCycle(featureID, f.Repos[i].Name); err != nil {
 			_ = ts.MarkFailed(featureID, "tweak complete repo cycle: "+err.Error())

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -1482,9 +1482,9 @@ func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		// Tweak Final Review modal intercept. The modal is feature-level:
 		// "y" runs Final Review across every Feature.Repos cumulative diff,
-		// "n" skips review and pushes, and "Esc" abandons. The repoName modal
-		// field is preserved on the model for compatibility but ignored by
-		// every dispatch.
+		// "n" skips review and completes the tweak, and "Esc" abandons. The
+		// repoName modal field is preserved on the model for compatibility but
+		// ignored by every dispatch.
 		if m.tweakReviewModalActive {
 			fid := m.tweakReviewModalFeatureID
 			switch msg.String() {
@@ -4987,7 +4987,8 @@ func (m AppModel) renderTweakReviewModal() string {
 	normalStyle := lipgloss.NewStyle()
 
 	skipLabel := "skip review and complete"
-	if f, err := m.featureManager.Get(m.tweakReviewModalFeatureID); err == nil && len(f.PRURLs()) > 0 {
+	if f, err := m.featureManager.Get(m.tweakReviewModalFeatureID); err == nil &&
+		len(f.PRURLs()) > 0 && f.Checkpoints.AutoPublish() && f.IsPublishable() {
 		skipLabel = "skip review, push changes"
 	}
 


### PR DESCRIPTION
## Summary

Fixes the post-tweak completion path so manual-publish and local-only features stop after local commits instead of entering the pull-rebase/push flow.

## Root Cause

`CompleteTweakCommit` correctly committed tweak changes locally, but `CompleteTweakFinish` treated any `hadChanges=true` tweak as publishable work and always called the push fan-out. That bypassed the normal `AutoPublish()` and `IsPublishable()` guards used by the regular publish path.

## Changes

- Gate tweak remote operations on both `Checkpoints.AutoPublish()` and `Feature.IsPublishable()`.
- Keep local tweak completion intact by clearing the active cycle and repo cycle entries after committing.
- Add a regression test for publishable-manual and local-only-manual tweak completion.
- Update the tweak review modal wording so it only says "push changes" when the backend will push.

## Verification

- Fast suite: `make test-fast`
- Static analysis: `go vet ./...`
- Build: `go build ./...`
- Focused regression: `go test ./internal/orchestrator -run TestCompleteTweakCommitFinish_AutoPublishOff_CommitsWithoutPush -count=1`
- Related package checks: `go test ./internal/orchestrator -count=1`, `go test ./internal/tui -count=1`

Skipped E2E smoke shell: tweak completion guard is covered at the orchestrator seam and does not touch launch behavior, embedded skills, or release packaging.
Skipped Isolated integration: lifecycle/state-machine coverage added in `internal/orchestrator`; no runs layout or protocol-violation behavior changed.
Skipped E2E Go (TUI / teatest): modal wording changed, not Bubble Tea lifecycle/session behavior.
Skipped TUI observability: no observer wiring or emitted observability events changed.
Skipped Race regression: narrow non-concurrency tweak guard change.
Skipped Eval: no live skill/guideline discovery behavior changed.