### PR TITLE
[codex] normalize opencode other permission inputs

### DIFF
--- a/internal/llm/opencode/control.go
+++ b/internal/llm/opencode/control.go
@@ -134,8 +134,14 @@ func normalizePermissionInput(tc PermissionToolCall) (string, json.RawMessage) {
 		}
 		return "Agent", inputObject("subagent_type", tc.Title)
 	case ToolKindOther:
+		if command := firstStringField(tc.RawInput, "", "command", "cmd", "script"); command != "" {
+			return "Bash", inputObject("command", command)
+		}
 		if tc.Title == "external_directory" {
 			return "ExternalDirectory", inputObject("path", firstStringField(tc.RawInput, tc.Title, "path", "filepath", "filePath", "directory", "dir", "parentDir"))
+		}
+		if parentDir := firstStringField(tc.RawInput, "", "parentDir", "directory", "dir"); parentDir != "" {
+			return "ExternalDirectory", inputObject("path", parentDir)
 		}
 		return unknownPermissionInput(tc)
 	default:

--- a/internal/llm/opencode/control_test.go
+++ b/internal/llm/opencode/control_test.go
@@ -50,6 +50,62 @@ func TestNormalizePermissionInput_EditFilepathLowercase(t *testing.T) {
 	}
 }
 
+// TestNormalizePermissionInput_OtherExternalDirectory guards the observed
+// OpenCode shape for external-directory access: recent runs emitted
+// kind="other" with filepath/parentDir instead of kind="read" or title
+// "external_directory". That must still map to ExternalDirectory so safe reads
+// from mounted context roots are auto-approved and not displayed as opaque
+// "other" prompts.
+func TestNormalizePermissionInput_OtherExternalDirectory(t *testing.T) {
+	parent := "/Users/x/.agentic-workflow/knowledge-base/repo"
+	tc := PermissionToolCall{
+		Kind:     ToolKindOther,
+		Title:    parent,
+		RawInput: json.RawMessage(`{"filepath":"` + parent + `/index.md","parentDir":"` + parent + `"}`),
+	}
+
+	name, input := normalizePermissionInput(tc)
+	if name != "ExternalDirectory" {
+		t.Fatalf("toolName = %q, want ExternalDirectory", name)
+	}
+	var got struct {
+		Path string `json:"path"`
+	}
+	if err := json.Unmarshal(input, &got); err != nil {
+		t.Fatalf("unmarshal normalized input: %v", err)
+	}
+	if got.Path != parent {
+		t.Fatalf("path = %q, want %q", got.Path, parent)
+	}
+}
+
+// TestNormalizePermissionInput_OtherCommand guards the observed OpenCode shape
+// for command-level path permission checks: a shell command can arrive as
+// kind="other" with command/directories/patterns. It should normalize to Bash
+// so prompts are recognizable and remembered Bash rules can match them.
+func TestNormalizePermissionInput_OtherCommand(t *testing.T) {
+	command := "cd /repo && cat > /tmp/debug-test.ts << 'EOF'\nEOF\nnpx vitest run"
+	tc := PermissionToolCall{
+		Kind:     ToolKindOther,
+		Title:    command,
+		RawInput: json.RawMessage(`{"command":"` + strings.ReplaceAll(command, "\n", `\n`) + `","directories":["/repo","/tmp"],"patterns":["/repo/*","/tmp/*"]}`),
+	}
+
+	name, input := normalizePermissionInput(tc)
+	if name != "Bash" {
+		t.Fatalf("toolName = %q, want Bash", name)
+	}
+	var got struct {
+		Command string `json:"command"`
+	}
+	if err := json.Unmarshal(input, &got); err != nil {
+		t.Fatalf("unmarshal normalized input: %v", err)
+	}
+	if got.Command != command {
+		t.Fatalf("command = %q, want %q", got.Command, command)
+	}
+}
+
 // permissionRequestLine builds a session/request_permission server request with
 // the given tool-call kind, raw input, and a standard allow/reject option set.
 func permissionRequestLine(t *testing.T, id int, kind, title string, rawInput map[string]any) []byte {


### PR DESCRIPTION
## Summary

Normalize OpenCode permission prompts that arrive as `kind=other` into the existing tool shapes when their raw input clearly describes a shell command or external directory access.

## Why

Recent OpenCode runs can emit command-level and external-directory permission checks as opaque `other` tool calls. Those previously fell through to unknown permission handling, making prompts less recognizable and preventing remembered Bash or ExternalDirectory approval rules from matching.

## Changes

- Map `kind=other` raw `command` / `cmd` / `script` fields to Bash permission input.
- Map `kind=other` raw `parentDir` / `directory` / `dir` fields to ExternalDirectory permission input.
- Add regression tests for observed OpenCode command and external-directory shapes.

## Verification

- Fast suite: `make test-fast`
- Static analysis: `go vet ./...`
- Build: `go build ./...`
- Skipped E2E smoke shell: no launch behavior, embedded skills, or release packaging changes.
- Skipped Isolated integration: no lifecycle, state-machine, runs layout, or protocol-violation behavior changes.
- Skipped E2E Go / TUI observability: no TUI, Bubble Tea model, observer wiring, or emitted observability changes.
- Skipped Race regression: localized normalization logic with no concurrency-sensitive changes.