### PR TITLE
Keep sessions alive while background subagents are still running

### DIFF
--- a/internal/agent/implement.go
+++ b/internal/agent/implement.go
@@ -1209,6 +1209,39 @@ const maxAutoResumeAttempts = 3
 // the completion protocol so a genuinely-finished agent can exit cleanly.
 const autoResumeMessage = "Continue where you left off. If you have already finished the task, write the phase_complete marker file now."
 
+// backgroundTaskPollInterval is how often the waiter re-checks a session that
+// ended its turn while background subagents were still running. Declared as
+// var (not const) so tests can override it.
+var backgroundTaskPollInterval = 2 * time.Second
+
+// backgroundTaskQuietGrace is how long a session whose background tasks have
+// all finished may stay quiet (no stdout) before the waiter concludes the CLI
+// did not re-invoke the agent on its own and sends the auto-resume
+// continuation.
+var backgroundTaskQuietGrace = 15 * time.Second
+
+// backgroundTaskStallTimeout bounds how long the waiter defers to
+// still-"live" background tasks with zero stdout activity. Running subagents
+// emit periodic task_progress lines, so a totally silent stream this long
+// means the CLI wedged; give up instead of waiting forever.
+var backgroundTaskStallTimeout = 10 * time.Minute
+
+// liveBackgroundTaskCounter is the optional session capability that reports
+// running background subagents. Provider sessions that do not track them
+// (or test doubles that predate the capability) simply never defer.
+type liveBackgroundTaskCounter interface {
+	LiveBackgroundTaskCount() int
+}
+
+// liveBackgroundTasks returns the session's running background-subagent
+// count, or 0 when the session does not expose the capability.
+func liveBackgroundTasks(sess ports.SessionView) int {
+	if c, ok := sess.(liveBackgroundTaskCounter); ok {
+		return c.LiveBackgroundTaskCount()
+	}
+	return 0
+}
+
 // maxFinishOrViolateNudges caps how many times a session that ended its turn
 // without writing the required completion artifacts is nudged to finish on the
 // same live session before the turn is counted as a protocol violation.
@@ -1414,6 +1447,12 @@ func iterationContextMeta(sess ports.SessionView, handoff contextSnapshot) *Cont
 //     maxAutoResumeAttempts consecutive times. This covers the common case
 //     where the claude CLI ends an invocation while the agent is still
 //     working, without the agent having asked anything.
+//   - TermAwaitingBackgroundTasks (turn ended while background subagents
+//     were still running) defers without sending anything: the CLI
+//     re-invokes the agent when its tasks complete. If the tasks finish and
+//     no re-invocation arrives, the waiter falls back to the auto-resume
+//     continuation; a fully wedged stream is bounded by
+//     backgroundTaskStallTimeout.
 //   - Anything else (EndedAfterText, Refused, Errored), or an exhausted
 //     truncation retry budget, returns MISSING_PHASE_COMPLETE so the caller
 //     can count the turn as a protocol violation.
@@ -1476,6 +1515,14 @@ func waitForStatusDetailed(sess ports.SessionHandle, _ ports.SessionManager, _ s
 		ThresholdPct: defaultContextHandoffThresholdPct,
 	}
 
