### PR TITLE
Add implementation handoff receipts

### DIFF
--- a/internal/agent/artifacts.go
+++ b/internal/agent/artifacts.go
@@ -140,6 +140,40 @@ type ContextMeta struct {
 	HandoffTotalTokens int    `yaml:"handoff_total_tokens,omitempty"`
 }
 
+// HandoffArtifact identifies a handoff input without embedding its contents.
+// Paths are relative to the implementation artifact root so receipts remain
+// portable when a state directory is moved or attached to an issue.
+type HandoffArtifact struct {
+	Path   string `yaml:"path"`
+	SHA256 string `yaml:"sha256"`
+}
+
+// ImplementationHandoffReceipt is the privacy-safe, machine-readable join
+// between an implementation iteration that hit the context threshold and the
+// fresh iteration that resumes from its durable artifacts.
+type ImplementationHandoffReceipt struct {
+	Version               int             `yaml:"version"`
+	FeatureID             string          `yaml:"feature_id"`
+	Phase                 string          `yaml:"phase"`
+	RoadmapPhase          int             `yaml:"roadmap_phase,omitempty"`
+	Repo                  string          `yaml:"repo,omitempty"`
+	FromIterationID       string          `yaml:"from_iteration_id"`
+	ToIterationID         string          `yaml:"to_iteration_id"`
+	SessionID             string          `yaml:"session_id"`
+	Provider              string          `yaml:"provider,omitempty"`
+	Trigger               string          `yaml:"trigger"`
+	ObservedPct           int             `yaml:"observed_pct"`
+	ThresholdPct          int             `yaml:"threshold_pct"`
+	ObservedTotalTokens   int             `yaml:"observed_total_tokens,omitempty"`
+	ContextWindowTokens   int             `yaml:"context_window_tokens,omitempty"`
+	ContextBaselineTokens int             `yaml:"context_baseline_tokens,omitempty"`
+	CanonicalArtifact     HandoffArtifact `yaml:"canonical_artifact"`
+	VerificationArtifact  HandoffArtifact `yaml:"verification_artifact"`
+	IntentionallyDropped  []string        `yaml:"intentionally_dropped"`
+	NextSafeAction        string          `yaml:"next_safe_action"`
+	CreatedAt             time.Time       `yaml:"created_at"`
+}
+
 // ArtifactManager handles iteration directory creation and file writing.
 type ArtifactManager struct {
 	BaseDir string
@@ -167,6 +201,34 @@ func (am *ArtifactManager) WriteMeta(iterDir string, meta IterationMeta) error {
 		return fmt.Errorf("marshaling meta: %w", err)
 	}
 	return os.WriteFile(filepath.Join(iterDir, "meta.yaml"), data, 0o644)
+}
+
+// WriteImplementationHandoffReceipt writes a compact receipt into the source
+// iteration. It fingerprints the durable inputs the next iteration will use,
+// but never copies prompts, transcripts, or artifact contents into the receipt.
+func (am *ArtifactManager) WriteImplementationHandoffReceipt(iterDir string, receipt ImplementationHandoffReceipt) error {
+	progressPath := filepath.Join(am.BaseDir, "progress.md")
+	verificationPath := filepath.Join(iterDir, "verification-report.yaml")
+
+	progressHash, err := Fingerprint(progressPath)
+	if err != nil {
+		return fmt.Errorf("fingerprinting progress artifact: %w", err)
+	}
+	verificationHash, err := Fingerprint(verificationPath)
+	if err != nil {
+		return fmt.Errorf("fingerprinting verification artifact: %w", err)
+	}
+
+	receipt.CanonicalArtifact = HandoffArtifact{Path: "progress.md", SHA256: progressHash}
+	receipt.VerificationArtifact = HandoffArtifact{
+		Path:   filepath.ToSlash(filepath.Join(filepath.Base(iterDir), "verification-report.yaml")),
+		SHA256: verificationHash,
+	}
+	data, err := yaml.Marshal(receipt)
+	if err != nil {
+		return fmt.Errorf("marshaling implementation handoff receipt: %w", err)
+	}
+	return os.WriteFile(filepath.Join(iterDir, "handoff-receipt.yaml"), data, 0o644)
 }
 
 // WriteDebugPrompts writes the system and user prompts to files for debugging.

