### PR TITLE
Allow customizing the provider CLI binary name

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -33,13 +33,32 @@ var validKeyboardLayouts = map[string]bool{
 }
 
 type Config struct {
-	Defaults        DefaultsConfig        `yaml:"defaults"`
-	Repos           map[string]RepoConfig `yaml:"repos"`
-	WorkspaceRoots  []string              `yaml:"workspace_roots,omitempty"`
-	DiscoveredRepos map[string]RepoConfig `yaml:"-"` // in-memory only, never persisted
-	Notifications   NotificationConfig    `yaml:"notifications,omitempty"`
-	UI              UIConfig              `yaml:"ui,omitempty"`
-	Observability   ObservabilityConfig   `yaml:"observability,omitempty"`
+	Defaults        DefaultsConfig            `yaml:"defaults"`
+	Repos           map[string]RepoConfig     `yaml:"repos"`
+	WorkspaceRoots  []string                  `yaml:"workspace_roots,omitempty"`
+	DiscoveredRepos map[string]RepoConfig     `yaml:"-"` // in-memory only, never persisted
+	Notifications   NotificationConfig        `yaml:"notifications,omitempty"`
+	UI              UIConfig                  `yaml:"ui,omitempty"`
+	Observability   ObservabilityConfig       `yaml:"observability,omitempty"`
+	Providers       map[string]ProviderConfig `yaml:"providers,omitempty"`
+}
+
+// ProviderConfig holds per-provider overrides. CLI overrides the executable
+// name (or path) Agentico invokes for that provider; when empty, the provider's
+// built-in default binary name is used.
+type ProviderConfig struct {
+	CLI string `yaml:"cli,omitempty"`
+}
+
+// ProviderCLI returns the configured CLI binary for a provider, or fallback
+// when no override is set.
+func (c *Config) ProviderCLI(name, fallback string) string {
+	if pc, ok := c.Providers[name]; ok {
+		if b := strings.TrimSpace(pc.CLI); b != "" {
+			return b
+		}
+	}
+	return fallback
 }
 
 // ObservabilityConfig controls JSONL event emission and OTel export.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1856,3 +1856,87 @@ func TestObservabilityConfig(t *testing.T) {
 		}
 	})
 }
