### PR TITLE
[codex] Allow editing feature config while running

### DIFF
--- a/internal/orchestrator/lifecycle_delegates.go
+++ b/internal/orchestrator/lifecycle_delegates.go
@@ -574,29 +574,22 @@ type UpdateFeatureConfigInput struct {
 	Checkpoints feature.Checkpoints
 }
 
-// ErrFeatureNotQuiescent is returned by UpdateFeatureConfig when the
-// feature's status does not satisfy the idle-state predicate at write
-// time. The check runs inside the Store.Modify closure so it shares the
-// store mutex with the write and closes any TOCTOU window.
+// ErrFeatureNotQuiescent is kept for compatibility with older callers that
+// matched the former idle-only edit rejection. UpdateFeatureConfig no longer
+// returns it: feature-level config edits are persisted for any feature state,
+// and active sessions pick them up on the next phase or restart.
 var ErrFeatureNotQuiescent = errors.New("feature is not in a quiescent state")
 
-// UpdateFeatureConfig atomically validates quiescence and writes the
-// three editable config axes. Same idiom as ApplyRefactorPipeline —
-// Store.Modify handles locking + atomic write. On success, emits
-// ports.Event{Type: FeatureConfigChanged} (non-blocking) and fires
-// hooks.OnFeatureConfigChanged(before, after) so the observer writes a
-// feature.config_changed audit entry.
-//
-// Quiescence predicate: !f.Status.IsRunning() && !f.HasActiveRepoCycles()
-// && !f.Status.IsNeedsReview(). Mirrors the predicate used by the TUI
-// key handler; re-checking inside the closure under Store.mu closes any
-// TOCTOU window.
+// UpdateFeatureConfig atomically writes the three editable config axes. Same
+// idiom as ApplyRefactorPipeline — Store.Modify handles locking + atomic
+// write. On success, emits ports.Event{Type: FeatureConfigChanged}
+// (non-blocking) and fires hooks.OnFeatureConfigChanged(before, after) so the
+// observer writes a feature.config_changed audit entry.
 //
 // Re-entrancy: A second call with identical inputs against an already-
-// updated (and still quiescent) feature re-writes the same three fields
-// to the same values, emits a second audit + event, and returns nil.
-// This is acceptable — the audit trail explicitly records "no semantic
-// change" via before == after.
+// updated feature re-writes the same three fields to the same values, emits a
+// second audit + event, and returns nil. This is acceptable — the audit trail
+// explicitly records "no semantic change" via before == after.
 // Crash recovery: Store.Modify performs an atomic unique-temp + rename,
 // so a crash before rename leaves feature.yaml untouched; a crash after
 // rename leaves the new values on disk and the hook+event are simply not
