### PR TITLE
Harden RETRY routing, command evidence, and max-iterations restart

### DIFF
--- a/internal/agent/implement.go
+++ b/internal/agent/implement.go
@@ -578,6 +578,25 @@ func RunImplementationLoop(cfg ImplementConfig, sm ports.SessionManager) (result
 			// iteration starts fresh against the just-emitted progress.md
 			// (no reviewer feedback — RETRY is not a rejection).
 			if parsed.State == StateRetry {
+				if retryNeedsUserInput(parsed, outcome.VerificationReport) {
+					gatePath := NeedUserInputPath(iterDir)
+					rec := synthesizeRetryNeedUserInputGate(parsed, outcome.VerificationReport, i)
+					if err := WriteNeedUserInputRecord(gatePath, rec); err != nil {
+						return nil, fmt.Errorf("persisting escalated retry gate: %w", err)
+					}
+					meta.AgentStatus = "NEED_USER_INPUT"
+					meta.ReviewStatus = "skipped_need_user_input"
+					_ = am.WriteMeta(iterDir, meta)
+					_ = am.WriteSummary(summaryPath, meta)
+					consecutiveFailures = 0
+					cfg.Observer.IterationEnded(iterCtx, i, toSessionUsage(cost), time.Since(iterStart), "need_user_input")
+					return &LoopResult{
+						FinalStatus:       "need_user_input",
+						Iterations:        i,
+						LastError:         rec.Summary,
+						NeedUserInputPath: gatePath,
+					}, nil
+				}
 				meta.ReviewStatus = "skipped_retry"
 				meta.AgentStatus = "RETRY"
 				_ = am.WriteMeta(iterDir, meta)

--- a/internal/agent/implement_routing_test.go
+++ b/internal/agent/implement_routing_test.go
@@ -188,6 +188,117 @@ touch "$_d/phase_complete"
 	}
 }
 