+
+func TestProviderCLI_OverrideAndFallback(t *testing.T) {
+	tests := []struct {
+		name      string
+		providers map[string]ProviderConfig
+		key       string
+		fallback  string
+		want      string
+	}{
+		{
+			name:      "override set returns override",
+			providers: map[string]ProviderConfig{"claude": {CLI: "fcc-claude"}},
+			key:       "claude",
+			fallback:  "claude",
+			want:      "fcc-claude",
+		},
+		{
+			name:      "empty CLI returns fallback",
+			providers: map[string]ProviderConfig{"claude": {CLI: ""}},
+			key:       "claude",
+			fallback:  "claude",
+			want:      "claude",
+		},
+		{
+			name:      "whitespace CLI returns fallback",
+			providers: map[string]ProviderConfig{"claude": {CLI: "   "}},
+			key:       "claude",
+			fallback:  "claude",
+			want:      "claude",
+		},
+		{
+			name:      "key absent returns fallback",
+			providers: map[string]ProviderConfig{"codex": {CLI: "my-codex"}},
+			key:       "claude",
+			fallback:  "claude",
+			want:      "claude",
+		},
+		{
+			name:      "nil providers map returns fallback",
+			providers: nil,
+			key:       "claude",
+			fallback:  "claude",
+			want:      "claude",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := &Config{Providers: tc.providers}
+			if got := cfg.ProviderCLI(tc.key, tc.fallback); got != tc.want {
+				t.Errorf("ProviderCLI(%q, %q) = %q, want %q", tc.key, tc.fallback, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestProvidersRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+
+	original := NewDefault()
+	original.Providers = map[string]ProviderConfig{"claude": {CLI: "fcc-claude"}}
+	if err := Save(path, original); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	loaded, err := Load(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if got := loaded.ProviderCLI("claude", "claude"); got != "fcc-claude" {
+		t.Errorf("providers.claude.cli mismatch after round-trip: got %q, want fcc-claude", got)
+	}
+}
+
+func TestProvidersEmptyOmittedFromYAML(t *testing.T) {
+	data, err := yaml.Marshal(NewDefault())
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(data), "providers:") {
+		t.Errorf("empty Providers map should be omitted from YAML, got:\n%s", data)
+	}
+}

--- a/internal/llm/claude/discovery.go
+++ b/internal/llm/claude/discovery.go
@@ -58,6 +58,7 @@ func (p *Provider) DiscoverModelCatalogWithProgress(ctx context.Context, report 
 	if runner == nil {
 		runner = clirun.DefaultRunner()
 	}
+	binary := p.cliBinary()
 
 	candidates := claudeModelProbeCandidates()
 	results := make([]claudeModelProbeResult, len(candidates))
@@ -72,7 +73,7 @@ func (p *Provider) DiscoverModelCatalogWithProgress(ctx context.Context, report 
 				results[i] = claudeModelProbeResult{candidate: candidate, err: err}
 				return
 			}
-			resolved, contextWindow, err := probeClaudeModel(ctx, runner, candidate)
+			resolved, contextWindow, err := probeClaudeModel(ctx, runner, binary, candidate)
 			if err != nil {
 				results[i] = claudeModelProbeResult{candidate: candidate, err: err}
 				return
@@ -138,13 +139,13 @@ func reportClaudeModelDiscovery(report llm.ModelDiscoveryReporter, info llm.Mode
 	report(info)
 }
 
-func probeClaudeModel(ctx context.Context, runner clirun.CommandRunner, candidate claudeModelProbeCandidate) (string, int, error) {
+func probeClaudeModel(ctx context.Context, runner clirun.CommandRunner, binary string, candidate claudeModelProbeCandidate) (string, int, error) {
 	var lastErr error
 	for range claudeModelProbeAttempts {
 		if err := ctx.Err(); err != nil {
 			return "", 0, err
 		}
-		out, err := runner(ctx, "claude", claudeModelProbeArgs(candidate.Selector), nil)
+		out, err := runner(ctx, binary, claudeModelProbeArgs(candidate.Selector), nil)
 		if err != nil {
 			if ctx.Err() != nil {
 				return "", 0, ctx.Err()

--- a/internal/llm/claude/module.go
+++ b/internal/llm/claude/module.go
@@ -15,13 +15,15 @@
 package claude
 
 import (
+	"github.com/doordash-oss/agentic-orchestrator/internal/config"
 	"github.com/doordash-oss/agentic-orchestrator/internal/llm"
 	"go.uber.org/fx"
 )
 
-// Module registers the Claude provider in the LLM registry.
+// Module registers the Claude provider in the LLM registry, honoring an
+// optional CLI binary override from config (providers.claude.cli).
 var Module = fx.Module("llm-claude",
-	fx.Invoke(func(r *llm.Registry) {
-		r.Register(&Provider{})
+	fx.Invoke(func(r *llm.Registry, cfg *config.Config) {
+		r.Register(&Provider{binary: cfg.ProviderCLI("claude", defaultBinary)})
 	}),
 )

--- a/internal/llm/claude/provider.go
+++ b/internal/llm/claude/provider.go
@@ -26,14 +26,29 @@ import (
 	"github.com/doordash-oss/agentic-orchestrator/internal/llm/clirun"
 )
 
+// defaultBinary is the executable name Agentico invokes for Claude when no
+// override is configured.
+const defaultBinary = "claude"
+
 // Provider implements llm.LLMProvider for Claude Code CLI.
 type Provider struct {
 	mu      sync.RWMutex
 	catalog []llm.ModelInfo
 	runner  clirun.CommandRunner
+	// binary overrides the CLI executable name; empty means defaultBinary.
+	binary string
 }
 
 func (p *Provider) Name() string { return "claude" }
+
+// cliBinary returns the configured CLI executable name, falling back to the
+// provider default when no override is set.
+func (p *Provider) cliBinary() string {
+	if p.binary != "" {
+		return p.binary
+	}
+	return defaultBinary
+}
 
 func (p *Provider) MatchesModel(model string) bool {
 	p.mu.RLock()
@@ -57,7 +72,7 @@ func (p *Provider) MatchesModel(model string) bool {
 }
 
 func (p *Provider) DetectCLI() bool {
-	_, err := exec.LookPath("claude")
+	_, err := exec.LookPath(p.cliBinary())
 	return err == nil
 }
 
@@ -77,7 +92,7 @@ func (p *Provider) AvailableModels() []string {
 
 func (p *Provider) BuildCommand(opts llm.CommandBuildOpts) ([]string, []string, error) {
 	opts.Model = p.claudeCLIModel(opts.Model)
-	args := buildInteractiveCommand(opts)
+	args := buildInteractiveCommand(p.cliBinary(), opts)
 	return args, nil, nil
 }
 
@@ -148,9 +163,10 @@ func (p *Provider) InstallHint() string {
 }
 
 func (p *Provider) VersionInfo() (string, error) {
-	out, err := exec.Command("claude", "--version").CombinedOutput()
+	bin := p.cliBinary()
+	out, err := exec.Command(bin, "--version").CombinedOutput()
 	if err != nil {
-		return "", fmt.Errorf("failed to run 'claude --version': %w", err)
+		return "", fmt.Errorf("failed to run '%s --version': %w", bin, err)
 	}
 	return strings.TrimSpace(string(out)), nil
 }
@@ -172,7 +188,7 @@ func (p *Provider) CheckReadiness(ctx context.Context) llm.ProviderReadiness {
 	if runner == nil {
 		runner = clirun.DefaultRunner()
 	}
-	out, err := runner(ctx, "claude", []string{"auth", "status", "--json"}, nil)
+	out, err := runner(ctx, p.cliBinary(), []string{"auth", "status", "--json"}, nil)
 
 	var status authStatus
 	if parseErr := json.Unmarshal(out, &status); parseErr == nil {
@@ -243,9 +259,10 @@ func (p *Provider) CLIVersion() (string, error) {
 	if runner == nil {
 		runner = clirun.DefaultRunner()
 	}
-	out, err := runner(context.Background(), "claude", []string{"--version"}, nil)
+	bin := p.cliBinary()
+	out, err := runner(context.Background(), bin, []string{"--version"}, nil)
 	if err != nil {
-		return "", fmt.Errorf("running claude --version: %w", err)
+		return "", fmt.Errorf("running %s --version: %w", bin, err)
 	}
 	return clirun.ParseVersionOutput(out)
 }
@@ -367,8 +384,8 @@ func InsertAfterBinary(cmd []string, flags ...string) []string {
 	return result
 }
 
-func buildInteractiveCommand(opts llm.CommandBuildOpts) []string {
-	args := []string{"claude",
+func buildInteractiveCommand(binary string, opts llm.CommandBuildOpts) []string {
+	args := []string{binary,
 		"--model", opts.Model,
 		"--output-format", "stream-json",
 		"--input-format", "stream-json",

--- a/internal/llm/claude/provider_test.go
+++ b/internal/llm/claude/provider_test.go
@@ -596,7 +596,7 @@ func TestBuildInteractiveCommand_PermissionMode(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			args := buildInteractiveCommand(llm.CommandBuildOpts{
+			args := buildInteractiveCommand(defaultBinary, llm.CommandBuildOpts{
 				Model:          "opus",
 				PermissionMode: tc.mode,
 			})
@@ -622,7 +622,7 @@ func TestBuildInteractiveCommand_PermissionMode(t *testing.T) {
 // runtime permission handling, but --permission-mode still suppresses the
 // auto-mode system-reminder.
 func TestBuildInteractiveCommand_PermissionMode_CoexistsWithDSP(t *testing.T) {
-	args := buildInteractiveCommand(llm.CommandBuildOpts{
+	args := buildInteractiveCommand(defaultBinary, llm.CommandBuildOpts{
 		Model:                "opus",
 		DangerouslySkipPerms: true,
 		PermissionMode:       "default",
@@ -633,4 +633,73 @@ func TestBuildInteractiveCommand_PermissionMode_CoexistsWithDSP(t *testing.T) {
 	if !slices.Contains(args, "--permission-mode") {
 		t.Errorf("missing --permission-mode:\n%v", args)
 	}
+}
+
+func TestClaudeProvider_CLIBinaryDefault(t *testing.T) {
+	if got := (&Provider{}).cliBinary(); got != "claude" {
+		t.Errorf("cliBinary() = %q, want claude", got)
+	}
+}
+
+func TestClaudeProvider_BuildCommandUsesCustomBinary(t *testing.T) {
+	t.Run("default", func(t *testing.T) {
+		args, _, err := (&Provider{}).BuildCommand(llm.CommandBuildOpts{Model: "opus"})
+		if err != nil {
+			t.Fatalf("BuildCommand() error: %v", err)
+		}
+		if len(args) == 0 || args[0] != "claude" {
+			t.Errorf("args[0] = %q, want claude; args=%v", firstArg(args), args)
+		}
+	})
+	t.Run("override", func(t *testing.T) {
+		p := &Provider{binary: "fcc-claude"}
+		args, _, err := p.BuildCommand(llm.CommandBuildOpts{Model: "opus"})
+		if err != nil {
+			t.Fatalf("BuildCommand() error: %v", err)
+		}
+		if len(args) == 0 || args[0] != "fcc-claude" {
+			t.Errorf("args[0] = %q, want fcc-claude; args=%v", firstArg(args), args)
+		}
+	})
+}
+
+func TestClaudeProvider_CheckReadinessUsesCustomBinary(t *testing.T) {
+	var gotName string
+	p := &Provider{
+		binary: "fcc-claude",
+		runner: func(ctx context.Context, name string, args []string, env []string) ([]byte, error) {
+			gotName = name
+			return []byte(`{"loggedIn":true,"authMethod":"claude.ai","email":"user@example.com"}`), nil
+		},
+	}
+	if status := p.CheckReadiness(context.Background()); !status.Ready {
+		t.Fatalf("CheckReadiness().Ready = false, detail=%q", status.Detail)
+	}
+	if gotName != "fcc-claude" {
+		t.Errorf("CheckReadiness probed %q, want fcc-claude", gotName)
+	}
+}
+
+func TestClaudeProvider_CLIVersionUsesCustomBinary(t *testing.T) {
+	var gotName string
+	p := &Provider{
+		binary: "fcc-claude",
+		runner: func(ctx context.Context, name string, args []string, env []string) ([]byte, error) {
+			gotName = name
+			return []byte("2.1.81 (Claude Code)"), nil
+		},
+	}
+	if _, err := p.CLIVersion(); err != nil {
+		t.Fatalf("CLIVersion() error: %v", err)
+	}
+	if gotName != "fcc-claude" {
+		t.Errorf("CLIVersion probed %q, want fcc-claude", gotName)
+	}
+}
+
+func firstArg(args []string) string {
+	if len(args) == 0 {
+		return ""
+	}
+	return args[0]
 }

--- a/internal/llm/codex/discovery.go
+++ b/internal/llm/codex/discovery.go
@@ -52,8 +52,9 @@ func (p *Provider) DiscoverModelCatalogWithProgress(ctx context.Context, report 
 	if runner == nil {
 		runner = clirun.DefaultRunner()
 	}
+	binary := p.cliBinary()
 
-	out, err := runner(ctx, "codex", []string{"debug", "models"}, nil)
+	out, err := runner(ctx, binary, []string{"debug", "models"}, nil)
 	if err == nil {
 		models, parseErr := parseCodexModelCatalogWithProgress(out, report)
 		if parseErr == nil {
@@ -62,7 +63,7 @@ func (p *Provider) DiscoverModelCatalogWithProgress(ctx context.Context, report 
 		err = parseErr
 	}
 
-	bundled, bundledErr := runner(ctx, "codex", []string{"debug", "models", "--bundled"}, nil)
+	bundled, bundledErr := runner(ctx, binary, []string{"debug", "models", "--bundled"}, nil)
 	if bundledErr != nil {
 		return nil, fmt.Errorf("running codex debug models: %w; bundled fallback: %v", err, bundledErr)
 	}

--- a/internal/llm/codex/module.go
+++ b/internal/llm/codex/module.go
@@ -15,15 +15,17 @@
 package codex
 
 import (
+	"github.com/doordash-oss/agentic-orchestrator/internal/config"
 	"github.com/doordash-oss/agentic-orchestrator/internal/llm"
 	"go.uber.org/fx"
 )
 
 // Module registers the Codex provider in the LLM registry and exports it
-// for downstream modules (e.g. agent) to configure.
+// for downstream modules (e.g. agent) to configure. An optional CLI binary
+// override is read from config (providers.codex.cli).
 var Module = fx.Module("llm-codex",
-	fx.Provide(func() *Provider {
-		return &Provider{}
+	fx.Provide(func(cfg *config.Config) *Provider {
+		return &Provider{binary: cfg.ProviderCLI("codex", defaultBinary)}
 	}),
 	fx.Invoke(func(r *llm.Registry, p *Provider) {
 		r.Register(p)

--- a/internal/llm/codex/provider.go
+++ b/internal/llm/codex/provider.go
@@ -30,14 +30,29 @@ import (
 	"github.com/doordash-oss/agentic-orchestrator/internal/llm/clirun"
 )
 
+// defaultBinary is the executable name Agentico invokes for Codex when no
+// override is configured.
+const defaultBinary = "codex"
+
 // Provider implements llm.LLMProvider for the Codex CLI (app-server mode).
 type Provider struct {
 	mu      sync.RWMutex
 	catalog []llm.ModelInfo
 	runner  clirun.CommandRunner
+	// binary overrides the CLI executable name; empty means defaultBinary.
+	binary string
 }
 
 func (p *Provider) Name() string { return "codex" }
+
+// cliBinary returns the configured CLI executable name, falling back to the
+// provider default when no override is set.
+func (p *Provider) cliBinary() string {
+	if p.binary != "" {
+		return p.binary
+	}
+	return defaultBinary
+}
 
 func (p *Provider) MatchesModel(model string) bool {
 	p.mu.RLock()
@@ -61,7 +76,7 @@ func (p *Provider) MatchesModel(model string) bool {
 }
 
 func (p *Provider) DetectCLI() bool {
-	_, err := exec.LookPath("codex")
+	_, err := exec.LookPath(p.cliBinary())
 	return err == nil
 }
 
@@ -96,7 +111,7 @@ func MapEffortLevel(level llm.EffortLevel) string {
 
 func (p *Provider) BuildCommand(opts llm.CommandBuildOpts) ([]string, []string, error) {
 	// Interactive: app-server mode. Model/prompt delivered via JSON-RPC.
-	args := []string{"codex", "app-server"}
+	args := []string{p.cliBinary(), "app-server"}
 	if opts.EffortLevel != "" {
 		args = append(args, "-c", "model_reasoning_effort="+MapEffortLevel(opts.EffortLevel))
 	}
@@ -207,9 +222,10 @@ func (p *Provider) InstallHint() string {
 }
 
 func (p *Provider) VersionInfo() (string, error) {
-	out, err := exec.Command("codex", "--version").CombinedOutput()
+	bin := p.cliBinary()
+	out, err := exec.Command(bin, "--version").CombinedOutput()
 	if err != nil {
-		return "", fmt.Errorf("failed to run 'codex --version': %w", err)
+		return "", fmt.Errorf("failed to run '%s --version': %w", bin, err)
 	}
 	return strings.TrimSpace(string(out)), nil
 }
@@ -234,7 +250,7 @@ func (p *Provider) CheckReadiness(ctx context.Context) llm.ProviderReadiness {
 		// logged-in account look like empty status.
 		runner = clirun.CombinedRunner()
 	}
-	out, err := runner(ctx, "codex", []string{"login", "status"}, nil)
+	out, err := runner(ctx, p.cliBinary(), []string{"login", "status"}, nil)
 	text := strings.TrimSpace(string(out))
 	lower := strings.ToLower(text)
 
@@ -298,9 +314,10 @@ func (p *Provider) CLIVersion() (string, error) {
 	if runner == nil {
 		runner = clirun.DefaultRunner()
 	}
-	out, err := runner(context.Background(), "codex", []string{"--version"}, nil)
+	bin := p.cliBinary()
+	out, err := runner(context.Background(), bin, []string{"--version"}, nil)
 	if err != nil {
-		return "", fmt.Errorf("running codex --version: %w", err)
+		return "", fmt.Errorf("running %s --version: %w", bin, err)
 	}
 	return clirun.ParseVersionOutput(out)
 }

--- a/internal/llm/codex/provider_test.go
+++ b/internal/llm/codex/provider_test.go
@@ -692,3 +692,57 @@ func TestCodexProvider_ContextWindowForModel_ReturnsHardcodedWithoutSeed(t *test
 		})
 	}
 }
+
+func TestCodexProvider_CLIBinaryDefault(t *testing.T) {
+	if got := (&Provider{}).cliBinary(); got != "codex" {
+		t.Errorf("cliBinary() = %q, want codex", got)
+	}
+}
+
+func TestCodexProvider_BuildCommandUsesCustomBinary(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("CODEX_HOME", filepath.Join(homeDir, ".codex"))
+
+	tests := []struct {
+		name   string
+		binary string
+		want   string
+	}{
+		{name: "default", binary: "", want: "codex"},
+		{name: "override", binary: "my-codex", want: "my-codex"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &Provider{binary: tt.binary}
+			cmd, _, err := p.BuildCommand(llm.CommandBuildOpts{Model: "gpt-5.4"})
+			if err != nil {
+				t.Fatalf("BuildCommand() error: %v", err)
+			}
+			if len(cmd) < 2 || cmd[0] != tt.want || cmd[1] != "app-server" {
+				t.Fatalf("BuildCommand() cmd = %v, want [%s app-server ...]", cmd, tt.want)
+			}
+		})
+	}
+}
+
+func TestCodexProvider_CheckReadinessUsesCustomBinary(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("CODEX_HOME", filepath.Join(homeDir, ".codex"))
+
+	var gotName string
+	p := &Provider{
+		binary: "my-codex",
+		runner: func(ctx context.Context, name string, args []string, env []string) ([]byte, error) {
+			gotName = name
+			return []byte("Logged in using ChatGPT\n"), nil
+		},
+	}
+	if status := p.CheckReadiness(context.Background()); !status.Ready {
+		t.Fatalf("CheckReadiness().Ready = false, detail=%q", status.Detail)
+	}
+	if gotName != "my-codex" {
+		t.Errorf("CheckReadiness probed %q, want my-codex", gotName)
+	}
+}

--- a/internal/llm/opencode/discovery.go
+++ b/internal/llm/opencode/discovery.go
@@ -77,11 +77,12 @@ func (p *Provider) DiscoverModelCatalogWithProgress(ctx context.Context, report 
 		runner = clirun.DefaultRunner()
 	}
 
+	binary := p.cliBinary()
 	attempts := discoveryAttempts()
 	var lastErr error
 	for i, args := range attempts {
 		attemptCtx, cancel := discoveryAttemptContext(ctx, len(attempts)-i)
-		out, err := runner(attemptCtx, "opencode", args, nil)
+		out, err := runner(attemptCtx, binary, args, nil)
 		cancel()
 		if err != nil {
 			lastErr = fmt.Errorf(

--- a/internal/llm/opencode/managed.go
+++ b/internal/llm/opencode/managed.go
@@ -112,7 +112,7 @@ type managedAgent struct {
 // into the highest-precedence inline channel, and appends the inherited-surface
 // isolation environment. Any failure aborts before a launchable command exists
 // and returns a redacted, actionable error.
-func buildManagedSession(opts llm.CommandBuildOpts) (args, env []string, err error) {
+func buildManagedSession(binary string, opts llm.CommandBuildOpts) (args, env []string, err error) {
 	backend := BackendModel(opts.Model)
 	if err := validateBackendModel(backend); err != nil {
 		return nil, nil, err
@@ -137,7 +137,7 @@ func buildManagedSession(opts llm.CommandBuildOpts) (args, env []string, err err
 	}
 	applyEffort(&cfg, backend, opts.EffortLevel)
 
-	args = []string{"opencode", "acp"}
+	args = []string{binary, "acp"}
 
 	systemPrompt := opts.SystemPrompt
 	dir := managedSessionDir(opts.StateDir, sessionFingerprint(opts, backend))

--- a/internal/llm/opencode/module.go
+++ b/internal/llm/opencode/module.go
@@ -15,6 +15,7 @@
 package opencode
 
 import (
+	"github.com/doordash-oss/agentic-orchestrator/internal/config"
 	"github.com/doordash-oss/agentic-orchestrator/internal/llm"
 	"go.uber.org/fx"
 )
@@ -26,7 +27,9 @@ import (
 // registered and ready it discovers and contributes a model catalog like the
 // other providers.
 var Module = fx.Module("llm-opencode",
-	fx.Provide(New),
+	fx.Provide(func(cfg *config.Config) *Provider {
+		return NewWithBinary(cfg.ProviderCLI(providerName, defaultBinary))
+	}),
 	fx.Invoke(func(r *llm.Registry, p *Provider) {
 		r.Register(p)
 	}),

--- a/internal/llm/opencode/provider.go
+++ b/internal/llm/opencode/provider.go
@@ -66,6 +66,21 @@ type Provider struct {
 	catalog []llm.ModelInfo
 	rates   map[string]modelRate
 	runner  clirun.CommandRunner
+	// binary overrides the CLI executable name; empty means defaultBinary.
+	binary string
+}
+
+// defaultBinary is the executable name Agentico invokes for OpenCode when no
+// override is configured.
+const defaultBinary = "opencode"
+
+// cliBinary returns the configured CLI executable name, falling back to the
+// provider default when no override is set.
+func (p *Provider) cliBinary() string {
+	if p.binary != "" {
+		return p.binary
+	}
+	return defaultBinary
 }
 
 // modelRate holds the per-million-token pricing discovered for one backend
@@ -77,8 +92,14 @@ type modelRate struct {
 	outputPerMToken float64
 }
 
-// New returns a Provider with the default (production) command runner.
+// New returns a Provider with the default (production) command runner and the
+// default CLI binary name.
 func New() *Provider { return &Provider{} }
+
+// NewWithBinary returns a Provider that invokes the supplied CLI binary name
+// (or the default when empty). It is the constructor used by the FX module to
+// honor the providers.opencode.cli config override.
+func NewWithBinary(binary string) *Provider { return &Provider{binary: binary} }
 
 // NewWithRunner returns a Provider that uses the supplied command runner for its
 // version, readiness, and model-discovery probes instead of shelling out to the
@@ -145,7 +166,7 @@ func (p *Provider) catalogContains(model string) bool {
 
 // DetectCLI reports whether the OpenCode CLI binary is available in PATH.
 func (p *Provider) DetectCLI() bool {
-	_, err := exec.LookPath("opencode")
+	_, err := exec.LookPath(p.cliBinary())
 	return err == nil
 }
 
@@ -181,7 +202,7 @@ func (p *Provider) AvailableModels() []string {
 // none of which mutates the user's global OpenCode configuration. Any build
 // failure aborts before a launchable command exists. See buildManagedSession.
 func (p *Provider) BuildCommand(opts llm.CommandBuildOpts) ([]string, []string, error) {
-	return buildManagedSession(opts)
+	return buildManagedSession(p.cliBinary(), opts)
 }
 
 // validateBackendModel reports whether a stripped OpenCode backend model is a
@@ -277,9 +298,10 @@ func (p *Provider) VersionInfo() (string, error) {
 	if runner == nil {
 		runner = clirun.DefaultRunner()
 	}
-	out, err := runner(context.Background(), "opencode", []string{"--version"}, nil)
+	bin := p.cliBinary()
+	out, err := runner(context.Background(), bin, []string{"--version"}, nil)
 	if err != nil {
-		return "", fmt.Errorf("failed to run 'opencode --version': %w", err)
+		return "", fmt.Errorf("failed to run '%s --version': %w", bin, err)
 	}
 	version, err := clirun.ParseVersionOutput(out)
 	if err != nil {
@@ -493,7 +515,7 @@ func (p *Provider) CheckReadiness(ctx context.Context) llm.ProviderReadiness {
 		runner = clirun.DefaultRunner()
 	}
 
-	out, err := runner(ctx, "opencode", []string{"models"}, nil)
+	out, err := runner(ctx, p.cliBinary(), []string{"models"}, nil)
 	if err != nil {
 		if ctx.Err() == context.DeadlineExceeded {
 			return llm.ProviderReadiness{

--- a/internal/llm/opencode/provider_test.go
+++ b/internal/llm/opencode/provider_test.go
@@ -229,6 +229,26 @@ func TestBuildCommand_ACPStdioWithModelEnv(t *testing.T) {
 	}
 }
 
+func TestOpenCodeProvider_CLIBinaryDefault(t *testing.T) {
+	if got := New().cliBinary(); got != "opencode" {
+		t.Errorf("cliBinary() = %q, want opencode", got)
+	}
+	if got := NewWithBinary("").cliBinary(); got != "opencode" {
+		t.Errorf("NewWithBinary(\"\").cliBinary() = %q, want opencode", got)
+	}
+}
+
+func TestOpenCodeProvider_BuildCommandUsesCustomBinary(t *testing.T) {
+	p := NewWithBinary("my-opencode")
+	cmd, _, err := p.BuildCommand(llm.CommandBuildOpts{Model: "anthropic/claude-sonnet-4-5"})
+	if err != nil {
+		t.Fatalf("BuildCommand() error: %v", err)
+	}
+	if !slices.Equal(cmd, []string{"my-opencode", "acp"}) {
+		t.Fatalf("BuildCommand() cmd = %v, want [my-opencode acp]", cmd)
+	}
+}
+
 func TestBuildCommand_StripsRoutingPrefixBeforeModelEnv(t *testing.T) {
 	// Defensive: even if the routing-prefixed form reaches BuildCommand, the
 	// prefix is stripped exactly once before being handed to OpenCode.

--- a/skills/chat/user-guide/configuration.md
+++ b/skills/chat/user-guide/configuration.md
@@ -66,6 +66,20 @@ Agentic Orchestrator needs at least one authenticated provider CLI. Claude, Code
 
 Restrict the orchestrator to the CLIs you actually have with `--providers <list>` (e.g. `--providers claude,codex,opencode` or `--providers opencode`). With no flag, every installed and ready provider is registered.
 
+### Custom CLI binary
+
+Each provider invokes a default executable name (`claude`, `codex`, `opencode`). Override the binary Agentico launches with the `providers.<name>.cli` setting — useful when the CLI is installed under a different name or wrapped by a launcher script:
+
+```yaml
+providers:
+  claude:
+    cli: fcc-claude
+  codex:
+    cli: /opt/tools/bin/codex
+```
+
+The value can be a bare name resolved on `PATH` or an absolute path. It applies everywhere Agentico shells out to that provider — CLI detection, authentication/readiness checks, version checks, model discovery, and session launch — so the custom binary must be on `PATH` (or given as an absolute path) and behave like the provider CLI it replaces. When unset, the built-in default name is used, so existing configs are unaffected.
+
 ### OpenCode
 
 Install OpenCode from [opencode.ai](https://opencode.ai) (`curl -fsSL https://opencode.ai/install | bash`) and authenticate a backend provider with `opencode auth login`. OpenCode is a router in front of a backend model (Anthropic, OpenAI, Google, a local Ollama model, and so on); Agentico selects it with the explicit `opencode:<backend/model>` prefix or a bare slash-form backend id, as documented under [Model Configuration](#opencode-model-ids).


### PR DESCRIPTION
## Summary

Each provider (Claude, Codex, OpenCode) previously hardcoded the executable name it launches (`claude`, `codex`, `opencode`). This adds a `providers.<name>.cli` config option so users can point Agentico at a differently-named or wrapped binary — e.g. call `fcc-claude` instead of `claude`.

## Rationale

Some environments install the agent CLI under a different name, wrap it in a launcher script, or ship it at an absolute path. There was no way to customize this short of shadowing the binary on `PATH`. This follows the project's existing customization pattern: user-facing options live in `config.yaml` (env vars are only used for third-party CLI conventions, terminal detection, and test gates), and providers are constructed via their FX modules.

## Changes

- **Config**: new `providers` map with a per-provider `ProviderConfig{ cli }` and a `Config.ProviderCLI(name, fallback)` helper. Empty/absent overrides fall back to the built-in default, and an empty map is omitted from YAML, so existing configs are unaffected.
- **Providers**: each provider gains a `binary` field (set from config in its FX `module.go`) and a `cliBinary()` resolver. All hardcoded binary literals are replaced across every call site that shells out — `DetectCLI`, `BuildCommand`, readiness/auth checks, `VersionInfo`/`CLIVersion`, and model discovery — plus the OpenCode `buildManagedSession` and Claude `buildInteractiveCommand` helpers.
- **Docs**: documented `providers.<name>.cli` under Provider Selection in the configuration guide.

Config example:

```yaml
providers:
  claude:
    cli: fcc-claude
  codex:
    cli: /opt/tools/bin/codex
```

The session/exec layer already runs `command[0]`, so no changes were needed there. Because empty `binary` falls back to today's literal, all existing tests and default behavior are unchanged.

## Test plan

- [x] Unit tests: `ProviderCLI` (override / empty / whitespace / absent / nil map), providers YAML round-trip + omit-when-empty, and per-provider `cliBinary()` default + custom-binary assertions for `BuildCommand`/readiness/version across claude, codex, and opencode.
- [x] `go build ./...`
- [x] `go vet ./...`

## Verification

- Fast suite (`make test-fast`) — 12s, pass
- E2E smoke shell (`bash test/e2e/smoke.sh`) — pass (touches launch behavior)
- Skipped Isolated integration / E2E Go (TUI) / Race regression: change is a read-only per-provider field with no lifecycle, TUI, or concurrency impact.

Made with Cursor