### PR TITLE
[codex] Retry early infrastructure session failures

### DIFF
--- a/internal/agent/bounded_helper.go
+++ b/internal/agent/bounded_helper.go
@@ -172,10 +172,24 @@ func (pr *PhaseRunner) runBoundedHelperSession(ctx context.Context, cfg boundedH
 	if label == "" {
 		label = "bounded helper"
 	}
+	baseSessionID := cfg.sessionID
+	for sessionAttempt := 1; ; sessionAttempt++ {
+		cfg.sessionID = retrySessionID(baseSessionID, sessionAttempt)
+		if sessionAttempt > 1 && cfg.phaseCompleteDir != "" {
+			RemovePhaseComplete(cfg.phaseCompleteDir)
+		}
+		result, err, retryable := pr.runBoundedHelperSessionOnce(ctx, cfg, label)
+		if retryable && sessionAttempt < retryableInfrastructureSessionMaxAttempts {
+			continue
+		}
+		return result, err
+	}
+}
 
+func (pr *PhaseRunner) runBoundedHelperSessionOnce(ctx context.Context, cfg boundedHelperRunConfig, label string) (*BoundedHelperResult, error, bool) {
 	sess, err := pr.SessionManager.StartSession(cfg.sessionID, cfg.featureID, cfg.phase, cfg.command, cfg.workDir, cfg.env, cfg.sessOpts)
 	if err != nil {
-		return nil, fmt.Errorf("running %s: starting session: %w", label, err)
+		return nil, fmt.Errorf("running %s: starting session: %w", label, err), false
 	}
 
 	sessionCtx := observe.SpanContext{}
@@ -225,12 +239,19 @@ func (pr *PhaseRunner) runBoundedHelperSession(ctx context.Context, cfg boundedH
 	// maxFinishOrViolateNudges and armed only when cfg.finishOrViolateNudge is
 	// set (capability-positive providers).
 	finishOrViolateNudges := 0
+	finish := func(result *BoundedHelperResult, err error) (*BoundedHelperResult, error, bool) {
+		retryable := err != nil &&
+			result != nil &&
+			result.Status == BoundedHelperStatusFailed &&
+			isRetryableInfrastructureSessionFailure(sess, ExtractSessionCost(sess), time.Since(sessionStart))
+		return result, err, retryable
+	}
 
 	for {
 		select {
 		case <-ctx.Done():
 			result := boundedHelperSnapshot(cfg.responsePath, sess, BoundedHelperStatusTimedOut)
-			return result, fmt.Errorf("running %s: %w", label, ctx.Err())
+			return finish(result, fmt.Errorf("running %s: %w", label, ctx.Err()))
 
 		case msg, ok := <-attachCh:
 			if !ok {
@@ -242,10 +263,10 @@ func (pr *PhaseRunner) runBoundedHelperSession(ctx context.Context, cfg boundedH
 			}
 			if msg.ControlRequest.Request.ToolName == "AskUserQuestion" {
 				result := boundedHelperSnapshot(cfg.responsePath, sess, BoundedHelperStatusAskedUser)
-				return result, fmt.Errorf("running %s: helper asked for user input", label)
+				return finish(result, fmt.Errorf("running %s: helper asked for user input", label))
 			}
 			result := boundedHelperSnapshot(cfg.responsePath, sess, BoundedHelperStatusPermissionRequired)
-			return result, fmt.Errorf("running %s: helper requested tool permission for %s", label, msg.ControlRequest.Request.ToolName)
+			return finish(result, fmt.Errorf("running %s: helper requested tool permission for %s", label, msg.ControlRequest.Request.ToolName))
 
 		case <-statusCh:
 			// Peek at why the turn ended (mirroring finalizeBoundedHelperResult's
@@ -257,12 +278,14 @@ func (pr *PhaseRunner) runBoundedHelperSession(ctx context.Context, cfg boundedH
 					continue
 				}
 			}
-			return finalizeBoundedHelperResult(cfg.responsePath, sess, label, cfg.requireOutput, cfg.phaseCompleteDir, cfg.contractPhase, cfg.contractRole)
+			result, err := finalizeBoundedHelperResult(cfg.responsePath, sess, label, cfg.requireOutput, cfg.phaseCompleteDir, cfg.contractPhase, cfg.contractRole)
+			return finish(result, err)
 
 		case <-sess.Done():
 			// The process already exited; there is nothing to nudge. Never unify
 			// this arm with the statusCh arm above.
-			return finalizeBoundedHelperResult(cfg.responsePath, sess, label, cfg.requireOutput, cfg.phaseCompleteDir, cfg.contractPhase, cfg.contractRole)
+			result, err := finalizeBoundedHelperResult(cfg.responsePath, sess, label, cfg.requireOutput, cfg.phaseCompleteDir, cfg.contractPhase, cfg.contractRole)
+			return finish(result, err)
 		}
 	}
 }

--- a/internal/agent/bounded_helper_test.go
+++ b/internal/agent/bounded_helper_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -456,6 +457,47 @@ func TestRunBoundedHelper_DoneBranchDoesNotNudge(t *testing.T) {
 	// nudge/decide path would change this count.
 	if sess.stopCalls != 1 {
 		t.Errorf("stopCalls = %d, want 1 (single deferred Stop)", sess.stopCalls)
+	}
+}
+
+func TestRunBoundedHelper_RetriesEarlyInfrastructureFailure(t *testing.T) {
+	phaseDir := t.TempDir()
+	workDir := t.TempDir()
+	var sessionIDs []string
+
+	sm := mocks.NewMockSessionManager()
+	sm.StartSessionFn = func(id, featureID string, phase feature.Phase, command []string, workdir string, env []string, opts ...*session.SessionOpts) (ports.SessionHandle, error) {
+		sessionIDs = append(sessionIDs, id)
+		if len(sessionIDs) == 1 {
+			return newTerminalStatusTestSession(ports.SessionFailed), nil
+		}
+		writeReviewFeedbackFile(t, filepath.Join(phaseDir, "review-feedback.md"), testutil.StructuredReviewFeedback("", "", "APPROVED"))
+		if err := os.WriteFile(filepath.Join(phaseDir, PhaseCompleteFile), nil, 0o644); err != nil {
+			t.Fatalf("write marker: %v", err)
+		}
+		sess := newUtilityTestSession()
+		sess.result = &llm.ResultMessage{Type: "result", Subtype: "success", StopReason: "end_turn"}
+		sess.statusCh <- agentStatusSuccess
+		return sess, nil
+	}
+	pr := &PhaseRunner{SessionManager: sm, StateDir: t.TempDir()}
+
+	result, err := pr.runBoundedHelperSession(context.Background(), boundedHelperRunConfig{
+		sessionID:        "review-helper",
+		workDir:          workDir,
+		phaseCompleteDir: phaseDir,
+		contractPhase:    feature.PhaseReview,
+		contractRole:     RoleIterationReviewer,
+	})
+	if err != nil {
+		t.Fatalf("runBoundedHelperSession() error = %v", err)
+	}
+	if result.Status != BoundedHelperStatusCompleted {
+		t.Fatalf("Status = %q, want %q", result.Status, BoundedHelperStatusCompleted)
+	}
+	wantSessionIDs := []string{"review-helper", "review-helper-retry-02"}
+	if !reflect.DeepEqual(sessionIDs, wantSessionIDs) {
+		t.Fatalf("session IDs = %#v, want %#v", sessionIDs, wantSessionIDs)
 	}
 }
 

--- a/internal/agent/plan_validation.go
+++ b/internal/agent/plan_validation.go
@@ -200,10 +200,7 @@ func nextPlanSessionAttempt(artifactDir string, attempt int) int {
 }
 
 func planAttemptSessionID(base string, sessionAttempt int) string {
-	if sessionAttempt <= 1 {
-		return base
-	}
-	return fmt.Sprintf("%s-retry-%02d", base, sessionAttempt)
+	return retrySessionID(base, sessionAttempt)
 }
 
 // AxisApproval is a sticky approval recovered from a prior validation attempt.
@@ -1443,6 +1440,7 @@ func RunRoadmapPlanningLoop(cfg PlanLoopConfig, sm ports.SessionManager) (result
 		loopStart = startAttempt
 	}
 
+roadmapAttemptLoop:
 	for attempt := loopStart; attempt <= maxAttempts; attempt++ {
 		if isFeatureInterrupted(cfg.FeatureStore, cfg.Feature.ID) {
 			return &PlanLoopResult{FinalStatus: "interrupted", Iterations: attempt - 1}, nil
@@ -1492,152 +1490,163 @@ func RunRoadmapPlanningLoop(cfg PlanLoopConfig, sm ports.SessionManager) (result
 			if len(addDirs) == 0 {
 				addDirs = []string{cfg.StateDir}
 			}
-			// Clear stale phase_complete BEFORE spawning the script: otherwise
-			// the agent may write the marker before we get here, and we'd
-			// delete it.
-			RemovePhaseComplete(attemptDir)
-			cmd, env, sessOpts, err := cfg.BuildSession(BuildSessionOpts{
-				Model:                          cfg.Feature.Models.Planning,
-				Prompt:                         prompt,
-				SystemPrompt:                   systemPrompt,
-				AdditionalDirs:                 addDirs,
-				AgentNames:                     explorationAgentNames(),
-				PIDDir:                         pidDir,
-				PermHandler:                    permHandlerFor(cfg.DangerouslySkipPermissions, cfg.PermissionCache, cfg.RepoName),
-				WorkDir:                        cfg.WorkDir,
-				EffortLevel:                    cfg.EffortLevel,
-				Phase:                          feature.PhasePlan,
-				SystemPromptHasUsefulResources: true,
-				MarkerPath:                     filepath.Join(attemptDir, PhaseCompleteFile),
-			})
-			if err != nil {
-				return nil, fmt.Errorf("building roadmap session (attempt %d): %w", attempt, err)
-			}
-			sessOpts = enableTruncatedTurnAutoResume(sessOpts)
-			if cfg.FinishOrViolateNudge {
-				sessOpts.TurnMode = ports.TurnModeInteractive
-			}
-			WriteDebugPrompts(attemptDir, sessOpts.DebugSystemPrompt, prompt)
-			sessOpts.PermCacheScope = cfg.RepoName
-
 			sessionAttempt := nextPlanSessionAttempt(artifactDir, attempt)
-			sessionID := planAttemptSessionID(fmt.Sprintf("%s-roadmap-%02d", cfg.Feature.ID, attempt), sessionAttempt)
-			planSessionCtx := cfg.PhaseSpanCtx.Child()
-			if attempt == 1 {
-				sessOpts.AskUserAutoPick = askUserAutoPickConfig(
-					cfg.FeatureStore,
-					cfg.Observer,
-					cfg.Feature,
-					ports.AskUserAutoPickPurposeRoadmapCreator,
-					planSessionCtx,
-					sessionID,
-					cfg.RepoName,
-					0,
-				)
-			}
-			startSession := cfg.SessionStartFunc
-			if startSession == nil {
-				startSession = sm.StartSession
-			}
-			sess, err := startSession(sessionID, cfg.Feature.ID, feature.PhasePlan, cmd, cfg.WorkDir, env, sessOpts)
-			if err != nil {
-				if errors.Is(err, ports.ErrSessionShuttingDown) {
-					return &PlanLoopResult{FinalStatus: "interrupted", Iterations: attempt - 1}, nil
-				}
-				return nil, fmt.Errorf("starting roadmap session (attempt %d): %w", attempt, err)
-			}
-
-			providerName := ""
-			if sessOpts != nil {
-				providerName = sessOpts.ProviderName
-			}
-			cfg.Observer.SessionStarted(planSessionCtx, "plan", sessionID, providerName, cfg.Feature.Models.Planning, cfg.RepoName)
-			(&ContextReadTracker{
-				KBBaseDir:     filepath.Join(filepath.Dir(cfg.StateDir), "knowledge-base"),
-				SkillsDir:     cfg.SkillsDir,
-				GuidelinesDir: cfg.GuidelinesDir,
-				Observer:      cfg.Observer,
-			}).Install(sess, planSessionCtx, "plan", sessionID)
-			sessionStart := time.Now()
-
-			logPath := filepath.Join(attemptDir, "output.txt")
-			logFile, err := os.Create(logPath)
-			if err == nil {
-				sess.SetLogFile(logFile)
-			}
-
-			agentStatus := waitForStatusDetailed(sess, sm, sessionID, waitForStatusOptions{
-				ReadyCheck: func() bool {
-					if HasPhaseComplete(attemptDir) {
-						sess.SetHasUnansweredQuestion(false)
-						return true
-					}
-					return false
-				},
-				FinishOrViolateNudge: cfg.FinishOrViolateNudge,
-				MissingArtifacts:     []string{"roadmap.md"},
-			}).Status
-
-			cost := ExtractSessionCost(sess)
-			if cfg.FeatureStore != nil && cost.TotalCostUSD > 0 {
-				_ = cfg.FeatureStore.Modify(cfg.Feature.ID, func(f *feature.Feature) error {
-					f.RecordSessionCost(feature.SessionCostRecord{
-						SessionID:     sessionID,
-						PhaseKey:      "plan",
-						ObserverPhase: "plan",
-						RepoName:      cfg.RepoName,
-						CostUSD:       cost.TotalCostUSD,
-					})
-					return nil
+			for {
+				// Clear stale phase_complete BEFORE spawning the script: otherwise
+				// the agent may write the marker before we get here, and we'd
+				// delete it.
+				RemovePhaseComplete(attemptDir)
+				cmd, env, sessOpts, err := cfg.BuildSession(BuildSessionOpts{
+					Model:                          cfg.Feature.Models.Planning,
+					Prompt:                         prompt,
+					SystemPrompt:                   systemPrompt,
+					AdditionalDirs:                 addDirs,
+					AgentNames:                     explorationAgentNames(),
+					PIDDir:                         pidDir,
+					PermHandler:                    permHandlerFor(cfg.DangerouslySkipPermissions, cfg.PermissionCache, cfg.RepoName),
+					WorkDir:                        cfg.WorkDir,
+					EffortLevel:                    cfg.EffortLevel,
+					Phase:                          feature.PhasePlan,
+					SystemPromptHasUsefulResources: true,
+					MarkerPath:                     filepath.Join(attemptDir, PhaseCompleteFile),
 				})
-			}
-
-			cfg.Observer.SessionEnded(planSessionCtx, "plan", sessionID, cfg.RepoName,
-				toSessionUsage(cost), time.Since(sessionStart), sessionErrFromAgentStatus(agentStatus))
-
-			output := sess.MessageLog().Text()
-			_ = os.WriteFile(logPath, []byte(output), 0o644)
-
-			if agentStatus != "SUCCESS" {
-				// Graceful shutdown: see implement.go:377 for the rationale.
-				if agentStatus == "FAILED" && sm != nil && sm.IsShuttingDown() {
-					return &PlanLoopResult{FinalStatus: "interrupted", Iterations: attempt - 1}, nil
+				if err != nil {
+					return nil, fmt.Errorf("building roadmap session (attempt %d): %w", attempt, err)
 				}
-				if agentStatus == agentStatusMissingMarker {
-					violations := missingPhaseCompleteViolations()
-					lastErr := formatProtocolViolationError(plannerSpec.Role, attemptDir, violations)
-					criticFeedback = formatPlanContractViolationFeedback(plannerSpec.Role, violations)
-					_ = os.WriteFile(filepath.Join(attemptDir, "validation-feedback.md"), []byte(criticFeedback), 0o644)
+				sessOpts = enableTruncatedTurnAutoResume(sessOpts)
+				if cfg.FinishOrViolateNudge {
+					sessOpts.TurnMode = ports.TurnModeInteractive
+				}
+				WriteDebugPrompts(attemptDir, sessOpts.DebugSystemPrompt, prompt)
+				sessOpts.PermCacheScope = cfg.RepoName
+
+				sessionID := planAttemptSessionID(fmt.Sprintf("%s-roadmap-%02d", cfg.Feature.ID, attempt), sessionAttempt)
+				planSessionCtx := cfg.PhaseSpanCtx.Child()
+				if attempt == 1 {
+					sessOpts.AskUserAutoPick = askUserAutoPickConfig(
+						cfg.FeatureStore,
+						cfg.Observer,
+						cfg.Feature,
+						ports.AskUserAutoPickPurposeRoadmapCreator,
+						planSessionCtx,
+						sessionID,
+						cfg.RepoName,
+						0,
+					)
+				}
+				startSession := cfg.SessionStartFunc
+				if startSession == nil {
+					startSession = sm.StartSession
+				}
+				sess, err := startSession(sessionID, cfg.Feature.ID, feature.PhasePlan, cmd, cfg.WorkDir, env, sessOpts)
+				if err != nil {
+					if errors.Is(err, ports.ErrSessionShuttingDown) {
+						return &PlanLoopResult{FinalStatus: "interrupted", Iterations: attempt - 1}, nil
+					}
+					return nil, fmt.Errorf("starting roadmap session (attempt %d): %w", attempt, err)
+				}
+
+				providerName := ""
+				if sessOpts != nil {
+					providerName = sessOpts.ProviderName
+				}
+				cfg.Observer.SessionStarted(planSessionCtx, "plan", sessionID, providerName, cfg.Feature.Models.Planning, cfg.RepoName)
+				(&ContextReadTracker{
+					KBBaseDir:     filepath.Join(filepath.Dir(cfg.StateDir), "knowledge-base"),
+					SkillsDir:     cfg.SkillsDir,
+					GuidelinesDir: cfg.GuidelinesDir,
+					Observer:      cfg.Observer,
+				}).Install(sess, planSessionCtx, "plan", sessionID)
+				sessionStart := time.Now()
+
+				logPath := filepath.Join(attemptDir, "output.txt")
+				logFile, err := os.Create(logPath)
+				if err == nil {
+					sess.SetLogFile(logFile)
+				}
+
+				agentStatus := waitForStatusDetailed(sess, sm, sessionID, waitForStatusOptions{
+					ReadyCheck: func() bool {
+						if HasPhaseComplete(attemptDir) {
+							sess.SetHasUnansweredQuestion(false)
+							return true
+						}
+						return false
+					},
+					FinishOrViolateNudge: cfg.FinishOrViolateNudge,
+					MissingArtifacts:     []string{"roadmap.md"},
+				}).Status
+
+				cost := ExtractSessionCost(sess)
+				if cfg.FeatureStore != nil && cost.TotalCostUSD > 0 {
+					_ = cfg.FeatureStore.Modify(cfg.Feature.ID, func(f *feature.Feature) error {
+						f.RecordSessionCost(feature.SessionCostRecord{
+							SessionID:     sessionID,
+							PhaseKey:      "plan",
+							ObserverPhase: "plan",
+							RepoName:      cfg.RepoName,
+							CostUSD:       cost.TotalCostUSD,
+						})
+						return nil
+					})
+				}
+
+				cfg.Observer.SessionEnded(planSessionCtx, "plan", sessionID, cfg.RepoName,
+					toSessionUsage(cost), time.Since(sessionStart), sessionErrFromAgentStatus(agentStatus))
+
+				output := sess.MessageLog().Text()
+				_ = os.WriteFile(logPath, []byte(output), 0o644)
+
+				if agentStatus != "SUCCESS" {
+					// Graceful shutdown: see implement.go:377 for the rationale.
+					if agentStatus == "FAILED" && sm != nil && sm.IsShuttingDown() {
+						return &PlanLoopResult{FinalStatus: "interrupted", Iterations: attempt - 1}, nil
+					}
+					if agentStatus == agentStatusMissingMarker {
+						violations := missingPhaseCompleteViolations()
+						lastErr := formatProtocolViolationError(plannerSpec.Role, attemptDir, violations)
+						criticFeedback = formatPlanContractViolationFeedback(plannerSpec.Role, violations)
+						_ = os.WriteFile(filepath.Join(attemptDir, "validation-feedback.md"), []byte(criticFeedback), 0o644)
+						_ = WritePlanAttemptMeta(artifactDir, PlanAttemptMeta{
+							Attempt:      attempt,
+							AgentStatus:  "SUCCESS",
+							ReviewStatus: "CHANGES_REQUESTED",
+						})
+						if attempt >= maxAttempts {
+							return &PlanLoopResult{FinalStatus: "protocol_violation", Iterations: attempt, LastError: lastErr}, nil
+						}
+						continue roadmapAttemptLoop
+					}
 					_ = WritePlanAttemptMeta(artifactDir, PlanAttemptMeta{
-						Attempt:      attempt,
-						AgentStatus:  "SUCCESS",
-						ReviewStatus: "CHANGES_REQUESTED",
+						Attempt:        attempt,
+						SessionAttempt: sessionAttempt,
+						AgentStatus:    "FAILED",
 					})
-					if attempt >= maxAttempts {
-						return &PlanLoopResult{FinalStatus: "protocol_violation", Iterations: attempt, LastError: lastErr}, nil
+					if shouldRetryPlanInfrastructureSession(agentStatus, sess, cost, time.Since(sessionStart), sessionAttempt) {
+						sessionAttempt++
+						continue
 					}
-					continue
+					return &PlanLoopResult{FinalStatus: "failed", Iterations: attempt, LastError: "roadmap session did not complete successfully"}, nil
 				}
-				_ = WritePlanAttemptMeta(artifactDir, PlanAttemptMeta{
-					Attempt:        attempt,
-					SessionAttempt: sessionAttempt,
-					AgentStatus:    "FAILED",
-				})
-				return &PlanLoopResult{FinalStatus: "failed", Iterations: attempt, LastError: "roadmap session did not complete successfully"}, nil
-			}
-			if attempt == 1 {
-				if _, err := WriteQAFile(sess.QALog(), artifactDir); err != nil {
-					return nil, fmt.Errorf("writing roadmap qa file: %w", err)
+				if attempt == 1 {
+					if _, err := WriteQAFile(sess.QALog(), artifactDir); err != nil {
+						return nil, fmt.Errorf("writing roadmap qa file: %w", err)
+					}
 				}
-			}
 
-			// Write intermediate meta so a restart resumes at validation
-			// instead of re-running the planning session.
-			_ = WritePlanAttemptMeta(artifactDir, PlanAttemptMeta{
-				Attempt:      attempt,
-				AgentStatus:  "SUCCESS",
-				ReviewStatus: "VALIDATION_PENDING",
-			})
+				// Write intermediate meta so a restart resumes at validation
+				// instead of re-running the planning session.
+				meta := PlanAttemptMeta{
+					Attempt:      attempt,
+					AgentStatus:  "SUCCESS",
+					ReviewStatus: "VALIDATION_PENDING",
+				}
+				if sessionAttempt > 1 {
+					meta.SessionAttempt = sessionAttempt
+				}
+				_ = WritePlanAttemptMeta(artifactDir, meta)
+				break
+			}
 		} // end else (!resumeValidation)
 
 		plannerRole := roadmapPlannerRoleForAttempt(attempt)
@@ -1836,6 +1845,7 @@ func RunPhasePlanningLoop(cfg PhasePlanLoopConfig, sm ports.SessionManager) (res
 	// being interrupted after attempt N-1.
 	axisStallTracker := loadAxisStallState(artifactDir)
 
+phasePlanAttemptLoop:
 	for attempt := loopStart; attempt <= maxAttempts; attempt++ {
 		if isFeatureInterrupted(cfg.FeatureStore, cfg.Feature.ID) {
 			return &PlanLoopResult{FinalStatus: "interrupted", Iterations: attempt - 1}, nil
@@ -1885,153 +1895,164 @@ func RunPhasePlanningLoop(cfg PhasePlanLoopConfig, sm ports.SessionManager) (res
 			if len(addDirs) == 0 {
 				addDirs = []string{cfg.StateDir}
 			}
-			// Clear stale phase_complete BEFORE spawning the script: otherwise
-			// the agent may write the marker before we get here, and we'd
-			// delete it.
-			RemovePhaseComplete(attemptDir)
-			cmd, env, sessOpts, err := cfg.BuildSession(BuildSessionOpts{
-				Model:                          cfg.Feature.Models.Planning,
-				Prompt:                         prompt,
-				SystemPrompt:                   systemPrompt,
-				AdditionalDirs:                 addDirs,
-				AgentNames:                     explorationAgentNames(),
-				PIDDir:                         pidDir,
-				PermHandler:                    permHandlerFor(cfg.DangerouslySkipPermissions, cfg.PermissionCache, cfg.RepoName),
-				WorkDir:                        cfg.WorkDir,
-				EffortLevel:                    cfg.EffortLevel,
-				Phase:                          feature.PhasePlan,
-				SystemPromptHasUsefulResources: true,
-				MarkerPath:                     filepath.Join(attemptDir, PhaseCompleteFile),
-			})
-			if err != nil {
-				return nil, fmt.Errorf("building phase plan session (attempt %d): %w", attempt, err)
-			}
-			sessOpts = enableTruncatedTurnAutoResume(sessOpts)
-			if cfg.FinishOrViolateNudge {
-				sessOpts.TurnMode = ports.TurnModeInteractive
-			}
-			WriteDebugPrompts(attemptDir, sessOpts.DebugSystemPrompt, prompt)
-			sessOpts.PermCacheScope = cfg.RepoName
-
 			sessionAttempt := nextPlanSessionAttempt(artifactDir, attempt)
-			sessionID := planAttemptSessionID(fmt.Sprintf("%s-phase-%02d-plan-%02d", cfg.Feature.ID, cfg.Phase.Number, attempt), sessionAttempt)
-			planSessionCtx := cfg.PlanLoopConfig.PhaseSpanCtx.Child()
-			if attempt == 1 {
-				sessOpts.AskUserAutoPick = askUserAutoPickConfig(
-					cfg.FeatureStore,
-					cfg.Observer,
-					cfg.Feature,
-					ports.AskUserAutoPickPurposePhasePlanCreator,
-					planSessionCtx,
-					sessionID,
-					cfg.RepoName,
-					0,
-				)
-			}
-			startSession := cfg.SessionStartFunc
-			if startSession == nil {
-				startSession = sm.StartSession
-			}
-			sess, err := startSession(sessionID, cfg.Feature.ID, feature.PhasePlan, cmd, cfg.WorkDir, env, sessOpts)
-			if err != nil {
-				if errors.Is(err, ports.ErrSessionShuttingDown) {
-					return &PlanLoopResult{FinalStatus: "interrupted", Iterations: attempt - 1}, nil
-				}
-				return nil, fmt.Errorf("starting phase plan session (attempt %d): %w", attempt, err)
-			}
-
-			providerName := ""
-			if sessOpts != nil {
-				providerName = sessOpts.ProviderName
-			}
-			cfg.Observer.SessionStarted(planSessionCtx, "plan", sessionID, providerName, cfg.Feature.Models.Planning, cfg.RepoName)
-			(&ContextReadTracker{
-				KBBaseDir:     filepath.Join(filepath.Dir(cfg.StateDir), "knowledge-base"),
-				SkillsDir:     cfg.SkillsDir,
-				GuidelinesDir: cfg.GuidelinesDir,
-				Observer:      cfg.Observer,
-			}).Install(sess, planSessionCtx, "plan", sessionID)
-			sessionStart := time.Now()
-
-			logPath := filepath.Join(attemptDir, "output.txt")
-			logFile, err := os.Create(logPath)
-			if err == nil {
-				sess.SetLogFile(logFile)
-			}
-
-			agentStatus := waitForStatusDetailed(sess, sm, sessionID, waitForStatusOptions{
-				ReadyCheck: func() bool {
-					if HasPhaseComplete(attemptDir) {
-						sess.SetHasUnansweredQuestion(false)
-						return true
-					}
-					return false
-				},
-				FinishOrViolateNudge: cfg.FinishOrViolateNudge,
-				MissingArtifacts:     []string{"plan.md"},
-			}).Status
-
-			cost := ExtractSessionCost(sess)
-			if cfg.FeatureStore != nil && cost.TotalCostUSD > 0 {
-				costKey := fmt.Sprintf("phase-%d-plan", cfg.Phase.Number)
-				_ = cfg.FeatureStore.Modify(cfg.Feature.ID, func(f *feature.Feature) error {
-					f.RecordSessionCost(feature.SessionCostRecord{
-						SessionID:     sessionID,
-						PhaseKey:      costKey,
-						ObserverPhase: "plan",
-						RepoName:      cfg.RepoName,
-						CostUSD:       cost.TotalCostUSD,
-					})
-					return nil
+			for {
+				// Clear stale phase_complete BEFORE spawning the script: otherwise
+				// the agent may write the marker before we get here, and we'd
+				// delete it.
+				RemovePhaseComplete(attemptDir)
+				cmd, env, sessOpts, err := cfg.BuildSession(BuildSessionOpts{
+					Model:                          cfg.Feature.Models.Planning,
+					Prompt:                         prompt,
+					SystemPrompt:                   systemPrompt,
+					AdditionalDirs:                 addDirs,
+					AgentNames:                     explorationAgentNames(),
+					PIDDir:                         pidDir,
+					PermHandler:                    permHandlerFor(cfg.DangerouslySkipPermissions, cfg.PermissionCache, cfg.RepoName),
+					WorkDir:                        cfg.WorkDir,
+					EffortLevel:                    cfg.EffortLevel,
+					Phase:                          feature.PhasePlan,
+					SystemPromptHasUsefulResources: true,
+					MarkerPath:                     filepath.Join(attemptDir, PhaseCompleteFile),
 				})
-			}
-
-			cfg.Observer.SessionEnded(planSessionCtx, "plan", sessionID, cfg.RepoName,
-				toSessionUsage(cost), time.Since(sessionStart), sessionErrFromAgentStatus(agentStatus))
-
-			output := sess.MessageLog().Text()
-			_ = os.WriteFile(logPath, []byte(output), 0o644)
-
-			if agentStatus != "SUCCESS" {
-				// Graceful shutdown: see implement.go:377 for the rationale.
-				if agentStatus == "FAILED" && sm != nil && sm.IsShuttingDown() {
-					return &PlanLoopResult{FinalStatus: "interrupted", Iterations: attempt - 1}, nil
+				if err != nil {
+					return nil, fmt.Errorf("building phase plan session (attempt %d): %w", attempt, err)
 				}
-				if agentStatus == agentStatusMissingMarker {
-					violations := missingPhaseCompleteViolations()
-					lastErr := formatProtocolViolationError(plannerSpec.Role, attemptDir, violations)
-					criticFeedback = formatPlanContractViolationFeedback(plannerSpec.Role, violations)
-					_ = os.WriteFile(filepath.Join(attemptDir, "validation-feedback.md"), []byte(criticFeedback), 0o644)
+				sessOpts = enableTruncatedTurnAutoResume(sessOpts)
+				if cfg.FinishOrViolateNudge {
+					sessOpts.TurnMode = ports.TurnModeInteractive
+				}
+				WriteDebugPrompts(attemptDir, sessOpts.DebugSystemPrompt, prompt)
+				sessOpts.PermCacheScope = cfg.RepoName
+
+				sessionID := planAttemptSessionID(fmt.Sprintf("%s-phase-%02d-plan-%02d", cfg.Feature.ID, cfg.Phase.Number, attempt), sessionAttempt)
+				planSessionCtx := cfg.PlanLoopConfig.PhaseSpanCtx.Child()
+				if attempt == 1 {
+					sessOpts.AskUserAutoPick = askUserAutoPickConfig(
+						cfg.FeatureStore,
+						cfg.Observer,
+						cfg.Feature,
+						ports.AskUserAutoPickPurposePhasePlanCreator,
+						planSessionCtx,
+						sessionID,
+						cfg.RepoName,
+						0,
+					)
+				}
+				startSession := cfg.SessionStartFunc
+				if startSession == nil {
+					startSession = sm.StartSession
+				}
+				sess, err := startSession(sessionID, cfg.Feature.ID, feature.PhasePlan, cmd, cfg.WorkDir, env, sessOpts)
+				if err != nil {
+					if errors.Is(err, ports.ErrSessionShuttingDown) {
+						return &PlanLoopResult{FinalStatus: "interrupted", Iterations: attempt - 1}, nil
+					}
+					return nil, fmt.Errorf("starting phase plan session (attempt %d): %w", attempt, err)
+				}
+
+				providerName := ""
+				if sessOpts != nil {
+					providerName = sessOpts.ProviderName
+				}
+				cfg.Observer.SessionStarted(planSessionCtx, "plan", sessionID, providerName, cfg.Feature.Models.Planning, cfg.RepoName)
+				(&ContextReadTracker{
+					KBBaseDir:     filepath.Join(filepath.Dir(cfg.StateDir), "knowledge-base"),
+					SkillsDir:     cfg.SkillsDir,
+					GuidelinesDir: cfg.GuidelinesDir,
+					Observer:      cfg.Observer,
+				}).Install(sess, planSessionCtx, "plan", sessionID)
+				sessionStart := time.Now()
+
+				logPath := filepath.Join(attemptDir, "output.txt")
+				logFile, err := os.Create(logPath)
+				if err == nil {
+					sess.SetLogFile(logFile)
+				}
+
+				agentStatus := waitForStatusDetailed(sess, sm, sessionID, waitForStatusOptions{
+					ReadyCheck: func() bool {
+						if HasPhaseComplete(attemptDir) {
+							sess.SetHasUnansweredQuestion(false)
+							return true
+						}
+						return false
+					},
+					FinishOrViolateNudge: cfg.FinishOrViolateNudge,
+					MissingArtifacts:     []string{"plan.md"},
+				}).Status
+
+				cost := ExtractSessionCost(sess)
+				if cfg.FeatureStore != nil && cost.TotalCostUSD > 0 {
+					costKey := fmt.Sprintf("phase-%d-plan", cfg.Phase.Number)
+					_ = cfg.FeatureStore.Modify(cfg.Feature.ID, func(f *feature.Feature) error {
+						f.RecordSessionCost(feature.SessionCostRecord{
+							SessionID:     sessionID,
+							PhaseKey:      costKey,
+							ObserverPhase: "plan",
+							RepoName:      cfg.RepoName,
+							CostUSD:       cost.TotalCostUSD,
+						})
+						return nil
+					})
+				}
+
+				cfg.Observer.SessionEnded(planSessionCtx, "plan", sessionID, cfg.RepoName,
+					toSessionUsage(cost), time.Since(sessionStart), sessionErrFromAgentStatus(agentStatus))
+
+				output := sess.MessageLog().Text()
+				_ = os.WriteFile(logPath, []byte(output), 0o644)
+
+				if agentStatus != "SUCCESS" {
+					// Graceful shutdown: see implement.go:377 for the rationale.
+					if agentStatus == "FAILED" && sm != nil && sm.IsShuttingDown() {
+						return &PlanLoopResult{FinalStatus: "interrupted", Iterations: attempt - 1}, nil
+					}
+					if agentStatus == agentStatusMissingMarker {
+						violations := missingPhaseCompleteViolations()
+						lastErr := formatProtocolViolationError(plannerSpec.Role, attemptDir, violations)
+						criticFeedback = formatPlanContractViolationFeedback(plannerSpec.Role, violations)
+						_ = os.WriteFile(filepath.Join(attemptDir, "validation-feedback.md"), []byte(criticFeedback), 0o644)
+						_ = WritePlanAttemptMeta(artifactDir, PlanAttemptMeta{
+							Attempt:      attempt,
+							AgentStatus:  "SUCCESS",
+							ReviewStatus: "CHANGES_REQUESTED",
+						})
+						if attempt >= maxAttempts {
+							return &PlanLoopResult{FinalStatus: "protocol_violation", Iterations: attempt, LastError: lastErr}, nil
+						}
+						continue phasePlanAttemptLoop
+					}
 					_ = WritePlanAttemptMeta(artifactDir, PlanAttemptMeta{
-						Attempt:      attempt,
-						AgentStatus:  "SUCCESS",
-						ReviewStatus: "CHANGES_REQUESTED",
+						Attempt:        attempt,
+						SessionAttempt: sessionAttempt,
+						AgentStatus:    "FAILED",
 					})
-					if attempt >= maxAttempts {
-						return &PlanLoopResult{FinalStatus: "protocol_violation", Iterations: attempt, LastError: lastErr}, nil
+					if shouldRetryPlanInfrastructureSession(agentStatus, sess, cost, time.Since(sessionStart), sessionAttempt) {
+						sessionAttempt++
+						continue
 					}
-					continue
+					return &PlanLoopResult{FinalStatus: "failed", Iterations: attempt, LastError: "phase plan session did not complete"}, nil
 				}
-				_ = WritePlanAttemptMeta(artifactDir, PlanAttemptMeta{
-					Attempt:        attempt,
-					SessionAttempt: sessionAttempt,
-					AgentStatus:    "FAILED",
-				})
-				return &PlanLoopResult{FinalStatus: "failed", Iterations: attempt, LastError: "phase plan session did not complete"}, nil
-			}
-			if attempt == 1 {
-				if _, err := WriteQAFile(sess.QALog(), artifactDir); err != nil {
-					return nil, fmt.Errorf("writing phase plan qa file: %w", err)
+				if attempt == 1 {
+					if _, err := WriteQAFile(sess.QALog(), artifactDir); err != nil {
+						return nil, fmt.Errorf("writing phase plan qa file: %w", err)
+					}
 				}
-			}
 
-			// Write intermediate meta so a restart resumes at validation
-			// instead of re-running the planning session.
-			_ = WritePlanAttemptMeta(artifactDir, PlanAttemptMeta{
-				Attempt:      attempt,
-				AgentStatus:  "SUCCESS",
-				ReviewStatus: "VALIDATION_PENDING",
-			})
+				// Write intermediate meta so a restart resumes at validation
+				// instead of re-running the planning session.
+				meta := PlanAttemptMeta{
+					Attempt:      attempt,
+					AgentStatus:  "SUCCESS",
+					ReviewStatus: "VALIDATION_PENDING",
+				}
+				if sessionAttempt > 1 {
+					meta.SessionAttempt = sessionAttempt
+				}
+				_ = WritePlanAttemptMeta(artifactDir, meta)
+				break
+			}
 		} // end else (!resumeValidation)
 
 		plannerRole := phasePlanPlannerRoleForAttempt(attempt)

--- a/internal/agent/plan_validation_test.go
+++ b/internal/agent/plan_validation_test.go
@@ -1249,6 +1249,76 @@ func TestRunPhasePlanningLoopRetriesFailedAttemptWithFreshSessionID(t *testing.T
 	}
 }
 
+func TestRunPhasePlanningLoopRetriesEarlyInfrastructureFailureInProcess(t *testing.T) {
+	tmpDir := t.TempDir()
+	workDir := filepath.Join(tmpDir, "work")
+	phasePlanDir := filepath.Join(tmpDir, "test-plan-001", "runs", "run-001", "phase-01", "plan")
+	for _, dir := range []string{workDir, phasePlanDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("MkdirAll(%q): %v", dir, err)
+		}
+	}
+
+	store := feature.NewStore(tmpDir)
+	f := newTestPlanFeature(t, workDir)
+	f.Pipeline = feature.PipelineMedium
+	if err := store.Save(f); err != nil {
+		t.Fatal(err)
+	}
+
+	var sessionIDs []string
+	result, err := RunPhasePlanningLoop(PhasePlanLoopConfig{
+		PlanLoopConfig: PlanLoopConfig{
+			Feature:      f,
+			FeatureStore: store,
+			StateDir:     tmpDir,
+			WorkDir:      workDir,
+			MaxAttempts:  1,
+			BuildSession: func(opts BuildSessionOpts) ([]string, []string, *ports.SessionOpts, error) {
+				return []string{"echo", "unused"}, nil, &ports.SessionOpts{PIDDir: opts.PIDDir}, nil
+			},
+			SessionStartFunc: func(id, featureID string, phase feature.Phase, command []string, workdir string, env []string, opts ...*ports.SessionOpts) (ports.SessionHandle, error) {
+				sessionIDs = append(sessionIDs, id)
+				if len(sessionIDs) == 1 {
+					return newTerminalStatusTestSession(ports.SessionFailed), nil
+				}
+				attemptDir := filepath.Join(phasePlanDir, "attempt-01")
+				if err := os.WriteFile(filepath.Join(phasePlanDir, "plan.md"), []byte(validPhasePlanText()), 0o644); err != nil {
+					t.Fatalf("write plan.md: %v", err)
+				}
+				if err := os.WriteFile(filepath.Join(attemptDir, PhaseCompleteFile), nil, 0o644); err != nil {
+					t.Fatalf("write phase_complete: %v", err)
+				}
+				sess := newUtilityTestSession()
+				sess.statusCh <- agentStatusSuccess
+				return sess, nil
+			},
+		},
+		Phase: RoadmapPhase{
+			Number: 1,
+			Name:   "Retry plan",
+			Type:   "tdd-fill-in",
+			Goal:   "Retry a provider child process that died before doing work",
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("RunPhasePlanningLoop() error = %v", err)
+	}
+	if result.FinalStatus != "approved" {
+		t.Fatalf("FinalStatus = %q, want approved", result.FinalStatus)
+	}
+	wantSessionIDs := []string{
+		"test-plan-001-phase-01-plan-01",
+		"test-plan-001-phase-01-plan-01-retry-02",
+	}
+	if !reflect.DeepEqual(sessionIDs, wantSessionIDs) {
+		t.Fatalf("session IDs = %#v, want %#v", sessionIDs, wantSessionIDs)
+	}
+	if _, err := os.Stat(filepath.Join(phasePlanDir, "attempt-02")); !os.IsNotExist(err) {
+		t.Fatalf("attempt-02 stat err = %v, want not exist", err)
+	}
+}
+
 func TestPlanRetrySessionAttempt(t *testing.T) {
 	dir := t.TempDir()
 	if got := nextPlanSessionAttempt(dir, 2); got != 1 {

--- a/internal/agent/session_retry.go
+++ b/internal/agent/session_retry.go
@@ -1,0 +1,73 @@
+// Copyright 2026 DoorDash, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agent
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/doordash-oss/agentic-orchestrator/internal/ports"
+)
+
+const (
+	retryableInfrastructureSessionMaxAttempts = 3
+	retryableInfrastructureSessionMaxDuration = 30 * time.Second
+)
+
+func retrySessionID(base string, sessionAttempt int) string {
+	if sessionAttempt <= 1 {
+		return base
+	}
+	return fmt.Sprintf("%s-retry-%02d", base, sessionAttempt)
+}
+
+func shouldRetryPlanInfrastructureSession(agentStatus string, sess ports.SessionView, cost SessionCost, duration time.Duration, sessionAttempt int) bool {
+	if sessionAttempt >= retryableInfrastructureSessionMaxAttempts {
+		return false
+	}
+	if agentStatus != agentStatusFailed {
+		return false
+	}
+	return isRetryableInfrastructureSessionFailure(sess, cost, duration)
+}
+
+func isRetryableInfrastructureSessionFailure(sess ports.SessionView, cost SessionCost, duration time.Duration) bool {
+	if sess == nil {
+		return false
+	}
+	if sess.Status() != ports.SessionFailed {
+		return false
+	}
+	if duration > retryableInfrastructureSessionMaxDuration {
+		return false
+	}
+	if sess.Cost() != nil {
+		return false
+	}
+	if cost.TotalCostUSD != 0 {
+		return false
+	}
+	if cost.Usage.InputTokens != 0 ||
+		cost.Usage.OutputTokens != 0 ||
+		cost.Usage.CacheReadInputTokens != 0 ||
+		cost.Usage.CacheCreationInputTokens != 0 {
+		return false
+	}
+	if log := sess.MessageLog(); log != nil && strings.TrimSpace(log.Text()) != "" {
+		return false
+	}
+	return true
+}

--- a/internal/agent/utility_run_test.go
+++ b/internal/agent/utility_run_test.go
@@ -44,6 +44,24 @@ type utilityTestSession struct {
 	pendingAsk  bool
 }
 
+type terminalStatusTestSession struct {
+	*utilityTestSession
+	status ports.SessionStatus
+}
+
+func newTerminalStatusTestSession(status ports.SessionStatus) *terminalStatusTestSession {
+	sess := &terminalStatusTestSession{
+		utilityTestSession: newUtilityTestSession(),
+		status:             status,
+	}
+	close(sess.done)
+	return sess
+}
+
+func (s *terminalStatusTestSession) Status() ports.SessionStatus {
+	return s.status
+}
+
 func newUtilityTestSession() *utilityTestSession {
 	return &utilityTestSession{
 		done:     make(chan struct{}),

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -129,8 +129,9 @@ At iteration end, write artifacts in this exact order:
 
 1. `{iteration_dir}/verification-report.yaml`.
 2. `{phase_dir}/progress.md`.
-3. `{iteration_dir}/need-user-input.yaml` only when `progress.md` reports `NEED_USER_INPUT`.
-4. `{iteration_dir}/phase_complete`.
+3. Run `"$AGENTICO_BIN" validate-artifacts --phase implement --role implementer --dir "{iteration_dir}"`; fix any reported issue and rerun before continuing.
+4. `{iteration_dir}/need-user-input.yaml` only when `progress.md` reports `NEED_USER_INPUT`.
+5. `{iteration_dir}/phase_complete`.
 
 `progress.md` must use this schema:
 


### PR DESCRIPTION
## What changed

- Added shared retry classification for early infrastructure session failures: failed session, no cost, no token usage, no message log, and under the retry duration threshold.
- Retried roadmap planning, phase planning, and bounded helper sessions with stable logical attempt directories and retry-specific session IDs.
- Cleared stale `phase_complete` markers before bounded-helper retries.
- Updated the implementer skill to run `agentico validate-artifacts` before writing `phase_complete`.

## Why

A provider child process can fail before doing useful work. Previously those failures consumed the logical planning/helper attempt and could surface as user-visible failures even though no model work happened.

## Impact

Transient zero-work infrastructure failures get retried in process while preserving existing attempt accounting and review/validation behavior. Implementer sessions also validate required artifacts before signaling completion.

## Verification

- Fast suite: `make test-fast` passed.
- Static checks: `go vet ./...` passed; `go build ./...` passed; `git diff --check` passed.
- E2E smoke shell: `bash test/e2e/smoke.sh` passed.
- E2E Go (TUI / teatest): `go test ./test/e2e/... -count=1 -race` passed.
- Isolated integration: `go test ./test/integration/... -count=1` failed on pre-existing tweak publish tests:
  - `TestCycleConflictPropagation_TweakConflict_OneRepoFailsAnotherSucceeds`: expected pull-rebase conflict error, got nil.
  - `TestTweakSession_MultiRepo_3Repo_TwoModified_OrchestratorCommitsAndPushes`: api/backend bare HEAD did not advance.
  - Baseline check: extracted `origin/main` to `/tmp/agentic-main-check-20260706` and reproduced `TestTweakSession_MultiRepo_3Repo_TwoModified_OrchestratorCommitsAndPushes` failing the same bare-HEAD assertions.
- Skipped Race regression: not run before draft PR; targeted E2E race gate was run for session lifecycle coverage.
