### PR TITLE
Add per-phase extra instructions from config

### DIFF
--- a/cmd/agentico/main.go
+++ b/cmd/agentico/main.go
@@ -811,6 +811,14 @@ func runTUI(configPath, stateDir string, dangerouslySkipPerms bool, enabledProvi
 	}
 	stop()
 
+	// Load operator-provided per-phase extra instructions. Missing/unreadable
+	// files only warn; startup continues without them.
+	extraInstructions, extraWarnings := agent.LoadPhaseExtraInstructions(cfg.Defaults.PhaseExtraInstructions, filepath.Dir(configPath))
+	for _, w := range extraWarnings {
+		fmt.Fprintln(os.Stderr, w)
+	}
+	agent.SetPhaseExtraInstructions(extraInstructions)
+
 	// Provider-generic version check (replaces old CheckCLIVersion)
 	for _, vr := range agent.CheckProviderVersions(detected) {
 		if vr.Err != nil {

--- a/internal/agent/phase_extra_instructions.go
+++ b/internal/agent/phase_extra_instructions.go
@@ -1,0 +1,133 @@
+// Copyright 2026 DoorDash, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agent
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/doordash-oss/agentic-orchestrator/internal/config"
+	"github.com/doordash-oss/agentic-orchestrator/internal/feature"
+)
+
+// phaseExtraInstructions holds operator-provided per-phase instruction text,
+// keyed by feature.Phase.InstructionKey(). It is process-global, immutable
+// startup configuration: set once via SetPhaseExtraInstructions before any
+// session launches and only read thereafter (during system-prompt
+// composition in BuildRoleSystemPrompt). A nil map means no phase has extra
+// instructions.
+var phaseExtraInstructions map[string]string
+
+// SetPhaseExtraInstructions installs the process-wide per-phase extra
+// instruction map. Call once at startup with the result of
+// LoadPhaseExtraInstructions. Passing nil clears it.
+func SetPhaseExtraInstructions(m map[string]string) {
+	phaseExtraInstructions = m
+}
+
+// PhaseExtraInstruction returns the operator instruction text configured for
+// the given phase, or "" when none is set. Safe to call when no instructions
+// were configured.
+func PhaseExtraInstruction(p feature.Phase) string {
+	if phaseExtraInstructions == nil {
+		return ""
+	}
+	return phaseExtraInstructions[p.InstructionKey()]
+}
+
+// LoadPhaseExtraInstructions reads the operator-provided per-phase extra
+// instruction files named in config.Defaults.PhaseExtraInstructions and
+// returns a map keyed by feature.Phase.InstructionKey() -> file contents.
+//
+// configDir is the directory of the config file; relative paths are resolved
+// against it. Paths may also be absolute or "~/"-prefixed.
+//
+// This is intentionally non-fatal at bootstrap: an unknown phase key, an
+// unreadable/missing file, or an empty file produces a warning (returned in
+// the second result) and is skipped so startup continues. Returns a nil map
+// when nothing valid was loaded.
+func LoadPhaseExtraInstructions(configured map[string]string, configDir string) (map[string]string, []string) {
+	if len(configured) == 0 {
+		return nil, nil
+	}
+
+	var warnings []string
+	result := make(map[string]string, len(configured))
+
+	for key, rawPath := range configured {
+		phase, ok := feature.PhaseFromInstructionKey(key)
+		if !ok {
+			warnings = append(warnings, fmt.Sprintf(
+				"Warning: phase_extra_instructions: unknown phase key %q; skipping", key))
+			continue
+		}
+
+		path := strings.TrimSpace(rawPath)
+		if path == "" {
+			warnings = append(warnings, fmt.Sprintf(
+				"Warning: phase_extra_instructions[%s]: empty path; skipping", key))
+			continue
+		}
+		path = config.ExpandHome(path)
+		if !filepath.IsAbs(path) && configDir != "" {
+			path = filepath.Join(configDir, path)
+		}
+
+		data, err := os.ReadFile(path)
+		if err != nil {
+			warnings = append(warnings, fmt.Sprintf(
+				"Warning: phase_extra_instructions[%s]: could not read %q: %v; skipping", key, path, err))
+			continue
+		}
+
+		if looksBinary(data) {
+			warnings = append(warnings, fmt.Sprintf(
+				"Warning: phase_extra_instructions[%s]: file %q is not a UTF-8 text file (binary content); skipping", key, path))
+			continue
+		}
+
+		content := strings.TrimSpace(string(data))
+		if content == "" {
+			warnings = append(warnings, fmt.Sprintf(
+				"Warning: phase_extra_instructions[%s]: file %q is empty; skipping", key, path))
+			continue
+		}
+
+		result[phase.InstructionKey()] = content
+	}
+
+	if len(result) == 0 {
+		return nil, warnings
+	}
+	return result, warnings
+}
+
+// looksBinary reports whether data is unsuitable for injection into a text
+// prompt. It flags any NUL byte (the classic binary marker, matching git's
+// heuristic) and any content that is not valid UTF-8. Empty input is treated
+// as text so the caller's dedicated empty-file check handles it.
+func looksBinary(data []byte) bool {
+	if len(data) == 0 {
+		return false
+	}
+	if bytes.IndexByte(data, 0) >= 0 {
+		return true
+	}
+	return !utf8.Valid(data)
+}

--- a/internal/agent/phase_extra_instructions_test.go
+++ b/internal/agent/phase_extra_instructions_test.go
@@ -1,0 +1,170 @@
+// Copyright 2026 DoorDash, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/doordash-oss/agentic-orchestrator/internal/feature"
+)
+
+func TestLoadPhaseExtraInstructions(t *testing.T) {
+	// Not parallel: no globals touched here, but keep consistent with the
+	// package-global accessor tests below.
+	dir := t.TempDir()
+	planPath := filepath.Join(dir, "plan-extra.md")
+	if err := os.WriteFile(planPath, []byte("  Always include a rollback section.\n"), 0o644); err != nil {
+		t.Fatalf("write plan file: %v", err)
+	}
+	emptyPath := filepath.Join(dir, "empty.md")
+	if err := os.WriteFile(emptyPath, []byte("   \n"), 0o644); err != nil {
+		t.Fatalf("write empty file: %v", err)
+	}
+
+	configured := map[string]string{
+		"plan":        "plan-extra.md",               // relative -> resolved against configDir
+		"implement":   filepath.Join(dir, "nope.md"), // missing -> warn + skip
+		"review":      emptyPath,                     // empty -> warn + skip
+		"not_a_phase": planPath,                      // unknown key -> warn + skip
+	}
+
+	got, warnings := LoadPhaseExtraInstructions(configured, dir)
+
+	if len(got) != 1 {
+		t.Fatalf("expected 1 loaded entry, got %d: %v", len(got), got)
+	}
+	if got[feature.PhasePlan.InstructionKey()] != "Always include a rollback section." {
+		t.Fatalf("plan content not trimmed/loaded correctly: %q", got[feature.PhasePlan.InstructionKey()])
+	}
+	if _, ok := got["implement"]; ok {
+		t.Fatalf("missing file should have been skipped")
+	}
+	// One warning each for: missing file, empty file, unknown key.
+	if len(warnings) != 3 {
+		t.Fatalf("expected 3 warnings, got %d: %v", len(warnings), warnings)
+	}
+}
+
+func TestLoadPhaseExtraInstructionsRejectsBinary(t *testing.T) {
+	dir := t.TempDir()
+
+	nulPath := filepath.Join(dir, "nul.md")
+	if err := os.WriteFile(nulPath, []byte("plan text\x00more"), 0o644); err != nil {
+		t.Fatalf("write nul file: %v", err)
+	}
+	invalidUTF8Path := filepath.Join(dir, "invalid.md")
+	if err := os.WriteFile(invalidUTF8Path, []byte{0xff, 0xfe, 0xfd, 0xfc}, 0o644); err != nil {
+		t.Fatalf("write invalid utf8 file: %v", err)
+	}
+
+	configured := map[string]string{
+		"plan":      nulPath,
+		"implement": invalidUTF8Path,
+	}
+
+	got, warnings := LoadPhaseExtraInstructions(configured, dir)
+
+	if len(got) != 0 {
+		t.Fatalf("binary files should have been skipped, got %d entries: %v", len(got), got)
+	}
+	if len(warnings) != 2 {
+		t.Fatalf("expected 2 binary warnings, got %d: %v", len(warnings), warnings)
+	}
+	for _, w := range warnings {
+		if !strings.Contains(w, "binary content") {
+			t.Errorf("warning should mention binary content: %q", w)
+		}
+	}
+}
+
+func TestLooksBinary(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		data []byte
+		want bool
+	}{
+		{"empty", nil, false},
+		{"plain ascii", []byte("hello world"), false},
+		{"valid utf8", []byte("caffè — 日本語"), false},
+		{"nul byte", []byte("abc\x00def"), true},
+		{"invalid utf8", []byte{0xff, 0xfe}, true},
+	}
+	for _, tt := range tests {
+		if got := looksBinary(tt.data); got != tt.want {
+			t.Errorf("looksBinary(%q) = %v, want %v", tt.name, got, tt.want)
+		}
+	}
+}
+
+func TestLoadPhaseExtraInstructionsEmptyConfig(t *testing.T) {
+	got, warnings := LoadPhaseExtraInstructions(nil, "/tmp")
+	if got != nil || warnings != nil {
+		t.Fatalf("nil config should yield (nil, nil), got (%v, %v)", got, warnings)
+	}
+}
+
+func TestPhaseExtraInstructionAccessor(t *testing.T) {
+	orig := phaseExtraInstructions
+	t.Cleanup(func() { SetPhaseExtraInstructions(orig) })
+
+	SetPhaseExtraInstructions(nil)
+	if PhaseExtraInstruction(feature.PhasePlan) != "" {
+		t.Fatalf("nil store should return empty string")
+	}
+
+	SetPhaseExtraInstructions(map[string]string{
+		feature.PhaseImplement.InstructionKey(): "Prefer table-driven tests.",
+	})
+	if got := PhaseExtraInstruction(feature.PhaseImplement); got != "Prefer table-driven tests." {
+		t.Fatalf("PhaseExtraInstruction(implement) = %q", got)
+	}
+	if got := PhaseExtraInstruction(feature.PhasePlan); got != "" {
+		t.Fatalf("unconfigured phase should return empty, got %q", got)
+	}
+}
+
+func TestBuildRoleSystemPromptRendersPhaseExtraInstructions(t *testing.T) {
+	orig := phaseExtraInstructions
+	t.Cleanup(func() { SetPhaseExtraInstructions(orig) })
+
+	SetPhaseExtraInstructions(map[string]string{
+		feature.PhaseImplement.InstructionKey(): "Never touch generated files.",
+	})
+
+	got := BuildImplementSystemPrompt(BuildImplementSystemPromptInput{
+		IterationDir: "/state/feat-x/run-001/phase-01/implement/iteration-01",
+		SkillsDir:    "/skills",
+	})
+	if !strings.Contains(got, "## Operator Instructions (Highest Priority)") {
+		t.Fatalf("implement system prompt missing operator section:\n%s", got)
+	}
+	if !strings.Contains(got, "Never touch generated files.") {
+		t.Fatalf("implement system prompt missing operator text:\n%s", got)
+	}
+
+	// A phase with no configured instructions renders no operator section.
+	reviewPrompt := BuildRoleSystemPrompt(BuildRoleSystemPromptInput{
+		Spec:         FinalReviewerRoleSpec(),
+		IterationDir: "/state/feat-x/run-001/review/iteration-01",
+		SkillsDir:    "/skills",
+	})
+	if strings.Contains(reviewPrompt, "## Operator Instructions") {
+		t.Fatalf("unconfigured phase should not render operator section:\n%s", reviewPrompt)
+	}
+}