@@ -604,9 +597,6 @@ var ErrFeatureNotQuiescent = errors.New("feature is not in a quiescent state")
 func (o *Orchestrator) UpdateFeatureConfig(featureID string, input UpdateFeatureConfigInput) error {
 	var before, after feature.ConfigSnapshot
 	err := o.deps.Store.Modify(featureID, func(f *feature.Feature) error {
-		if f.Status.IsRunning() || f.HasActiveRepoCycles() || f.Status.IsNeedsReview() {
-			return fmt.Errorf("update feature %s config: %w", featureID, ErrFeatureNotQuiescent)
-		}
 		before = feature.ConfigSnapshot{Models: f.Models, Inquireness: f.Inquireness, Checkpoints: f.Checkpoints}
 		f.Models = input.Models
 		f.Inquireness = input.Inquireness

--- a/internal/orchestrator/update_feature_config_test.go
+++ b/internal/orchestrator/update_feature_config_test.go
@@ -15,7 +15,6 @@
 package orchestrator_test
 
 import (
-	"errors"
 	"testing"
 
 	"github.com/doordash-oss/agentic-orchestrator/internal/agent"
@@ -136,11 +135,11 @@ func TestUpdateFeatureConfig_QuiescentWritesAllThreeAxes(t *testing.T) {
 	}
 }
 
-// TestUpdateFeatureConfig_RejectedOnNonQuiescent verifies that non-quiescent
-// features (running, needs-review, or with an active repo cycle) return an
-// error wrapping ErrFeatureNotQuiescent, leave feature state untouched, do
-// not fire the hook, and do not emit an event.
-func TestUpdateFeatureConfig_RejectedOnNonQuiescent(t *testing.T) {
+// TestUpdateFeatureConfig_NonQuiescentWritesAllThreeAxes verifies that
+// running, needs-review, and active repo-cycle features can still update the
+// persisted config. The active session keeps its current snapshot; the new
+// values are picked up by the next phase or restart.
+func TestUpdateFeatureConfig_NonQuiescentWritesAllThreeAxes(t *testing.T) {
 	cases := []struct {
 		name  string
 		setup func(f *feature.Feature)
@@ -166,15 +165,13 @@ func TestUpdateFeatureConfig_RejectedOnNonQuiescent(t *testing.T) {
 		}},
 	}
 
-	originalInquireness := feature.InquirenessMedium
-	originalModels := config.ModelConfig{Research: "untouched"}
-
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			f := &feature.Feature{
 				ID:          "feat-1",
-				Models:      originalModels,
-				Inquireness: originalInquireness,
+				Models:      config.ModelConfig{Research: "old-research"},
+				Inquireness: feature.InquirenessMedium,
+				Checkpoints: feature.Checkpoints{RoadmapReview: true},
 			}
 			tc.setup(f)
 
@@ -190,30 +187,35 @@ func TestUpdateFeatureConfig_RejectedOnNonQuiescent(t *testing.T) {
 			o := orchestrator.New(orchestrator.Deps{Lifecycle: lc, Store: fs}, hooks)
 
 			err := o.UpdateFeatureConfig("feat-1", orchestrator.UpdateFeatureConfigInput{
-				Models:      config.ModelConfig{Research: "should-not-land"},
+				Models:      config.ModelConfig{Research: "new-research"},
 				Inquireness: feature.InquirenessHigh,
+				Checkpoints: feature.Checkpoints{ManualPublish: true},
 			})
-			if err == nil {
-				t.Fatal("expected error for non-quiescent feature, got nil")
-			}
-			if !errors.Is(err, orchestrator.ErrFeatureNotQuiescent) {
-				t.Errorf("error does not wrap ErrFeatureNotQuiescent: %v", err)
+			if err != nil {
+				t.Fatalf("UpdateFeatureConfig: %v", err)
 			}
 
-			if f.Models.Research != "untouched" {
-				t.Errorf("Models.Research = %q, want untouched", f.Models.Research)
+			if f.Models.Research != "new-research" {
+				t.Errorf("Models.Research = %q, want new-research", f.Models.Research)
 			}
-			if f.Inquireness != originalInquireness {
-				t.Errorf("Inquireness = %q, want unchanged %q", f.Inquireness, originalInquireness)
+			if f.Inquireness != feature.InquirenessHigh {
+				t.Errorf("Inquireness = %q, want high", f.Inquireness)
 			}
-			if hookCount != 0 {
-				t.Errorf("hook fired %d times, want 0", hookCount)
+			if !f.Checkpoints.ManualPublish || f.Checkpoints.RoadmapReview {
+				t.Errorf("Checkpoints not overwritten to edited values: %+v", f.Checkpoints)
+			}
+			if hookCount != 1 {
+				t.Errorf("hook fired %d times, want 1", hookCount)
 			}
 			events := drainEvents(o)
+			var found bool
 			for _, ev := range events {
-				if ev.Type == ports.FeatureConfigChanged {
-					t.Errorf("unexpected FeatureConfigChanged event emitted on rejected update: %+v", ev)
+				if ev.Type == ports.FeatureConfigChanged && ev.FeatureID == "feat-1" {
+					found = true
 				}
+			}
+			if !found {
+				t.Errorf("expected FeatureConfigChanged event for non-quiescent update; got %+v", events)
 			}
 		})
 	}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -431,7 +431,7 @@ type AppModel struct {
 	tweakReviewModalFeatureID string
 	tweakReviewModalRepoName  string
 
-	// Edit config overlay state (feature-config editing on quiescent features).
+	// Edit config overlay state (feature-level model, behavior, and gate edits).
 	editConfigActive bool
 	editConfig       EditConfigModel
 
@@ -3608,15 +3608,10 @@ func (m AppModel) updateDashboardRightPanel(msg tea.KeyPressMsg) (tea.Model, tea
 		}
 
 	case key.Matches(msg, keys.EditConfig):
-		if f != nil && isFeatureQuiescent(f) {
+		if canEditFeatureConfig(f) {
 			cat := BuildPhaseModelCatalog(m.registry, m.featureManager.Config.Defaults)
 			m.editConfig = NewEditConfigModel(f, cat, f.IsPublishable())
 			m.editConfigActive = true
-			return m, nil
-		}
-		if f != nil {
-			m.statusMessage = "Config can only be edited when the feature is idle"
-			m.statusTime = time.Now()
 			return m, nil
 		}
 
@@ -3921,15 +3916,10 @@ func (m AppModel) updateDetail(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 
 	case key.Matches(msg, keys.EditConfig):
 		f := m.detail.feature
-		if f != nil && isFeatureQuiescent(f) {
+		if canEditFeatureConfig(f) {
 			cat := BuildPhaseModelCatalog(m.registry, m.featureManager.Config.Defaults)
 			m.editConfig = NewEditConfigModel(f, cat, f.IsPublishable())
 			m.editConfigActive = true
-			return m, nil
-		}
-		if f != nil {
-			m.statusMessage = "Config can only be edited when the feature is idle"
-			m.statusTime = time.Now()
 			return m, nil
 		}
 		return m, nil
@@ -7449,14 +7439,20 @@ func hasInterruptibleRepoCycles(f *feature.Feature) bool {
 	return false
 }
 
-// isFeatureQuiescent reports whether the `e` key should offer the edit-
-// config overlay for this feature. Mirrors the quiescence predicate used
-// inside Orchestrator.UpdateFeatureConfig's Store.Modify closure.
-func isFeatureQuiescent(f *feature.Feature) bool {
+// canEditFeatureConfig reports whether the `e` key should offer the
+// feature-level config overlay.
+func canEditFeatureConfig(f *feature.Feature) bool {
+	return f != nil
+}
+
+// featureConfigChangesDeferred reports whether a saved config change is
+// persisted immediately but cannot affect currently active work until the
+// next phase boundary or restart.
+func featureConfigChangesDeferred(f *feature.Feature) bool {
 	if f == nil {
 		return false
 	}
-	return !f.Status.IsRunning() && !f.HasActiveRepoCycles() && !f.Status.IsNeedsReview()
+	return f.Status.IsRunning() || f.HasActiveRepoCycles()
 }
 
 // editConfigResultMsg signals completion of a UpdateFeatureConfig call from

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -578,7 +578,7 @@ func (m DashboardModel) renderFooter() string {
 				len(f.Repos) > 0 && f.Repos[0].WorktreePath != "" {
 				hints = append(hints, "[c] Clean worktree")
 			}
-			if isFeatureQuiescent(f) {
+			if canEditFeatureConfig(f) {
 				hints = append(hints, "[e] Edit config")
 			}
 			hints = append(hints, "[Shift+N] Input alerts")

--- a/internal/tui/detail.go
+++ b/internal/tui/detail.go
@@ -312,7 +312,7 @@ func (m DetailModel) View() string {
 		if (f.Status == feature.StatusPublished || f.Status == feature.StatusDone) && len(f.Repos) > 0 && f.Repos[0].WorktreePath != "" {
 			actionParts = append(actionParts, "[c] Clean worktree")
 		}
-		if isFeatureQuiescent(f) {
+		if canEditFeatureConfig(f) {
 			actionParts = append(actionParts, "[e] Edit config")
 		}
 		actionParts = append(actionParts, "[Shift+N] Input alerts", "[d] Delete", "[esc] Back")

--- a/internal/tui/editconfig.go
+++ b/internal/tui/editconfig.go
@@ -60,16 +60,17 @@ const (
 // save error for the banner, and the one-shot discard-confirm prompt
 // state.
 type EditConfigModel struct {
-	featureID   string
-	featureName string
-	repos       []string
-	pipeline    feature.PipelineProfile
-	publishable bool
-	editor      ConfigEditorModel
-	activeTab   configTab
-	focus       configFocusZone
-	saving      bool
-	saveErr     string
+	featureID             string
+	featureName           string
+	repos                 []string
+	pipeline              feature.PipelineProfile
+	publishable           bool
+	deferredEffectWarning bool
+	editor                ConfigEditorModel
+	activeTab             configTab
+	focus                 configFocusZone
+	saving                bool
+	saveErr               string
 	// discardConfirm is true after esc-with-changes and before y/n resolution.
 	discardConfirm bool
 }
@@ -87,14 +88,15 @@ func NewEditConfigModel(f *feature.Feature, cat PhaseModelCatalog, provisionalPu
 		repos = append(repos, repo.Name)
 	}
 	return EditConfigModel{
-		featureID:   f.ID,
-		featureName: f.Name,
-		repos:       repos,
-		pipeline:    f.Pipeline,
-		publishable: provisionalPublishable,
-		editor:      NewConfigEditorModel(f, cat, provisionalPublishable),
-		activeTab:   tabModels,
-		focus:       configFocusTabs,
+		featureID:             f.ID,
+		featureName:           f.Name,
+		repos:                 repos,
+		pipeline:              f.Pipeline,
+		publishable:           provisionalPublishable,
+		deferredEffectWarning: featureConfigChangesDeferred(f),
+		editor:                NewConfigEditorModel(f, cat, provisionalPublishable),
+		activeTab:             tabModels,
+		focus:                 configFocusTabs,
 	}
 }
 
@@ -197,7 +199,14 @@ func (m EditConfigModel) View() string {
 	b.WriteString(titleStyle.Render(fmt.Sprintf(" Edit Config · %s ", m.featureName)))
 	b.WriteString("\n")
 	b.WriteString(diffStyle.Render(m.diffSummary()))
-	b.WriteString("\n\n")
+	b.WriteString("\n")
+	if m.deferredEffectWarning {
+		warningStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("11"))
+		b.WriteString("\n")
+		b.WriteString(warningStyle.Render("Running feature: new config will be picked up on the next restart or next phase."))
+		b.WriteString("\n")
+	}
+	b.WriteString("\n")
 
 	b.WriteString(m.renderTabStrip())
 	b.WriteString("\n\n")

--- a/internal/tui/editconfig_test.go
+++ b/internal/tui/editconfig_test.go
@@ -19,12 +19,10 @@ import (
 	"strings"
 	"testing"
 
+	tea "charm.land/bubbletea/v2"
 	"github.com/doordash-oss/agentic-orchestrator/internal/config"
 	"github.com/doordash-oss/agentic-orchestrator/internal/feature"
 	"github.com/doordash-oss/agentic-orchestrator/internal/llm"
-	"github.com/doordash-oss/agentic-orchestrator/internal/orchestrator"
-
-	tea "charm.land/bubbletea/v2"
 )
 
 // ptrFalse returns a pointer to false for seeding FeatureRepo.Publishable.
@@ -105,7 +103,7 @@ func TestAppModel_EditConfigResultMsg_OnErrorKeepsOverlayOpen(t *testing.T) {
 	app.editConfigActive = true
 	app.editConfig = EditConfigModel{featureID: "f1", saving: true}
 
-	errIn := errors.New("update feature f1 config: " + orchestrator.ErrFeatureNotQuiescent.Error())
+	errIn := errors.New("write feature config: disk full")
 	updated, _ := app.Update(editConfigResultMsg{featureID: "f1", err: errIn})
 	got := updated.(AppModel)
 	if !got.editConfigActive {
@@ -119,19 +117,19 @@ func TestAppModel_EditConfigResultMsg_OnErrorKeepsOverlayOpen(t *testing.T) {
 	}
 }
 
-// TestIsFeatureQuiescent covers the predicate that gates the `e` key.
-func TestIsFeatureQuiescent(t *testing.T) {
+// TestCanEditFeatureConfig covers the predicate that gates the `e` key.
+func TestCanEditFeatureConfig(t *testing.T) {
 	tests := []struct {
 		name string
 		f    *feature.Feature
 		want bool
 	}{
 		{"nil", nil, false},
-		{"failed (quiescent)", &feature.Feature{Status: feature.StatusFailed}, true},
-		{"created (quiescent)", &feature.Feature{Status: feature.StatusCreated}, true},
-		{"code-ready (quiescent)", &feature.Feature{Status: feature.StatusCodeReady}, true},
-		{"implementing (running)", &feature.Feature{Status: feature.StatusImplementing}, false},
-		{"plan-needs-review", &feature.Feature{Status: feature.StatusPlanNeedsReview}, false},
+		{"failed", &feature.Feature{Status: feature.StatusFailed}, true},
+		{"created", &feature.Feature{Status: feature.StatusCreated}, true},
+		{"code-ready", &feature.Feature{Status: feature.StatusCodeReady}, true},
+		{"implementing (running)", &feature.Feature{Status: feature.StatusImplementing}, true},
+		{"plan-needs-review", &feature.Feature{Status: feature.StatusPlanNeedsReview}, true},
 		{
 			"active repo cycle",
 			&feature.Feature{
@@ -140,15 +138,56 @@ func TestIsFeatureQuiescent(t *testing.T) {
 					"a": {Status: "running"},
 				},
 			},
-			false,
+			true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := isFeatureQuiescent(tt.f); got != tt.want {
-				t.Errorf("isFeatureQuiescent = %v, want %v", got, tt.want)
+			if got := canEditFeatureConfig(tt.f); got != tt.want {
+				t.Errorf("canEditFeatureConfig = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestFeatureConfigChangesDeferred(t *testing.T) {
+	tests := []struct {
+		name string
+		f    *feature.Feature
+		want bool
+	}{
+		{"nil", nil, false},
+		{"created", &feature.Feature{Status: feature.StatusCreated}, false},
+		{"plan-needs-review", &feature.Feature{Status: feature.StatusPlanNeedsReview}, false},
+		{"implementing", &feature.Feature{Status: feature.StatusImplementing}, true},
+		{
+			"active repo cycle",
+			&feature.Feature{
+				Status: feature.StatusPublished,
+				RepoCycles: map[string]*feature.RepoCycleState{
+					"a": {Status: "running"},
+				},
+			},
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := featureConfigChangesDeferred(tt.f); got != tt.want {
+				t.Errorf("featureConfigChangesDeferred = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEditConfigOverlay_RunningFeatureShowsDeferredEffectWarning(t *testing.T) {
+	f := &feature.Feature{ID: "f1", Name: "running", Status: feature.StatusImplementing}
+	cat := BuildPhaseModelCatalog(nil, config.DefaultsConfig{})
+	m := NewEditConfigModel(f, cat, true)
+
+	view := m.View()
+	if !strings.Contains(view, "next restart or next phase") {
+		t.Fatalf("running feature edit overlay missing deferred-effect warning:\n%s", view)
 	}
 }
 
@@ -862,7 +901,7 @@ func TestEditConfig_CatalogBuiltAtModalOpen(t *testing.T) {
 	updated, _ := app.updateDashboardRightPanel(tea.KeyPressMsg{Code: 'e', Text: "e"})
 	got := updated.(AppModel)
 	if !got.editConfigActive {
-		t.Fatal("right-panel `e` should open the overlay for a quiescent feature")
+		t.Fatal("right-panel `e` should open the overlay for a feature")
 	}
 	if n := len(got.editConfig.editor.catalog.Fields); n != 6 {
 		t.Errorf("catalog.Fields = %d entries, want 6", n)
@@ -879,9 +918,49 @@ func TestEditConfig_CatalogBuiltAtModalOpen(t *testing.T) {
 	updated2, _ := app2.updateDetail(tea.KeyPressMsg{Code: 'e', Text: "e"})
 	got2 := updated2.(AppModel)
 	if !got2.editConfigActive {
-		t.Fatal("detail-view `e` should open the overlay for a quiescent feature")
+		t.Fatal("detail-view `e` should open the overlay for a feature")
 	}
 	if n := len(got2.editConfig.editor.catalog.Fields); n != 6 {
 		t.Errorf("catalog.Fields = %d entries, want 6", n)
+	}
+}
+
+func TestEditConfig_RunningFeatureCanOpenFromDashboardAndDetail(t *testing.T) {
+	app, fm := newTestAppModel(t)
+	f, err := fm.Create("running-dashboard", "desc", nil, config.ModelConfig{}, "", "medium", nil)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	f.Status = feature.StatusImplementing
+	app.currentView = ViewDashboard
+	app.dashboard.SetFeatures([]*feature.Feature{f})
+	app.dashboard.MoveToAdjacentFeature(1)
+	if app.dashboard.SelectedFeature() == nil {
+		app.dashboard.MoveToAdjacentFeature(-1)
+	}
+	if app.dashboard.SelectedFeature() == nil {
+		t.Skip("dashboard selection did not resolve to a feature — layout dependent")
+	}
+	app.dashboard.focusPanel = 1
+
+	updated, _ := app.updateDashboardRightPanel(tea.KeyPressMsg{Code: 'e', Text: "e"})
+	got := updated.(AppModel)
+	if !got.editConfigActive {
+		t.Fatal("right-panel `e` should open the overlay for a running feature")
+	}
+
+	app2, fm2 := newTestAppModel(t)
+	f2, err := fm2.Create("running-detail", "desc", nil, config.ModelConfig{}, "", "medium", nil)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	f2.Status = feature.StatusImplementing
+	app2.currentView = ViewDetail
+	app2.detail = NewDetailModel(f2, fm2.Store.BaseDir)
+
+	updated2, _ := app2.updateDetail(tea.KeyPressMsg{Code: 'e', Text: "e"})
+	got2 := updated2.(AppModel)
+	if !got2.editConfigActive {
+		t.Fatal("detail-view `e` should open the overlay for a running feature")
 	}
 }

--- a/internal/tui/help_data.go
+++ b/internal/tui/help_data.go
@@ -53,7 +53,7 @@ var DetailSection = HelpSection{
 		{"m", "Manual publish"},
 		{"t", "Tweak implementation (code ready or published)"},
 		{"b", "Rebase on main (code ready or published)"},
-		{"e", "Edit config (when feature is idle)"},
+		{"e", "Edit config"},
 		{"Shift+M", "Merge to base branch (local repos)"},
 		{"Shift+D", "Mark as done"},
 		{"g", "Review comments (published)"},


### PR DESCRIPTION
## Summary

- Allow feature-level model, inquiry level, and gate configuration edits regardless of the feature current status.
- Keep the persisted config update atomic while making active sessions pick up changes on the next phase or restart.
- Surface a warning in the edit-config modal for running features so users know the new config is deferred.
- Update dashboard, detail, and help affordances so `e` is no longer idle-only.

## Impact

Users can tune feature config while work is running instead of stopping first. Running work keeps its current session configuration; saved edits take effect at the next phase boundary or restart.

## Verification

- Fast suite: `make test-fast`
- E2E Go (TUI / teatest): `go test ./test/e2e/... -count=1 -race`
- Static analysis: `go vet ./...`
- Build: `go build ./...`
- Attempted Isolated integration: `go test ./test/integration/... -count=1` failed in unrelated tweak/push tests:
  - `TestCycleConflictPropagation_TweakConflict_OneRepoFailsAnotherSucceeds`
  - `TestTweakSession_MultiRepo_3Repo_TwoModified_OrchestratorCommitsAndPushes`
