### PR TITLE
[codex] Update generated signature label

### DIFF
--- a/internal/git/signature.go
+++ b/internal/git/signature.go
@@ -24,10 +24,10 @@ const (
 	CommitSignatureTrailer = "Generated-by: Agentic (" + AgenticURL + ")"
 
 	// PRSignature is the markdown signature appended to PR bodies and comments.
-	PRSignature = "\n\n---\n\n*Generated with [Agentic](" + AgenticURL + ")*"
+	PRSignature = "\n\n---\n\n*Generated with [agentic orchestrator](" + AgenticURL + ")*"
 )
 
-// InjectPRSignature appends the Agentic signature to a PR body or comment.
+// InjectPRSignature appends the agentic orchestrator signature to a PR body or comment.
 // Idempotent — skips if the signature is already present.
 func InjectPRSignature(body string) string {
 	if strings.Contains(body, PRSignature) {

--- a/internal/git/signature_test.go
+++ b/internal/git/signature_test.go
@@ -98,7 +98,10 @@ func TestConstants(t *testing.T) {
 	if !strings.Contains(CommitSignatureTrailer, "Generated-by: Agentic") {
 		t.Errorf("CommitSignatureTrailer should contain 'Generated-by: Agentic'")
 	}
-	if !strings.Contains(PRSignature, "Generated with [Agentic]") {
-		t.Errorf("PRSignature should contain 'Generated with [Agentic]'")
+	if !strings.Contains(PRSignature, "Generated with [agentic orchestrator]") {
+		t.Errorf("PRSignature should contain 'Generated with [agentic orchestrator]'")
+	}
+	if strings.Contains(PRSignature, "Generated with [Agentic]") {
+		t.Errorf("PRSignature should not contain legacy 'Generated with [Agentic]' label")
 	}
 }


### PR DESCRIPTION
## Summary

- Update the shared Markdown signature for generated PR descriptions and review comments to say `agentic orchestrator`.
- Add a regression assertion so the legacy `Generated with [Agentic]` footer label is rejected.

## Root Cause

The shared `PRSignature` constant in `internal/git/signature.go` was hardcoded to `Generated with [Agentic]`. Both PR publication and review-comment replies call `InjectPRSignature`, so the old label appeared in both generated surfaces.

## Impact

Generated PR descriptions and review comments now attribute output as `Generated with agentic orchestrator` while preserving the existing repository link.

## Verification

- `go test ./internal/git -run TestConstants -count=1`
- `go test ./internal/git -count=1`
- Fast suite: `make test-fast`
- `go vet ./...`
- `go build ./...`