### PR TITLE
Align pipeline reasoning effort

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ When creating a feature, choose a pipeline depth:
 |---------|--------|----------|
 | **Medium** | Roadmap plan → per-phase plan/implement loop → Final Review → Publish | Small, well-understood changes where you already know the approach |
 | **Large** | KB → Inquire → Research → Design → roadmap loop → Final Review → Publish | Most complex features (default) |
-| **Moonshot** | Same phase sequence as Large, with max effort and per-iteration implementation review | High-risk or highly ambiguous changes |
+| **Moonshot** | Same phase sequence as Large, with high effort and per-iteration implementation review | High-risk or highly ambiguous changes |
 
 ### Worktree Isolation
 

--- a/internal/feature/pipeline.go
+++ b/internal/feature/pipeline.go
@@ -115,15 +115,15 @@ func (p PipelineProfile) NextPhase(current Phase) (Phase, bool) {
 }
 
 // EffortLevel returns the provider-agnostic effort level for this pipeline profile.
-// Medium → Medium, Large → High, Moonshot → Max.
+// Medium → Medium; Large and Moonshot → High.
 func (p PipelineProfile) EffortLevel() llm.EffortLevel {
 	switch p {
 	case PipelineMedium:
 		return llm.EffortMedium
-	case PipelineLarge:
+	case PipelineLarge, PipelineMoonshot:
 		return llm.EffortHigh
-	default: // PipelineMoonshot
-		return llm.EffortMax
+	default:
+		return llm.EffortHigh
 	}
 }
 

--- a/internal/feature/pipeline_test.go
+++ b/internal/feature/pipeline_test.go
@@ -427,7 +427,7 @@ func TestPipelineEffortLevel(t *testing.T) {
 	}{
 		{PipelineMedium, "medium"},
 		{PipelineLarge, "high"},
-		{PipelineMoonshot, "max"},
+		{PipelineMoonshot, "high"},
 	}
 	for _, tt := range tests {
 		t.Run(string(tt.profile), func(t *testing.T) {

--- a/internal/llm/provider.go
+++ b/internal/llm/provider.go
@@ -277,8 +277,8 @@ type ProtocolOpts struct {
 
 // EffortLevel is a provider-agnostic effort/reasoning level that each provider
 // maps to its own CLI-specific naming. Utility sessions can request Low
-// directly; pipeline profiles determine phase effort as Medium → Medium,
-// Large → High, Moonshot → Max.
+// directly; pipeline profiles determine phase effort as Medium → Medium and
+// Large/Moonshot → High.
 type EffortLevel string
 
 const (

--- a/skills/chat/user-guide/getting-started.md
+++ b/skills/chat/user-guide/getting-started.md
@@ -68,7 +68,7 @@ Choose a **pipeline profile** that controls how many phases your feature runs th
 |---------|--------|--------|
 | **Medium** | Plan → Implement → Review → Publish | Medium |
 | **Large** | KB Build → Inquire → Research → Design → Plan → Implement → Review → Publish | High |
-| **Moonshot** | Same as Large, with maximum rigor | Max |
+| **Moonshot** | Same as Large, with maximum rigor | High |
 
 ### Step 4 — Review
 


### PR DESCRIPTION
## Summary

- Map Medium pipelines to `medium` reasoning effort.
- Map both Large and Moonshot pipelines to `high` across providers.
- Update the pipeline-effort test and user-facing documentation.

## Why

Moonshot previously selected Agentico's provider-agnostic `max` effort level, which providers could map differently. Aligning Large and Moonshot on `high` makes the configured effort consistent across providers.

## Verification

- Fast suite: `make test-fast`

Co-authored-by: Codex <noreply@openai.com>