### PR TITLE
Fix GPT-5.6 pricing estimates

### DIFF
--- a/internal/llm/codex/protocol.go
+++ b/internal/llm/codex/protocol.go
@@ -83,6 +83,7 @@ type Protocol struct {
 	inputTokens        int
 	cachedInputTokens  int
 	outputTokens       int
+	totalCostUSD       float64
 	modelContextWindow int
 	deltaBuf           map[string]string
 	questionIDs        map[string]string
@@ -781,10 +782,10 @@ func (p *Protocol) parseNotification(method string, params json.RawMessage) (llm
 		switch completed.Turn.Status {
 		case "completed":
 			p.mu.Lock()
-			model := p.model
 			inTok := p.inputTokens
 			cachedInTok := p.cachedInputTokens
 			outTok := p.outputTokens
+			costUSD := p.totalCostUSD
 			hadToolUse := p.turnHadToolUse
 			lastText := p.lastAssistantText
 			if lastText == "" {
@@ -849,7 +850,6 @@ func (p *Protocol) parseNotification(method string, params json.RawMessage) (llm
 			p.formatRetryCount = 0
 			p.mu.Unlock()
 
-			costUSD := computeCost(model, inTok, cachedInTok, outTok)
 			msg := llm.SDKMessage{
 				Type:    "result",
 				Subtype: "success",
@@ -870,13 +870,12 @@ func (p *Protocol) parseNotification(method string, params json.RawMessage) (llm
 
 		case "failed":
 			p.mu.Lock()
-			model := p.model
 			inTok := p.inputTokens
 			cachedInTok := p.cachedInputTokens
 			outTok := p.outputTokens
+			costUSD := p.totalCostUSD
 			p.mu.Unlock()
 
-			costUSD := computeCost(model, inTok, cachedInTok, outTok)
 			errMsg := fmt.Sprintf("codex turn failed: %s", completed.Turn.ID)
 			if completed.Turn.Error != nil {
 				errMsg = completed.Turn.Error.Message
@@ -914,13 +913,12 @@ func (p *Protocol) parseNotification(method string, params json.RawMessage) (llm
 
 		case "interrupted":
 			p.mu.Lock()
-			model := p.model
 			inTok := p.inputTokens
 			cachedInTok := p.cachedInputTokens
 			outTok := p.outputTokens
+			costUSD := p.totalCostUSD
 			p.mu.Unlock()
 
-			costUSD := computeCost(model, inTok, cachedInTok, outTok)
 			msg := llm.SDKMessage{
 				Type:    "result",
 				Subtype: "error",
@@ -954,6 +952,21 @@ func (p *Protocol) parseNotification(method string, params json.RawMessage) (llm
 		// Total = lifetime cumulative (for cost calculation on turn completion).
 		// Last = current context fill (resets on compaction; use for context %).
 		p.mu.Lock()
+		inputDelta := usage.TokenUsage.Total.InputTokens - p.inputTokens
+		cachedInputDelta := usage.TokenUsage.Total.CachedInputTokens - p.cachedInputTokens
+		outputDelta := usage.TokenUsage.Total.OutputTokens - p.outputTokens
+		if inputDelta >= 0 && cachedInputDelta >= 0 && outputDelta >= 0 {
+			// The app-server protocol does not expose cache-write token counts,
+			// so cache writes remain zero until that telemetry becomes available.
+			p.totalCostUSD += computeCostForContext(
+				p.model,
+				inputDelta,
+				cachedInputDelta,
+				0,
+				outputDelta,
+				usage.TokenUsage.Last.InputTokens,
+			)
+		}
 		p.inputTokens = usage.TokenUsage.Total.InputTokens
 		p.cachedInputTokens = usage.TokenUsage.Total.CachedInputTokens
 		p.outputTokens = usage.TokenUsage.Total.OutputTokens
@@ -1659,19 +1672,41 @@ func (p *Protocol) SystemPromptForTest() string {
 	return p.opts.SystemPrompt
 }
 
-func computeCost(model string, inputTokens, cachedInputTokens, outputTokens int) float64 {
+func computeCost(model string, inputTokens, cachedInputTokens, cacheWriteTokens, outputTokens int) float64 {
+	return computeCostForContext(model, inputTokens, cachedInputTokens, cacheWriteTokens, outputTokens, inputTokens)
+}
+
+func computeCostForContext(model string, inputTokens, cachedInputTokens, cacheWriteTokens, outputTokens, contextInputTokens int) float64 {
 	r, ok := lookupRate(model)
 	if !ok {
 		return 0
 	}
-	if cachedInputTokens < 0 {
-		cachedInputTokens = 0
-	}
+	inputTokens = max(inputTokens, 0)
+	cachedInputTokens = max(cachedInputTokens, 0)
+	cacheWriteTokens = max(cacheWriteTokens, 0)
+	outputTokens = max(outputTokens, 0)
 	if cachedInputTokens > inputTokens {
 		cachedInputTokens = inputTokens
 	}
-	uncachedInputTokens := inputTokens - cachedInputTokens
-	return (float64(uncachedInputTokens)/1_000_000)*r.inputPerMToken +
-		(float64(cachedInputTokens)/1_000_000)*r.cachedInputPerMToken +
-		(float64(outputTokens)/1_000_000)*r.outputPerMToken
+	inputRate := r.inputPerMToken
+	cachedInputRate := r.cachedInputPerMToken
+	cacheWriteRate := r.cacheWritePerMToken
+	outputRate := r.outputPerMToken
+	if contextInputTokens > longContextInputThreshold && r.longInputPerMToken > 0 {
+		inputRate = r.longInputPerMToken
+		cachedInputRate = r.longCachedInputPerMToken
+		cacheWriteRate = r.longCacheWritePerMToken
+		outputRate = r.longOutputPerMToken
+	}
+	if cacheWriteRate == 0 {
+		cacheWriteTokens = 0
+	} else if cacheWriteTokens > inputTokens-cachedInputTokens {
+		cacheWriteTokens = inputTokens - cachedInputTokens
+	}
+	uncachedInputTokens := inputTokens - cachedInputTokens - cacheWriteTokens
+
+	return (float64(uncachedInputTokens)/1_000_000)*inputRate +
+		(float64(cachedInputTokens)/1_000_000)*cachedInputRate +
+		(float64(cacheWriteTokens)/1_000_000)*cacheWriteRate +
+		(float64(outputTokens)/1_000_000)*outputRate
 }

--- a/internal/llm/codex/protocol_test.go
+++ b/internal/llm/codex/protocol_test.go
@@ -839,7 +839,7 @@ func TestTurnCompletedComputesCostWithCachedInputTokens(t *testing.T) {
 	if msg.Result == nil {
 		t.Fatal("Result = nil")
 	}
-	const want = 6.20 // 600K full input at $5/M + 400K cached at $0.50/M + 100K output at $30/M
+	const want = 10.90 // Long context: 600K at $10/M + 400K cached at $1/M + 100K output at $45/M
 	if diff := msg.Result.TotalCostUSD - want; diff < -0.001 || diff > 0.001 {
 		t.Fatalf("TotalCostUSD = %.6f, want %.2f", msg.Result.TotalCostUSD, want)
 	}
@@ -848,6 +848,57 @@ func TestTurnCompletedComputesCostWithCachedInputTokens(t *testing.T) {
 	}
 	if msg.Result.Usage.CacheReadInputTokens != 400_000 {
 		t.Fatalf("Result.Usage.CacheReadInputTokens = %d, want 400000", msg.Result.Usage.CacheReadInputTokens)
+	}
+}
+
+func TestTurnCompletedAccumulatesShortAndLongContextRates(t *testing.T) {
+	p := NewProtocol(llm.ProtocolOpts{WorkDir: "/tmp/test", Model: "gpt-5.6-luna"})
+
+	updates := []map[string]interface{}{
+		{
+			"total": map[string]interface{}{
+				"inputTokens": 200_000, "cachedInputTokens": 20_000,
+				"outputTokens": 10_000, "totalTokens": 210_000,
+			},
+			"last": map[string]interface{}{
+				"inputTokens": 200_000, "cachedInputTokens": 20_000,
+				"outputTokens": 10_000, "totalTokens": 210_000,
+			},
+		},
+		{
+			"total": map[string]interface{}{
+				"inputTokens": 300_000, "cachedInputTokens": 30_000,
+				"outputTokens": 20_000, "totalTokens": 320_000,
+			},
+			"last": map[string]interface{}{
+				"inputTokens": 300_000, "cachedInputTokens": 30_000,
+				"outputTokens": 20_000, "totalTokens": 320_000,
+			},
+		},
+	}
+	for _, tokenUsage := range updates {
+		params, err := json.Marshal(map[string]interface{}{
+			"threadId":   "thread-1",
+			"turnId":     "turn-1",
+			"tokenUsage": tokenUsage,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, ok := p.parseNotification("thread/tokenUsage/updated", params); !ok {
+			t.Fatal("token usage notification ok = false, want true")
+		}
+	}
+
+	msg, ok := p.parseNotification("turn/completed", completedTurnParams(t, "thread-1"))
+	if !ok || msg.Result == nil {
+		t.Fatal("turn completed did not return a result")
+	}
+	// First update uses short-context rates ($0.242); the 100K/10K/10K
+	// deltas in the second update use long-context rates ($0.272).
+	const want = 0.514
+	if diff := msg.Result.TotalCostUSD - want; diff < -0.001 || diff > 0.001 {
+		t.Fatalf("TotalCostUSD = %.6f, want %.3f", msg.Result.TotalCostUSD, want)
 	}
 }
 

--- a/internal/llm/codex/provider.go
+++ b/internal/llm/codex/provider.go
@@ -153,7 +153,7 @@ Self-check before sending every question. If any answer is "no" and the free-for
 }
 
 func (p *Provider) ComputeCost(model string, inputTokens, outputTokens int64) float64 {
-	return computeCost(model, int(inputTokens), 0, int(outputTokens))
+	return computeCost(model, int(inputTokens), 0, 0, int(outputTokens))
 }
 
 func (p *Provider) ContextWindowForModel(model string) int {

--- a/internal/llm/codex/rates.go
+++ b/internal/llm/codex/rates.go
@@ -22,19 +22,43 @@ import (
 
 // tokenRate holds per-million-token pricing for a model.
 type tokenRate struct {
-	inputPerMToken       float64
-	cachedInputPerMToken float64
-	outputPerMToken      float64
+	inputPerMToken           float64
+	cachedInputPerMToken     float64
+	cacheWritePerMToken      float64
+	outputPerMToken          float64
+	longInputPerMToken       float64
+	longCachedInputPerMToken float64
+	longCacheWritePerMToken  float64
+	longOutputPerMToken      float64
 }
 
 // modelRates maps canonical model names to their token pricing.
-// Source: https://developers.openai.com/api/docs/pricing (June 2026)
+// Source: https://developers.openai.com/api/docs/pricing (July 2026)
 var modelRates = map[string]tokenRate{
-	"gpt-5.5":       {inputPerMToken: 5.00, cachedInputPerMToken: 0.50, outputPerMToken: 30.00},
-	"gpt-5.4":       {inputPerMToken: 2.50, cachedInputPerMToken: 0.25, outputPerMToken: 15.00},
+	"gpt-5.6": {
+		inputPerMToken: 5.00, cachedInputPerMToken: 0.50, cacheWritePerMToken: 6.25, outputPerMToken: 30.00,
+		longInputPerMToken: 10.00, longCachedInputPerMToken: 1.00, longCacheWritePerMToken: 12.50, longOutputPerMToken: 45.00,
+	},
+	"gpt-5.6-sol": {
+		inputPerMToken: 5.00, cachedInputPerMToken: 0.50, cacheWritePerMToken: 6.25, outputPerMToken: 30.00,
+		longInputPerMToken: 10.00, longCachedInputPerMToken: 1.00, longCacheWritePerMToken: 12.50, longOutputPerMToken: 45.00,
+	},
+	"gpt-5.6-terra": {
+		inputPerMToken: 2.50, cachedInputPerMToken: 0.25, cacheWritePerMToken: 3.125, outputPerMToken: 15.00,
+		longInputPerMToken: 5.00, longCachedInputPerMToken: 0.50, longCacheWritePerMToken: 6.25, longOutputPerMToken: 22.50,
+	},
+	"gpt-5.6-luna": {
+		inputPerMToken: 1.00, cachedInputPerMToken: 0.10, cacheWritePerMToken: 1.25, outputPerMToken: 6.00,
+		longInputPerMToken: 2.00, longCachedInputPerMToken: 0.20, longCacheWritePerMToken: 2.50, longOutputPerMToken: 9.00,
+	},
+	"gpt-5.5":       {inputPerMToken: 5.00, cachedInputPerMToken: 0.50, outputPerMToken: 30.00, longInputPerMToken: 10.00, longCachedInputPerMToken: 1.00, longOutputPerMToken: 45.00},
+	"gpt-5.4":       {inputPerMToken: 2.50, cachedInputPerMToken: 0.25, outputPerMToken: 15.00, longInputPerMToken: 5.00, longCachedInputPerMToken: 0.50, longOutputPerMToken: 22.50},
 	"gpt-5.4-mini":  {inputPerMToken: 0.75, cachedInputPerMToken: 0.075, outputPerMToken: 4.50},
 	"gpt-5.3-codex": {inputPerMToken: 1.75, cachedInputPerMToken: 0.175, outputPerMToken: 14.00},
 }
+
+// OpenAI applies long-context rates when a request exceeds 272K input tokens.
+const longContextInputThreshold = 272_000
 
 // defaultModel is the fallback when a model string doesn't match any rate entry.
 const defaultModel = "gpt-5.4"

--- a/internal/llm/codex/rates_test.go
+++ b/internal/llm/codex/rates_test.go
@@ -21,34 +21,46 @@ import (
 
 func TestLookupRate(t *testing.T) {
 	tests := []struct {
-		model      string
-		wantOK     bool
-		wantIn     float64
-		wantCached float64
-		wantOut    float64
+		model          string
+		wantOK         bool
+		wantIn         float64
+		wantCached     float64
+		wantWrite      float64
+		wantOut        float64
+		wantLongIn     float64
+		wantLongCached float64
+		wantLongWrite  float64
+		wantLongOut    float64
 	}{
+		// GPT-5.6 family, including the generic alias.
+		{"gpt-5.6", true, 5.00, 0.50, 6.25, 30.00, 10.00, 1.00, 12.50, 45.00},
+		{"gpt-5.6[1M]", true, 5.00, 0.50, 6.25, 30.00, 10.00, 1.00, 12.50, 45.00},
+		{"gpt-5.6-sol", true, 5.00, 0.50, 6.25, 30.00, 10.00, 1.00, 12.50, 45.00},
+		{"gpt-5.6-terra", true, 2.50, 0.25, 3.125, 15.00, 5.00, 0.50, 6.25, 22.50},
+		{"gpt-5.6-luna", true, 1.00, 0.10, 1.25, 6.00, 2.00, 0.20, 2.50, 9.00},
+
 		// Direct matches
-		{"gpt-5.5", true, 5.00, 0.50, 30.00},
-		{"gpt-5.5[1M]", true, 5.00, 0.50, 30.00},
-		{"gpt-5.4", true, 2.50, 0.25, 15.00},
-		{"gpt-5.4[1M]", true, 2.50, 0.25, 15.00},
-		{"gpt-5.4-mini", true, 0.75, 0.075, 4.50},
-		{"gpt-5.4-mini[1M]", true, 0.75, 0.075, 4.50},
-		{"gpt-5.3-codex", true, 1.75, 0.175, 14.00},
+		{"gpt-5.5", true, 5.00, 0.50, 0, 30.00, 10.00, 1.00, 0, 45.00},
+		{"gpt-5.5[1M]", true, 5.00, 0.50, 0, 30.00, 10.00, 1.00, 0, 45.00},
+		{"gpt-5.4", true, 2.50, 0.25, 0, 15.00, 5.00, 0.50, 0, 22.50},
+		{"gpt-5.4[1M]", true, 2.50, 0.25, 0, 15.00, 5.00, 0.50, 0, 22.50},
+		{"gpt-5.4-mini", true, 0.75, 0.075, 0, 4.50, 0, 0, 0, 0},
+		{"gpt-5.4-mini[1M]", true, 0.75, 0.075, 0, 4.50, 0, 0, 0, 0},
+		{"gpt-5.3-codex", true, 1.75, 0.175, 0, 14.00, 0, 0, 0, 0},
 
 		// Empty model uses the default model rate.
-		{"", true, 2.50, 0.25, 15.00},
+		{"", true, 2.50, 0.25, 0, 15.00, 5.00, 0.50, 0, 22.50},
 
 		// Unknown gpt-* variants fall back to default
-		{"gpt-future-model", true, 2.50, 0.25, 15.00},
+		{"gpt-future-model", true, 2.50, 0.25, 0, 15.00, 5.00, 0.50, 0, 22.50},
 
 		// Case insensitive
-		{"GPT-5.4", true, 2.50, 0.25, 15.00},
+		{"GPT-5.6-LUNA", true, 1.00, 0.10, 1.25, 6.00, 2.00, 0.20, 2.50, 9.00},
 		// Non-matching models
-		{"codex", false, 0, 0, 0},
-		{"opus", false, 0, 0, 0},
-		{"sonnet", false, 0, 0, 0},
-		{"unknown", false, 0, 0, 0},
+		{"codex", false, 0, 0, 0, 0, 0, 0, 0, 0},
+		{"opus", false, 0, 0, 0, 0, 0, 0, 0, 0},
+		{"sonnet", false, 0, 0, 0, 0, 0, 0, 0, 0},
+		{"unknown", false, 0, 0, 0, 0, 0, 0, 0, 0},
 	}
 
 	for _, tt := range tests {
@@ -66,44 +78,82 @@ func TestLookupRate(t *testing.T) {
 			if math.Abs(r.cachedInputPerMToken-tt.wantCached) > 0.001 {
 				t.Errorf("cachedInputPerMToken = %f, want %f", r.cachedInputPerMToken, tt.wantCached)
 			}
+			if math.Abs(r.cacheWritePerMToken-tt.wantWrite) > 0.001 {
+				t.Errorf("cacheWritePerMToken = %f, want %f", r.cacheWritePerMToken, tt.wantWrite)
+			}
 			if math.Abs(r.outputPerMToken-tt.wantOut) > 0.001 {
 				t.Errorf("outputPerMToken = %f, want %f", r.outputPerMToken, tt.wantOut)
+			}
+			if math.Abs(r.longInputPerMToken-tt.wantLongIn) > 0.001 {
+				t.Errorf("longInputPerMToken = %f, want %f", r.longInputPerMToken, tt.wantLongIn)
+			}
+			if math.Abs(r.longCachedInputPerMToken-tt.wantLongCached) > 0.001 {
+				t.Errorf("longCachedInputPerMToken = %f, want %f", r.longCachedInputPerMToken, tt.wantLongCached)
+			}
+			if math.Abs(r.longCacheWritePerMToken-tt.wantLongWrite) > 0.001 {
+				t.Errorf("longCacheWritePerMToken = %f, want %f", r.longCacheWritePerMToken, tt.wantLongWrite)
+			}
+			if math.Abs(r.longOutputPerMToken-tt.wantLongOut) > 0.001 {
+				t.Errorf("longOutputPerMToken = %f, want %f", r.longOutputPerMToken, tt.wantLongOut)
 			}
 		})
 	}
 }
 
 func TestComputeCost(t *testing.T) {
-	// 1M input + 1M output tokens at gpt-5.4 rates = $2.50 + $15.00 = $17.50
-	cost := computeCost("gpt-5.4", 1_000_000, 0, 1_000_000)
-	if math.Abs(cost-17.50) > 0.001 {
-		t.Errorf("computeCost(gpt-5.4, 1M, 1M) = %f, want 17.50", cost)
+	// 1M input + 1M output tokens use gpt-5.4 long-context rates.
+	cost := computeCost("gpt-5.4", 1_000_000, 0, 0, 1_000_000)
+	if math.Abs(cost-27.50) > 0.001 {
+		t.Errorf("computeCost(gpt-5.4, 1M, 1M) = %f, want 27.50", cost)
 	}
 
 	// 600K uncached input + 400K cached input + 100K output at gpt-5.5 rates =
-	// $3.00 + $0.20 + $3.00 = $6.20.
-	costCached := computeCost("gpt-5.5", 1_000_000, 400_000, 100_000)
-	if math.Abs(costCached-6.20) > 0.001 {
-		t.Errorf("computeCost(gpt-5.5, 1M, 400K, 100K) = %f, want 6.20", costCached)
+	// $6.00 + $0.40 + $4.50 = $10.90 at long-context rates.
+	costCached := computeCost("gpt-5.5", 1_000_000, 400_000, 0, 100_000)
+	if math.Abs(costCached-10.90) > 0.001 {
+		t.Errorf("computeCost(gpt-5.5, 1M, 400K, 100K) = %f, want 10.90", costCached)
 	}
 
 	// Cached input is bounded by total input, matching the billing model that
 	// treats cached tokens as a discounted subset of input tokens.
-	costClamped := computeCost("gpt-5.5", 100_000, 200_000, 0)
+	costClamped := computeCost("gpt-5.5", 100_000, 200_000, 0, 0)
 	if math.Abs(costClamped-0.05) > 0.001 {
 		t.Errorf("computeCost(gpt-5.5, 100K, 200K, 0) = %f, want 0.05", costClamped)
 	}
 
 	// Empty model should also work (default)
-	costEmpty := computeCost("", 1_000_000, 0, 1_000_000)
-	if math.Abs(costEmpty-17.50) > 0.001 {
-		t.Errorf("computeCost('', 1M, 1M) = %f, want 17.50", costEmpty)
+	costEmpty := computeCost("", 1_000_000, 0, 0, 1_000_000)
+	if math.Abs(costEmpty-27.50) > 0.001 {
+		t.Errorf("computeCost('', 1M, 1M) = %f, want 27.50", costEmpty)
 	}
 
 	// Unknown non-gpt model returns 0
-	costUnknown := computeCost("opus", 1_000_000, 0, 1_000_000)
+	costUnknown := computeCost("opus", 1_000_000, 0, 0, 1_000_000)
 	if costUnknown != 0 {
 		t.Errorf("computeCost(opus, 1M, 1M) = %f, want 0", costUnknown)
+	}
+
+	// Cache reads and writes replace full-price input tokens.
+	costCacheWrite := computeCost("gpt-5.6-luna", 200_000, 50_000, 50_000, 10_000)
+	if math.Abs(costCacheWrite-0.2275) > 0.001 {
+		t.Errorf("computeCost(gpt-5.6-luna, cache write) = %f, want 0.2275", costCacheWrite)
+	}
+	// Models without separate cache-write pricing keep those tokens at the
+	// ordinary input rate instead of treating them as free.
+	costNoWriteRate := computeCost("gpt-5.5", 100_000, 0, 50_000, 0)
+	if math.Abs(costNoWriteRate-0.50) > 0.001 {
+		t.Errorf("computeCost(gpt-5.5, unsupported cache write) = %f, want 0.50", costNoWriteRate)
+	}
+
+	// The threshold itself remains short-context pricing; only larger requests
+	// use the 2x input and 1.5x output rates.
+	costAtThreshold := computeCost("gpt-5.6-luna", 272_000, 0, 0, 1_000)
+	if math.Abs(costAtThreshold-0.278) > 0.001 {
+		t.Errorf("computeCost(gpt-5.6-luna, threshold) = %f, want 0.278", costAtThreshold)
+	}
+	costAboveThreshold := computeCost("gpt-5.6-luna", 273_000, 0, 0, 1_000)
+	if math.Abs(costAboveThreshold-0.555) > 0.001 {
+		t.Errorf("computeCost(gpt-5.6-luna, long context) = %f, want 0.555", costAboveThreshold)
 	}
 }
 


### PR DESCRIPTION
## Summary

- add explicit standard and long-context rates for `gpt-5.6`, `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna`
- represent GPT-5.6 cache-write pricing and apply the documented rates above the 272K input threshold
- accumulate usage deltas at the active context tier so later long-context requests do not retroactively reprice earlier requests
- add regression coverage for model lookup, cache writes, threshold behavior, and mixed short/long-context sessions

The current Codex app-server usage schema does not expose cache-write token counts, so live session estimates continue to omit that component until upstream telemetry becomes available. The pricing model and calculator now support it when reported.

Pricing source: https://developers.openai.com/api/docs/pricing

## Verification

- Fast suite: `make test-fast`
- Codex package: `go test ./internal/llm/codex/... -count=1`
- Static analysis: `go vet ./...`
- Build: `go build ./...`

Co-authored-by: Codex <noreply@openai.com>