+	// awaitingBackgroundTasks is set when the agent ended its turn while its
+	// background subagents were still running. The waiter then defers: the CLI
+	// re-invokes the agent when the tasks complete, so no nudge is sent and no
+	// budget is consumed. The bgTicker below provides the fallback paths.
+	awaitingBackgroundTasks := false
+	bgTicker := time.NewTicker(backgroundTaskPollInterval)
+	defer bgTicker.Stop()
+
 	handleStatus := func(status string, sessionDone bool) (string, bool) {
 		if status == agentStatusAPIError {
 			if sessionDone {
@@ -1492,8 +1539,21 @@ func waitForStatusDetailed(sess ports.SessionHandle, _ ports.SessionManager, _ s
 				Result:                 sess.Cost(),
 				PhaseCompleteExists:    false, // isReady just returned false
 				AskUserQuestionPending: sess.HasPendingAskUserQuestion(),
+				// A dead process cannot deliver task notifications; never
+				// defer to a stale task set.
+				BackgroundTasksRunning: !sessionDone && liveBackgroundTasks(sess) > 0,
 			}
 			class := llm.ClassifyTermination(inputs)
+
+			// The agent yielded while its background subagents are still
+			// running. Keep the session alive and wait: the CLI re-invokes
+			// the agent when the tasks complete. The bgTicker case handles
+			// the CLI failing to do so.
+			if class == llm.TermAwaitingBackgroundTasks {
+				awaitingBackgroundTasks = true
+				return "", false
+			}
+			awaitingBackgroundTasks = false
 
 			if class == llm.TermTurnTruncated && autoResumeAttempts < maxAutoResumeAttempts {
 				autoResumeAttempts++
@@ -1550,6 +1610,38 @@ func waitForStatusDetailed(sess ports.SessionHandle, _ ports.SessionManager, _ s
 				}
 			}
 			// On send error, leave handoffSent=false so a later tick retries.
+
+		case <-bgTicker.C:
+			if !awaitingBackgroundTasks {
+				continue
+			}
+			quiet := time.Since(sess.LastStdoutAt())
+			if liveBackgroundTasks(sess) > 0 {
+				// Running subagents emit periodic task_progress lines; a
+				// stream this quiet means the CLI wedged. Give up rather
+				// than wait forever.
+				if quiet >= backgroundTaskStallTimeout {
+					_ = sess.Stop()
+					return waitForStatusResult{Status: agentStatusMissingMarker, Handoff: handoff}
+				}
+				continue
+			}
+			// All tasks finished but no new result arrived: the CLI did not
+			// re-invoke the agent on its own. Resume it explicitly, reusing
+			// the truncation budget so a session that keeps yielding without
+			// finishing still converges to a violation.
+			if quiet < backgroundTaskQuietGrace {
+				continue
+			}
+			awaitingBackgroundTasks = false
+			if autoResumeAttempts < maxAutoResumeAttempts {
+				autoResumeAttempts++
+				if err := sess.SendUserMessage(autoResumeMessage); err == nil {
+					continue
+				}
+			}
+			_ = sess.Stop()
+			return waitForStatusResult{Status: agentStatusMissingMarker, Handoff: handoff}
 
 		case <-doneCh:
 			// Session exited — drain StatusCh for any pending status

--- a/internal/agent/implement_test.go
+++ b/internal/agent/implement_test.go
@@ -2998,3 +2998,187 @@ func TestImplementLoop_SkillReadInstruction(t *testing.T) {
 		t.Errorf("user prompt should not contain RoleSpec-owned skill path %q", expectedSkillPath)
 	}
 }
+
+// bgTaskSession is a SessionHandle double whose live-background-task count and
+// stdout-activity timestamp are test-controlled, mirroring a Claude session
+// that spawned background Task subagents.
+type bgTaskSession struct {
+	*utilityTestSession
+	liveTasks    atomic.Int32
+	lastStdoutNs atomic.Int64
+	userMessages chan string
+	stopped      atomic.Bool
+}
+
+func newBgTaskSession() *bgTaskSession {
+	s := &bgTaskSession{
+		utilityTestSession: newUtilityTestSession(),
+		userMessages:       make(chan string, 4),
+	}
+	s.lastStdoutNs.Store(time.Now().UnixNano())
+	return s
+}
+
+func (s *bgTaskSession) LiveBackgroundTaskCount() int { return int(s.liveTasks.Load()) }
+func (s *bgTaskSession) LastStdoutAt() time.Time      { return time.Unix(0, s.lastStdoutNs.Load()) }
+func (s *bgTaskSession) SendUserMessage(text string) error {
+	s.userMessages <- text
+	return nil
+}
+func (s *bgTaskSession) Stop() error {
+	s.stopped.Store(true)
+	return nil
+}
+
+func withBackgroundTaskPollInterval(t *testing.T, d time.Duration) {
+	t.Helper()
+	prev := backgroundTaskPollInterval
+	backgroundTaskPollInterval = d
+	t.Cleanup(func() { backgroundTaskPollInterval = prev })
+}
+
+func TestWaitForStatus_BackgroundTasks(t *testing.T) {
+	t.Run("end_turn with live tasks keeps waiting without nudge or stop", func(t *testing.T) {
+		withBackgroundTaskPollInterval(t, 5*time.Millisecond)
+
+		sess := newBgTaskSession()
+		sess.result = newEndedAfterTextResult()
+		sess.liveTasks.Store(3)
+		sess.lastStdoutNs.Store(time.Now().UnixNano())
+
+		var ready atomic.Bool
+		done := make(chan string, 1)
+		go func() {
+			done <- waitForStatus(sess, nil, "", func() bool { return ready.Load() })
+		}()
+
+		sess.statusCh <- agentStatusSuccess
+
+		select {
+		case got := <-done:
+			t.Fatalf("waitForStatus() returned %q; want it to keep waiting on background tasks", got)
+		case msg := <-sess.userMessages:
+			t.Fatalf("unexpected user message %q while background tasks run", msg)
+		case <-time.After(100 * time.Millisecond):
+		}
+		if sess.stopped.Load() {
+			t.Fatal("session was stopped while background tasks were running")
+		}
+
+		// Background tasks finish; the CLI re-invokes the agent, which
+		// completes normally.
+		sess.liveTasks.Store(0)
+		ready.Store(true)
+		sess.statusCh <- agentStatusSuccess
+
+		select {
+		case got := <-done:
+			if got != agentStatusSuccess {
+				t.Fatalf("waitForStatus() = %q, want %q", got, agentStatusSuccess)
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatal("timed out waiting for final SUCCESS")
+		}
+		select {
+		case msg := <-sess.userMessages:
+			t.Fatalf("unexpected user message %q; completion needed no nudge", msg)
+		default:
+		}
+	})
+
+	t.Run("tasks finish quietly without re-invocation triggers auto-resume", func(t *testing.T) {
+		withBackgroundTaskPollInterval(t, 5*time.Millisecond)
+
+		sess := newBgTaskSession()
+		sess.result = newEndedAfterTextResult()
+		sess.liveTasks.Store(1)
+		sess.lastStdoutNs.Store(time.Now().UnixNano())
+
+		var ready atomic.Bool
+		done := make(chan string, 1)
+		go func() {
+			done <- waitForStatus(sess, nil, "", func() bool { return ready.Load() })
+		}()
+
+		sess.statusCh <- agentStatusSuccess
+
+		// Give the waiter a moment to defer, then finish the tasks with a
+		// stale stdout stamp: the CLI never re-invoked the agent.
+		time.Sleep(20 * time.Millisecond)
+		sess.lastStdoutNs.Store(time.Now().Add(-time.Hour).UnixNano())
+		sess.liveTasks.Store(0)
+
+		select {
+		case msg := <-sess.userMessages:
+			if !strings.Contains(msg, "Continue where you left off") {
+				t.Fatalf("SendUserMessage() = %q, want auto-resume message", msg)
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatal("timed out waiting for auto-resume after tasks finished")
+		}
+
+		ready.Store(true)
+		sess.statusCh <- agentStatusSuccess
+		select {
+		case got := <-done:
+			if got != agentStatusSuccess {
+				t.Fatalf("waitForStatus() = %q, want %q", got, agentStatusSuccess)
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatal("timed out waiting for final SUCCESS")
+		}
+	})
+
+	t.Run("wedged session with live tasks hits stall backstop", func(t *testing.T) {
+		withBackgroundTaskPollInterval(t, 5*time.Millisecond)
+		prev := backgroundTaskStallTimeout
+		backgroundTaskStallTimeout = 30 * time.Millisecond
+		t.Cleanup(func() { backgroundTaskStallTimeout = prev })
+
+		sess := newBgTaskSession()
+		sess.result = newEndedAfterTextResult()
+		sess.liveTasks.Store(1)
+		sess.lastStdoutNs.Store(time.Now().UnixNano())
+
+		done := make(chan string, 1)
+		go func() {
+			done <- waitForStatus(sess, nil, "", func() bool { return false })
+		}()
+
+		sess.statusCh <- agentStatusSuccess
+
+		select {
+		case got := <-done:
+			if got != agentStatusMissingMarker {
+				t.Fatalf("waitForStatus() = %q, want %q", got, agentStatusMissingMarker)
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatal("timed out waiting for stall backstop")
+		}
+		if !sess.stopped.Load() {
+			t.Fatal("session was not stopped by the stall backstop")
+		}
+	})
+
+	t.Run("dead session with stale live tasks does not hang", func(t *testing.T) {
+		sess := newBgTaskSession()
+		sess.result = newEndedAfterTextResult()
+		sess.liveTasks.Store(2)
+		sess.statusCh <- agentStatusSuccess
+		close(sess.done)
+
+		done := make(chan string, 1)
+		go func() {
+			done <- waitForStatus(sess, nil, "", func() bool { return false })
+		}()
+
+		select {
+		case got := <-done:
+			if got != agentStatusMissingMarker {
+				t.Fatalf("waitForStatus() = %q, want %q", got, agentStatusMissingMarker)
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatal("waitForStatus() hung on a dead session with stale background tasks")
+		}
+	})
+}

--- a/internal/llm/message.go
+++ b/internal/llm/message.go
@@ -348,6 +348,13 @@ const (
 	// TermErrored means the CLI reported an error (subtype=error or
 	// is_error=true).
 	TermErrored
+
+	// TermAwaitingBackgroundTasks means the agent ended its turn while
+	// background subagents (Task tool, run in background) were still running —
+	// it yielded to wait for their notifications, not to stop. The invocation
+	// should be kept alive until the tasks complete, not counted as a
+	// protocol violation.
+	TermAwaitingBackgroundTasks
 )
 
 // String returns the enum name — used in logs and tests.
@@ -365,6 +372,8 @@ func (t TerminationClass) String() string {
 		return "Refused"
 	case TermErrored:
 		return "Errored"
+	case TermAwaitingBackgroundTasks:
+		return "AwaitingBackgroundTasks"
 	default:
 		return "Unknown"
 	}
@@ -383,6 +392,11 @@ type TerminationInputs struct {
 	// is still awaiting the user's response. If the question was already
 	// answered before the Result arrived, this should be false.
 	AskUserQuestionPending bool
+	// BackgroundTasksRunning is true when background subagents spawned by the
+	// session are still running at the time the Result is classified. Callers
+	// must only set this for live sessions — a dead process cannot deliver
+	// task notifications, so its stale task set must not defer classification.
+	BackgroundTasksRunning bool
 }
 
 // ClassifyTermination returns the TerminationClass for a completed invocation
@@ -406,6 +420,9 @@ func ClassifyTermination(in TerminationInputs) TerminationClass {
 	}
 	if in.AskUserQuestionPending {
 		return TermAskedFormal
+	}
+	if in.BackgroundTasksRunning {
+		return TermAwaitingBackgroundTasks
 	}
 	switch r.StopReason {
 	case "refusal":

--- a/internal/llm/messages_test.go
+++ b/internal/llm/messages_test.go
@@ -341,6 +341,58 @@ func TestClassifyTermination_Priorities(t *testing.T) {
 	})
 }
 
+func TestClassifyTermination_BackgroundTasks(t *testing.T) {
+	// An end_turn while background subagents are still running is the agent
+	// yielding to wait for them, not a deliberate stop.
+	t.Run("end_turn with running background tasks awaits", func(t *testing.T) {
+		in := TerminationInputs{
+			Result:                 &ResultMessage{Subtype: "success", StopReason: "end_turn"},
+			BackgroundTasksRunning: true,
+		}
+		if got := ClassifyTermination(in); got != TermAwaitingBackgroundTasks {
+			t.Errorf("got %s, want AwaitingBackgroundTasks", got)
+		}
+	})
+	t.Run("truncation with running background tasks awaits", func(t *testing.T) {
+		in := TerminationInputs{
+			Result:                 &ResultMessage{Subtype: "success", StopReason: "tool_use"},
+			BackgroundTasksRunning: true,
+		}
+		if got := ClassifyTermination(in); got != TermAwaitingBackgroundTasks {
+			t.Errorf("got %s, want AwaitingBackgroundTasks", got)
+		}
+	})
+	t.Run("error beats running background tasks", func(t *testing.T) {
+		in := TerminationInputs{
+			Result:                 &ResultMessage{Subtype: "error", IsError: true},
+			BackgroundTasksRunning: true,
+		}
+		if got := ClassifyTermination(in); got != TermErrored {
+			t.Errorf("got %s, want Errored", got)
+		}
+	})
+	t.Run("phase_complete beats running background tasks", func(t *testing.T) {
+		in := TerminationInputs{
+			Result:                 &ResultMessage{Subtype: "success", StopReason: "end_turn"},
+			PhaseCompleteExists:    true,
+			BackgroundTasksRunning: true,
+		}
+		if got := ClassifyTermination(in); got != TermCompleted {
+			t.Errorf("got %s, want Completed", got)
+		}
+	})
+	t.Run("pending AskUserQuestion beats running background tasks", func(t *testing.T) {
+		in := TerminationInputs{
+			Result:                 &ResultMessage{Subtype: "success", StopReason: "end_turn"},
+			AskUserQuestionPending: true,
+			BackgroundTasksRunning: true,
+		}
+		if got := ClassifyTermination(in); got != TermAskedFormal {
+			t.Errorf("got %s, want AskedFormal", got)
+		}
+	})
+}
+
 func TestSDKMessage_UnmarshalJSON_ControlRequest(t *testing.T) {
 	data := `{
 		"type": "control_request",

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -240,6 +240,14 @@ type Session struct {
 	// hang.
 	keepAliveOnTruncatedResult bool
 
+	// liveBackgroundTasks tracks background subagents (Task tool) that have
+	// started but not yet emitted their terminal task_notification. A
+	// loop-managed session with live entries stays up after an end_turn
+	// Result: the agent yielded to wait for its tasks, and the CLI will
+	// re-invoke it when they complete. Keyed by task_id (tool_use_id
+	// fallback). Guarded by mu.
+	liveBackgroundTasks map[string]struct{}
+
 	// askUserAutoPick optionally answers confidence-qualified AskUserQuestion
 	// bundles before they enter pending TUI routing.
 	askUserAutoPick *ports.AskUserAutoPickConfig
@@ -1045,6 +1053,11 @@ func (s *Session) readMessages(onMessage func(llm.SDKMessage)) {
 				}
 			}
 
+			// Track subagent (Task tool) lifecycle so shouldShutdownOnResult
+			// and the loop waiter can tell an agent that yielded for running
+			// background tasks apart from one that deliberately stopped.
+			s.observeBackgroundTasks(msg)
+
 			// Notify subagent (Task tool) lifecycle callback. These messages
 			// are the main signal that a Task() call is still alive while the
 			// main agent is blocked waiting for it to return, so we surface
@@ -1777,6 +1790,53 @@ func (s *Session) Wait() {
 	<-s.done
 }
 
+// observeBackgroundTasks maintains liveBackgroundTasks from subagent (Task
+// tool) lifecycle messages. task_started and task_progress mark a task live
+// (progress covers tasks whose start predates this session's stream);
+// task_notification is the terminal event and removes it.
+func (s *Session) observeBackgroundTasks(msg llm.SDKMessage) {
+	key := ""
+	live := false
+	switch {
+	case msg.TaskStarted != nil:
+		key, live = backgroundTaskKey(msg.TaskStarted.TaskID, msg.TaskStarted.ToolUseID), true
+	case msg.TaskProgress != nil:
+		key, live = backgroundTaskKey(msg.TaskProgress.TaskID, msg.TaskProgress.ToolUseID), true
+	case msg.TaskNotification != nil:
+		key = backgroundTaskKey(msg.TaskNotification.TaskID, msg.TaskNotification.ToolUseID)
+	default:
+		return
+	}
+	if key == "" {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if live {
+		if s.liveBackgroundTasks == nil {
+			s.liveBackgroundTasks = make(map[string]struct{})
+		}
+		s.liveBackgroundTasks[key] = struct{}{}
+		return
+	}
+	delete(s.liveBackgroundTasks, key)
+}
+
+func backgroundTaskKey(taskID, toolUseID string) string {
+	if taskID != "" {
+		return taskID
+	}
+	return toolUseID
+}
+
+// LiveBackgroundTaskCount returns the number of background subagents that
+// have started but not yet reached their terminal task_notification.
+func (s *Session) LiveBackgroundTaskCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.liveBackgroundTasks)
+}
+
 // shouldShutdownOnResult reports whether this session's underlying CLI should
 // be torn down after a Result message. Single-shot autonomous sessions need
 // wrapper cleanup (stdin close + SIGTERM/SIGKILL watchdog) to unstick a
@@ -1791,11 +1851,18 @@ func (s *Session) shouldShutdownOnResult(result *llm.ResultMessage) bool {
 	name := s.providerName
 	turnMode := s.turnMode
 	keepAliveOnTruncatedResult := s.keepAliveOnTruncatedResult
+	liveBackgroundTasks := len(s.liveBackgroundTasks)
 	s.mu.Unlock()
 	if turnMode == ports.TurnModeInteractive {
 		return false
 	}
 	if keepAliveOnTruncatedResult && result.IsTurnTruncated() {
+		return false
+	}
+	// An end_turn with background subagents still running is the agent
+	// yielding until their notifications arrive — the CLI re-invokes it when
+	// they complete, so the process must stay up for the loop waiter.
+	if keepAliveOnTruncatedResult && liveBackgroundTasks > 0 {
 		return false
 	}
 	return name != "codex"

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -2247,3 +2247,94 @@ func TestSession_StatusChSignalAfterResultCallback(t *testing.T) {
 
 	<-done
 }
+
+func taskStartedMsg(taskID string) llm.SDKMessage {
+	return llm.SDKMessage{
+		Type: "system", Subtype: "task_started",
+		TaskStarted: &llm.TaskStartedMessage{TaskID: taskID},
+	}
+}
+
+func taskProgressMsg(taskID string) llm.SDKMessage {
+	return llm.SDKMessage{
+		Type: "system", Subtype: "task_progress",
+		TaskProgress: &llm.TaskProgressMessage{TaskID: taskID},
+	}
+}
+
+func taskNotificationMsg(taskID string) llm.SDKMessage {
+	return llm.SDKMessage{
+		Type: "system", Subtype: "task_notification",
+		TaskNotification: &llm.TaskNotificationMessage{TaskID: taskID, Status: "completed"},
+	}
+}
+
+func TestObserveBackgroundTasks_TracksLifecycle(t *testing.T) {
+	s := NewSession("bg-test", "feat-1", feature.PhaseImplement)
+
+	if got := s.LiveBackgroundTaskCount(); got != 0 {
+		t.Fatalf("initial LiveBackgroundTaskCount() = %d, want 0", got)
+	}
+
+	s.observeBackgroundTasks(taskStartedMsg("task-a"))
+	s.observeBackgroundTasks(taskStartedMsg("task-b"))
+	if got := s.LiveBackgroundTaskCount(); got != 2 {
+		t.Fatalf("after two starts LiveBackgroundTaskCount() = %d, want 2", got)
+	}
+
+	// Duplicate progress for a known task must not double-count.
+	s.observeBackgroundTasks(taskProgressMsg("task-a"))
+	if got := s.LiveBackgroundTaskCount(); got != 2 {
+		t.Fatalf("after progress LiveBackgroundTaskCount() = %d, want 2", got)
+	}
+
+	// Progress for a task whose start we never saw (session attach mid-task)
+	// registers it as live.
+	s.observeBackgroundTasks(taskProgressMsg("task-c"))
+	if got := s.LiveBackgroundTaskCount(); got != 3 {
+		t.Fatalf("after unseen-task progress LiveBackgroundTaskCount() = %d, want 3", got)
+	}
+
+	// task_notification is the terminal lifecycle event.
+	s.observeBackgroundTasks(taskNotificationMsg("task-a"))
+	s.observeBackgroundTasks(taskNotificationMsg("task-b"))
+	s.observeBackgroundTasks(taskNotificationMsg("task-c"))
+	if got := s.LiveBackgroundTaskCount(); got != 0 {
+		t.Fatalf("after notifications LiveBackgroundTaskCount() = %d, want 0", got)
+	}
+
+	// Notification for an unknown task is a no-op, not a panic or negative count.
+	s.observeBackgroundTasks(taskNotificationMsg("task-x"))
+	if got := s.LiveBackgroundTaskCount(); got != 0 {
+		t.Fatalf("after unknown notification LiveBackgroundTaskCount() = %d, want 0", got)
+	}
+}
+
+func TestShouldShutdownOnResult_LiveBackgroundTasksKeepAlive(t *testing.T) {
+	endTurn := &llm.ResultMessage{Type: "result", Subtype: "success", StopReason: "end_turn"}
+
+	t.Run("keep-alive session with live tasks stays up on end_turn", func(t *testing.T) {
+		s := NewSession("bg-keepalive", "feat-1", feature.PhaseImplement)
+		s.keepAliveOnTruncatedResult = true
+		s.observeBackgroundTasks(taskStartedMsg("task-a"))
+		if s.shouldShutdownOnResult(endTurn) {
+			t.Error("shouldShutdownOnResult() = true, want false while background tasks run")
+		}
+	})
+
+	t.Run("keep-alive session without live tasks shuts down on end_turn", func(t *testing.T) {
+		s := NewSession("bg-none", "feat-1", feature.PhaseImplement)
+		s.keepAliveOnTruncatedResult = true
+		if !s.shouldShutdownOnResult(endTurn) {
+			t.Error("shouldShutdownOnResult() = false, want true with no background tasks")
+		}
+	})
+
+	t.Run("non-loop session with live tasks still shuts down", func(t *testing.T) {
+		s := NewSession("bg-oneshot", "feat-1", feature.PhaseImplement)
+		s.observeBackgroundTasks(taskStartedMsg("task-a"))
+		if !s.shouldShutdownOnResult(endTurn) {
+			t.Error("shouldShutdownOnResult() = false, want true for non-keep-alive session")
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Fable-class implementers launch Task subagents in the background and deliberately end their turn, expecting the harness to re-invoke them when the tasks complete. The loop waiter treated any `end_turn` without `phase_complete` as a protocol violation, tore the session down, and killed the in-flight subagents — observed on the first-ever Fable implementation iteration.

This never surfaced before because every prior implementation model (Opus/Sonnet/GPT/GLM) runs Task subagents in the foreground: the turn cannot end until they return, so "SDK success ⇒ agent claims done" held by construction.

## Changes

- **Classifier** (`internal/llm/message.go`): new `TermAwaitingBackgroundTasks` termination class with a `BackgroundTasksRunning` input. Ranks below errors, a present `phase_complete` marker, and pending AskUserQuestion — existing verdicts unchanged — but above the `end_turn` → deliberate-stop inference.
- **Session** (`internal/session/session.go`): track live background tasks from `task_started`/`task_progress`/`task_notification` stream events (`task_progress` also registers tasks whose start predates the stream, covering resumes). `shouldShutdownOnResult` keeps loop-managed sessions alive on an `end_turn` result while tasks are live, instead of closing stdin and SIGTERMing the CLI.
- **Waiter** (`internal/agent/implement.go`): on SUCCESS without `phase_complete` with live background tasks, defer — no nudge, no violation, no retry budget consumed — since the CLI re-invokes the agent when its tasks complete. Bounded by two fallbacks: if tasks finish with no re-invocation within a 15s quiet grace, send the existing auto-resume continuation (reusing the truncation budget so a session that keeps yielding still converges to a violation); a fully silent stream with "live" tasks hits a 10-minute stall backstop. Dead processes never defer — stale task sets are ignored, so no hangs.

Covers all loops using `waitForStatusDetailed` (implement, plan validation, final review, refactor). Bounded helper sessions are unchanged: they don't set keep-alive, so there is nothing to wait on.

## Test plan

- [x] 12 new tests written first (TDD): classifier priorities with background tasks; session task-lifecycle tracking and shutdown gating; waiter scenarios including the exact observed failure sequence (end_turn with live tasks → no stop/no nudge → completes), quiet-fallback auto-resume, stall backstop, and dead-session no-hang
- [x] `go build ./...`, `go vet ./...` clean
- [x] Full `go test ./...` passes
- [ ] Live validation: re-run a Fable implementation phase that backgrounds Task subagents and confirm the iteration survives turn-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)