--- a/internal/agent/artifacts_test.go
+++ b/internal/agent/artifacts_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/doordash-oss/agentic-orchestrator/internal/feature"
+	"gopkg.in/yaml.v3"
 )
 
 func TestArtifactManagerCreateDir(t *testing.T) {
@@ -364,6 +365,62 @@ func TestArtifactManagerReadMeta(t *testing.T) {
 	_, err = am.ReadMeta(filepath.Join(dir, "no-such-dir"))
 	if err == nil {
 		t.Error("expected error for non-existent dir")
+	}
+}
+
+func TestWriteImplementationHandoffReceipt(t *testing.T) {
+	dir := t.TempDir()
+	am := NewArtifactManager(dir)
+	iterDir, err := am.CreateIterationDir(2)
+	if err != nil {
+		t.Fatalf("create iteration dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "progress.md"), []byte("resume here\n"), 0o644); err != nil {
+		t.Fatalf("write progress: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(iterDir, "verification-report.yaml"), []byte("version: 1\n"), 0o644); err != nil {
+		t.Fatalf("write verification report: %v", err)
+	}
+
+	wantTime := time.Date(2026, 7, 13, 23, 0, 0, 0, time.UTC)
+	err = am.WriteImplementationHandoffReceipt(iterDir, ImplementationHandoffReceipt{
+		Version:              1,
+		FeatureID:            "feat-1",
+		Phase:                "implement",
+		FromIterationID:      "iteration-02",
+		ToIterationID:        "iteration-03",
+		SessionID:            "feat-1-impl-02",
+		Provider:             "claude",
+		Trigger:              "context_threshold",
+		ObservedPct:          61,
+		ThresholdPct:         60,
+		IntentionallyDropped: []string{"prior interactive transcript"},
+		NextSafeAction:       "Resume from progress.md.",
+		CreatedAt:            wantTime,
+	})
+	if err != nil {
+		t.Fatalf("write handoff receipt: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(iterDir, "handoff-receipt.yaml"))
+	if err != nil {
+		t.Fatalf("read handoff receipt: %v", err)
+	}
+	var got ImplementationHandoffReceipt
+	if err := yaml.Unmarshal(data, &got); err != nil {
+		t.Fatalf("parse handoff receipt: %v", err)
+	}
+	if got.FromIterationID != "iteration-02" || got.ToIterationID != "iteration-03" {
+		t.Errorf("iteration link mismatch: %+v", got)
+	}
+	if got.CanonicalArtifact.Path != "progress.md" || got.CanonicalArtifact.SHA256 == "" {
+		t.Errorf("canonical artifact missing fingerprint: %+v", got.CanonicalArtifact)
+	}
+	if got.VerificationArtifact.Path != "iteration-02/verification-report.yaml" || got.VerificationArtifact.SHA256 == "" {
+		t.Errorf("verification artifact missing fingerprint: %+v", got.VerificationArtifact)
+	}
+	if !got.CreatedAt.Equal(wantTime) {
+		t.Errorf("created_at = %s, want %s", got.CreatedAt, wantTime)
 	}
 }
 

--- a/internal/agent/implement.go
+++ b/internal/agent/implement.go
@@ -583,6 +583,31 @@ func RunImplementationLoop(cfg ImplementConfig, sm ports.SessionManager) (result
 			if parsed.State == StateRetry {
 				meta.ReviewStatus = "skipped_retry"
 				meta.AgentStatus = "RETRY"
+				if i < cfg.MaxIterations && meta.Context != nil && meta.Context.HandoffTriggered {
+					receipt := ImplementationHandoffReceipt{
+						Version:               1,
+						FeatureID:             cfg.Feature.ID,
+						Phase:                 "implement",
+						RoadmapPhase:          cfg.Feature.CurrentRoadmapPhase,
+						Repo:                  cfg.RepoName,
+						FromIterationID:       fmt.Sprintf("iteration-%02d", i),
+						ToIterationID:         fmt.Sprintf("iteration-%02d", i+1),
+						SessionID:             sessionID,
+						Provider:              meta.Context.Provider,
+						Trigger:               "context_threshold",
+						ObservedPct:           meta.Context.HandoffPct,
+						ThresholdPct:          meta.Context.ThresholdPct,
+						ObservedTotalTokens:   meta.Context.HandoffTotalTokens,
+						ContextWindowTokens:   meta.Context.WindowTokens,
+						ContextBaselineTokens: meta.Context.BaselineTokens,
+						IntentionallyDropped:  []string{"prior interactive transcript"},
+						NextSafeAction:        "Resume implementation from progress.md and verify its fingerprint before taking new work.",
+						CreatedAt:             time.Now().UTC(),
+					}
+					if err := am.WriteImplementationHandoffReceipt(iterDir, receipt); err != nil {
+						return nil, fmt.Errorf("writing implementation handoff receipt: %w", err)
+					}
+				}
 				_ = am.WriteMeta(iterDir, meta)
 				_ = am.WriteSummary(summaryPath, meta)
 				consecutiveFailures = 0


### PR DESCRIPTION
## Summary

- emit `handoff-receipt.yaml` when an implementation session crosses the context threshold, writes a valid `RETRY` handoff, and another iteration can actually resume
- link the source and destination iteration IDs and record provider/context trigger metadata
- fingerprint `progress.md` and the iteration's `verification-report.yaml` without copying prompts, transcripts, or artifact contents
- record what was intentionally dropped and the bounded next safe action

This is the focused first step suggested in #65: implementation-phase handoffs only, using the durable artifacts the next iteration already consumes.

## Why this shape

The existing `meta.yaml` records that a threshold handoff happened, but it does not provide a portable join between the iteration being wound down and the fresh iteration. The receipt makes that boundary inspectable while keeping sensitive session content out of the artifact.

No receipt is emitted for the final allowed iteration, because there is no destination iteration to claim.

## Verification

- Fast suite: `make test-fast` (pass, 9s)
- Targeted: `go test ./internal/agent -run 'TestWriteImplementationHandoffReceipt|TestArtifactManagerReadMeta|TestImplementLoopNoSkipIterationReview' -count=1`
- Static analysis: `go vet ./...`
- Build: `go build ./...`

One earlier Fast suite run hit an existing order-sensitive cost assertion in `TestImplementLoopNoSkipIterationReview`; the isolated test passed and the complete Fast suite passed on immediate rerun.

## Contribution status

Draft for maintainer feedback. CLA acceptance is intentionally not asserted here; it remains pending operator review.