--- a/internal/agent/prompts/prompts_test.go
+++ b/internal/agent/prompts/prompts_test.go
@@ -682,6 +682,38 @@ func TestRoleSystemPromptGatesSubagentClause(t *testing.T) {
 	}
 }
 
+func TestRoleSystemPromptOperatorInstructions(t *testing.T) {
+	base := RoleSystemInput{
+		OutputRoots: []OutputRootView{{Name: "phase_dir", Path: "/state/feat-x/x"}},
+		MarkerPath:  "/state/feat-x/x/phase_complete",
+	}
+
+	const header = "## Operator Instructions (Highest Priority)"
+
+	// Empty: no section, and the prompt must still end at the asking clause
+	// slot (no trailing operator block).
+	empty := RoleSystemPrompt(base)
+	if strings.Contains(empty, header) {
+		t.Fatalf("empty ExtraInstructions rendered the operator section:\n%s", empty)
+	}
+
+	// Set: section present, positioned after the asking clause, and carries
+	// the operator text verbatim.
+	withExtra := base
+	withExtra.AskingClause = "## Asking Questions\n\nAsk via provider."
+	withExtra.ExtraInstructions = "Always write commit messages in haiku."
+	got := RoleSystemPrompt(withExtra)
+	if !strings.Contains(got, header) {
+		t.Fatalf("ExtraInstructions set but operator section missing:\n%s", got)
+	}
+	if !strings.Contains(got, "Always write commit messages in haiku.") {
+		t.Fatalf("operator instruction text missing:\n%s", got)
+	}
+	if strings.Index(got, header) < strings.Index(got, "## Asking Questions") {
+		t.Fatalf("operator section should render after the asking clause (recency slot):\n%s", got)
+	}
+}
+
 func TestLegacyPromptSurfacesAreRemoved(t *testing.T) {
 	removedPaths := []string{
 		filepath.Join("templates", "system_completion_protocol.tmpl"),

--- a/internal/agent/prompts/templates/system.tmpl
+++ b/internal/agent/prompts/templates/system.tmpl
@@ -80,4 +80,12 @@ In addition to the skill(s) already loaded in your system instructions, the foll
 {{ end }}
 {{ end }}{{ end }}
 {{ .AskingClause }}
+{{- if .ExtraInstructions }}
+
+## Operator Instructions (Highest Priority)
+
+The following instructions were provided by the operator for this phase. Treat them as the highest priority; where they conflict with any earlier guidance, follow these.
+
+{{ .ExtraInstructions }}
+{{- end }}
 {{- end -}}

--- a/internal/agent/prompts/types.go
+++ b/internal/agent/prompts/types.go
@@ -82,6 +82,12 @@ type RoleSystemInput struct {
 	SubagentsAvailable bool
 
 	AskingClause string
+
+	// ExtraInstructions is operator-provided text (from a per-phase markdown
+	// file) rendered as the final, highest-priority section of the system
+	// prompt. Empty suppresses the section entirely so default renders are
+	// unchanged.
+	ExtraInstructions string
 }
 
 // PreflightInput is the data passed to the RoleSpec system template's

--- a/internal/agent/rolespec_prompt.go
+++ b/internal/agent/rolespec_prompt.go
@@ -93,6 +93,7 @@ func BuildRoleSystemPrompt(in BuildRoleSystemPromptInput) string {
 		ReadOnlyOutsideRoots: spec.ReadOnlyOutsideRoots,
 		SubagentsAvailable:   !in.SuppressSubagents,
 		AskingClause:         askingClause,
+		ExtraInstructions:    PhaseExtraInstruction(spec.Phase),
 	})
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -87,6 +87,13 @@ type DefaultsConfig struct {
 	MaxConsecutiveNoProgress int                           `yaml:"max_consecutive_no_progress"`
 	MaxPhasePlanIterations   int                           `yaml:"max_phase_plan_iterations,omitempty"`
 	Checkpoints              Checkpoints                   `yaml:"checkpoints"`
+	// PhaseExtraInstructions maps a lifecycle phase key (e.g. "research",
+	// "plan", "implement", "review", "final_review", "publish", "design",
+	// "inquire", "knowledge_base") to a path to a markdown file whose contents
+	// are appended to that phase's system prompt as the highest-priority
+	// section. Paths may be absolute, "~/"-prefixed, or relative to the config
+	// file's directory. Missing files are logged and skipped at startup.
+	PhaseExtraInstructions map[string]string `yaml:"phase_extra_instructions,omitempty"`
 }
 
 // PipelinePreference stores the last-used feature-creation settings for a

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -87,12 +87,14 @@ type DefaultsConfig struct {
 	MaxConsecutiveNoProgress int                           `yaml:"max_consecutive_no_progress"`
 	MaxPhasePlanIterations   int                           `yaml:"max_phase_plan_iterations,omitempty"`
 	Checkpoints              Checkpoints                   `yaml:"checkpoints"`
-	// PhaseExtraInstructions maps a lifecycle phase key (e.g. "research",
-	// "plan", "implement", "review", "final_review", "publish", "design",
-	// "inquire", "knowledge_base") to a path to a markdown file whose contents
-	// are appended to that phase's system prompt as the highest-priority
-	// section. Paths may be absolute, "~/"-prefixed, or relative to the config
-	// file's directory. Missing files are logged and skipped at startup.
+	// PhaseExtraInstructions maps a lifecycle phase key to a path to a markdown
+	// file whose contents are appended to that phase's system prompt as the
+	// highest-priority section. Accepted keys: "knowledge_base", "inquire",
+	// "research", "design", "plan", "implement", "review" (the "review" key
+	// also governs the final-review pass, which shares the review RoleSpec).
+	// Paths may be absolute, "~/"-prefixed, or relative to the config file's
+	// directory. Missing/unreadable/binary files and unknown keys are logged
+	// and skipped at startup.
 	PhaseExtraInstructions map[string]string `yaml:"phase_extra_instructions,omitempty"`
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -159,6 +159,31 @@ func TestSaveAndLoad(t *testing.T) {
 	}
 }
 
+func TestLoadPhaseExtraInstructions(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+
+	original := NewDefault()
+	original.Defaults.PhaseExtraInstructions = map[string]string{
+		"plan":      "./prompts/plan-extra.md",
+		"implement": "~/agentico/impl.md",
+	}
+
+	if err := Save(path, original); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	loaded, err := Load(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if got := loaded.Defaults.PhaseExtraInstructions["plan"]; got != "./prompts/plan-extra.md" {
+		t.Errorf("plan path mismatch: got %q", got)
+	}
+	if got := loaded.Defaults.PhaseExtraInstructions["implement"]; got != "~/agentico/impl.md" {
+		t.Errorf("implement path mismatch: got %q", got)
+	}
+}
+
 func TestLoadOrCreate(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.yaml")

--- a/internal/feature/feature.go
+++ b/internal/feature/feature.go
@@ -149,10 +149,16 @@ func (p Phase) DirName() string {
 	}
 }
 
-// InstructionKey returns the stable, collision-free config key used to attach
-// per-phase extra instructions (config.Defaults.PhaseExtraInstructions).
-// Unlike DirName, PhaseReview and PhaseFinalReview map to distinct keys so an
-// operator can target the deferred end-of-feature review pass separately.
+// InstructionKey returns the stable config key used to attach per-phase extra
+// instructions (config.Defaults.PhaseExtraInstructions).
+//
+// Only phases whose sessions are composed through BuildRoleSystemPrompt are
+// operator-addressable and return a non-empty key. PhaseFinalReview and
+// PhasePublish return "" on purpose: final review/fix sessions run under the
+// PhaseReview RoleSpec (so the "review" key already governs them), and publish
+// builds no system prompt at all. Returning "" keeps them out of the
+// accepted-key set so a misconfigured entry warns instead of silently
+// no-op'ing.
 func (p Phase) InstructionKey() string {
 	switch p {
 	case PhaseKnowledgeBase:
@@ -169,17 +175,14 @@ func (p Phase) InstructionKey() string {
 		return "implement"
 	case PhaseReview:
 		return "review"
-	case PhaseFinalReview:
-		return "final_review"
-	case PhasePublish:
-		return "publish"
 	default:
 		return ""
 	}
 }
 
 // PhaseFromInstructionKey resolves a lifecycle phase from its InstructionKey.
-// The bool is false for unknown keys so callers can warn on typos.
+// The bool is false for unknown or non-addressable keys (e.g. "final_review",
+// "publish") so callers can warn on typos and unsupported phases.
 func PhaseFromInstructionKey(key string) (Phase, bool) {
 	switch key {
 	case "knowledge_base":
@@ -196,10 +199,6 @@ func PhaseFromInstructionKey(key string) (Phase, bool) {
 		return PhaseImplement, true
 	case "review":
 		return PhaseReview, true
-	case "final_review":
-		return PhaseFinalReview, true
-	case "publish":
-		return PhasePublish, true
 	default:
 		return Phase(0), false
 	}

--- a/internal/feature/feature.go
+++ b/internal/feature/feature.go
@@ -149,6 +149,62 @@ func (p Phase) DirName() string {
 	}
 }
 
+// InstructionKey returns the stable, collision-free config key used to attach
+// per-phase extra instructions (config.Defaults.PhaseExtraInstructions).
+// Unlike DirName, PhaseReview and PhaseFinalReview map to distinct keys so an
+// operator can target the deferred end-of-feature review pass separately.
+func (p Phase) InstructionKey() string {
+	switch p {
+	case PhaseKnowledgeBase:
+		return "knowledge_base"
+	case PhaseInquire:
+		return "inquire"
+	case PhaseResearch:
+		return "research"
+	case PhaseDesign:
+		return "design"
+	case PhasePlan:
+		return "plan"
+	case PhaseImplement:
+		return "implement"
+	case PhaseReview:
+		return "review"
+	case PhaseFinalReview:
+		return "final_review"
+	case PhasePublish:
+		return "publish"
+	default:
+		return ""
+	}
+}
+
+// PhaseFromInstructionKey resolves a lifecycle phase from its InstructionKey.
+// The bool is false for unknown keys so callers can warn on typos.
+func PhaseFromInstructionKey(key string) (Phase, bool) {
+	switch key {
+	case "knowledge_base":
+		return PhaseKnowledgeBase, true
+	case "inquire":
+		return PhaseInquire, true
+	case "research":
+		return PhaseResearch, true
+	case "design":
+		return PhaseDesign, true
+	case "plan":
+		return PhasePlan, true
+	case "implement":
+		return PhaseImplement, true
+	case "review":
+		return PhaseReview, true
+	case "final_review":
+		return PhaseFinalReview, true
+	case "publish":
+		return PhasePublish, true
+	default:
+		return Phase(0), false
+	}
+}
+
 // RequiresGrilling reports whether a phase relies on the [grill-me] directive
 // — i.e. whether its prompt expects the agent to interview the user. Used by
 // session builders to override the user's Claude Code "auto" default mode,

--- a/internal/feature/feature_test.go
+++ b/internal/feature/feature_test.go
@@ -243,8 +243,6 @@ func TestPhaseInstructionKeyRoundTrip(t *testing.T) {
 		PhasePlan,
 		PhaseImplement,
 		PhaseReview,
-		PhaseFinalReview,
-		PhasePublish,
 	}
 	seen := make(map[string]Phase, len(phases))
 	for _, p := range phases {
@@ -263,14 +261,20 @@ func TestPhaseInstructionKeyRoundTrip(t *testing.T) {
 		}
 	}
 
-	// Review and FinalReview must be distinct keys even though they share a
-	// DirName.
-	if PhaseReview.InstructionKey() == PhaseFinalReview.InstructionKey() {
-		t.Fatalf("review and final_review must have distinct instruction keys")
+	// PhaseFinalReview and PhasePublish are not operator-addressable: final
+	// review runs under the PhaseReview RoleSpec (the "review" key covers it)
+	// and publish builds no system prompt. They must yield an empty key and be
+	// rejected as config keys so a misconfigured entry warns instead of
+	// silently no-op'ing.
+	for _, p := range []Phase{PhaseFinalReview, PhasePublish} {
+		if got := p.InstructionKey(); got != "" {
+			t.Errorf("Phase(%d).InstructionKey() = %q, want empty (not addressable)", p, got)
+		}
 	}
-
-	if _, ok := PhaseFromInstructionKey("nonsense"); ok {
-		t.Fatalf("PhaseFromInstructionKey(unknown) should return ok=false")
+	for _, key := range []string{"final_review", "publish", "nonsense"} {
+		if _, ok := PhaseFromInstructionKey(key); ok {
+			t.Errorf("PhaseFromInstructionKey(%q) should return ok=false", key)
+		}
 	}
 }
 

--- a/internal/feature/feature_test.go
+++ b/internal/feature/feature_test.go
@@ -232,6 +232,48 @@ func TestPhaseDirName(t *testing.T) {
 	}
 }
 
+func TestPhaseInstructionKeyRoundTrip(t *testing.T) {
+	t.Parallel()
+	// parallel-candidate: pure value, table-driven, no shared state.
+	phases := []Phase{
+		PhaseKnowledgeBase,
+		PhaseInquire,
+		PhaseResearch,
+		PhaseDesign,
+		PhasePlan,
+		PhaseImplement,
+		PhaseReview,
+		PhaseFinalReview,
+		PhasePublish,
+	}
+	seen := make(map[string]Phase, len(phases))
+	for _, p := range phases {
+		key := p.InstructionKey()
+		if key == "" {
+			t.Errorf("Phase(%d).InstructionKey() is empty", p)
+			continue
+		}
+		if prev, dup := seen[key]; dup {
+			t.Errorf("InstructionKey %q collides between Phase(%d) and Phase(%d)", key, prev, p)
+		}
+		seen[key] = p
+		got, ok := PhaseFromInstructionKey(key)
+		if !ok || got != p {
+			t.Errorf("PhaseFromInstructionKey(%q) = (%d, %v), want (%d, true)", key, got, ok, p)
+		}
+	}
+
+	// Review and FinalReview must be distinct keys even though they share a
+	// DirName.
+	if PhaseReview.InstructionKey() == PhaseFinalReview.InstructionKey() {
+		t.Fatalf("review and final_review must have distinct instruction keys")
+	}
+
+	if _, ok := PhaseFromInstructionKey("nonsense"); ok {
+		t.Fatalf("PhaseFromInstructionKey(unknown) should return ok=false")
+	}
+}
+
 func TestStatusString(t *testing.T) {
 	t.Parallel()
 	// parallel-candidate: pure value, table-driven, or per-test temp-dir assertions with no shared state.

--- a/skills/chat/user-guide/configuration.md
+++ b/skills/chat/user-guide/configuration.md
@@ -148,6 +148,33 @@ defaults:
 
 A markdown checklist included in implementation prompts as success criteria. Customize this to match your project's quality standards.
 
+## Phase Extra Instructions
+
+Append your own markdown to a specific phase's system prompt. Each entry maps a
+lifecycle phase to a markdown file whose contents are added as the final,
+highest-priority section of that phase's system prompt.
+
+```yaml
+defaults:
+  phase_extra_instructions:
+    research: ./prompts/research-extra.md
+    plan: ~/agentico/plan-extra.md
+    implement: /abs/path/implement-extra.md
+```
+
+Accepted phase keys: `knowledge_base`, `inquire`, `research`, `design`, `plan`,
+`implement`, `review`, `final_review`, `publish`.
+
+Notes:
+
+- Paths may be absolute, `~/`-prefixed, or relative to the config file's directory.
+- The file contents are placed at the end of the system prompt, where they get
+  the strongest attention, under an "Operator Instructions (Highest Priority)"
+  header.
+- A missing, unreadable, empty, or non-text/binary file (or an unknown phase
+  key) only logs a warning at startup and is skipped — Agentico continues
+  without it. Files must be valid UTF-8 text with no NUL bytes.
+
 ## Workspace Roots
 
 ```yaml

--- a/skills/chat/user-guide/configuration.md
+++ b/skills/chat/user-guide/configuration.md
@@ -163,7 +163,9 @@ defaults:
 ```
 
 Accepted phase keys: `knowledge_base`, `inquire`, `research`, `design`, `plan`,
-`implement`, `review`, `final_review`, `publish`.
+`implement`, `review`. The `review` key also applies to the final-review pass,
+which runs under the same review role. (Publish has no agent prompt, so it is
+not configurable here.)
 
 Notes:
 


### PR DESCRIPTION
## Summary

Adds a way for operators to inject their own guidance into a lifecycle phase's prompt without editing embedded templates.

- New `defaults.phase_extra_instructions` map in `config.yaml`: keys are lifecycle phase names (`knowledge_base`, `inquire`, `research`, `design`, `plan`, `implement`, `review`), values are paths to markdown files.
- The file contents are appended to that phase's system prompt as the final, highest-priority section (`## Operator Instructions (Highest Priority)`), which is the strongest recency slot for instruction adherence. The top-of-prompt turn-ending protocol is left untouched.
- Loading is non-fatal at startup: a missing, unreadable, empty, binary (NUL byte or non-UTF-8), or unknown/unsupported-phase-key entry logs a warning and is skipped so bootstrap continues. Paths may be absolute, `~/`-prefixed, or relative to the config file's directory.

## Design notes

- The instruction map is a set-once package value read during system-prompt composition in `BuildRoleSystemPrompt`. Every primary phase session picks it up (including implement, which delegates through `BuildImplementSystemPrompt` -> `BuildRoleSystemPrompt`) without threading a new field through 6+ loop-config structs and their ~20 construction sites. Validators and other bounded helpers do not go through that function and are intentionally unaffected.
- Only phases whose sessions are composed through `BuildRoleSystemPrompt` are operator-addressable. `final_review` and `publish` are intentionally **not** accepted keys: final review/fix sessions run under the `PhaseReview` RoleSpec (so the `review` key already governs them) and publish builds no system prompt. Configuring an unsupported key produces a startup warning rather than a silent no-op.
- The template block is inert when nothing is configured, so existing prompt goldens are byte-identical.

## Example

```yaml
defaults:
  phase_extra_instructions:
    research: ./prompts/research-extra.md
    plan: ~/agentico/plan-extra.md
    implement: /abs/path/implement-extra.md
```

## Test plan

- [x] `internal/feature`: `InstructionKey` / `PhaseFromInstructionKey` round-trip for addressable phases; `final_review`/`publish` yield empty key and are rejected
- [x] `internal/config`: parses `phase_extra_instructions`
- [x] `internal/agent`: loader covers happy path (relative resolution + trim), missing file, empty file, unknown key, and binary rejection (NUL byte + invalid UTF-8); plus `looksBinary` unit table
- [x] `internal/agent`: `BuildRoleSystemPrompt`/`BuildImplementSystemPrompt` render the operator section when configured and omit it otherwise
- [x] `internal/agent/prompts`: operator section renders after the asking clause when set, absent when empty
- [x] Prompt goldens regenerated: no diff (template inert when unconfigured)

## Verification

- Fast suite (`make test-fast`): pass, 11s
- `go vet ./...`: clean
- `go build ./...`: clean
- Regenerated goldens (`go test ./internal/agent/prompts/... -update`): no diff
- Reviewed locally with `codex exec review --base main`; addressed its P2 finding (unsupported `final_review`/`publish` keys).
- Skipped E2E smoke / integration / race / TUI-observability tiers: change does not touch launch behavior, lifecycle/state-machine, concurrency, or TUI wiring; prompt composition is covered by unit tests.