+// TestImplementLoop_Routing_RETRY_CompleteWithBlockersEscalatesNeedUserInput
+// locks in the convergence guard for a contradictory handoff: RETRY claims
+// implementation is complete while required verification remains failed.
+// There is no actionable next iteration, so the harness must synthesize a
+// NEED_USER_INPUT gate instead of spending the remaining iteration budget.
+func TestImplementLoop_Routing_RETRY_CompleteWithBlockersEscalatesNeedUserInput(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	tmpDir := t.TempDir()
+	workDir := filepath.Join(tmpDir, "work")
+	artifactDir := filepath.Join(tmpDir, "artifacts")
+	stateDir := filepath.Join(tmpDir, "state", "test-feat-retry-blocked")
+	scriptsDir := filepath.Join(tmpDir, "scripts")
+	for _, d := range []string{workDir, artifactDir, stateDir, scriptsDir} {
+		_ = os.MkdirAll(d, 0o755)
+	}
+
+	agentScript := testutil.WriteScript(t, scriptsDir, "agent.sh", `for _d in "`+artifactDir+`"/iteration-*; do :; done
+mkdir -p "$_d"
+cat > "`+artifactDir+`/progress.md" <<PROGRESS_EOF
+# Iteration Progress
+
+## Iteration Handoff
+
+### Completed this iteration
+- implementation and evidence are complete
+
+### Remaining from the plan
+- the required integration check cannot run because Docker is unavailable
+
+### Where I stopped
+Complete for implementation; verification requires a Docker-enabled environment.
+
+### Gotchas / blockers / in-flight decisions
+- expanding scope or changing the verification contract requires a decision
+
+## Deferrals
+
+`+"~~~"+`yaml
+deferrals: []
+closed_deferrals: []
+`+"~~~"+`
+
+## Verification Report
+
+- **Path**: $_d/verification-report.yaml
+- **Summary**: 0 passed, 1 failed, 0 blocked, 0 not_run
+
+## Iteration State
+
+RETRY
+PROGRESS_EOF
+cat > "$_d/verification-report.yaml" <<'REPORT_EOF'
+version: 1
+required_checks:
+  - name: Integration tests pass
+    requirement: task test-coverage
+    status: failed
+    evidence: rootless Docker not found
+REPORT_EOF
+touch "$_d/phase_complete"
+`+testutil.JSONLInit+`
+`+testutil.JSONLSuccess+`
+`)
+	reviewScript := testutil.WriteScript(t, scriptsDir, "review.sh",
+		testutil.JSONLInit+"\n"+testutil.WriteReviewApproved(artifactDir)+"\n"+testutil.JSONLSuccess+"\n")
+
+	eventCh := make(chan interface{}, 100)
+	sm := session.NewManager(eventCh)
+	defer sm.Shutdown()
+
+	f := newTestFeature(t, workDir)
+	planPath := writePlanFile(t, artifactDir, "Blocked RETRY escalation test")
+	result, err := RunImplementationLoop(ImplementConfig{
+		Feature: f, WorkDir: workDir, PlanPath: planPath, MaxIterations: 3,
+		MaxConsecFails: 3, MaxConsecNoProgress: 3, ExitCriteria: "Relevant tests pass",
+		Model: "agent", ReviewModel: "reviewer", ArtifactDir: artifactDir, StateDir: stateDir,
+		BuildSession: mockBuildSession(agentScript, reviewScript),
+	}, sm)
+	if err != nil {
+		t.Fatalf("loop error: %v", err)
+	}
+	if result.FinalStatus != "need_user_input" {
+		t.Fatalf("FinalStatus = %q, want need_user_input (LastError=%q)", result.FinalStatus, result.LastError)
+	}
+	if result.Iterations != 1 {
+		t.Fatalf("Iterations = %d, want 1", result.Iterations)
+	}
+	if result.NeedUserInputPath == "" {
+		t.Fatal("NeedUserInputPath should point at the synthesized gate")
+	}
+	rec, err := ReadNeedUserInputRecord(result.NeedUserInputPath)
+	if err != nil {
+		t.Fatalf("read synthesized gate: %v", err)
+	}
+	if !strings.Contains(rec.Summary, "required verification") {
+		t.Errorf("gate summary = %q, want required-verification explanation", rec.Summary)
+	}
+	if len(rec.Questions) != 1 || !strings.Contains(rec.Questions[0].Prompt, "verification") {
+		t.Fatalf("gate questions = %+v, want one verification decision", rec.Questions)
+	}
+	meta, err := NewArtifactManager(artifactDir).ReadMeta(filepath.Join(artifactDir, "iteration-01"))
+	if err != nil {
+		t.Fatalf("read iteration meta: %v", err)
+	}
+	if meta.AgentStatus != "NEED_USER_INPUT" || meta.ReviewStatus != "skipped_need_user_input" {
+		t.Fatalf("meta statuses = %q/%q, want NEED_USER_INPUT/skipped_need_user_input", meta.AgentStatus, meta.ReviewStatus)
+	}
+}
+
 func padIter(n int) string {
 	if n < 10 {
 		return "0" + string(rune('0'+n))

--- a/internal/agent/need_user_input.go
+++ b/internal/agent/need_user_input.go
@@ -95,6 +95,123 @@ func reconcileNeedUserInputGate(agentRec *NeedUserInputRecord, progress *ParsedP
 	return rec
 }
 
+// retryNeedsUserInput catches a RETRY handoff that has no actionable
+// continuation: every unresolved check is externally blocked, or the agent
+// says implementation is complete while required verification still fails.
+// Letting either state re-enter the implementation loop only repeats the same
+// checks, so the harness promotes it to a user decision gate.
+func retryNeedsUserInput(progress *ParsedProgress, report *VerificationReport) bool {
+	if progress == nil || progress.State != StateRetry || report == nil {
+		return false
+	}
+	blockers := retryBlockingChecks(report)
+	if len(blockers) == 0 {
+		return false
+	}
+	if retryHasOnlyExternalBlockers(blockers) {
+		return true
+	}
+	whereStopped := strings.ToLower(strings.TrimSpace(progress.HandoffSections["Where I stopped"]))
+	return declaresImplementationComplete(whereStopped)
+}
+
+func declaresImplementationComplete(whereStopped string) bool {
+	whereStopped = strings.TrimLeft(strings.TrimSpace(whereStopped), "-* ")
+	for _, prefix := range []string{"complete", "completed"} {
+		if whereStopped == prefix {
+			return true
+		}
+		if strings.HasPrefix(whereStopped, prefix+" ") ||
+			strings.HasPrefix(whereStopped, prefix+";") ||
+			strings.HasPrefix(whereStopped, prefix+".") ||
+			strings.HasPrefix(whereStopped, prefix+":") {
+			return true
+		}
+	}
+	return false
+}
+
+func retryBlockingChecks(report *VerificationReport) []VerificationCheckResult {
+	if report == nil {
+		return nil
+	}
+	var blockers []VerificationCheckResult
+	for _, check := range reportChecks(report) {
+		switch NormalizeStatus(check.Status) {
+		case VerificationStatusFailed, VerificationStatusBlocked, VerificationStatusPendingHuman:
+			blockers = append(blockers, check)
+		}
+	}
+	return blockers
+}
+
+func retryHasOnlyExternalBlockers(blockers []VerificationCheckResult) bool {
+	if len(blockers) == 0 {
+		return false
+	}
+	for _, blocker := range blockers {
+		switch NormalizeStatus(blocker.Status) {
+		case VerificationStatusBlocked, VerificationStatusPendingHuman:
+			continue
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+func synthesizeRetryNeedUserInputGate(progress *ParsedProgress, report *VerificationReport, iteration int) NeedUserInputRecord {
+	blockers := retryBlockingChecks(report)
+	labels := make([]string, 0, len(blockers))
+	seenLabels := make(map[string]struct{}, len(blockers))
+	for _, blocker := range blockers {
+		label := strings.TrimSpace(blocker.Name)
+		if label == "" {
+			label = strings.TrimSpace(blocker.Requirement)
+		}
+		if label == "" {
+			label = strings.TrimSpace(blocker.ItemID)
+		}
+		if label != "" {
+			key := strings.ToLower(label)
+			if _, seen := seenLabels[key]; seen {
+				continue
+			}
+			seenLabels[key] = struct{}{}
+			labels = append(labels, label)
+		}
+	}
+	implementationComplete := false
+	if progress != nil {
+		whereStopped := strings.ToLower(strings.TrimSpace(progress.HandoffSections["Where I stopped"]))
+		implementationComplete = declaresImplementationComplete(whereStopped)
+	}
+	summary := "Required verification is externally blocked and cannot be resolved in the current session."
+	if implementationComplete {
+		summary = "Implementation is complete, but required verification remains unresolved."
+	}
+	if len(labels) > 0 {
+		if implementationComplete {
+			summary = fmt.Sprintf("Implementation is complete, but required verification remains unresolved: %s.", strings.Join(labels, "; "))
+		} else {
+			summary = fmt.Sprintf("Required verification is externally blocked and cannot be resolved in the current session: %s.", strings.Join(labels, "; "))
+		}
+	}
+	if progress != nil {
+		if remaining := strings.TrimSpace(progress.HandoffSections["Remaining from the plan"]); remaining != "" {
+			summary += " " + remaining
+		}
+	}
+	return NeedUserInputRecord{
+		Summary: summary,
+		Questions: []NeedUserInputQuestion{{
+			Index:  1,
+			Prompt: "Should Agentico revise or waive the blocking verification requirements, expand implementation scope to address them, or resume in an environment where they can pass?",
+		}},
+		Iteration: iteration,
+	}
+}
+
 // NeedUserInputPath returns the absolute path of the gate artifact for the
 // supplied iteration directory.
 func NeedUserInputPath(iterDir string) string {

--- a/internal/agent/need_user_input_test.go
+++ b/internal/agent/need_user_input_test.go
@@ -110,3 +110,91 @@ func TestReconcileNeedUserInputGate(t *testing.T) {
 		})
 	}
 }
+
+func TestRetryNeedsUserInput(t *testing.T) {
+	failed := VerificationCheckResult{
+		Name:   "Integration tests pass",
+		Status: VerificationStatusFailed,
+	}
+	blocked := VerificationCheckResult{
+		ItemID: "plan_docker",
+		Name:   "Container tests pass",
+		Status: VerificationStatusBlocked,
+	}
+	passed := VerificationCheckResult{
+		Name:   "Build succeeds",
+		Status: VerificationStatusPassed,
+	}
+	notRun := VerificationCheckResult{
+		Name:   "Tests remain to run",
+		Status: VerificationStatusNotRun,
+	}
+
+	tests := []struct {
+		name     string
+		progress *ParsedProgress
+		report   *VerificationReport
+		want     bool
+	}{
+		{
+			name: "complete retry with failed legacy check escalates",
+			progress: &ParsedProgress{
+				State: StateRetry,
+				HandoffSections: map[string]string{
+					"Where I stopped": "Complete for implementation; Docker is unavailable.",
+				},
+			},
+			report: &VerificationReport{RequiredChecks: []VerificationCheckResult{failed}},
+			want:   true,
+		},
+		{
+			name: "retry with only blocked contract results escalates",
+			progress: &ParsedProgress{
+				State: StateRetry,
+				HandoffSections: map[string]string{
+					"Where I stopped": "Waiting for external infrastructure.",
+				},
+			},
+			report: &VerificationReport{Results: []VerificationCheckResult{passed, blocked}},
+			want:   true,
+		},
+		{
+			name: "actionable retry stays in loop",
+			progress: &ParsedProgress{
+				State: StateRetry,
+				HandoffSections: map[string]string{
+					"Where I stopped": "Fix the failing parser test next.",
+				},
+			},
+			report: &VerificationReport{RequiredChecks: []VerificationCheckResult{failed}},
+		},
+		{
+			name: "complete retry with only not-run work stays in loop",
+			progress: &ParsedProgress{
+				State: StateRetry,
+				HandoffSections: map[string]string{
+					"Where I stopped": "Complete with the first task; continue with the second.",
+				},
+			},
+			report: &VerificationReport{RequiredChecks: []VerificationCheckResult{notRun}},
+		},
+		{
+			name: "success state never escalates",
+			progress: &ParsedProgress{
+				State: StateSuccess,
+				HandoffSections: map[string]string{
+					"Where I stopped": "Complete",
+				},
+			},
+			report: &VerificationReport{RequiredChecks: []VerificationCheckResult{failed}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := retryNeedsUserInput(tt.progress, tt.report); got != tt.want {
+				t.Errorf("retryNeedsUserInput() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/agent/report_integrity.go
+++ b/internal/agent/report_integrity.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -43,6 +44,8 @@ const (
 	// GateCategoryDeferral covers structured cross-phase commitment failures.
 	GateCategoryDeferral ReportGateCategory = "deferral"
 )
+
+var behavioralTranscriptExitCodeRE = regexp.MustCompile(`(?i)^\[?exit code:\s*(-?\d+)\]?$`)
 
 // ReportGateKind is a fine-grained finding type within a category. It
 // drives feedback consolidation: findings sharing the same Kind are
@@ -280,7 +283,10 @@ func validateEvidenceFiles(result *ReportGateResult, checks []VerificationCheckR
 			})
 			continue
 		}
-		validateEvidencePath(result, name, iterDir, root, "primary", c.EvidenceData.Primary)
+		primaryValid := validateEvidencePath(result, name, iterDir, root, "primary", c.EvidenceData.Primary)
+		if primaryValid && item.ExpectedEvidence.Matcher == testingContractCommandTranscriptMatcher {
+			validateBehavioralCommandTranscript(result, name, iterDir, c.EvidenceData.Primary, item)
+		}
 		for idx, attachment := range c.EvidenceData.Attachments {
 			field := fmt.Sprintf("attachments[%d]", idx)
 			validateEvidencePath(result, name, iterDir, root, field, attachment)
@@ -301,7 +307,7 @@ func evidenceFileRootForContractItem(item TestingContractItem) (string, bool) {
 	}
 }
 
-func validateEvidencePath(result *ReportGateResult, checkName, iterDir, root, field, raw string) {
+func validateEvidencePath(result *ReportGateResult, checkName, iterDir, root, field, raw string) bool {
 	clean, detail := cleanEvidencePath(raw, root)
 	if detail != "" {
 		result.Findings = append(result.Findings, ReportGateFinding{
@@ -310,7 +316,7 @@ func validateEvidencePath(result *ReportGateResult, checkName, iterDir, root, fi
 			Kind:      KindEvidenceFile,
 			Detail:    fmt.Sprintf("evidence.%s path %q is invalid: %s", field, raw, detail),
 		})
-		return
+		return false
 	}
 	fullPath := filepath.Join(iterDir, filepath.FromSlash(clean))
 	info, err := os.Stat(fullPath)
@@ -322,7 +328,7 @@ func validateEvidencePath(result *ReportGateResult, checkName, iterDir, root, fi
 				Kind:      KindEvidenceFile,
 				Detail:    fmt.Sprintf("evidence.%s path %q is missing under iteration directory", field, clean),
 			})
-			return
+			return false
 		}
 		result.Findings = append(result.Findings, ReportGateFinding{
 			CheckName: checkName,
@@ -330,7 +336,7 @@ func validateEvidencePath(result *ReportGateResult, checkName, iterDir, root, fi
 			Kind:      KindEvidenceFile,
 			Detail:    fmt.Sprintf("evidence.%s path %q could not be statted: %v", field, clean, err),
 		})
-		return
+		return false
 	}
 	if info.IsDir() {
 		result.Findings = append(result.Findings, ReportGateFinding{
@@ -339,7 +345,92 @@ func validateEvidencePath(result *ReportGateResult, checkName, iterDir, root, fi
 			Kind:      KindEvidenceFile,
 			Detail:    fmt.Sprintf("evidence.%s path %q is a directory, not a file", field, clean),
 		})
+		return false
 	}
+	return true
+}
+
+func validateBehavioralCommandTranscript(result *ReportGateResult, checkName, iterDir, rawPath string, item TestingContractItem) {
+	commands := requiredBehavioralTranscriptCommands(item.Name)
+	if len(commands) == 0 {
+		result.Findings = append(result.Findings, ReportGateFinding{
+			CheckName: checkName,
+			Category:  GateCategorySchema,
+			Kind:      KindEvidenceFile,
+			Detail:    "behavioral evidence expects an actual command transcript, but the testing-contract item names no parseable commands",
+		})
+		return
+	}
+
+	clean, detail := cleanEvidencePath(rawPath, "behaviors")
+	if detail != "" {
+		return
+	}
+	data, err := os.ReadFile(filepath.Join(iterDir, filepath.FromSlash(clean)))
+	if err != nil {
+		result.Findings = append(result.Findings, ReportGateFinding{
+			CheckName: checkName,
+			Category:  GateCategorySchema,
+			Kind:      KindEvidenceFile,
+			Detail:    fmt.Sprintf("behavioral evidence %q could not be read as an actual command transcript: %v", clean, err),
+		})
+		return
+	}
+
+	lines := strings.Split(string(data), "\n")
+	missing := make([]string, 0, len(commands))
+	for _, command := range commands {
+		if !hasBehavioralTranscriptBlock(lines, command) {
+			missing = append(missing, command)
+		}
+	}
+	if len(missing) > 0 {
+		result.Findings = append(result.Findings, ReportGateFinding{
+			CheckName: checkName,
+			Category:  GateCategorySchema,
+			Kind:      KindEvidenceFile,
+			Detail: fmt.Sprintf(
+				"behavioral evidence %q contains summaries instead of an actual command transcript for: %s; preserve a command header, exit code, and captured stdout/stderr for non-zero exits",
+				clean,
+				strings.Join(quoted(missing), ", "),
+			),
+		})
+	}
+}
+
+func hasBehavioralTranscriptBlock(lines []string, command string) bool {
+	normalizedCommand := normalizeVerificationCommand(command)
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if !isBehavioralTranscriptCommandHeader(trimmed) || !strings.Contains(normalizeVerificationCommand(trimmed), normalizedCommand) {
+			continue
+		}
+
+		exitCode := ""
+		hasOutput := false
+		for j := i + 1; j < len(lines); j++ {
+			next := strings.TrimSpace(lines[j])
+			if isBehavioralTranscriptCommandHeader(next) {
+				break
+			}
+			if match := behavioralTranscriptExitCodeRE.FindStringSubmatch(next); match != nil {
+				exitCode = match[1]
+				continue
+			}
+			if exitCode != "" && next != "" && !strings.EqualFold(next, "OUTPUT:") {
+				hasOutput = true
+			}
+		}
+		if exitCode == "0" || (exitCode != "" && hasOutput) {
+			return true
+		}
+	}
+	return false
+}
+
+func isBehavioralTranscriptCommandHeader(line string) bool {
+	upper := strings.ToUpper(line)
+	return strings.HasPrefix(line, "$ ") || strings.HasPrefix(upper, "COMMAND:")
 }
 
 func cleanEvidencePath(raw, root string) (string, string) {

--- a/internal/agent/report_integrity_test.go
+++ b/internal/agent/report_integrity_test.go
@@ -379,6 +379,131 @@ func TestValidateVerificationReportWithContext_EvidenceFiles(t *testing.T) {
 	}
 }
 
+func TestValidateVerificationReportWithContext_RejectsSummaryOnlyCommandTranscript(t *testing.T) {
+	iterDir := t.TempDir()
+	contract := compileCommandTranscriptContractForTest(iterDir)
+	foundBehavioral := false
+	for _, item := range contract.Items {
+		if item.Source != testingContractBehavioralSource {
+			continue
+		}
+		foundBehavioral = true
+		if item.ExpectedEvidence.Matcher != testingContractCommandTranscriptMatcher {
+			t.Fatalf("behavioral evidence matcher = %q, want %q; commands=%q", item.ExpectedEvidence.Matcher, testingContractCommandTranscriptMatcher, requiredBehavioralTranscriptCommands(item.Name))
+		}
+	}
+	if !foundBehavioral {
+		t.Fatal("compiled contract has no behavioral evidence item")
+	}
+
+	behaviorPath := filepath.Join(iterDir, "behaviors", "verification.log")
+	if err := os.MkdirAll(filepath.Dir(behaviorPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(behaviorPath, []byte(strings.Join([]string{
+		"Automated command results:",
+		"- dbaccess: `task lint` exited 201 because of existing findings.",
+		"- dbaccess: `task test-coverage` exited 201 because Docker is unavailable.",
+		"- agentic-orchestrator: `make test-fast` exited 0; all packages passed.",
+	}, "\n")), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	report := passedArtifactReportForTest(&contract, filepath.Join(iterDir, "testing-contract.yaml"))
+	setArtifactEvidenceForTest(&report, VerificationModeBehavioral, VerificationEvidence{
+		Summary: "verification.log records command outcomes",
+		Primary: "behaviors/verification.log",
+	})
+
+	result := ValidateVerificationReportWithContext(&report, nil, true, VerificationReportValidationContext{
+		IterationDir: iterDir,
+		Contract:     &contract,
+	})
+	if !result.Rejected {
+		t.Fatal("ValidateVerificationReportWithContext() accepted hand-written command summaries as command transcripts")
+	}
+	if details := reportGateDetailsForTest(result); !strings.Contains(details, "actual command transcript") {
+		t.Fatalf("ValidateVerificationReportWithContext() details = %q, want actual command transcript guidance", details)
+	}
+}
+
+func TestValidateVerificationReportWithContext_AcceptsCommandTranscriptFormats(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+	}{
+		{
+			name: "shell_capture",
+			content: strings.Join([]string{
+				"$ (cd /tmp/dbaccess && task lint)",
+				"[exit code: 201]",
+				"task: Failed to run task lint",
+				"$ (cd /tmp/dbaccess && task test-coverage)",
+				"[exit code: 201]",
+				"Docker is unavailable",
+				"$ (cd /tmp/agentic-orchestrator && make test-fast)",
+				"[exit code: 0]",
+			}, "\n"),
+		},
+		{
+			name: "labeled_capture",
+			content: strings.Join([]string{
+				"COMMAND: cd /tmp/dbaccess && task lint",
+				"EXIT CODE: 201",
+				"OUTPUT:",
+				"task: Failed to run task lint",
+				"COMMAND: cd /tmp/dbaccess && task test-coverage",
+				"EXIT CODE: 201",
+				"OUTPUT:",
+				"Docker is unavailable",
+				"COMMAND: cd /tmp/agentic-orchestrator && make test-fast",
+				"EXIT CODE: 0",
+				"OUTPUT:",
+			}, "\n"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			iterDir := t.TempDir()
+			contract := compileCommandTranscriptContractForTest(iterDir)
+			behaviorPath := filepath.Join(iterDir, "behaviors", "verification.log")
+			if err := os.MkdirAll(filepath.Dir(behaviorPath), 0o755); err != nil {
+				t.Fatalf("MkdirAll() error = %v", err)
+			}
+			if err := os.WriteFile(behaviorPath, []byte(tt.content), 0o644); err != nil {
+				t.Fatalf("WriteFile() error = %v", err)
+			}
+
+			report := passedArtifactReportForTest(&contract, filepath.Join(iterDir, "testing-contract.yaml"))
+			setArtifactEvidenceForTest(&report, VerificationModeBehavioral, VerificationEvidence{
+				Summary: "complete combined stdout/stderr",
+				Primary: "behaviors/verification.log",
+			})
+			result := ValidateVerificationReportWithContext(&report, nil, true, VerificationReportValidationContext{
+				IterationDir: iterDir,
+				Contract:     &contract,
+			})
+			if result.Rejected {
+				t.Fatalf("ValidateVerificationReportWithContext() rejected valid transcript: %+v", result.Findings)
+			}
+		})
+	}
+}
+
+func compileCommandTranscriptContractForTest(iterDir string) TestingContract {
+	return CompileTestingContractMultiRepo(MultiRepoContractInput{
+		Repos: []string{"agentic-orchestrator", "dbaccess"},
+		PlanText: strings.Join([]string{
+			"## Success Criteria",
+			"### Behavioral Evidence",
+			"- [ ] Record the verification command output for `task lint`, `task test-coverage`, and `make test-fast`.",
+		}, "\n"),
+		PlanPath:  filepath.Join(iterDir, "plan.md"),
+		PhaseType: "collapsed",
+	})
+}
+
 func TestValidateVerificationReportWithContext_EvidenceFilesSkippedForBlockedRows(t *testing.T) {
 	iterDir := t.TempDir()
 	contract := CompileTestingContract("## Success Criteria\n### Visual Evidence\n- [ ] Capture the dashboard screenshot.\n", filepath.Join(iterDir, "plan.md"), "collapsed")

--- a/internal/agent/testing_contract.go
+++ b/internal/agent/testing_contract.go
@@ -42,6 +42,7 @@ const (
 	testingContractVisualKind                = "visual_artifact"
 	testingContractBehavioralKind            = "behavioral_artifact"
 	testingContractEvidenceFileExistsMatcher = "file_exists"
+	testingContractCommandTranscriptMatcher  = "command_transcript"
 	// TestingContractCrossRepoTag is the value put on `repo:` for items
 	// that exercise more than one repo. The unified-flow implementer
 	// dispatches such items to the main session (no per-repo Task
@@ -180,7 +181,7 @@ func CompileTestingContractWithBaseline(planText, planPath, phaseType, baselineP
 			Command: command,
 			ExpectedEvidence: TestingContractExpectedEvidence{
 				Kind:    kind,
-				Matcher: testingContractEvidenceFileExistsMatcher,
+				Matcher: evidenceRequirementMatcher(source, description),
 			},
 			Policy: defaultTestingContractPolicy(source),
 		})
@@ -458,7 +459,7 @@ func CompileTestingContractMultiRepo(in MultiRepoContractInput) TestingContract 
 			Command: command,
 			ExpectedEvidence: TestingContractExpectedEvidence{
 				Kind:    kind,
-				Matcher: testingContractEvidenceFileExistsMatcher,
+				Matcher: evidenceRequirementMatcher(source, description),
 			},
 			Policy: defaultTestingContractPolicy(source),
 		})
@@ -624,6 +625,50 @@ func manualVerificationCommand(description string) string {
 
 func evidenceRequirementCommand(source, description string) string {
 	return strings.TrimSpace(source) + ": " + strings.TrimSpace(description)
+}
+
+func evidenceRequirementMatcher(source, description string) string {
+	if source == testingContractBehavioralSource && len(requiredBehavioralTranscriptCommands(description)) > 0 {
+		return testingContractCommandTranscriptMatcher
+	}
+	return testingContractEvidenceFileExistsMatcher
+}
+
+// requiredBehavioralTranscriptCommands returns the executable backtick spans
+// from behavioral requirements that explicitly ask for command output. Other
+// behavioral artifacts remain file-existence checks because their semantics
+// are intentionally assessed by the reviewer.
+func requiredBehavioralTranscriptCommands(description string) []string {
+	normalized := strings.ToLower(strings.TrimSpace(description))
+	if !strings.Contains(normalized, "command output") &&
+		!strings.Contains(normalized, "command transcript") &&
+		!strings.Contains(normalized, "stdout") &&
+		!strings.Contains(normalized, "stderr") {
+		return nil
+	}
+
+	spans := findBacktickSpans(description)
+	commands := make([]string, 0, len(spans))
+	seen := make(map[string]bool, len(spans))
+	for _, span := range spans {
+		command := strings.TrimSpace(description[span[2]:span[3]])
+		if !looksLikeShellCommand(command) {
+			continue
+		}
+		key := normalizeVerificationCommand(command)
+		if key == "" || seen[key] {
+			continue
+		}
+		seen[key] = true
+		commands = append(commands, command)
+	}
+	if len(commands) == 0 && len(spans) == 1 {
+		command := strings.TrimSpace(description[spans[0][2]:spans[0][3]])
+		if command != "" {
+			commands = append(commands, command)
+		}
+	}
+	return commands
 }
 
 func normalizeVerificationCommand(command string) string {

--- a/internal/tui/api_app.go
+++ b/internal/tui/api_app.go
@@ -115,6 +115,11 @@ const (
 )
 
 const (
+	maxIterationsRestartDelta     = 10
+	maxPlanIterationsRestartDelta = 2
+)
+
+const (
 	statusMsgNoFeatureSelected       = "No feature selected"
 	statusMsgNoActiveSessions        = "No active sessions to watch."
 	statusMsgLoadingReviewArtifact   = "Loading review artifact"
@@ -661,13 +666,15 @@ type apiReviewCommentsPanel struct {
 }
 
 type apiFeatureActionArgs struct {
-	Repo            string
-	Repos           []string
-	Title           string
-	Body            string
-	TargetPhase     string
-	RoadmapPhase    int
-	UpgradePipeline feature.PipelineProfile
+	Repo                   string
+	Repos                  []string
+	Title                  string
+	Body                   string
+	TargetPhase            string
+	RoadmapPhase           int
+	UpgradePipeline        feature.PipelineProfile
+	MaxIterationsDelta     int
+	MaxPlanIterationsDelta int
 }
 
 type apiRepoActionPanel struct {
@@ -1470,7 +1477,12 @@ func (m APIAppModel) handleAPIKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		if canRetrySetup(m.selectedAPIDashboardFeature()) {
 			return m, m.selectedFeatureActionCmd(mutationKindFeatureRetry, m.selectedFeature)
 		}
-		return m.confirmSelectedFeatureAction(mutationKindFeatureRestart), nil
+		args := apiFeatureActionArgs{}
+		if f := m.selectedAPIDashboardFeature(); f != nil && f.Status == feature.StatusFailed && f.FailureType == feature.FailureMaxIterations {
+			args.MaxIterationsDelta = maxIterationsRestartDelta
+			args.MaxPlanIterationsDelta = maxPlanIterationsRestartDelta
+		}
+		return m.confirmSelectedFeatureActionWithArgs(mutationKindFeatureRestart, args), nil
 	case "s":
 		return m.confirmSelectedFeatureAction(mutationKindFeatureStop), nil
 	case "d":
@@ -6082,7 +6094,11 @@ func (m APIAppModel) renderFeatureActionConfirm() string {
 	if m.actionConfirmArgs.TargetPhase != "" {
 		b.WriteString("  Target phase: " + apiRewindPhaseLabel(m.actionConfirmArgs.TargetPhase) + "\n\n")
 	}
-	if lines, ok := apiFeatureActionConfirmWarnings[m.actionConfirmKind]; ok {
+	if m.actionConfirmKind == mutationKindFeatureRestart && m.actionConfirmArgs.MaxIterationsDelta > 0 {
+		b.WriteString(WarningStyle.Render(fmt.Sprintf("  This will add %d more iterations and continue.", m.actionConfirmArgs.MaxIterationsDelta)))
+		b.WriteString("\n")
+		b.WriteString(WarningStyle.Render("  The failed phase will use the extended budget."))
+	} else if lines, ok := apiFeatureActionConfirmWarnings[m.actionConfirmKind]; ok {
 		b.WriteString(WarningStyle.Render("  " + lines[0]))
 		b.WriteString("\n")
 		b.WriteString(WarningStyle.Render("  " + lines[1]))
@@ -7110,7 +7126,10 @@ func (m APIAppModel) selectedFeatureActionCmd(kind, featureID string, argsOpt ..
 		case mutationKindFeatureMerge:
 			_, err = m.client.MergeFeature(ctx, featureID)
 		case mutationKindFeatureRestart:
-			_, err = m.client.RestartFeature(ctx, featureID, server.RestartFeatureRequest{})
+			_, err = m.client.RestartFeature(ctx, featureID, server.RestartFeatureRequest{
+				MaxIterationsDelta:     args.MaxIterationsDelta,
+				MaxPlanIterationsDelta: args.MaxPlanIterationsDelta,
+			})
 		case mutationKindFeatureRetry:
 			_, err = m.client.RetryFeature(ctx, featureID)
 		case mutationKindFeatureMarkDone:

--- a/internal/tui/api_app_test.go
+++ b/internal/tui/api_app_test.go
@@ -4406,6 +4406,52 @@ func TestAPIAppModelFeatureActionsConfirmBeforeRESTMutation(t *testing.T) {
 	}
 }
 
+func TestAPIAppModelMaxIterationsRestartExtendsBudgetAfterConfirmation(t *testing.T) {
+	t.Parallel()
+
+	summary := server.FeatureSummary{
+		ID:           testFeatureIDActive,
+		Name:         testFeatureNameClientCutover,
+		Slug:         testFeatureSlugClientCutover,
+		Status:       testFeatureStatusFailed,
+		CurrentPhase: testPhaseNameImplement,
+		CreatedAt:    time.Now(),
+	}
+	client := &fakeTUIAPIClient{
+		features: server.FeatureListResponse{Features: []server.FeatureSummary{summary}},
+		detail: server.FeatureDetailResponse{Feature: apiTestFeatureDetailWith(summary, server.FeatureDetailDTO{
+			Failure: &server.FailureDTO{Type: feature.FailureMaxIterations, Message: "reached maximum iteration count"},
+			Actions: []server.ActionDTO{
+				{ID: actionIDRestart, Enabled: true, Scope: server.ActionScopeDTO{Type: testActionScopeFeature}},
+			},
+		})},
+	}
+	app := newTestAPIAppModel(t, client)
+
+	model, cmd := app.Update(tea.KeyPressMsg{Code: 'r', Text: "r"})
+	if cmd != nil {
+		t.Fatal("Update(r) returned command before confirmation")
+	}
+	confirming := model.(APIAppModel)
+	if view := stripANSI(confirming.View().Content); !strings.Contains(view, "add 10 more iterations") {
+		t.Fatalf("max-iterations confirmation missing budget extension:\n%s", view)
+	}
+	if len(client.restartRequests) != 0 {
+		t.Fatalf("RestartFeature requests = %+v before confirmation, want none", client.restartRequests)
+	}
+
+	model, cmd = confirming.Update(tea.KeyPressMsg{Code: 'y', Text: "y"})
+	if cmd == nil {
+		t.Fatal("Update(y) returned nil command, want restart mutation")
+	}
+	_ = model
+	_ = cmd()
+
+	if got := client.restartRequests; len(got) != 1 || got[0].MaxIterationsDelta != 10 || got[0].MaxPlanIterationsDelta != 2 {
+		t.Fatalf("RestartFeature requests = %+v, want max_iterations_delta=10 and max_plan_iterations_delta=2", got)
+	}
+}
+
 func TestAPIAppModelFeatureConfigEditorLoadsFromRESTAndSavesMutation(t *testing.T) {
 	t.Parallel()
 
@@ -8420,6 +8466,7 @@ type fakeTUIAPIClient struct {
 	restartAccepted                apiTestActionResponse
 	restartErr                     error
 	restartFeatureIDs              []string
+	restartRequests                []server.RestartFeatureRequest
 	stopAccepted                   apiTestActionResponse
 	stopErr                        error
 	stopFeatureIDs                 []string
@@ -8688,9 +8735,10 @@ func (f *fakeTUIAPIClient) ResumeFeature(_ context.Context, featureID string) (s
 	return server.FeatureStartResponse{FeatureID: f.resumeAccepted.featureID(featureID), Result: f.resumeAccepted.result("resumed")}, f.resumeErr
 }
 
-func (f *fakeTUIAPIClient) RestartFeature(_ context.Context, featureID string, _ server.RestartFeatureRequest) (server.FeatureRestartResponse, error) {
+func (f *fakeTUIAPIClient) RestartFeature(_ context.Context, featureID string, req server.RestartFeatureRequest) (server.FeatureRestartResponse, error) {
 	f.calls = append(f.calls, "RestartFeature")
 	f.restartFeatureIDs = append(f.restartFeatureIDs, featureID)
+	f.restartRequests = append(f.restartRequests, req)
 	return server.FeatureRestartResponse{FeatureID: f.restartAccepted.featureID(featureID), Result: f.restartAccepted.result("restarted")}, f.restartErr
 }
 

--- a/internal/tui/detail.go
+++ b/internal/tui/detail.go
@@ -877,6 +877,9 @@ func formatDetailStatus(f *feature.Feature) string {
 		if f.FailureType != "" {
 			msg = "Failed (" + formatFailureType(f.FailureType) + ")"
 		}
+		if f.FailureType == feature.FailureMaxIterations {
+			return ErrorStyle.Render(msg + " — press [r] to add 10 more iterations, [l] logs")
+		}
 		return ErrorStyle.Render(msg + " — press [r] to restart, [l] logs")
 	}
 	if f.Status.IsNeedsReview() {
@@ -977,6 +980,9 @@ func formatDetailStatus(f *feature.Feature) string {
 		if f.FailureType != "" {
 			msg = "Failed (" + formatFailureType(f.FailureType) + ")"
 		}
+		if f.FailureType == feature.FailureMaxIterations {
+			return ErrorStyle.Render(msg + " \u2014 press [r] to add 10 more iterations, [l] logs")
+		}
 		return ErrorStyle.Render(msg + " \u2014 press [r] to restart, [l] logs")
 	default:
 		return f.Status.String()
@@ -1035,7 +1041,7 @@ func recoverySuggestion(ft string) string {
 	case feature.FailureSafetyRail:
 		return "Agent made no progress. Consider simplifying the task or adding more context."
 	case feature.FailureMaxIterations:
-		return "Reached max iterations. The task may need to be broken into smaller steps."
+		return "Reached max iterations. Press [r] to add 10 more iterations and continue."
 	case feature.FailureSessionCrash:
 		return "Session crashed. Press [r] to retry or [l] to view logs."
 	case feature.FailureMissingArtifact:

--- a/internal/tui/detail_test.go
+++ b/internal/tui/detail_test.go
@@ -337,6 +337,25 @@ func TestDetailViewFailedFeature(t *testing.T) {
 	}
 }
 
+func TestDetailViewMaxIterationsProposesAddingTenMore(t *testing.T) {
+	t.Parallel()
+
+	f := &feature.Feature{
+		ID:           "feat-max-iterations",
+		Slug:         "max-iterations",
+		Status:       feature.StatusFailed,
+		CurrentPhase: feature.PhaseImplement,
+		FailureType:  feature.FailureMaxIterations,
+		LastError:    "reached maximum iteration count",
+		Models:       config.ModelConfig{Research: "opus", Planning: "opus", Implementation: "opus", Review: "opus"},
+	}
+
+	view := stripANSI(NewDetailModel(f, "").ViewCompact(100))
+	if !strings.Contains(view, "press [r] to add 10 more iterations") {
+		t.Fatalf("ViewCompact() missing max-iteration continuation hint:\n%s", view)
+	}
+}
+
 func TestProtocolViolationFailureRendering(t *testing.T) {
 	t.Parallel()
 	f := &feature.Feature{

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -99,6 +99,7 @@ For visual and behavioral artifact rows, evidence is file-backed:
 - Put visual artifacts under `screenshots/` relative to `{iteration_dir}`.
 - Put behavioral artifacts under `behaviors/` relative to `{iteration_dir}`.
 - For `passed`, `failed`, and `pending_human` visual or behavioral rows, write real files and set `evidence.primary` to the required artifact path. Use `evidence.attachments[]` for optional supporting files. Paths must be relative and stay under the matching directory.
+- When a behavioral requirement asks for command output or a command transcript, preserve one transcript block per named command with the command line, exit code, and actual combined stdout/stderr. A hand-written outcome summary is not command evidence. On retries, carry the complete transcript forward and append or replace individual command blocks; never collapse it into summaries.
 - `blocked`, `not_run`, and `waived` visual or behavioral rows do not require artifact files. A genuine `blocked` row still needs `blocked_reason`; do not use `blocked` to hide missing artifacts.
 - Command and manual rows may keep using `evidence.summary` and `evidence.exit_code`; artifact rows may combine file fields with summary or exit code when useful.
 
@@ -175,7 +176,7 @@ The `## Deferrals` fenced YAML block must always include both keys. Deferrals ar
 `## Iteration State` must be exactly one of:
 
 - `SUCCESS`: every Task and Success Criteria item is complete, required checks pass, and due deferrals are reconciled.
-- `RETRY`: real progress landed, but work remains and the next iteration can continue from `progress.md`.
+- `RETRY`: real progress landed, work remains, and `### Where I stopped` names a concrete next action that the next iteration can perform with the current scope and environment. Do not use `RETRY` when implementation is complete and only an external blocker, plan/contract change, scope expansion, waiver, permission, or human decision remains.
 - `NEED_USER_INPUT`: the plan is wrong, repo state contradicts it, or a human decision is required.
 
 For `NEED_USER_INPUT`, insert this section between `## Verification Report` and `## Iteration State`:


### PR DESCRIPTION
## Summary

Three related hardening changes to the implementation loop's failure recovery and evidence integrity:

- **Escalate non-actionable RETRY handoffs to `NEED_USER_INPUT`.** When a RETRY has no possible next iteration — every unresolved check is externally blocked (`blocked`/`pending_human`), or the handoff declares implementation complete while a required check still `failed` — the harness now synthesizes a `NEED_USER_INPUT` gate instead of spending the remaining iteration budget re-running the same checks. The synthesized gate summarizes the blocking checks and asks the operator to revise/waive the requirement, expand scope, or resume in a capable environment.
- **Reject summary-only command evidence.** Behavioral testing-contract items that ask for command output (`command output`, `command transcript`, `stdout`, `stderr`) now compile with a `command_transcript` matcher. Report-integrity validation requires the evidence file to contain a real transcript block per named command — a command header (`$ ` or `COMMAND:`), an exit code, and captured stdout/stderr for non-zero exits — and flags hand-written outcome summaries.
- **Extend the budget on a max-iterations restart.** A feature that failed with `FailureMaxIterations` now restarts with `MaxIterationsDelta=10` / `MaxPlanIterationsDelta=2` when the operator presses `[r]`, continuing on the extended budget rather than a plain restart. TUI confirmation and status hints updated to say "add 10 more iterations and continue."

`skills/implement/SKILL.md` is updated to match: `RETRY` now requires `### Where I stopped` to name a concrete next action, and behavioral command evidence must preserve full transcripts across retries.

## Test plan

- `make test-fast` — pass (13s)
- `go test ./internal/agent/ -run 'TestImplementLoop_Routing_RETRY_CompleteWithBlockers|TestRetryNeedsUserInput|TestValidateVerificationReportWithContext_(Rejects|Accepts)' -count=1` — pass (full mode, new tests)

New tests added:
- `TestImplementLoop_Routing_RETRY_CompleteWithBlockersEscalatesNeedUserInput`
- `TestRetryNeedsUserInput`
- `TestValidateVerificationReportWithContext_RejectsSummaryOnlyCommandTranscript`
- `TestValidateVerificationReportWithContext_AcceptsCommandTranscriptFormats`
- `TestAPIAppModelMaxIterationsRestartExtendsBudgetAfterConfirmation`
- `TestDetailViewMaxIterationsProposesAddingTenMore`

🤖 Generated with [Claude Code](https://claude.com/claude-code)