### PR TITLE
Add configurable exponential backoff for rate-limited phase retries

### DIFF
--- a/internal/agent/protocol_retry.go
+++ b/internal/agent/protocol_retry.go
@@ -16,6 +16,8 @@ package agent
 
 import (
 	"fmt"
+	"math"
+	"math/rand"
 	"os"
 	"path/filepath"
 	"strings"
@@ -50,6 +52,10 @@ type ProtocolRetrySidecar struct {
 	Consecutive   int       `yaml:"consecutive"`
 	LastViolation string    `yaml:"last_violation"`
 	UpdatedAt     time.Time `yaml:"updated_at"`
+	// RateLimited records whether the current violation streak was classified
+	// as an upstream rate-limit failure (and therefore governed by the
+	// larger rate-limit budget and exponential backoff).
+	RateLimited bool `yaml:"rate_limited,omitempty"`
 }
 
 // ProtocolRetryDecision tells the caller whether to succeed, retry, or fail terminally.
@@ -58,6 +64,108 @@ type ProtocolRetryDecision struct {
 	Consecutive    int
 	FormattedError string
 	NewSidecar     *ProtocolRetrySidecar
+	// RetryDelay is how long the caller should wait before restarting the
+	// phase. It is non-zero only for rate-limit-classified retries under an
+	// enabled RateLimitRetryPolicy; all other retries are immediate.
+	RetryDelay time.Duration
+}
+
+// RateLimitRetryPolicy tunes the bounded exponential backoff applied to
+// rate-limit-classified protocol violations. The zero value is inert; callers
+// build one via DefaultRateLimitRetryPolicy or from config. Numeric zero
+// fields fall back to defaults at decision time so partially-specified
+// policies stay safe.
+type RateLimitRetryPolicy struct {
+	Enabled    bool
+	MaxRetries int
+	BaseDelay  time.Duration
+	MaxDelay   time.Duration
+	Multiplier float64
+	Jitter     float64
+
+	// jitterFn, when set, replaces the default RNG for jitter. It must return
+	// a value in [-1, 1]. Test-only seam for deterministic backoff assertions.
+	jitterFn func() float64
+}
+
+// DefaultRateLimitRetryPolicy returns the built-in backoff policy: enabled, a
+// 6-attempt budget, 15s base doubling up to a 5m cap, with 20% jitter.
+func DefaultRateLimitRetryPolicy() RateLimitRetryPolicy {
+	return RateLimitRetryPolicy{
+		Enabled:    true,
+		MaxRetries: 6,
+		BaseDelay:  15 * time.Second,
+		MaxDelay:   5 * time.Minute,
+		Multiplier: 2.0,
+		Jitter:     0.2,
+	}
+}
+
+// WithJitterFn returns a copy of the policy with a deterministic jitter
+// source. Intended for tests.
+func (p RateLimitRetryPolicy) WithJitterFn(fn func() float64) RateLimitRetryPolicy {
+	p.jitterFn = fn
+	return p
+}
+
+// withDefaults fills numeric zero/invalid fields from the built-in defaults,
+// leaving Enabled and the jitter seam untouched.
+func (p RateLimitRetryPolicy) withDefaults() RateLimitRetryPolicy {
+	d := DefaultRateLimitRetryPolicy()
+	if p.MaxRetries <= 0 {
+		p.MaxRetries = d.MaxRetries
+	}
+	if p.BaseDelay <= 0 {
+		p.BaseDelay = d.BaseDelay
+	}
+	if p.MaxDelay <= 0 {
+		p.MaxDelay = d.MaxDelay
+	}
+	if p.MaxDelay < p.BaseDelay {
+		p.MaxDelay = p.BaseDelay
+	}
+	if p.Multiplier <= 1 {
+		p.Multiplier = d.Multiplier
+	}
+	if p.Jitter < 0 {
+		p.Jitter = 0
+	}
+	return p
+}
+
+// backoffDelay computes the delay for the given 1-based consecutive attempt:
+// base * multiplier^(consecutive-1), clamped to MaxDelay, then randomized by
+// +/- Jitter. Assumes withDefaults has been applied.
+func (p RateLimitRetryPolicy) backoffDelay(consecutive int) time.Duration {
+	if consecutive < 1 {
+		consecutive = 1
+	}
+	grown := float64(p.BaseDelay) * math.Pow(p.Multiplier, float64(consecutive-1))
+	maxD := float64(p.MaxDelay)
+	if grown > maxD || math.IsInf(grown, 1) {
+		grown = maxD
+	}
+	if p.Jitter > 0 {
+		grown *= 1 + p.Jitter*p.jitterFraction()
+	}
+	if grown < 0 {
+		grown = 0
+	}
+	return time.Duration(grown)
+}
+
+func (p RateLimitRetryPolicy) jitterFraction() float64 {
+	if p.jitterFn != nil {
+		f := p.jitterFn()
+		if f < -1 {
+			return -1
+		}
+		if f > 1 {
+			return 1
+		}
+		return f
+	}
+	return rand.Float64()*2 - 1 //nolint:gosec // jitter does not need crypto-grade randomness
 }
 
 // ReadProtocolRetrySidecar reads a retry sidecar from dir. Missing files are not errors.
@@ -155,7 +263,9 @@ func RemovePhaseCompleteMarker(dir string) error {
 	return fmt.Errorf("removing phase_complete marker: %w", err)
 }
 
-// DecideProtocolRetry computes the bounded retry action for protocol violations.
+// DecideProtocolRetry computes the bounded retry action for protocol
+// violations using the default immediate-retry policy (no backoff). Callers
+// that want rate-limit-aware backoff use DecideProtocolRetryWithRateLimit.
 func DecideProtocolRetry(
 	role Role,
 	phaseDir string,
@@ -163,6 +273,37 @@ func DecideProtocolRetry(
 	sidecar *ProtocolRetrySidecar,
 	violations []ProtocolViolation,
 	maxConsecutive int,
+) ProtocolRetryDecision {
+	return decideProtocolRetry(role, phaseDir, currentActiveRun, sidecar, violations, maxConsecutive, false, RateLimitRetryPolicy{})
+}
+
+// DecideProtocolRetryWithRateLimit is DecideProtocolRetry plus rate-limit
+// awareness. When isRateLimit is true and policy.Enabled is set, the decision
+// uses the policy's larger MaxRetries budget as the cap and returns an
+// exponential RetryDelay; otherwise it behaves identically to
+// DecideProtocolRetry (immediate retry, defaultMaxConsecutive cap).
+func DecideProtocolRetryWithRateLimit(
+	role Role,
+	phaseDir string,
+	currentActiveRun int,
+	sidecar *ProtocolRetrySidecar,
+	violations []ProtocolViolation,
+	defaultMaxConsecutive int,
+	isRateLimit bool,
+	policy RateLimitRetryPolicy,
+) ProtocolRetryDecision {
+	return decideProtocolRetry(role, phaseDir, currentActiveRun, sidecar, violations, defaultMaxConsecutive, isRateLimit, policy)
+}
+
+func decideProtocolRetry(
+	role Role,
+	phaseDir string,
+	currentActiveRun int,
+	sidecar *ProtocolRetrySidecar,
+	violations []ProtocolViolation,
+	maxConsecutive int,
+	isRateLimit bool,
+	policy RateLimitRetryPolicy,
 ) ProtocolRetryDecision {
 	if len(violations) == 0 {
 		return ProtocolRetryDecision{Action: ProtocolRetryActionSucceed}
@@ -178,9 +319,22 @@ func DecideProtocolRetry(
 		cap = DefaultMaxConsecutiveProtocolViolations
 	}
 
+	// Rate-limit failures get a larger budget and exponential backoff, but
+	// only when the policy is enabled. A disabled policy degrades to the
+	// default immediate-retry path even for rate-limit classifications.
+	rateLimited := isRateLimit && policy.Enabled
+	var retryDelay time.Duration
+	if rateLimited {
+		pol := policy.withDefaults()
+		cap = pol.MaxRetries
+		retryDelay = pol.backoffDelay(consecutive)
+	}
+
 	action := ProtocolRetryActionRetry
 	if consecutive >= cap {
 		action = ProtocolRetryActionTerminal
+		// No point waiting before a terminal failure.
+		retryDelay = 0
 	}
 
 	lastViolation := JoinProtocolViolations(violations)
@@ -188,12 +342,14 @@ func DecideProtocolRetry(
 		Action:         action,
 		Consecutive:    consecutive,
 		FormattedError: FormatSingleShotProtocolViolationError(role, phaseDir, violations),
+		RetryDelay:     retryDelay,
 		NewSidecar: &ProtocolRetrySidecar{
 			Role:          role,
 			ActiveRun:     currentActiveRun,
 			Consecutive:   consecutive,
 			LastViolation: lastViolation,
 			UpdatedAt:     time.Now().UTC().Round(0),
+			RateLimited:   rateLimited,
 		},
 	}
 }

--- a/internal/agent/protocol_retry_ratelimit_test.go
+++ b/internal/agent/protocol_retry_ratelimit_test.go
@@ -1,0 +1,253 @@
+// Copyright 2026 DoorDash, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agent
+
+import (
+	"testing"
+	"time"
+)
+
+var rlViolations = []ProtocolViolation{{Artifact: PhaseCompleteFile, Reason: "missing"}}
+
+// noJitter is a deterministic jitter source (fraction 0 => nominal delay).
+func noJitterPolicy() RateLimitRetryPolicy {
+	return RateLimitRetryPolicy{
+		Enabled:    true,
+		MaxRetries: 6,
+		BaseDelay:  time.Second,
+		MaxDelay:   time.Hour,
+		Multiplier: 2.0,
+		Jitter:     0,
+	}.WithJitterFn(func() float64 { return 0 })
+}
+
+func researcherSidecar(activeRun, consecutive int, rateLimited bool) *ProtocolRetrySidecar {
+	return &ProtocolRetrySidecar{
+		Role:        RoleResearcher,
+		ActiveRun:   activeRun,
+		Consecutive: consecutive,
+		RateLimited: rateLimited,
+	}
+}
+
+func decideRL(sidecar *ProtocolRetrySidecar, isRateLimit bool, policy RateLimitRetryPolicy) ProtocolRetryDecision {
+	return DecideProtocolRetryWithRateLimit(
+		RoleResearcher, "/dir", 1, sidecar, rlViolations,
+		DefaultMaxConsecutiveProtocolViolations, isRateLimit, policy,
+	)
+}
+
+func TestDecideProtocolRetry_NonRateLimit_UnchangedCap3(t *testing.T) {
+	t.Parallel()
+	policy := noJitterPolicy()
+
+	// consecutive 1 and 2 retry, delay always zero.
+	for _, prior := range []int{0, 1} {
+		var sc *ProtocolRetrySidecar
+		if prior > 0 {
+			sc = researcherSidecar(1, prior, false)
+		}
+		got := decideRL(sc, false, policy)
+		if got.Action != ProtocolRetryActionRetry {
+			t.Fatalf("prior=%d Action = %v, want Retry", prior, got.Action)
+		}
+		if got.RetryDelay != 0 {
+			t.Errorf("prior=%d RetryDelay = %v, want 0 (non-rate-limit is immediate)", prior, got.RetryDelay)
+		}
+		if got.NewSidecar.RateLimited {
+			t.Errorf("prior=%d NewSidecar.RateLimited = true, want false", prior)
+		}
+	}
+
+	// third consecutive terminates at the default cap.
+	got := decideRL(researcherSidecar(1, 2, false), false, policy)
+	if got.Action != ProtocolRetryActionTerminal {
+		t.Fatalf("Action = %v, want Terminal at cap %d", got.Action, DefaultMaxConsecutiveProtocolViolations)
+	}
+}
+
+func TestDecideProtocolRetry_RateLimit_UsesLargerCap(t *testing.T) {
+	t.Parallel()
+	policy := noJitterPolicy() // MaxRetries=6
+
+	// consecutive 3, 4, 5 still retry (past the default cap of 3).
+	for _, prior := range []int{2, 3, 4} {
+		got := decideRL(researcherSidecar(1, prior, true), true, policy)
+		if got.Action != ProtocolRetryActionRetry {
+			t.Errorf("prior=%d Action = %v, want Retry under rate-limit cap 6", prior, got.Action)
+		}
+		if !got.NewSidecar.RateLimited {
+			t.Errorf("prior=%d NewSidecar.RateLimited = false, want true", prior)
+		}
+	}
+
+	// sixth consecutive hits the rate-limit cap and terminates.
+	got := decideRL(researcherSidecar(1, 5, true), true, policy)
+	if got.Action != ProtocolRetryActionTerminal {
+		t.Fatalf("Action = %v, want Terminal at rate-limit cap 6", got.Action)
+	}
+	if got.RetryDelay != 0 {
+		t.Errorf("terminal RetryDelay = %v, want 0", got.RetryDelay)
+	}
+}
+
+func TestDecideProtocolRetry_ExponentialGrowth(t *testing.T) {
+	t.Parallel()
+	policy := noJitterPolicy() // base 1s, mult 2, no jitter
+
+	cases := []struct {
+		prior int
+		want  time.Duration
+	}{
+		{prior: 0, want: 1 * time.Second},
+		{prior: 1, want: 2 * time.Second},
+		{prior: 2, want: 4 * time.Second},
+		{prior: 3, want: 8 * time.Second},
+	}
+	for _, c := range cases {
+		var sc *ProtocolRetrySidecar
+		if c.prior > 0 {
+			sc = researcherSidecar(1, c.prior, true)
+		}
+		got := decideRL(sc, true, policy)
+		if got.RetryDelay != c.want {
+			t.Errorf("prior=%d RetryDelay = %v, want %v", c.prior, got.RetryDelay, c.want)
+		}
+	}
+}
+
+func TestDecideProtocolRetry_MaxDelayClamp(t *testing.T) {
+	t.Parallel()
+	policy := RateLimitRetryPolicy{
+		Enabled:    true,
+		MaxRetries: 20,
+		BaseDelay:  time.Second,
+		MaxDelay:   5 * time.Second,
+		Multiplier: 2.0,
+		Jitter:     0,
+	}.WithJitterFn(func() float64 { return 0 })
+
+	// prior=4 => 1s*2^4 = 16s, clamped to 5s.
+	got := decideRL(researcherSidecar(1, 4, true), true, policy)
+	if got.RetryDelay != 5*time.Second {
+		t.Errorf("RetryDelay = %v, want clamp to 5s", got.RetryDelay)
+	}
+}
+
+func TestDecideProtocolRetry_JitterBounds(t *testing.T) {
+	t.Parallel()
+	// Deterministic jitter source cycling extreme and mid fractions.
+	fracs := []float64{-1, -0.5, 0, 0.5, 1, 0.9, -0.9}
+	i := 0
+	policy := RateLimitRetryPolicy{
+		Enabled:    true,
+		MaxRetries: 10,
+		BaseDelay:  10 * time.Second,
+		MaxDelay:   time.Hour,
+		Multiplier: 2.0,
+		Jitter:     0.2,
+	}.WithJitterFn(func() float64 {
+		f := fracs[i%len(fracs)]
+		i++
+		return f
+	})
+
+	nominal := 10 * time.Second // prior=0
+	lo := time.Duration(float64(nominal) * 0.8)
+	hi := time.Duration(float64(nominal) * 1.2)
+	for n := 0; n < len(fracs); n++ {
+		got := decideRL(nil, true, policy)
+		if got.RetryDelay < lo || got.RetryDelay > hi {
+			t.Errorf("iter %d RetryDelay = %v, want within [%v, %v]", n, got.RetryDelay, lo, hi)
+		}
+	}
+}
+
+func TestDecideProtocolRetry_PolicyDisabled(t *testing.T) {
+	t.Parallel()
+	policy := noJitterPolicy()
+	policy.Enabled = false
+
+	// Even though isRateLimit is true, a disabled policy behaves like the
+	// default immediate path: cap 3, zero delay, sidecar not rate-limited.
+	got := decideRL(researcherSidecar(1, 2, false), true, policy)
+	if got.Action != ProtocolRetryActionTerminal {
+		t.Errorf("Action = %v, want Terminal at default cap 3 when disabled", got.Action)
+	}
+	got = decideRL(nil, true, policy)
+	if got.RetryDelay != 0 {
+		t.Errorf("RetryDelay = %v, want 0 when disabled", got.RetryDelay)
+	}
+	if got.NewSidecar.RateLimited {
+		t.Error("NewSidecar.RateLimited = true, want false when disabled")
+	}
+}
+
+func TestDecideProtocolRetry_ZeroValuesFallBackToDefaults(t *testing.T) {
+	t.Parallel()
+	// Enabled but everything else zero: withDefaults should supply sane
+	// values so a retry is produced with a positive delay and the default
+	// rate-limit budget (6) rather than terminating immediately.
+	policy := RateLimitRetryPolicy{Enabled: true}.WithJitterFn(func() float64 { return 0 })
+
+	got := decideRL(nil, true, policy)
+	if got.Action != ProtocolRetryActionRetry {
+		t.Fatalf("Action = %v, want Retry", got.Action)
+	}
+	if got.RetryDelay <= 0 {
+		t.Errorf("RetryDelay = %v, want positive default base delay", got.RetryDelay)
+	}
+
+	// consecutive 5 still retries under the default cap of 6.
+	got = decideRL(researcherSidecar(1, 4, true), true, policy)
+	if got.Action != ProtocolRetryActionRetry {
+		t.Errorf("Action = %v, want Retry under default cap 6", got.Action)
+	}
+}
+
+func TestDecideProtocolRetry_SidecarRateLimitedPersisted(t *testing.T) {
+	t.Parallel()
+	policy := noJitterPolicy()
+
+	got := decideRL(researcherSidecar(1, 1, true), true, policy)
+	if got.Consecutive != 2 {
+		t.Errorf("Consecutive = %d, want 2 (streak continuity)", got.Consecutive)
+	}
+	if !got.NewSidecar.RateLimited {
+		t.Error("NewSidecar.RateLimited = false, want true")
+	}
+}
+
+func TestDecideProtocolRetry_SidecarRateLimitedRoundTrip(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	want := ProtocolRetrySidecar{
+		Role:        RoleResearcher,
+		ActiveRun:   3,
+		Consecutive: 2,
+		RateLimited: true,
+		UpdatedAt:   time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC),
+	}
+	if err := WriteProtocolRetrySidecar(dir, want); err != nil {
+		t.Fatalf("WriteProtocolRetrySidecar() error = %v", err)
+	}
+	got, err := ReadProtocolRetrySidecar(dir)
+	if err != nil {
+		t.Fatalf("ReadProtocolRetrySidecar() error = %v", err)
+	}
+	if got == nil || !got.RateLimited {
+		t.Fatalf("round-trip RateLimited = %v, want true", got)
+	}
+}

--- a/internal/agent/rate_limit.go
+++ b/internal/agent/rate_limit.go
@@ -1,0 +1,53 @@
+// Copyright 2026 DoorDash, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agent
+
+import "strings"
+
+// RateLimitSignatures is the case-insensitive substring set that marks an
+// upstream rate-limit / capacity failure across the supported model CLIs
+// (Claude "rate limit"/"429", Codex "Usage limit exceeded"/"Server
+// overloaded", and the shared "[rate_limit]" transcript marker). It is an
+// exported package var so new provider phrasings or HTTP codes can be added
+// with a single-line append without touching the matcher.
+var RateLimitSignatures = []string{
+	"429",
+	"rate limit",
+	"ratelimit",
+	"rate_limit",
+	"too many requests",
+	"overloaded",
+	"usage limit exceeded",
+	"quota",
+}
+
+// IsRateLimitError reports whether text contains any known rate-limit
+// signature. Matching is case-insensitive and substring-based so it works on
+// raw CLI error strings and full session transcripts alike.
+func IsRateLimitError(text string) bool {
+	if strings.TrimSpace(text) == "" {
+		return false
+	}
+	lower := strings.ToLower(text)
+	for _, sig := range RateLimitSignatures {
+		if sig == "" {
+			continue
+		}
+		if strings.Contains(lower, strings.ToLower(sig)) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/agent/rate_limit_test.go
+++ b/internal/agent/rate_limit_test.go
@@ -1,0 +1,75 @@
+// Copyright 2026 DoorDash, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agent
+
+import "testing"
+
+func TestIsRateLimitError(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		text string
+		want bool
+	}{
+		{name: "claude_rate_limit_429", text: "API rate limit exceeded (429)", want: true},
+		{name: "http_429_too_many_requests", text: "HTTP 429 Too Many Requests", want: true},
+		{name: "underscore_marker", text: "[rate_limit] resets in 12s", want: true},
+		{name: "spaced_lowercase", text: "the model hit a rate limit, retrying", want: true},
+		{name: "mixed_case_ratelimit", text: "RateLimit reached for org", want: true},
+		{name: "codex_usage_limit", text: "Usage limit exceeded", want: true},
+		{name: "codex_usage_limit_mixed_case", text: "USAGE LIMIT EXCEEDED for account", want: true},
+		{name: "server_overloaded", text: "Server overloaded (529)", want: true},
+		{name: "quota", text: "quota exceeded for this project", want: true},
+		{name: "digits_429_substring_matches", text: "error code 4291", want: true},
+
+		{name: "empty", text: "", want: false},
+		{name: "whitespace_only", text: "   \n\t ", want: false},
+		{name: "missing_phase_complete", text: "phase_complete was missing", want: false},
+		{name: "contract_failed", text: "contract validation failed", want: false},
+		{name: "file_not_found", text: "open research.md: no such file or directory", want: false},
+		{name: "generic_500", text: "internal server error 500", want: false},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := IsRateLimitError(tt.text); got != tt.want {
+				t.Errorf("IsRateLimitError(%q) = %v, want %v", tt.text, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestRateLimitSignaturesExtensible guards the "keep it open for future codes/
+// messages" requirement without mutating the shared package global (which
+// would race the parallel table test above): the signature set is a non-empty
+// exported var and every entry — including any future addition — is honored by
+// the classifier, case-insensitively and as a substring.
+func TestRateLimitSignaturesExtensible(t *testing.T) {
+	t.Parallel()
+	if len(RateLimitSignatures) == 0 {
+		t.Fatal("RateLimitSignatures must not be empty")
+	}
+	for _, sig := range RateLimitSignatures {
+		if sig == "" {
+			t.Error("RateLimitSignatures must not contain empty entries")
+			continue
+		}
+		if !IsRateLimitError("upstream said: " + sig + " (retry later)") {
+			t.Errorf("signature %q not honored by IsRateLimitError", sig)
+		}
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -106,6 +106,32 @@ type DefaultsConfig struct {
 	MaxConsecutiveNoProgress int                           `yaml:"max_consecutive_no_progress"`
 	MaxPhasePlanIterations   int                           `yaml:"max_phase_plan_iterations,omitempty"`
 	Checkpoints              Checkpoints                   `yaml:"checkpoints"`
+	RateLimitRetry           RateLimitRetryConfig          `yaml:"rate_limit_retry,omitempty"`
+}
+
+// RateLimitRetryConfig tunes the bounded exponential backoff applied when an
+// artifact phase (inquire/research/design) fails its completion contract
+// because the upstream model rate-limited the agent (HTTP 429 and friends).
+// Non-rate-limit protocol violations are unaffected and keep their immediate,
+// small-budget retry behavior. Delays are expressed as Go duration strings
+// (for example "15s", "5m") so they round-trip cleanly through YAML.
+type RateLimitRetryConfig struct {
+	// Enabled turns rate-limit-aware backoff on. When false, rate-limit
+	// violations fall back to the default immediate retry path.
+	Enabled bool `yaml:"enabled"`
+	// MaxRetries is the consecutive rate-limit violation budget before the
+	// feature fails terminally. Larger than the default protocol-violation
+	// cap so a transient rate limit has room to clear.
+	MaxRetries int `yaml:"max_retries,omitempty"`
+	// BaseDelay is the first backoff interval (Go duration string).
+	BaseDelay string `yaml:"base_delay,omitempty"`
+	// MaxDelay caps the exponential growth (Go duration string).
+	MaxDelay string `yaml:"max_delay,omitempty"`
+	// Multiplier is the exponential growth factor between attempts.
+	Multiplier float64 `yaml:"multiplier,omitempty"`
+	// Jitter is the fractional randomization applied to each delay in the
+	// range [0,1]; 0.2 means +/-20%.
+	Jitter float64 `yaml:"jitter,omitempty"`
 }
 
 // PipelinePreference stores the last-used feature-creation settings for a

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1940,3 +1940,76 @@ func TestProvidersEmptyOmittedFromYAML(t *testing.T) {
 		t.Errorf("empty Providers map should be omitted from YAML, got:\n%s", data)
 	}
 }
+
+func TestConfig_RateLimitRetry_Defaults(t *testing.T) {
+	rl := NewDefault().Defaults.RateLimitRetry
+	if !rl.Enabled {
+		t.Error("RateLimitRetry.Enabled = false, want true by default")
+	}
+	if rl.MaxRetries != 6 {
+		t.Errorf("MaxRetries = %d, want 6", rl.MaxRetries)
+	}
+	if rl.BaseDelay != "15s" {
+		t.Errorf("BaseDelay = %q, want 15s", rl.BaseDelay)
+	}
+	if rl.MaxDelay != "5m" {
+		t.Errorf("MaxDelay = %q, want 5m", rl.MaxDelay)
+	}
+	if rl.Multiplier != 2.0 {
+		t.Errorf("Multiplier = %v, want 2.0", rl.Multiplier)
+	}
+	if rl.Jitter != 0.2 {
+		t.Errorf("Jitter = %v, want 0.2", rl.Jitter)
+	}
+}
+
+func TestConfig_RateLimitRetry_YAMLRoundTrip(t *testing.T) {
+	const yamlBody = `
+defaults:
+  rate_limit_retry:
+    enabled: true
+    max_retries: 9
+    base_delay: "30s"
+    max_delay: "10m"
+    multiplier: 3
+    jitter: 0.5
+`
+	var cfg Config
+	if err := yaml.Unmarshal([]byte(yamlBody), &cfg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	rl := cfg.Defaults.RateLimitRetry
+	if !rl.Enabled || rl.MaxRetries != 9 || rl.BaseDelay != "30s" ||
+		rl.MaxDelay != "10m" || rl.Multiplier != 3 || rl.Jitter != 0.5 {
+		t.Fatalf("parsed rate_limit_retry = %+v, want the yaml values", rl)
+	}
+
+	// marshal -> unmarshal equality.
+	data, err := yaml.Marshal(&cfg)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var round Config
+	if err := yaml.Unmarshal(data, &round); err != nil {
+		t.Fatalf("re-unmarshal: %v", err)
+	}
+	if round.Defaults.RateLimitRetry != rl {
+		t.Errorf("round-trip mismatch: got %+v, want %+v", round.Defaults.RateLimitRetry, rl)
+	}
+}
+
+func TestConfig_RateLimitRetry_OmittedLeavesZeroValues(t *testing.T) {
+	const yamlBody = `
+defaults:
+  max_iterations: 5
+`
+	var cfg Config
+	if err := yaml.Unmarshal([]byte(yamlBody), &cfg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	// Without the block, the struct stays zero; the orchestrator getter
+	// (RateLimitRetryPolicyFromConfig) is responsible for supplying defaults.
+	if cfg.Defaults.RateLimitRetry != (RateLimitRetryConfig{}) {
+		t.Errorf("omitted rate_limit_retry = %+v, want zero value", cfg.Defaults.RateLimitRetry)
+	}
+}

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -21,6 +21,20 @@ const defaultExitCriteria = `- Feature fully implemented per plan
 - Relevant tests pass
 - No linting errors`
 
+// NewDefaultRateLimitRetry returns the built-in rate-limit backoff defaults:
+// enabled, a 6-attempt budget, 15s base delay doubling up to a 5m cap, with
+// 20% jitter.
+func NewDefaultRateLimitRetry() RateLimitRetryConfig {
+	return RateLimitRetryConfig{
+		Enabled:    true,
+		MaxRetries: 6,
+		BaseDelay:  "15s",
+		MaxDelay:   "5m",
+		Multiplier: 2.0,
+		Jitter:     0.2,
+	}
+}
+
 func NewDefault() *Config {
 	return &Config{
 		Defaults: DefaultsConfig{
@@ -47,6 +61,7 @@ func NewDefault() *Config {
 			MaxIterations:            10,
 			MaxConsecutiveFailures:   3,
 			MaxConsecutiveNoProgress: 3,
+			RateLimitRetry:           NewDefaultRateLimitRetry(),
 		},
 		Repos: make(map[string]RepoConfig),
 		Observability: ObservabilityConfig{

--- a/internal/orchestrator/completion.go
+++ b/internal/orchestrator/completion.go
@@ -444,13 +444,16 @@ func (o *Orchestrator) onArtifactPhaseCompletedWithKey(
 	if err != nil {
 		return fmt.Errorf("read %s retry sidecar: %w", phaseKey, err)
 	}
-	decision := agent.DecideProtocolRetry(
+	isRateLimit := artifactPhaseHitRateLimit(phaseDir)
+	decision := agent.DecideProtocolRetryWithRateLimit(
 		artifactPhaseRoleMust(input.Phase),
 		phaseDir,
 		f.ActiveRun,
 		sidecar,
 		violations,
 		agent.DefaultMaxConsecutiveProtocolViolations,
+		isRateLimit,
+		o.rateLimitRetryPolicy(),
 	)
 	switch decision.Action {
 	case agent.ProtocolRetryActionSucceed:
@@ -465,6 +468,13 @@ func (o *Orchestrator) onArtifactPhaseCompletedWithKey(
 		}
 		if err := agent.RemovePhaseCompleteMarker(phaseDir); err != nil {
 			return fmt.Errorf("remove %s phase_complete marker: %w", phaseKey, err)
+		}
+		// Rate-limit retries back off asynchronously so the upstream can
+		// recover; every other retry stays immediate and synchronous to
+		// preserve existing behavior.
+		if decision.RetryDelay > 0 {
+			o.scheduleArtifactPhaseRetry(featureID, input.Phase, decision.RetryDelay)
+			return nil
 		}
 		return o.retryArtifactPhase(featureID, input.Phase)
 	case agent.ProtocolRetryActionTerminal:
@@ -505,6 +515,23 @@ func (o *Orchestrator) onArtifactPhaseCompletedWithKey(
 func artifactPhaseRoleMust(phase feature.Phase) agent.Role {
 	role, _ := artifactPhaseRole(phase)
 	return role
+}
+
+// artifactPhaseHitRateLimit reports whether the just-finished artifact-phase
+// session recorded an upstream rate-limit failure. The TUI writes the full
+// session transcript to phaseDir/output.txt immediately before signaling
+// completion, so scanning it is a best-effort, self-contained classification
+// with no new plumbing. A missing or unreadable file classifies as "not rate
+// limited" so unrelated protocol violations keep their immediate retry path.
+func artifactPhaseHitRateLimit(phaseDir string) bool {
+	if phaseDir == "" {
+		return false
+	}
+	data, err := os.ReadFile(filepath.Join(phaseDir, "output.txt"))
+	if err != nil {
+		return false
+	}
+	return agent.IsRateLimitError(string(data))
 }
 
 func (o *Orchestrator) retryArtifactPhase(featureID string, phase feature.Phase) error {

--- a/internal/orchestrator/completion_ratelimit_test.go
+++ b/internal/orchestrator/completion_ratelimit_test.go
@@ -1,0 +1,290 @@
+// Copyright 2026 DoorDash, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package orchestrator_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/doordash-oss/agentic-orchestrator/internal/agent"
+	"github.com/doordash-oss/agentic-orchestrator/internal/feature"
+	"github.com/doordash-oss/agentic-orchestrator/internal/orchestrator"
+)
+
+const rateLimitOutput = "assistant: retrying...\nAPI rate limit exceeded (429)\n"
+
+// writePhaseOutput writes the session transcript file the TUI persists to the
+// phase dir immediately before signaling completion. The orchestrator scans it
+// to classify rate-limit failures.
+func writePhaseOutput(t *testing.T, stateDir string, f *feature.Feature, phaseKey, content string) {
+	t.Helper()
+	phaseDir := filepath.Join(agent.ActiveRunDir(stateDir, f), phaseKey)
+	if err := os.MkdirAll(phaseDir, 0o755); err != nil {
+		t.Fatalf("mkdir phase dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(phaseDir, "output.txt"), []byte(content), 0o644); err != nil {
+		t.Fatalf("write output.txt: %v", err)
+	}
+}
+
+func withRateLimitPolicy(p agent.RateLimitRetryPolicy) func(*orchestrator.Deps) {
+	return func(d *orchestrator.Deps) { d.RateLimitRetry = &p }
+}
+
+// fastRateLimitPolicy backs off on sub-millisecond delays with no jitter so
+// scheduled retries drain near-instantly under WaitForCycles.
+func fastRateLimitPolicy() agent.RateLimitRetryPolicy {
+	return agent.RateLimitRetryPolicy{
+		Enabled:    true,
+		MaxRetries: 6,
+		BaseDelay:  time.Millisecond,
+		MaxDelay:   2 * time.Millisecond,
+		Multiplier: 2.0,
+		Jitter:     0,
+	}
+}
+
+func completeArtifactPhase(t *testing.T, fix artifactPhaseRetryFixture, phase feature.Phase) {
+	t.Helper()
+	if err := fix.orchestrator.HandlePhaseCompletion(fix.feature.ID, orchestrator.PhaseCompletionInput{
+		Phase:   phase,
+		Success: true,
+	}); err != nil {
+		t.Fatalf("HandlePhaseCompletion() error = %v", err)
+	}
+}
+
+func TestOrchestrator_ArtifactPhase_RateLimit_RetriesBeyondThree(t *testing.T) {
+	for _, tc := range artifactPhaseCases() {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			fix := newArtifactPhaseRetryFixture(t, tc, feature.Checkpoints{}, withRateLimitPolicy(fastRateLimitPolicy()))
+
+			const attempts = 4 // past the old default cap of 3
+			for i := 0; i < attempts; i++ {
+				// Each re-run's session (re)writes output.txt; simulate that
+				// the re-run also hit the rate limit. The scheduled retry
+				// truncates output.txt via os.Create, so re-seed every round.
+				writePhaseOutput(t, fix.store.BaseDir, fix.feature, tc.phaseKey, rateLimitOutput)
+				completeArtifactPhase(t, fix, tc.phase)
+				fix.orchestrator.WaitForCycles()
+				drainEvents(fix.orchestrator)
+			}
+
+			reloaded := loadStoredFeature(t, fix.store, fix.feature.ID)
+			if reloaded.FailureType != "" {
+				t.Fatalf("FailureType = %q, want empty (rate-limit budget not exhausted)", reloaded.FailureType)
+			}
+			sidecar, err := agent.ReadProtocolRetrySidecar(fix.phaseDir)
+			if err != nil {
+				t.Fatalf("ReadProtocolRetrySidecar() error = %v", err)
+			}
+			if sidecar == nil || sidecar.Consecutive != attempts {
+				t.Fatalf("sidecar = %#v, want Consecutive %d", sidecar, attempts)
+			}
+			if !sidecar.RateLimited {
+				t.Error("sidecar.RateLimited = false, want true")
+			}
+			if got := len(fix.runner.capturedByPhase(tc.phase)); got != attempts {
+				t.Fatalf("starter captures = %d, want %d", got, attempts)
+			}
+		})
+	}
+}
+
+func TestOrchestrator_ArtifactPhase_RateLimit_TerminatesAtMaxRetries(t *testing.T) {
+	for _, tc := range artifactPhaseCases() {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			policy := fastRateLimitPolicy() // MaxRetries=6
+			fix := newArtifactPhaseRetryFixture(t, tc, feature.Checkpoints{}, withRateLimitPolicy(policy))
+
+			for i := 0; i < policy.MaxRetries; i++ {
+				writePhaseOutput(t, fix.store.BaseDir, fix.feature, tc.phaseKey, rateLimitOutput)
+				completeArtifactPhase(t, fix, tc.phase)
+				fix.orchestrator.WaitForCycles()
+			}
+
+			reloaded := loadStoredFeature(t, fix.store, fix.feature.ID)
+			if reloaded.FailureType != feature.FailureProtocolViolation {
+				t.Fatalf("FailureType = %q, want %q", reloaded.FailureType, feature.FailureProtocolViolation)
+			}
+			sidecar, err := agent.ReadProtocolRetrySidecar(fix.phaseDir)
+			if err != nil {
+				t.Fatalf("ReadProtocolRetrySidecar() error = %v", err)
+			}
+			if sidecar == nil || sidecar.Consecutive != policy.MaxRetries {
+				t.Fatalf("sidecar = %#v, want Consecutive %d", sidecar, policy.MaxRetries)
+			}
+			if !sidecar.RateLimited {
+				t.Error("sidecar.RateLimited = false, want true")
+			}
+			// Retries scheduled for the first MaxRetries-1 attempts; the last
+			// hits the cap and fails without scheduling another.
+			if got := len(fix.runner.capturedByPhase(tc.phase)); got != policy.MaxRetries-1 {
+				t.Fatalf("starter captures = %d, want %d", got, policy.MaxRetries-1)
+			}
+		})
+	}
+}
+
+func TestOrchestrator_ArtifactPhase_NonRateLimitOutput_StillTerminatesAtThree(t *testing.T) {
+	for _, tc := range artifactPhaseCases() {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			// Default policy (enabled, long delay) is fine: a non-rate-limit
+			// classification never reaches the backoff branch.
+			fix := newArtifactPhaseRetryFixture(t, tc, feature.Checkpoints{})
+			writePhaseOutput(t, fix.store.BaseDir, fix.feature, tc.phaseKey, "assistant: no artifact written this turn\n")
+
+			for i := 0; i < agent.DefaultMaxConsecutiveProtocolViolations; i++ {
+				completeArtifactPhase(t, fix, tc.phase)
+			}
+			fix.orchestrator.WaitForCycles()
+
+			reloaded := loadStoredFeature(t, fix.store, fix.feature.ID)
+			if reloaded.FailureType != feature.FailureProtocolViolation {
+				t.Fatalf("FailureType = %q, want %q", reloaded.FailureType, feature.FailureProtocolViolation)
+			}
+			sidecar, err := agent.ReadProtocolRetrySidecar(fix.phaseDir)
+			if err != nil {
+				t.Fatalf("ReadProtocolRetrySidecar() error = %v", err)
+			}
+			if sidecar == nil || sidecar.Consecutive != agent.DefaultMaxConsecutiveProtocolViolations {
+				t.Fatalf("sidecar = %#v, want Consecutive %d", sidecar, agent.DefaultMaxConsecutiveProtocolViolations)
+			}
+			if sidecar.RateLimited {
+				t.Error("sidecar.RateLimited = true, want false for non-rate-limit output")
+			}
+		})
+	}
+}
+
+func TestOrchestrator_ArtifactPhase_MissingOutputTxt_TreatedAsNonRateLimit(t *testing.T) {
+	for _, tc := range artifactPhaseCases() {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			fix := newArtifactPhaseRetryFixture(t, tc, feature.Checkpoints{}, withRateLimitPolicy(fastRateLimitPolicy()))
+			// No output.txt written.
+
+			for i := 0; i < agent.DefaultMaxConsecutiveProtocolViolations; i++ {
+				completeArtifactPhase(t, fix, tc.phase)
+			}
+			fix.orchestrator.WaitForCycles()
+
+			reloaded := loadStoredFeature(t, fix.store, fix.feature.ID)
+			if reloaded.FailureType != feature.FailureProtocolViolation {
+				t.Fatalf("FailureType = %q, want %q (absent output.txt is not rate-limit)", reloaded.FailureType, feature.FailureProtocolViolation)
+			}
+		})
+	}
+}
+
+func TestOrchestrator_ArtifactPhase_RateLimitRetry_IsScheduledNotBlocking(t *testing.T) {
+	tc := artifactPhaseCases()[1] // research
+	policy := agent.RateLimitRetryPolicy{
+		Enabled:    true,
+		MaxRetries: 6,
+		BaseDelay:  60 * time.Second, // long enough that it cannot run inline
+		MaxDelay:   60 * time.Second,
+		Multiplier: 2.0,
+		Jitter:     0,
+	}
+	fix := newArtifactPhaseRetryFixture(t, tc, feature.Checkpoints{}, withRateLimitPolicy(policy))
+	writePhaseOutput(t, fix.store.BaseDir, fix.feature, tc.phaseKey, rateLimitOutput)
+
+	// Returns promptly; the restart is deferred to a background timer.
+	completeArtifactPhase(t, fix, tc.phase)
+
+	if got := len(fix.runner.capturedByPhase(tc.phase)); got != 0 {
+		t.Fatalf("starter captures = %d, want 0 (retry must be scheduled, not inline)", got)
+	}
+	reloaded := loadStoredFeature(t, fix.store, fix.feature.ID)
+	if reloaded.FailureType != "" {
+		t.Fatalf("FailureType = %q, want empty", reloaded.FailureType)
+	}
+	sidecar, err := agent.ReadProtocolRetrySidecar(fix.phaseDir)
+	if err != nil {
+		t.Fatalf("ReadProtocolRetrySidecar() error = %v", err)
+	}
+	if sidecar == nil || !sidecar.RateLimited || sidecar.Consecutive != 1 {
+		t.Fatalf("sidecar = %#v, want Consecutive 1 RateLimited true", sidecar)
+	}
+
+	// Shutdown cancels the pending timer so WaitForCycles drains without
+	// waiting out the 60s delay.
+	_ = fix.orchestrator.Shutdown()
+	fix.orchestrator.WaitForCycles()
+	if got := len(fix.runner.capturedByPhase(tc.phase)); got != 0 {
+		t.Fatalf("starter captures after shutdown = %d, want 0 (timer cancelled)", got)
+	}
+}
+
+func TestOrchestrator_ArtifactPhase_RateLimit_DisabledPolicyImmediate(t *testing.T) {
+	tc := artifactPhaseCases()[1] // research
+	policy := fastRateLimitPolicy()
+	policy.Enabled = false
+	fix := newArtifactPhaseRetryFixture(t, tc, feature.Checkpoints{}, withRateLimitPolicy(policy))
+	writePhaseOutput(t, fix.store.BaseDir, fix.feature, tc.phaseKey, rateLimitOutput)
+
+	// Disabled policy => default cap of 3, immediate retries even though the
+	// output is rate-limit-flavored.
+	for i := 0; i < agent.DefaultMaxConsecutiveProtocolViolations; i++ {
+		completeArtifactPhase(t, fix, tc.phase)
+	}
+	fix.orchestrator.WaitForCycles()
+
+	reloaded := loadStoredFeature(t, fix.store, fix.feature.ID)
+	if reloaded.FailureType != feature.FailureProtocolViolation {
+		t.Fatalf("FailureType = %q, want %q when policy disabled", reloaded.FailureType, feature.FailureProtocolViolation)
+	}
+	sidecar, err := agent.ReadProtocolRetrySidecar(fix.phaseDir)
+	if err != nil {
+		t.Fatalf("ReadProtocolRetrySidecar() error = %v", err)
+	}
+	if sidecar == nil || sidecar.RateLimited {
+		t.Fatalf("sidecar = %#v, want RateLimited false when disabled", sidecar)
+	}
+}
+
+func TestOrchestrator_ArtifactPhase_RateLimitThenSuccessAdvances(t *testing.T) {
+	for _, tc := range artifactPhaseCases() {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			fix := newArtifactPhaseRetryFixture(t, tc, retrySuccessCheckpointForTest(tc.phase), withRateLimitPolicy(fastRateLimitPolicy()))
+			writePhaseOutput(t, fix.store.BaseDir, fix.feature, tc.phaseKey, rateLimitOutput)
+
+			// First completion: rate-limit violation -> scheduled retry.
+			completeArtifactPhase(t, fix, tc.phase)
+			fix.orchestrator.WaitForCycles()
+			drainEvents(fix.orchestrator)
+
+			// Second completion: artifacts present -> success + advance.
+			writePhaseComplete(t, fix.store.BaseDir, fix.feature, tc.phaseKey)
+			artifactPath := writePhaseMarkdown(t, fix.store.BaseDir, fix.feature, tc.phaseKey, tc.phaseKey+".md")
+			completeArtifactPhase(t, fix, tc.phase)
+
+			if _, err := os.Stat(filepath.Join(fix.phaseDir, agent.ProtocolRetrySidecarFile)); !os.IsNotExist(err) {
+				t.Fatalf("sidecar stat err = %v, want removed after success", err)
+			}
+			reloaded := loadStoredFeature(t, fix.store, fix.feature.ID)
+			if got := reloaded.Artifacts[tc.artifactKey]; got != artifactPath {
+				t.Fatalf("Artifacts[%q] = %q, want %q", tc.artifactKey, got, artifactPath)
+			}
+		})
+	}
+}

--- a/internal/orchestrator/completion_test.go
+++ b/internal/orchestrator/completion_test.go
@@ -850,7 +850,7 @@ type artifactPhaseRetryFixture struct {
 	lifecycle    *mocks.MockFeatureLifecycle
 }
 
-func newArtifactPhaseRetryFixture(t *testing.T, tc artifactPhaseCase, checkpoints feature.Checkpoints) artifactPhaseRetryFixture {
+func newArtifactPhaseRetryFixture(t *testing.T, tc artifactPhaseCase, checkpoints feature.Checkpoints, depsOpts ...func(*orchestrator.Deps)) artifactPhaseRetryFixture {
 	t.Helper()
 
 	cpr := newCapturingPhaseRunner(t)
@@ -922,13 +922,17 @@ func newArtifactPhaseRetryFixture(t *testing.T, tc artifactPhaseCase, checkpoint
 		})
 	}
 
-	o := orchestrator.New(orchestrator.Deps{
+	deps := orchestrator.Deps{
 		Lifecycle:   lc,
 		Store:       store,
 		Sessions:    cpr.sm,
 		PhaseRunner: cpr.pr,
 		CmdRunner:   cpr.cmd,
-	}, orchestrator.Hooks{})
+	}
+	for _, opt := range depsOpts {
+		opt(&deps)
+	}
+	o := orchestrator.New(deps, orchestrator.Hooks{})
 
 	return artifactPhaseRetryFixture{
 		orchestrator: o,

--- a/internal/orchestrator/module.go
+++ b/internal/orchestrator/module.go
@@ -112,6 +112,9 @@ var Module = fx.Module("orchestrator",
 			// feature manager so orphan-session discovery and dispatch can
 			// reach the right state without widening ports.SessionManager.
 			Recovery: session.NewRecoveryAdapter(p.FeatureStore.BaseDir, p.FeatureManager),
+			// Rate-limit backoff policy derived from user config; nil-safe
+			// when the feature manager has no config attached.
+			RateLimitRetry: rateLimitRetryFromManager(p.FeatureManager),
 		}, BuildHooks(p.Observer, p.PermissionStore, p.FeatureStore, p.FeatureStore.BaseDir))
 
 		p.Lifecycle.Append(fx.Hook{
@@ -123,3 +126,14 @@ var Module = fx.Module("orchestrator",
 		return o
 	}),
 )
+
+// rateLimitRetryFromManager derives the rate-limit backoff policy from the
+// feature manager's config, returning nil (defaults) when no config is
+// attached so the orchestrator's getter supplies the built-in policy.
+func rateLimitRetryFromManager(m *feature.Manager) *agent.RateLimitRetryPolicy {
+	if m == nil || m.Config == nil {
+		return nil
+	}
+	policy := RateLimitRetryPolicyFromConfig(m.Config.Defaults.RateLimitRetry)
+	return &policy
+}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"time"
 
 	"github.com/doordash-oss/agentic-orchestrator/internal/agent"
 	"github.com/doordash-oss/agentic-orchestrator/internal/config"
@@ -173,6 +174,12 @@ type Deps struct {
 	CmdRunner   ports.CommandRunner
 	Recovery    ports.RecoveryOperator
 	PhaseRunner *agent.PhaseRunner // concrete — not behind a port interface
+
+	// RateLimitRetry, when non-nil, tunes the exponential backoff applied to
+	// rate-limit-classified artifact-phase protocol violations. Nil means
+	// "use the built-in defaults" so tests that construct Deps directly get
+	// sensible behavior without wiring config.
+	RateLimitRetry *agent.RateLimitRetryPolicy
 }
 
 // PhaseStartOutcome enumerates the possible results of starting a phase.
@@ -336,6 +343,70 @@ func (o *Orchestrator) Done() <-chan struct{} { return o.doneCh }
 // t.TempDir(): without synchronizing on the goroutine, TempDir cleanup
 // can race with in-flight writes from the implementation/refactor loop.
 func (o *Orchestrator) WaitForCycles() { o.cycleWG.Wait() }
+
+// rateLimitRetryPolicy returns the effective rate-limit backoff policy,
+// falling back to the built-in defaults when Deps.RateLimitRetry is unset.
+func (o *Orchestrator) rateLimitRetryPolicy() agent.RateLimitRetryPolicy {
+	if o.deps.RateLimitRetry != nil {
+		return *o.deps.RateLimitRetry
+	}
+	return agent.DefaultRateLimitRetryPolicy()
+}
+
+// RateLimitRetryPolicyFromConfig converts the user-facing config block into an
+// agent.RateLimitRetryPolicy, parsing duration strings and falling back to the
+// built-in defaults for empty or invalid values.
+func RateLimitRetryPolicyFromConfig(c config.RateLimitRetryConfig) agent.RateLimitRetryPolicy {
+	def := agent.DefaultRateLimitRetryPolicy()
+	policy := agent.RateLimitRetryPolicy{
+		Enabled:    c.Enabled,
+		MaxRetries: c.MaxRetries,
+		BaseDelay:  parseDurationOr(c.BaseDelay, def.BaseDelay),
+		MaxDelay:   parseDurationOr(c.MaxDelay, def.MaxDelay),
+		Multiplier: c.Multiplier,
+		Jitter:     c.Jitter,
+	}
+	if policy.MaxRetries <= 0 {
+		policy.MaxRetries = def.MaxRetries
+	}
+	if policy.Multiplier <= 1 {
+		policy.Multiplier = def.Multiplier
+	}
+	if policy.Jitter < 0 {
+		policy.Jitter = def.Jitter
+	}
+	return policy
+}
+
+func parseDurationOr(s string, fallback time.Duration) time.Duration {
+	if d, err := time.ParseDuration(s); err == nil && d > 0 {
+		return d
+	}
+	return fallback
+}
+
+// scheduleArtifactPhaseRetry restarts an artifact phase after delay, tracked
+// by cycleWG so tests can drain it via WaitForCycles. The wait honors
+// Shutdown via doneCh. Runs off the caller's goroutine so it never blocks the
+// synchronous HandlePhaseCompletion path (which executes inside the Bubble
+// Tea Update loop).
+func (o *Orchestrator) scheduleArtifactPhaseRetry(featureID string, phase feature.Phase, delay time.Duration) {
+	o.cycleWG.Go(func() {
+		if delay > 0 {
+			timer := time.NewTimer(delay)
+			defer timer.Stop()
+			select {
+			case <-timer.C:
+			case <-o.doneCh:
+				return
+			}
+		}
+		if err := o.retryArtifactPhase(featureID, phase); err != nil {
+			o.emitPhaseCompleted(featureID, phase, err)
+			_ = o.markFailedWithEvent(featureID, feature.FailureInfrastructure, err.Error())
+		}
+	})
+}
 
 // SetPublishFn installs a test hook that intercepts publish dispatch in place
 // of o.Publish. Intended for tests only — production code leaves it unset so

--- a/test/integration/research_rate_limit_retry_test.go
+++ b/test/integration/research_rate_limit_retry_test.go
@@ -1,0 +1,166 @@
+// Copyright 2026 DoorDash, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package integration
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/doordash-oss/agentic-orchestrator/internal/agent"
+	"github.com/doordash-oss/agentic-orchestrator/internal/config"
+	"github.com/doordash-oss/agentic-orchestrator/internal/feature"
+	"github.com/doordash-oss/agentic-orchestrator/internal/orchestrator"
+	"github.com/doordash-oss/agentic-orchestrator/internal/session"
+)
+
+// TestResearch_RateLimitRetry_EndToEnd wires a real config, feature.Manager,
+// orchestrator, PhaseRunner, and session.Manager and drives the research
+// artifact-phase completion path against an on-disk output.txt that carries a
+// 429. The observable contract: the config-derived exponential-backoff budget
+// lets the feature retry past the default cap of 3, and it only fails
+// terminally with protocol_violation once the configured MaxRetries is
+// exhausted, with the retry sidecar flagged rate-limited.
+func TestResearch_RateLimitRetry_EndToEnd(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	stateDir := t.TempDir()
+	store := feature.NewStore(stateDir)
+
+	cfg := config.NewDefault()
+	cfg.Defaults.RateLimitRetry = config.RateLimitRetryConfig{
+		Enabled:    true,
+		MaxRetries: 4, // small budget: still larger than the default cap of 3
+		BaseDelay:  "1ms",
+		MaxDelay:   "2ms",
+		Multiplier: 2.0,
+		Jitter:     0,
+	}
+	mgr := feature.NewManager(store, cfg)
+
+	f := &feature.Feature{
+		ID:            "research-rate-limit",
+		Name:          "Research rate limit retry",
+		Slug:          "research-rate-limit",
+		Status:        feature.StatusResearching,
+		CurrentPhase:  feature.PhaseResearch,
+		ActiveRun:     1,
+		RunCount:      1,
+		SchemaVersion: feature.SchemaVersionCurrent,
+		Artifacts:     map[string]string{},
+	}
+
+	// Research requires the inquire artifact to build its prompt.
+	inquireDir := filepath.Join(agent.ActiveRunDir(stateDir, f), "inquire")
+	if err := os.MkdirAll(inquireDir, 0o755); err != nil {
+		t.Fatalf("mkdir inquire dir: %v", err)
+	}
+	inquirePath := filepath.Join(inquireDir, "inquire.md")
+	if err := os.WriteFile(inquirePath, []byte("# questions\n"), 0o644); err != nil {
+		t.Fatalf("write inquire artifact: %v", err)
+	}
+	f.Artifacts["inquire"] = inquirePath
+	if err := store.Save(f); err != nil {
+		t.Fatalf("save feature: %v", err)
+	}
+
+	eventCh := make(chan interface{}, 100)
+	sm := session.NewManager(eventCh)
+	defer sm.Shutdown()
+
+	pr := &agent.PhaseRunner{
+		SessionManager: sm,
+		FeatureStore:   store,
+		StateDir:       stateDir,
+	}
+	// The re-run session writes nothing to stdout (so it never clobbers the
+	// output.txt we re-seed each round). runInteractivePhase truncates
+	// output.txt via os.Create on every restart, mirroring production.
+	pr.BuildSessionFn = func(opts agent.BuildSessionOpts) ([]string, []string, *session.SessionOpts, error) {
+		return []string{"true"}, nil, &session.SessionOpts{
+			PIDDir:        opts.PIDDir,
+			PermHandler:   opts.PermHandler,
+			InitialPrompt: opts.Prompt,
+		}, nil
+	}
+
+	policy := orchestrator.RateLimitRetryPolicyFromConfig(cfg.Defaults.RateLimitRetry)
+	o := orchestrator.New(orchestrator.Deps{
+		Lifecycle:      mgr,
+		Store:          store,
+		Sessions:       sm,
+		PhaseRunner:    pr,
+		RateLimitRetry: &policy,
+	}, orchestrator.Hooks{})
+	defer func() { _ = o.Shutdown() }()
+
+	researchDir := filepath.Join(agent.ActiveRunDir(stateDir, f), "research")
+	seedRateLimitOutput := func() {
+		if err := os.MkdirAll(researchDir, 0o755); err != nil {
+			t.Fatalf("mkdir research dir: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(researchDir, "output.txt"),
+			[]byte("assistant: working...\nAPI rate limit exceeded (429)\n"), 0o644); err != nil {
+			t.Fatalf("write output.txt: %v", err)
+		}
+	}
+
+	// Drive completions up to the configured budget. Each round re-seeds the
+	// rate-limit transcript (the restart truncates it) and completes with no
+	// phase_complete / markdown, so every attempt is a rate-limit violation.
+	for attempt := 1; attempt <= cfg.Defaults.RateLimitRetry.MaxRetries; attempt++ {
+		seedRateLimitOutput()
+
+		reloaded, err := store.Load(f.ID)
+		if err != nil {
+			t.Fatalf("load feature: %v", err)
+		}
+		if reloaded.Status == feature.StatusFailed {
+			t.Fatalf("attempt %d: feature already failed before reaching MaxRetries", attempt)
+		}
+
+		if err := o.HandlePhaseCompletion(f.ID, orchestrator.PhaseCompletionInput{
+			Phase:   feature.PhaseResearch,
+			Success: true,
+		}); err != nil {
+			t.Fatalf("attempt %d: HandlePhaseCompletion() error = %v", attempt, err)
+		}
+		o.WaitForCycles()
+	}
+
+	final, err := store.Load(f.ID)
+	if err != nil {
+		t.Fatalf("load final feature: %v", err)
+	}
+	if final.FailureType != feature.FailureProtocolViolation {
+		t.Fatalf("FailureType = %q, want %q", final.FailureType, feature.FailureProtocolViolation)
+	}
+
+	sidecar, err := agent.ReadProtocolRetrySidecar(researchDir)
+	if err != nil {
+		t.Fatalf("ReadProtocolRetrySidecar() error = %v", err)
+	}
+	if sidecar == nil {
+		t.Fatal("sidecar = nil, want terminal retry state")
+	}
+	if sidecar.Consecutive != cfg.Defaults.RateLimitRetry.MaxRetries {
+		t.Errorf("sidecar.Consecutive = %d, want %d", sidecar.Consecutive, cfg.Defaults.RateLimitRetry.MaxRetries)
+	}
+	if !sidecar.RateLimited {
+		t.Error("sidecar.RateLimited = false, want true")
+	}
+}


### PR DESCRIPTION
## Summary

When the upstream model rate-limits an artifact-phase agent (inquire/research/design), the session can end "successfully" without writing `phase_complete` + the phase markdown. The orchestrator treated this as a protocol violation and retried **immediately** under the hardcoded cap of `DefaultMaxConsecutiveProtocolViolations = 3`, so all three retries fired back-to-back against the still-rate-limited upstream and the feature terminated with `protocol_violation`.

This change classifies rate-limit-caused violations and gives them a **separate, larger, exponential-backoff retry budget**, while leaving every other protocol violation on its existing immediate-retry path.

- **Classifier** (`internal/agent/rate_limit.go`): `IsRateLimitError` matches an exported, extensible `RateLimitSignatures` list (`429`, `rate limit`, `overloaded`, `usage limit exceeded`, `quota`, …). Adding new provider phrasings/codes is a one-line append.
- **Decision** (`internal/agent/protocol_retry.go`): `DecideProtocolRetryWithRateLimit` + `RateLimitRetryPolicy` compute `RetryDelay = base * multiplier^(n-1)`, clamped to `MaxDelay`, with `±jitter`. The retry sidecar gains a `RateLimited` flag. A disabled policy degrades to the existing immediate path.
- **Detection + scheduling** (`internal/orchestrator/completion.go`, `orchestrator.go`): the failure is classified by scanning the phase's `output.txt` (already persisted by the TUI before completion). Rate-limit retries are scheduled on a background goroutine tracked by `cycleWG` (honoring shutdown via `doneCh`) so they never block the Bubble Tea update loop. Non-rate-limit retries stay synchronous.
- **Config** (`internal/config`): new `defaults.rate_limit_retry` block, wired into the orchestrator from `FeatureManager.Config` with a nil-safe fallback to built-in defaults.

### Configuration

```yaml
defaults:
  rate_limit_retry:
    enabled: true       # default
    max_retries: 6      # default; larger than the cap-3 for normal violations
    base_delay: "15s"   # default
    max_delay: "5m"     # default
    multiplier: 2.0     # default
    jitter: 0.2         # default (+/-20%)
```

## Test plan

- [x] Classifier table tests + signature-extensibility invariant (`internal/agent/rate_limit_test.go`)
- [x] Backoff-math/cap tests: exponential growth, max-delay clamp, deterministic jitter bounds, disabled policy, zero-value fallback, larger cap, sidecar `RateLimited` round-trip (`internal/agent/protocol_retry_ratelimit_test.go`)
- [x] Config default + YAML round-trip + omitted-block tests (`internal/config/config_test.go`)
- [x] Orchestrator completion tests across inquire/research/design: retries beyond 3, terminates at `MaxRetries`, non-rate-limit still caps at 3, missing `output.txt` treated as non-rate-limit, scheduled-not-blocking, disabled-immediate, rate-limit-then-success advances (`internal/orchestrator/completion_ratelimit_test.go`)
- [x] Integration test wiring real config -> `feature.Manager` -> orchestrator -> `PhaseRunner` -> real `session.Manager` (`test/integration/research_rate_limit_retry_test.go`)

## Verification

- Fast suite: `make test-fast`
- Isolated integration: `go test ./test/integration/... -count=1` (touches lifecycle / protocol-violation behavior; two pre-existing tweak-session git-push/rebase failures are unrelated and reproduce on a clean tree)
- Race check on the new async scheduling: `go test ./internal/orchestrator/ -run ArtifactPhase_RateLimit -race`
- `go vet ./...`, `go build ./...`

Made with Cursor
