### PR TITLE
Isolate agents to active runs and harden validator failures

### DIFF
--- a/internal/agent/final_review_loop.go
+++ b/internal/agent/final_review_loop.go
@@ -114,8 +114,8 @@ func RunFeatureFinalReviewLoop(cfg OrchestratorConfig, sm ports.SessionManager) 
 		return &FeatureFinalReviewResult{FinalStatus: finalStatusReviewPassed}, nil
 	}
 
-	// Build the cross-repo workspace. Cwd at the feature state dir, with
-	// --add-dir for every Feature.Repos worktree (and the state dir).
+	// Build the cross-repo workspace. Cwd at the active run dir, with
+	// --add-dir for every Feature.Repos worktree (and the active run).
 	stateDir := filepath.Join(cfg.StateDir, cfg.Feature.ID)
 	workspace, err := BuildWorkspace(cfg.Feature, stateDir)
 	if err != nil {
@@ -235,8 +235,8 @@ func RunFeatureCycleFinalReviewLoop(cfg OrchestratorConfig, sm ports.SessionMana
 		return &FeatureFinalReviewResult{FinalStatus: finalStatusReviewPassed}, nil
 	}
 
-	// Build the cross-repo workspace. Cwd at the feature state dir, with
-	// --add-dir for every Feature.Repos worktree (and the state dir).
+	// Build the cross-repo workspace. Cwd at the active run dir, with
+	// --add-dir for every Feature.Repos worktree (and the active run).
 	stateDir := filepath.Join(cfg.StateDir, cfg.Feature.ID)
 	workspace, err := BuildWorkspace(cfg.Feature, stateDir)
 	if err != nil {
@@ -440,7 +440,7 @@ func (s *featureFinalReviewLoopState) run() (*FeatureFinalReviewResult, error) {
 }
 
 // runReview launches one feature-level review session for iteration i.
-// Cwd at the feature state dir, --add-dir for every Feature.Repos
+// Cwd at the active run dir, --add-dir for every Feature.Repos
 // worktree. The reviewer reads the cumulative diff across all repos and
 // writes review-feedback.md at iterDir.
 func (s *featureFinalReviewLoopState) runReview(iteration int, iterDir string) (ReviewStatus, string, error) {
@@ -490,8 +490,9 @@ func (s *featureFinalReviewLoopState) runReview(iteration int, iterDir string) (
 
 	additionalDirs := append([]string(nil), additionalDirsExcludingStateDir(s.workspace, s.stateDir)...)
 	additionalDirs = append(additionalDirs, guidelineAdditionalDirs(cfg.GuidelinesDir)...)
-	// State dir always present so the agent can navigate ./<run>/<phase>/...
-	additionalDirs = append([]string{s.stateDir}, additionalDirs...)
+	// Only the active run is mounted; the containing feature state directory
+	// also contains sealed predecessor runs.
+	additionalDirs = append([]string{s.workspace.Cwd}, additionalDirs...)
 
 	systemPrompt := BuildRoleSystemPrompt(BuildRoleSystemPromptInput{
 		Spec:          FinalReviewerRoleSpec(),
@@ -642,7 +643,7 @@ func (s *featureFinalReviewLoopState) runFix(iteration int, iterDir, feedback st
 
 	RemovePhaseComplete(iterDir)
 
-	additionalDirs := append([]string{s.stateDir}, additionalDirsExcludingStateDir(s.workspace, s.stateDir)...)
+	additionalDirs := append([]string{s.workspace.Cwd}, additionalDirsExcludingStateDir(s.workspace, s.stateDir)...)
 	additionalDirs = append(additionalDirs, guidelineAdditionalDirs(cfg.GuidelinesDir)...)
 
 	command, env, sessOpts, buildErr := cfg.BuildSession(BuildSessionOpts{

--- a/internal/agent/implement.go
+++ b/internal/agent/implement.go
@@ -47,6 +47,7 @@ type ImplementConfig struct {
 	ReviewModel         string
 	ArtifactDir         string // base dir for iteration artifacts
 	StateDir            string // feature state directory for PID files
+	RunDir              string // active run directory granted to the agent; empty derives from Feature.ActiveRun
 
 	// AdditionalDirs are extra directories to pass as --add-dir flags to the
 	// claude CLI, giving the agent file-system access beyond WorkDir and StateDir.
@@ -369,9 +370,18 @@ func RunImplementationLoop(cfg ImplementConfig, sm ports.SessionManager) (result
 				permRepoName = cfg.Feature.Repos[0].Name
 			}
 
-			// Build command + session opts via BuildSession. The additional dirs
-			// list includes the state dir + any upstream repo dirs.
-			dirs := append([]string{cfg.StateDir}, cfg.AdditionalDirs...)
+			// Build command + session opts via BuildSession. Only the active run
+			// state is granted; the containing feature state directory also holds
+			// sealed predecessor runs and must remain orchestrator-private.
+			runDir := cfg.RunDir
+			if runDir == "" {
+				runNumber := cfg.Feature.ActiveRun
+				if runNumber <= 0 {
+					runNumber = 1
+				}
+				runDir = filepath.Join(cfg.StateDir, "runs", feature.RunDirName(runNumber))
+			}
+			dirs := append([]string{runDir}, cfg.AdditionalDirs...)
 			command, env, sessOpts, buildErr := cfg.BuildSession(BuildSessionOpts{
 				Model:                          cfg.Model,
 				Prompt:                         prompt,

--- a/internal/agent/implement_test.go
+++ b/internal/agent/implement_test.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -93,6 +94,79 @@ func TestBuildImplementPromptMinimal(t *testing.T) {
 	}
 	if strings.Contains(prompt, "## Handoff Contract") {
 		t.Error("Handoff Contract section should be owned by the implement skill and system prompt")
+	}
+}
+
+func TestRunImplementationLoop_GrantsOnlyActiveRunState(t *testing.T) {
+	tmpDir := t.TempDir()
+	featureStateDir := filepath.Join(tmpDir, "state", "feature-a")
+	sealedRunDir := filepath.Join(featureStateDir, "runs", "run-004")
+	activeRunDir := filepath.Join(featureStateDir, "runs", "run-005")
+	artifactDir := filepath.Join(activeRunDir, "phase-01", "implement")
+	repoDir := filepath.Join(tmpDir, "repo")
+	scriptsDir := filepath.Join(tmpDir, "scripts")
+	for _, dir := range []string{sealedRunDir, artifactDir, repoDir, scriptsDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("MkdirAll(%q) error = %v", dir, err)
+		}
+	}
+	planPath := filepath.Join(activeRunDir, "phase-01", "plan", "phase-plan.md")
+	if err := os.MkdirAll(filepath.Dir(planPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll(plan dir) error = %v", err)
+	}
+	if err := os.WriteFile(planPath, []byte("# Plan\nImplement something\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(plan) error = %v", err)
+	}
+
+	agentScript := testutil.WriteScript(t, scriptsDir, "agent.sh",
+		testutil.JSONLInit+"\n"+
+			testutil.WriteImplementSuccessArtifacts(artifactDir)+"\n"+
+			testutil.JSONLSuccess+"\n")
+	buildSession, captured := capturingBuildSession(agentScript, "")
+	f := &feature.Feature{
+		ID:        "feature-a",
+		ActiveRun: 5,
+		RunCount:  5,
+		Repos:     []feature.FeatureRepo{{Name: "repo-a", Path: repoDir}},
+	}
+	sm := session.NewManager(make(chan interface{}, 100))
+	defer sm.Shutdown()
+
+	result, err := RunImplementationLoop(ImplementConfig{
+		Feature:                    f,
+		WorkDir:                    activeRunDir,
+		PlanPath:                   planPath,
+		MaxIterations:              1,
+		MaxConsecFails:             3,
+		MaxConsecNoProgress:        3,
+		ExitCriteria:               "Implementation completes",
+		Model:                      "implementer",
+		ArtifactDir:                artifactDir,
+		StateDir:                   featureStateDir,
+		AdditionalDirs:             []string{repoDir},
+		DangerouslySkipPermissions: true,
+		BuildSession:               buildSession,
+		SkipIterationReview:        true,
+	}, sm)
+	if err != nil {
+		t.Fatalf("RunImplementationLoop() error = %v", err)
+	}
+	if result.FinalStatus != finalStatusReviewPassed {
+		t.Fatalf("FinalStatus = %q, want %q", result.FinalStatus, finalStatusReviewPassed)
+	}
+	if len(*captured) == 0 {
+		t.Fatal("BuildSession was not called")
+	}
+	grants := (*captured)[0].AdditionalDirs
+	for _, want := range []string{activeRunDir, repoDir} {
+		if !slices.Contains(grants, want) {
+			t.Fatalf("AdditionalDirs = %v, missing grant %q", grants, want)
+		}
+	}
+	for _, forbidden := range []string{featureStateDir, sealedRunDir} {
+		if slices.Contains(grants, forbidden) {
+			t.Fatalf("AdditionalDirs = %v, must not grant predecessor scope %q", grants, forbidden)
+		}
 	}
 }
 

--- a/internal/agent/orchestrator.go
+++ b/internal/agent/orchestrator.go
@@ -199,7 +199,7 @@ func phaseRepoStatuses(repos []string, status string) map[string]string {
 // Called by completion.go after the last roadmap-phase implement returns
 // "awaiting_final_review".
 //
-// Cwd at the feature state dir; --add-dir for every Feature.Repos
+// Cwd at the active run dir; --add-dir for every Feature.Repos
 // worktree. The reviewer reads the cumulative diff across all repos and
 // emits one APPROVED / CHANGES_REQUESTED verdict. FR atomicity: every
 // repo at Touched (staged for FR) transitions to review_passed

--- a/internal/agent/phase.go
+++ b/internal/agent/phase.go
@@ -432,10 +432,10 @@ func (pr *PhaseRunner) RunKnowledgeBaseForRepo(f *feature.Feature, repo feature.
 		Model:        kbModel,
 		Prompt:       prompt,
 		SystemPrompt: systemPrompt,
-		// kbDir is a sibling of pr.StateDir (under knowledge-base/<repo>), not a
-		// descendant, so it must be mounted explicitly: this makes it readable and,
-		// via the default writable-root derivation, writable for managed providers.
-		AdditionalDirs:                 []string{pr.StateDir, kbDir},
+		// kbDir is a sibling of pr.StateDir (under knowledge-base/<repo>), so it
+		// must be mounted explicitly. The global feature-state root is not KB
+		// context and must not be exposed to this agent.
+		AdditionalDirs:                 []string{kbDir},
 		AgentNames:                     knowledgeBaseAgentNames(),
 		PIDDir:                         pidDir,
 		PermHandler:                    permHandlerFor(pr.DangerouslySkipPermissions, pr.PermissionCache, repo.Name),
@@ -690,6 +690,7 @@ func (pr *PhaseRunner) RunImplementation(f *feature.Feature, planPath string, kb
 		ReviewModel:                reviewModel,
 		ArtifactDir:                pr.resolveImplementArtifactDir(f),
 		StateDir:                   filepath.Join(pr.StateDir, f.ID),
+		RunDir:                     ActiveRunDir(pr.StateDir, f),
 		PhaseType:                  phaseType,
 		RoadmapPath:                roadmapPath,
 		DesignArtifactPath:         f.DesignArtifactPath(),
@@ -719,7 +720,7 @@ func (pr *PhaseRunner) RunImplementation(f *feature.Feature, planPath string, kb
 }
 
 // RunFeatureCycleFinalReview spawns the unified feature-level Final Review
-// loop for a post-publish cycle. Cwd at the feature state dir; --add-dir for every
+// loop for a post-publish cycle. Cwd at the active run dir; --add-dir for every
 // Feature.Repos worktree. The reviewer reads the cumulative diff across
 // all repos. Unlike the engine FR, the post-cycle FR does NOT atomic-stamp
 // per-repo state on completion — the surrounding cycle owns the post-FR
@@ -984,13 +985,14 @@ func (pr *PhaseRunner) resolveImplementArtifactDir(f *feature.Feature) string {
 // for unified phases (Inquire, Research, Design, Plan).
 //
 // With worktrees: workDir = worktree parent, additionalDirs includes
-// each repo's worktree path plus stateDir.
+// each repo's worktree path plus the active run directory.
 // Without worktrees: workDir = repos[0].Path, additionalDirs includes
-// each other repo's path plus stateDir.
-// No repos: workDir = stateDir, additionalDirs = [stateDir].
+// each other repo's path plus the active run directory.
+// No repos: workDir = active run dir, additionalDirs = [active run dir].
 func resolveUnifiedWorkDir(f *feature.Feature, stateDir string) (workDir string, additionalDirs []string) {
+	activeRunDir := ActiveRunDir(stateDir, f)
 	if len(f.Repos) == 0 {
-		return stateDir, []string{stateDir}
+		return activeRunDir, []string{activeRunDir}
 	}
 	allWorktrees := true
 	for _, r := range f.Repos {
@@ -1001,14 +1003,14 @@ func resolveUnifiedWorkDir(f *feature.Feature, stateDir string) (workDir string,
 	}
 	if allWorktrees {
 		workDir = filepath.Dir(f.Repos[0].WorktreePath)
-		additionalDirs = []string{stateDir}
+		additionalDirs = []string{activeRunDir}
 		for _, r := range f.Repos {
 			additionalDirs = append(additionalDirs, r.WorktreePath)
 		}
 		return workDir, additionalDirs
 	}
 	workDir = f.Repos[0].Path
-	additionalDirs = []string{stateDir}
+	additionalDirs = []string{activeRunDir}
 	for _, r := range f.Repos[1:] {
 		additionalDirs = append(additionalDirs, r.Path)
 	}
@@ -1024,8 +1026,9 @@ type BuildSessionOpts struct {
 	DisallowedTools []string
 	AdditionalDirs  []string
 	// WritableRoots overrides the provider write surface. Nil preserves the
-	// default StateDir + AdditionalDirs behavior, except that read-only context
-	// mounts are not passed as command-level writable roots.
+	// default WorkDir + AdditionalDirs behavior, except that read-only context
+	// mounts are not passed as command-level writable roots. The orchestrator's
+	// global state root is never granted implicitly.
 	WritableRoots []string
 	PIDDir        string
 	PermHandler   ports.PermissionHandler
@@ -1115,6 +1118,26 @@ func subtractRoots(roots, remove []string) []string {
 	return out
 }
 
+func appendUniqueRoots(roots []string, additions ...string) []string {
+	seen := make(map[string]struct{}, len(roots)+len(additions))
+	for _, root := range roots {
+		if root != "" {
+			seen[root] = struct{}{}
+		}
+	}
+	for _, root := range additions {
+		if root == "" {
+			continue
+		}
+		if _, ok := seen[root]; ok {
+			continue
+		}
+		seen[root] = struct{}{}
+		roots = append(roots, root)
+	}
+	return roots
+}
+
 // BuildSession creates CLI command args, env vars, and session opts by
 // routing through the provider registry. This is the primary entry point
 // for all session creation (research, KB, implementation, review, planning).
@@ -1164,17 +1187,16 @@ func (pr *PhaseRunner) BuildSession(opts BuildSessionOpts) (cmd []string, env []
 
 	writableRoots := append([]string(nil), opts.WritableRoots...)
 	if opts.WritableRoots == nil {
-		writableRoots = []string{pr.StateDir}
-		writableRoots = append(writableRoots, opts.AdditionalDirs...)
+		writableRoots = appendUniqueRoots(nil, opts.AdditionalDirs...)
+		writableRoots = appendUniqueRoots(writableRoots, opts.WorkDir)
 	}
 
 	// Read roots are everything a provider may read without per-call mediation:
-	// the feature state, the working directory, and every additional mounted dir
-	// (skills, guidelines, worktrees, knowledge base, images, attachments).
-	readRoots := append([]string{pr.StateDir}, opts.AdditionalDirs...)
-	if opts.WorkDir != "" {
-		readRoots = append(readRoots, opts.WorkDir)
-	}
+	// the working directory and every additional mounted dir (active-run state,
+	// skills, guidelines, worktrees, knowledge base, images, attachments). The
+	// global state root is provider bookkeeping, not agent context.
+	readRoots := appendUniqueRoots(nil, opts.AdditionalDirs...)
+	readRoots = appendUniqueRoots(readRoots, opts.WorkDir)
 
 	// Command-level writable roots omit read-only context mounts unless the
 	// caller supplied an explicit writable-root list.

--- a/internal/agent/phase_implement_loop.go
+++ b/internal/agent/phase_implement_loop.go
@@ -55,8 +55,8 @@ type PhaseImplementLoopResult struct {
 
 // RunPhaseImplementLoop runs the unified phase-implement loop for the feature.
 //
-// Single Claude session per iteration. Cwd at the feature state dir; --add-dir
-// for every Feature.Repos worktree (and the state dir). Per-repo Task
+// Single Claude session per iteration. Cwd at the active run dir; --add-dir
+// for every Feature.Repos worktree (and the active run). Per-repo Task
 // sub-agents are dispatched by prompt scope, not cwd — the existing
 // main-vs-sub split (≤3 files / ≤50 lines stays in main; everything else
 // delegated) is preserved by the implement skill prompt.
@@ -110,8 +110,8 @@ func RunPhaseImplementLoop(cfg OrchestratorConfig, sm ports.SessionManager) (*Ph
 		}, nil
 	}
 
-	// Build the cross-repo workspace. Cwd at the feature state dir, with
-	// --add-dir for every Feature.Repos worktree (and the state dir).
+	// Build the cross-repo workspace. Cwd at the active run dir, with
+	// --add-dir for every Feature.Repos worktree (and the active run).
 	stateDir := filepath.Join(cfg.StateDir, cfg.Feature.ID)
 	workspace, err := BuildWorkspace(cfg.Feature, stateDir)
 	if err != nil {
@@ -149,6 +149,7 @@ func RunPhaseImplementLoop(cfg OrchestratorConfig, sm ports.SessionManager) (*Ph
 		ReviewModel:                cfg.ReviewModel,
 		ArtifactDir:                artifactDir,
 		StateDir:                   stateDir,
+		RunDir:                     runDir,
 		AdditionalDirs:             additionalDirsExcludingStateDir(workspace, stateDir),
 		KBInfos:                    cfg.KBInfos,
 		PhaseType:                  cfg.Feature.RoadmapPhaseType,
@@ -270,11 +271,11 @@ func resolveUnifiedPhaseImplementDir(f *feature.Feature, runDir string) string {
 	return filepath.Join(base, "implement")
 }
 
-// additionalDirsExcludingStateDir filters out the state-dir entry that
-// BuildWorkspace puts at AdditionalDirs[0] — the state dir is already passed
-// to ImplementConfig.StateDir, and BuildImplementPrompt prepends it to the
-// AdditionalDirs slice unconditionally. Without this filter the agent would
-// see the state dir twice in --add-dir.
+// additionalDirsExcludingStateDir filters out the workspace cwd entry that
+// BuildWorkspace puts at AdditionalDirs[0]. The active run is passed separately
+// through ImplementConfig.RunDir; without this filter the agent would see it
+// twice in --add-dir. The legacy stateDir comparison keeps manually constructed
+// WorkspaceSetup values compatible.
 func additionalDirsExcludingStateDir(ws WorkspaceSetup, stateDir string) []string {
 	out := make([]string, 0, len(ws.AdditionalDirs))
 	abs, _ := filepath.Abs(stateDir)

--- a/internal/agent/phase_test.go
+++ b/internal/agent/phase_test.go
@@ -453,8 +453,8 @@ func TestResolveUnifiedWorkDir(t *testing.T) {
 				Repos: nil,
 			},
 			stateDir:        "/tmp/state",
-			expectedWorkDir: "/tmp/state",
-			expectedAddDirs: []string{"/tmp/state"},
+			expectedWorkDir: "/tmp/state/runs/run-001",
+			expectedAddDirs: []string{"/tmp/state/runs/run-001"},
 		},
 		{
 			name: "single_repo",
@@ -465,7 +465,7 @@ func TestResolveUnifiedWorkDir(t *testing.T) {
 			},
 			stateDir:        "/tmp/state",
 			expectedWorkDir: "/tmp/repos/a",
-			expectedAddDirs: []string{"/tmp/state"},
+			expectedAddDirs: []string{"/tmp/state/runs/run-001"},
 		},
 		{
 			name: "multi_repo_with_worktrees",
@@ -477,7 +477,7 @@ func TestResolveUnifiedWorkDir(t *testing.T) {
 			},
 			stateDir:        "/tmp/state",
 			expectedWorkDir: "/tmp/worktrees",
-			expectedAddDirs: []string{"/tmp/state", "/tmp/worktrees/a", "/tmp/worktrees/b"},
+			expectedAddDirs: []string{"/tmp/state/runs/run-001", "/tmp/worktrees/a", "/tmp/worktrees/b"},
 		},
 		{
 			name: "multi_repo_no_worktrees",
@@ -489,7 +489,7 @@ func TestResolveUnifiedWorkDir(t *testing.T) {
 			},
 			stateDir:        "/tmp/state",
 			expectedWorkDir: "/tmp/repos/a",
-			expectedAddDirs: []string{"/tmp/state", "/tmp/repos/b"},
+			expectedAddDirs: []string{"/tmp/state/runs/run-001", "/tmp/repos/b"},
 		},
 		{
 			name: "multi_repo_partial_worktrees",
@@ -501,7 +501,7 @@ func TestResolveUnifiedWorkDir(t *testing.T) {
 			},
 			stateDir:        "/tmp/state",
 			expectedWorkDir: "/tmp/repos/a",
-			expectedAddDirs: []string{"/tmp/state", "/tmp/repos/b"},
+			expectedAddDirs: []string{"/tmp/state/runs/run-001", "/tmp/repos/b"},
 		},
 		{
 			name: "single_repo_fresh_with_worktree",
@@ -513,7 +513,7 @@ func TestResolveUnifiedWorkDir(t *testing.T) {
 			},
 			stateDir:        "/tmp/state",
 			expectedWorkDir: "/tmp/worktrees",
-			expectedAddDirs: []string{"/tmp/state", "/tmp/worktrees/a"},
+			expectedAddDirs: []string{"/tmp/state/runs/run-001", "/tmp/worktrees/a"},
 		},
 		{
 			name: "single_repo_fresh_no_worktree",
@@ -525,7 +525,7 @@ func TestResolveUnifiedWorkDir(t *testing.T) {
 			},
 			stateDir:        "/tmp/state",
 			expectedWorkDir: "/tmp/repos/a",
-			expectedAddDirs: []string{"/tmp/state"},
+			expectedAddDirs: []string{"/tmp/state/runs/run-001"},
 		},
 	}
 	for _, tt := range tests {
@@ -538,6 +538,24 @@ func TestResolveUnifiedWorkDir(t *testing.T) {
 				t.Errorf("additionalDirs = %v, want %v", addDirs, tt.expectedAddDirs)
 			}
 		})
+	}
+}
+
+func TestResolveUnifiedWorkDir_GrantsOnlyActiveRunState(t *testing.T) {
+	f := &feature.Feature{
+		ID:        "feature-a",
+		ActiveRun: 5,
+		Repos: []feature.FeatureRepo{
+			{Name: "repo-a", Path: "/tmp/repos/a"},
+		},
+	}
+	workDir, additionalDirs := resolveUnifiedWorkDir(f, "/tmp/state")
+	if workDir != "/tmp/repos/a" {
+		t.Fatalf("workDir = %q, want repo workdir", workDir)
+	}
+	wantRunDir := "/tmp/state/feature-a/runs/run-005"
+	if !reflect.DeepEqual(additionalDirs, []string{wantRunDir}) {
+		t.Fatalf("additionalDirs = %v, want only active run %q", additionalDirs, wantRunDir)
 	}
 }
 
@@ -804,8 +822,12 @@ func TestRunInteractivePhase_CommandStructure(t *testing.T) {
 				}
 			}
 
-			if !slices.Contains(cap.additionalDirs, stateDir) {
-				t.Errorf("additionalDirs %v does not include stateDir %q", cap.additionalDirs, stateDir)
+			activeRunDir := filepath.Join(stateDir, tt.featureID, "runs", "run-001")
+			if !slices.Contains(cap.additionalDirs, activeRunDir) {
+				t.Errorf("additionalDirs %v does not include active run dir %q", cap.additionalDirs, activeRunDir)
+			}
+			if slices.Contains(cap.additionalDirs, stateDir) {
+				t.Errorf("additionalDirs %v must not expose global state dir %q", cap.additionalDirs, stateDir)
 			}
 		})
 	}
@@ -1390,17 +1412,20 @@ func TestBuildSessionForwardsProviderBoundaries(t *testing.T) {
 		t.Fatalf("BuildSession() error: %v", err)
 	}
 
-	for _, want := range []string{dir, kbDir, skillsDir, guidelinesDir, workDir} {
+	for _, want := range []string{kbDir, skillsDir, guidelinesDir, workDir} {
 		if !slices.Contains(provider.buildOpts.ReadRoots, want) {
 			t.Fatalf("ReadRoots = %v, missing %q", provider.buildOpts.ReadRoots, want)
 		}
 	}
-	for _, want := range []string{dir, kbDir} {
+	for _, want := range []string{kbDir, workDir} {
 		if !slices.Contains(provider.buildOpts.WritableRoots, want) {
 			t.Fatalf("WritableRoots = %v, missing %q", provider.buildOpts.WritableRoots, want)
 		}
 	}
-	for _, forbidden := range []string{skillsDir, guidelinesDir} {
+	if slices.Contains(provider.buildOpts.ReadRoots, dir) {
+		t.Fatalf("ReadRoots = %v, should omit global state directory %q", provider.buildOpts.ReadRoots, dir)
+	}
+	for _, forbidden := range []string{dir, skillsDir, guidelinesDir} {
 		if slices.Contains(provider.buildOpts.WritableRoots, forbidden) {
 			t.Fatalf("WritableRoots = %v, should omit read-only context dir %q", provider.buildOpts.WritableRoots, forbidden)
 		}

--- a/internal/agent/plan_validation.go
+++ b/internal/agent/plan_validation.go
@@ -421,7 +421,10 @@ func frozenSectionsDigest(planPath string, frozen []string) string {
 	return hex.EncodeToString(h.Sum(nil))
 }
 
-const maxPlanValidationAttempts = 10
+const (
+	maxPlanValidationAttempts                 = 10
+	maxValidatorInfrastructureSessionAttempts = 2
+)
 
 // DefaultMaxPlanAttempts is the exported default for TUI use (e.g. extending iterations).
 const DefaultMaxPlanAttempts = maxPlanValidationAttempts
@@ -658,7 +661,6 @@ func runSpecializedPlanValidationForArtifact(cfg PlanLoopConfig, sm ports.Sessio
 	if err := os.MkdirAll(helperIterDir, 0o755); err != nil {
 		return ReviewFailed, "", ValidatorMarkers{}, fmt.Errorf("creating %s validator helper directory: %w", domain.Name, err)
 	}
-	RemovePhaseComplete(helperIterDir)
 
 	feedbackPath := filepath.Join(helperIterDir, fmt.Sprintf("validation-%s-feedback.md", domainLower))
 	parentFeedbackPath := filepath.Join(attemptDir, fmt.Sprintf("validation-%s-feedback.md", domainLower))
@@ -674,7 +676,7 @@ func runSpecializedPlanValidationForArtifact(cfg PlanLoopConfig, sm ports.Sessio
 	logPath := filepath.Join(helperIterDir, fmt.Sprintf("validation-%s-output.txt", domainLower))
 	addDirs := cfg.AdditionalDirs
 	if len(addDirs) == 0 {
-		addDirs = []string{cfg.StateDir}
+		addDirs = []string{ActiveRunDir(cfg.StateDir, cfg.Feature)}
 	}
 	reviewID := fmt.Sprintf("%s-planreview-%s-%02d", cfg.Feature.ID, domainLower, attempt)
 	helper := &PhaseRunner{
@@ -686,27 +688,39 @@ func runSpecializedPlanValidationForArtifact(cfg PlanLoopConfig, sm ports.Sessio
 		Observer:       cfg.Observer,
 		BuildSessionFn: cfg.BuildSession,
 	}
-	helperResult, err := helper.RunReadOnlyReviewHelper(context.Background(), ReviewHelperConfig{
-		SessionID:              reviewID,
-		FeatureID:              cfg.Feature.ID,
-		Phase:                  feature.PhasePlan,
-		ParentSpanCtx:          parentCtx,
-		Model:                  validatorModel,
-		Prompt:                 validationPrompt,
-		PromptPath:             promptPath,
-		FeedbackPath:           feedbackPath,
-		HelperIterDir:          helperIterDir,
-		Role:                   validatorSpec.Role,
-		WorkDir:                cfg.WorkDir,
-		RepoName:               cfg.RepoName,
-		AdditionalDirs:         addDirs,
-		LogPath:                logPath,
-		SystemPromptPrefix:     "validation-" + domainLower,
-		CompletionAskingClause: cfg.AskingClause,
-		EffortLevel:            cfg.EffortLevel,
-		Kind:                   ports.KindValidator,
-		Label:                  domain.Name,
-	})
+	var helperResult *ReviewHelperResult
+	var err error
+	for sessionAttempt := 1; sessionAttempt <= maxValidatorInfrastructureSessionAttempts; sessionAttempt++ {
+		// Infrastructure retries stay inside the same plan attempt. Clear any
+		// synthetic artifacts from the failed session and use a distinct session
+		// ID so lifecycle bookkeeping cannot alias the completed process.
+		RemovePhaseComplete(helperIterDir)
+		_ = os.Remove(feedbackPath)
+		helperResult, err = helper.RunReadOnlyReviewHelper(context.Background(), ReviewHelperConfig{
+			SessionID:              retrySessionID(reviewID, sessionAttempt),
+			FeatureID:              cfg.Feature.ID,
+			Phase:                  feature.PhasePlan,
+			ParentSpanCtx:          parentCtx,
+			Model:                  validatorModel,
+			Prompt:                 validationPrompt,
+			PromptPath:             promptPath,
+			FeedbackPath:           feedbackPath,
+			HelperIterDir:          helperIterDir,
+			Role:                   validatorSpec.Role,
+			WorkDir:                cfg.WorkDir,
+			RepoName:               cfg.RepoName,
+			AdditionalDirs:         addDirs,
+			LogPath:                logPath,
+			SystemPromptPrefix:     "validation-" + domainLower,
+			CompletionAskingClause: cfg.AskingClause,
+			EffortLevel:            cfg.EffortLevel,
+			Kind:                   ports.KindValidator,
+			Label:                  domain.Name,
+		})
+		if err == nil || isProtocolViolationError(err) {
+			break
+		}
+	}
 	if err != nil {
 		feedback := ""
 		markers := ValidatorMarkers{}
@@ -1302,6 +1316,7 @@ func clearValidatorStatuses(cfg PlanLoopConfig) {
 func composeValidatorResults(results []ValidatorResult, risk feature.RiskLevel) (ReviewStatus, string, error) {
 	var b strings.Builder
 	hasError := false
+	var validatorErrors []error
 	approvedCount := 0
 	nitsCount := 0
 	changesCount := 0
@@ -1317,6 +1332,7 @@ func composeValidatorResults(results []ValidatorResult, risk feature.RiskLevel) 
 		case r.Error != nil:
 			verdict = "ERROR"
 			hasError = true
+			validatorErrors = append(validatorErrors, fmt.Errorf("%s validator: %w", r.Domain, r.Error))
 		case r.Status == ReviewApproved:
 			approvedCount++
 		case r.Status == ReviewChangesRequested:
@@ -1359,7 +1375,7 @@ func composeValidatorResults(results []ValidatorResult, risk feature.RiskLevel) 
 		}
 	}
 
-	return overallStatus, b.String(), nil
+	return overallStatus, b.String(), errors.Join(validatorErrors...)
 }
 
 // validatorWeight returns the display weight for a validator domain.
@@ -1501,7 +1517,7 @@ roadmapAttemptLoop:
 
 			addDirs := cfg.AdditionalDirs
 			if len(addDirs) == 0 {
-				addDirs = []string{cfg.StateDir}
+				addDirs = []string{ActiveRunDir(cfg.StateDir, cfg.Feature)}
 			}
 			sessionAttempt := nextPlanSessionAttempt(artifactDir, attempt)
 			for {
@@ -1714,7 +1730,7 @@ roadmapAttemptLoop:
 			_ = WritePlanAttemptMeta(artifactDir, PlanAttemptMeta{Attempt: attempt, AgentStatus: agentStatusSuccess, ReviewStatus: "FAILED"})
 			criticFeedback = fmt.Sprintf("Roadmap validation failed: %v", reviewErr)
 			_ = os.WriteFile(filepath.Join(attemptDir, "validation-feedback.md"), []byte(criticFeedback), 0o644)
-			continue
+			return &PlanLoopResult{FinalStatus: "failed", Iterations: attempt, LastError: reviewErr.Error()}, nil
 		}
 
 		switch reviewStatus {
@@ -1882,7 +1898,7 @@ phasePlanAttemptLoop:
 
 			addDirs := cfg.AdditionalDirs
 			if len(addDirs) == 0 {
-				addDirs = []string{cfg.StateDir}
+				addDirs = []string{ActiveRunDir(cfg.StateDir, cfg.Feature)}
 			}
 			sessionAttempt := nextPlanSessionAttempt(artifactDir, attempt)
 			for {
@@ -2102,7 +2118,7 @@ phasePlanAttemptLoop:
 			_ = WritePlanAttemptMeta(artifactDir, PlanAttemptMeta{Attempt: attempt, AgentStatus: agentStatusSuccess, ReviewStatus: "FAILED"})
 			criticFeedback = fmt.Sprintf("Phase plan validation failed: %v", reviewErr)
 			_ = os.WriteFile(filepath.Join(attemptDir, "validation-feedback.md"), []byte(criticFeedback), 0o644)
-			continue
+			return &PlanLoopResult{FinalStatus: "failed", Iterations: attempt, LastError: reviewErr.Error()}, nil
 		}
 
 		switch reviewStatus {

--- a/internal/agent/plan_validation_test.go
+++ b/internal/agent/plan_validation_test.go
@@ -1478,6 +1478,7 @@ func TestComposeValidatorResults(t *testing.T) {
 		results    []ValidatorResult
 		wantStatus ReviewStatus
 		wantInFeed string
+		wantError  bool
 	}{
 		{
 			name: "all approved → APPROVED",
@@ -1489,12 +1490,25 @@ func TestComposeValidatorResults(t *testing.T) {
 			wantStatus: ReviewApproved,
 			wantInFeed: "Overall: APPROVED**",
 		},
+		{
+			name: "provider error is infrastructure failure",
+			results: []ValidatorResult{
+				{Domain: "architecture", Status: ReviewFailed, Error: fmt.Errorf("codex rejected turn/start")},
+				{Domain: "scope", Status: ReviewApproved},
+			},
+			wantStatus: ReviewChangesRequested,
+			wantInFeed: "architecture Validator — ERROR",
+			wantError:  true,
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			status, feedback, err := composeValidatorResults(tc.results, feature.RiskMedium)
-			if err != nil {
+			if err != nil && !tc.wantError {
 				t.Fatalf("compose err: %v", err)
+			}
+			if err == nil && tc.wantError {
+				t.Fatal("compose err = nil, want infrastructure error")
 			}
 			if status != tc.wantStatus {
 				t.Errorf("status = %s, want %s", status, tc.wantStatus)
@@ -1503,6 +1517,74 @@ func TestComposeValidatorResults(t *testing.T) {
 				t.Errorf("feedback missing %q; got:\n%s", tc.wantInFeed, feedback)
 			}
 		})
+	}
+}
+
+func TestRoadmapLoopValidatorInfrastructureFailureDoesNotRevisePlan(t *testing.T) {
+	tmpDir := t.TempDir()
+	workDir := filepath.Join(tmpDir, "work")
+	scriptsDir := filepath.Join(tmpDir, "scripts")
+	roadmapDir := filepath.Join(tmpDir, "test-plan-001", "runs", "run-001", "roadmap")
+	for _, dir := range []string{workDir, scriptsDir, roadmapDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("MkdirAll(%q): %v", dir, err)
+		}
+	}
+
+	planScript := testutil.WriteScript(t, scriptsDir, "plan.sh",
+		testutil.JSONLInit+"\n"+
+			writeRoadmapArtifactSnippet(roadmapDir)+
+			testutil.TouchPhaseCompleteInLatestAttemptDir(roadmapDir)+"\n"+
+			testutil.JSONLSuccess+"\n")
+	criticScript := testutil.WriteScript(t, scriptsDir, "critic-error.sh",
+		testutil.JSONLInit+"\n"+testutil.JSONLError("codex rejected turn/start")+"\n")
+	buildSession := mockBuildSession(planScript, criticScript)
+	var callsMu sync.Mutex
+	plannerCalls := 0
+	criticCalls := 0
+
+	store := feature.NewStore(tmpDir)
+	f := newTestPlanFeature(t, workDir)
+	f.Pipeline = feature.PipelineMoonshot
+	f.RiskLevel = feature.RiskLow
+	if err := store.Save(f); err != nil {
+		t.Fatal(err)
+	}
+
+	sm := session.NewManager(make(chan interface{}, 100))
+	defer sm.Shutdown()
+	result, err := RunRoadmapPlanningLoop(PlanLoopConfig{
+		Feature:      f,
+		FeatureStore: store,
+		StateDir:     tmpDir,
+		WorkDir:      workDir,
+		MaxAttempts:  3,
+		BuildSession: func(opts BuildSessionOpts) ([]string, []string, *ports.SessionOpts, error) {
+			callsMu.Lock()
+			if !isReviewHelper(opts.PermHandler) {
+				plannerCalls++
+			} else {
+				criticCalls++
+			}
+			callsMu.Unlock()
+			return buildSession(opts)
+		},
+	}, sm)
+	if err != nil {
+		t.Fatalf("RunRoadmapPlanningLoop() error = %v", err)
+	}
+	if result.FinalStatus != "failed" || result.Iterations != 1 {
+		t.Fatalf("result = %+v, want infrastructure failure in attempt 1", result)
+	}
+	if plannerCalls != 1 {
+		t.Fatalf("planner calls = %d, want 1; validator failure must not trigger plan revision", plannerCalls)
+	}
+	wantCriticCalls := len(roadmapValidatorsForRisk(feature.RiskLow)) * maxValidatorInfrastructureSessionAttempts
+	if criticCalls != wantCriticCalls {
+		t.Fatalf("critic calls = %d, want %d validation-only retries", criticCalls, wantCriticCalls)
+	}
+	if _, err := os.Stat(filepath.Join(roadmapDir, "attempt-02")); !os.IsNotExist(err) {
+		t.Fatalf("attempt-02 stat error = %v, want no second plan attempt", err)
 	}
 }
 

--- a/internal/agent/rebase_loop.go
+++ b/internal/agent/rebase_loop.go
@@ -299,6 +299,7 @@ func RunRebaseLoop(cfg RebaseLoopConfig, sm ports.SessionManager) (*RebaseLoopRe
 		ReviewModel:                cfg.ReviewModel,
 		ArtifactDir:                artifactDir,
 		StateDir:                   stateDir,
+		RunDir:                     runDir,
 		AdditionalDirs:             additionalDirsExcludingStateDir(workspace, stateDir),
 		KBInfos:                    cfg.KBInfos,
 		DesignArtifactPath:         cfg.Feature.DesignArtifactPath(),

--- a/internal/agent/refactor_feature_loop.go
+++ b/internal/agent/refactor_feature_loop.go
@@ -177,7 +177,7 @@ func RunRefactorFeatureLoop(cfg RefactorFeatureLoopConfig, sm ports.SessionManag
 		return nil, fmt.Errorf("refactor feature loop: prompt is empty")
 	}
 
-	// Build the cross-repo workspace. Cwd at the feature state dir, with
+	// Build the cross-repo workspace. Cwd at the active run dir, with
 	// --add-dir for every Feature.Repos worktree (refactors are cross-repo
 	// by design — even when the plan ends up scoped to one repo, the agent
 	// needs full visibility to judge cross-repo impact).
@@ -435,6 +435,7 @@ func RunRefactorFeatureLoop(cfg RefactorFeatureLoopConfig, sm ports.SessionManag
 		ReviewModel:                cfg.ReviewModel,
 		ArtifactDir:                artifactDir,
 		StateDir:                   stateDir,
+		RunDir:                     runDir,
 		AdditionalDirs:             additionalDirsExcludingStateDir(workspace, stateDir),
 		KBInfos:                    cfg.KBInfos,
 		PhaseType:                  cfg.Feature.RoadmapPhaseType,

--- a/internal/agent/review_comments_loop.go
+++ b/internal/agent/review_comments_loop.go
@@ -277,6 +277,7 @@ func RunReviewCommentsLoop(cfg ReviewCommentsLoopConfig, sm ports.SessionManager
 		ReviewModel:                cfg.ReviewModel,
 		ArtifactDir:                artifactDir,
 		StateDir:                   stateDir,
+		RunDir:                     runDir,
 		AdditionalDirs:             additionalDirsExcludingStateDir(workspace, stateDir),
 		KBInfos:                    cfg.KBInfos,
 		DesignArtifactPath:         cfg.Feature.DesignArtifactPath(),

--- a/internal/agent/workspace_setup.go
+++ b/internal/agent/workspace_setup.go
@@ -31,22 +31,21 @@ import (
 //
 // Construction is pure: feature → workspace. Callers may further filter the
 // AdditionalDirs slice (e.g. add a guidelines dir) but the canonical
-// "feature state dir + every Feature.Repos worktree" set lives here.
+// "active run dir + every Feature.Repos worktree" set lives here.
 type WorkspaceSetup struct {
 	// Cwd is the working directory the session runs in. Always set to the
-	// feature state dir (the per-feature artifacts root) so progress.md,
-	// verification-report.yaml, and review-feedback.md write-paths are
-	// stable across cycles. Per-repo loops historically used the repo's
-	// worktree path; the unified flow sits at the state dir and reaches
-	// each repo through AdditionalDirs.
+	// active run directory so relative artifact navigation cannot cross into a
+	// sealed predecessor run. Per-repo loops historically used the repo's
+	// worktree path; the unified flow sits at the active run and reaches each
+	// repo through AdditionalDirs.
 	Cwd string
 
 	// AdditionalDirs is the deduplicated, deterministically-ordered list of
-	// directories to mount via --add-dir. Always contains the feature state
-	// dir at index 0 (so the agent can navigate ./<run>/<phase>/... without
-	// needing the absolute path), followed by every Feature.Repos worktree
-	// (or repo.Path when worktrees aren't in use), sorted by repo name for
-	// stable test output.
+	// directories to mount via --add-dir. Always contains the active run dir at
+	// index 0, followed by every Feature.Repos worktree (or repo.Path when
+	// worktrees aren't in use), sorted by repo name for stable test output. The
+	// containing feature state directory is deliberately excluded because it
+	// also contains sealed predecessor runs.
 	AdditionalDirs []string
 
 	// RepoPaths is the per-repo absolute path map, keyed by repo name.
@@ -57,18 +56,19 @@ type WorkspaceSetup struct {
 }
 
 // BuildWorkspace returns the canonical workspace bootstrap for the given
-// feature. The state dir is the per-feature root (i.e. the directory that
-// contains `feature.yaml` and `runs/`).
+// feature. The state dir argument is the per-feature root (i.e. the directory
+// that contains `feature.yaml` and `runs/`); only its active run child is
+// exposed in the returned workspace.
 //
 // Behavior:
-//   - Cwd is always stateDir. Single-repo and multi-repo cases share this.
+//   - Cwd is always the feature's active run directory. Single-repo and
+//     multi-repo cases share this.
 //   - Every Feature.Repos entry contributes one AdditionalDirs path: the
 //     worktree path when set, falling back to repo.Path. Repos missing both
 //     fields are skipped silently (the validator catches this earlier).
-//   - The state dir is always present at AdditionalDirs[0] to keep
-//     navigation paths stable in the agent's prompt.
-//   - Output is order-stable for tests: state dir first, then repos sorted
-//     by name.
+//   - The active run dir is always present at AdditionalDirs[0].
+//   - Output is order-stable for tests: active run first, then repos sorted by
+//     name.
 func BuildWorkspace(feat *feature.Feature, stateDir string) (WorkspaceSetup, error) {
 	if feat == nil {
 		return WorkspaceSetup{}, fmt.Errorf("workspace setup: feature is nil")
@@ -80,14 +80,19 @@ func BuildWorkspace(feat *feature.Feature, stateDir string) (WorkspaceSetup, err
 	if err != nil {
 		return WorkspaceSetup{}, fmt.Errorf("workspace setup: state dir abs: %w", err)
 	}
+	runNumber := feat.ActiveRun
+	if runNumber <= 0 {
+		runNumber = 1
+	}
+	activeRunDir := filepath.Join(abs, "runs", feature.RunDirName(runNumber))
 
 	// Canonical sort: by repo name. Stable output for tests, predictable
 	// --add-dir ordering for the agent.
 	repos := append([]feature.FeatureRepo(nil), feat.Repos...)
 	sort.Slice(repos, func(i, j int) bool { return repos[i].Name < repos[j].Name })
 
-	dirs := []string{abs}
-	seen := map[string]bool{abs: true}
+	dirs := []string{activeRunDir}
+	seen := map[string]bool{activeRunDir: true}
 	paths := make(map[string]string, len(repos))
 	for _, r := range repos {
 		p := r.WorktreePath
@@ -109,7 +114,7 @@ func BuildWorkspace(feat *feature.Feature, stateDir string) (WorkspaceSetup, err
 	}
 
 	return WorkspaceSetup{
-		Cwd:            abs,
+		Cwd:            activeRunDir,
 		AdditionalDirs: dirs,
 		RepoPaths:      paths,
 	}, nil
@@ -117,9 +122,9 @@ func BuildWorkspace(feat *feature.Feature, stateDir string) (WorkspaceSetup, err
 
 // WorkspaceForRepos is a filtering helper for cycles that legitimately mount
 // only a subset of Feature.Repos (e.g. a rebase cycle scoped to the behind
-// repos). The base WorkspaceSetup is computed first so the state dir is
+// repos). The base WorkspaceSetup is computed first so the active run dir is
 // always present; the AdditionalDirs slice is then narrowed to the requested
-// repo names plus the state dir.
+// repo names plus the active run.
 //
 // Repo names not in feat.Repos are silently dropped. RepoPaths is filtered
 // to match. Returns the unfiltered workspace when repos is empty (treated as

--- a/internal/agent/workspace_setup_test.go
+++ b/internal/agent/workspace_setup_test.go
@@ -15,12 +15,41 @@
 package agent
 
 import (
+	"os"
 	"path/filepath"
 	"reflect"
+	"slices"
 	"testing"
 
 	"github.com/doordash-oss/agentic-orchestrator/internal/feature"
 )
+
+func TestBuildWorkspace_GrantsOnlyActiveRunState(t *testing.T) {
+	featureStateDir := t.TempDir()
+	sealedRunDir := filepath.Join(featureStateDir, "runs", "run-004")
+	activeRunDir := filepath.Join(featureStateDir, "runs", "run-005")
+	for _, dir := range []string{sealedRunDir, activeRunDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("MkdirAll(%q) error = %v", dir, err)
+		}
+	}
+
+	ws, err := BuildWorkspace(&feature.Feature{ActiveRun: 5}, featureStateDir)
+	if err != nil {
+		t.Fatalf("BuildWorkspace() error = %v", err)
+	}
+	if ws.Cwd != activeRunDir {
+		t.Fatalf("Cwd = %q, want active run %q", ws.Cwd, activeRunDir)
+	}
+	if !slices.Contains(ws.AdditionalDirs, activeRunDir) {
+		t.Fatalf("AdditionalDirs = %v, want active run %q", ws.AdditionalDirs, activeRunDir)
+	}
+	for _, forbidden := range []string{featureStateDir, sealedRunDir} {
+		if slices.Contains(ws.AdditionalDirs, forbidden) {
+			t.Fatalf("AdditionalDirs = %v, must not grant predecessor scope %q", ws.AdditionalDirs, forbidden)
+		}
+	}
+}
 
 func TestBuildWorkspace_SingleRepoWorktree(t *testing.T) {
 	stateDir := t.TempDir()
@@ -32,10 +61,11 @@ func TestBuildWorkspace_SingleRepoWorktree(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if ws.Cwd != stateDir {
-		t.Errorf("Cwd = %q, want %q", ws.Cwd, stateDir)
+	activeRunDir := filepath.Join(stateDir, "runs", "run-001")
+	if ws.Cwd != activeRunDir {
+		t.Errorf("Cwd = %q, want %q", ws.Cwd, activeRunDir)
 	}
-	want := []string{stateDir, wt}
+	want := []string{activeRunDir, wt}
 	if !reflect.DeepEqual(ws.AdditionalDirs, want) {
 		t.Errorf("AdditionalDirs = %v, want %v", ws.AdditionalDirs, want)
 	}
@@ -58,7 +88,7 @@ func TestBuildWorkspace_MultiRepoSorted(t *testing.T) {
 		t.Fatal(err)
 	}
 	abs := func(p string) string { a, _ := filepath.Abs(p); return a }
-	want := []string{stateDir, abs("/repos/alpha"), abs("/repos/mid"), abs("/repos/zeta")}
+	want := []string{filepath.Join(stateDir, "runs", "run-001"), abs("/repos/alpha"), abs("/repos/mid"), abs("/repos/zeta")}
 	if !reflect.DeepEqual(ws.AdditionalDirs, want) {
 		t.Errorf("AdditionalDirs = %v, want %v", ws.AdditionalDirs, want)
 	}
@@ -71,8 +101,9 @@ func TestBuildWorkspace_NoRepos(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(ws.AdditionalDirs) != 1 || ws.AdditionalDirs[0] != stateDir {
-		t.Errorf("AdditionalDirs = %v, want only state dir", ws.AdditionalDirs)
+	activeRunDir := filepath.Join(stateDir, "runs", "run-001")
+	if len(ws.AdditionalDirs) != 1 || ws.AdditionalDirs[0] != activeRunDir {
+		t.Errorf("AdditionalDirs = %v, want only active run dir", ws.AdditionalDirs)
 	}
 }
 
@@ -102,7 +133,7 @@ func TestWorkspaceForRepos_FiltersSubset(t *testing.T) {
 		t.Fatal(err)
 	}
 	abs := func(p string) string { a, _ := filepath.Abs(p); return a }
-	want := []string{stateDir, abs("/r/api"), abs("/r/web")}
+	want := []string{filepath.Join(stateDir, "runs", "run-001"), abs("/r/api"), abs("/r/web")}
 	if !reflect.DeepEqual(ws.AdditionalDirs, want) {
 		t.Errorf("AdditionalDirs = %v, want %v", ws.AdditionalDirs, want)
 	}

--- a/internal/llm/codex/protocol.go
+++ b/internal/llm/codex/protocol.go
@@ -80,6 +80,7 @@ type Protocol struct {
 	turnID             string
 	model              string
 	approvalPolicy     string
+	dangerFullAccess   bool
 	inputTokens        int
 	cachedInputTokens  int
 	outputTokens       int
@@ -98,18 +99,19 @@ type Protocol struct {
 
 // NewProtocol creates a new Codex protocol handler.
 func NewProtocol(opts llm.ProtocolOpts) *Protocol {
-	policy := opts.ApprovalPolicy
+	policy := strings.TrimSpace(opts.ApprovalPolicy)
 	if policy == "" {
-		if opts.DSP {
-			policy = "never"
-		} else {
-			policy = "on-request"
-		}
+		// DSP controls the sandbox boundary, not the approval-policy enum.
+		// Managed Codex installations may require on-request even when the
+		// sandbox itself is danger-full-access; sending never is rejected by
+		// those installations before the first turn starts.
+		policy = "on-request"
 	}
 	return &Protocol{
-		opts:           opts,
-		model:          llm.StripModelContextWindow(opts.Model),
-		approvalPolicy: policy,
+		opts:             opts,
+		model:            llm.StripModelContextWindow(opts.Model),
+		approvalPolicy:   policy,
+		dangerFullAccess: opts.DSP,
 	}
 }
 
@@ -309,7 +311,7 @@ func (p *Protocol) startThread() error {
 	id := int(nextID.Add(1))
 
 	sandbox := SandboxModeWorkspaceWrite
-	if p.approvalPolicy == "never" {
+	if p.dangerFullAccess {
 		sandbox = SandboxModeDangerFullAccess
 	}
 
@@ -339,6 +341,8 @@ func (p *Protocol) startTurn(userPrompt string) error {
 	threadID := p.threadID
 	systemPrompt := p.opts.SystemPrompt
 	writableRoots := append([]string(nil), p.opts.WritableRoots...)
+	policy := p.approvalPolicy
+	dangerFullAccess := p.dangerFullAccess
 	p.mu.Unlock()
 
 	model := p.model
@@ -355,7 +359,7 @@ func (p *Protocol) startTurn(userPrompt string) error {
 		WritableRoots: writableRoots,
 		NetworkAccess: true,
 	}
-	if p.approvalPolicy == "never" {
+	if dangerFullAccess {
 		sandboxPolicy = &SandboxPolicy{
 			Type:          "dangerFullAccess",
 			NetworkAccess: true,
@@ -373,7 +377,7 @@ func (p *Protocol) startTurn(userPrompt string) error {
 		Params: TurnStartParams{
 			ThreadID:       threadID,
 			Input:          input,
-			ApprovalPolicy: p.approvalPolicy,
+			ApprovalPolicy: policy,
 			SandboxPolicy:  sandboxPolicy,
 			CollaborationMode: &CollaborationMode{
 				Mode:     "default",
@@ -392,6 +396,7 @@ func (p *Protocol) sendFollowUpTurn(text string) error {
 	policy := p.approvalPolicy
 	model := p.model
 	writableRoots := append([]string(nil), p.opts.WritableRoots...)
+	dangerFullAccess := p.dangerFullAccess
 	p.mu.Unlock()
 
 	if policy == "" {
@@ -403,7 +408,7 @@ func (p *Protocol) sendFollowUpTurn(text string) error {
 		WritableRoots: writableRoots,
 		NetworkAccess: true,
 	}
-	if policy == "never" {
+	if dangerFullAccess {
 		sandbox = &SandboxPolicy{
 			Type:          "dangerFullAccess",
 			NetworkAccess: true,
@@ -535,6 +540,9 @@ func (p *Protocol) handleResponse(id int, result, errData json.RawMessage) (llm.
 	if err := json.Unmarshal(result, &threadResult); err == nil && threadResult.Thread.ID != "" {
 		p.mu.Lock()
 		p.threadID = threadResult.Thread.ID
+		if effectivePolicy := strings.TrimSpace(threadResult.ApprovalPolicy); effectivePolicy != "" {
+			p.approvalPolicy = effectivePolicy
+		}
 		if p.threadReady != nil {
 			select {
 			case <-p.threadReady:

--- a/internal/llm/codex/protocol_test.go
+++ b/internal/llm/codex/protocol_test.go
@@ -442,10 +442,62 @@ func TestCodexProtocol_DefaultApprovalPolicyIsOnRequest(t *testing.T) {
 	}
 }
 
-func TestCodexProtocol_DSPApprovalPolicyIsNever(t *testing.T) {
+func TestCodexProtocol_DSPUsesMDMCompatiblePolicyWithDangerFullAccess(t *testing.T) {
 	p := NewProtocol(llm.ProtocolOpts{WorkDir: "/tmp/test", Model: "codex", DSP: true})
-	if p.approvalPolicy != "never" {
-		t.Errorf("DSP approvalPolicy = %q, want %q", p.approvalPolicy, "never")
+	if p.approvalPolicy != "on-request" {
+		t.Errorf("DSP approvalPolicy = %q, want %q", p.approvalPolicy, "on-request")
+	}
+
+	var buf bytes.Buffer
+	p.SetStdin(&buf)
+	p.SetThreadIDForTest("thread-123")
+	if err := p.startTurn("do something"); err != nil {
+		t.Fatalf("startTurn() error: %v", err)
+	}
+	got := buf.String()
+	if !strings.Contains(got, `"approvalPolicy":"on-request"`) {
+		t.Fatalf("DSP turn must use MDM-compatible on-request policy; payload=%s", got)
+	}
+	if !strings.Contains(got, `"type":"dangerFullAccess"`) {
+		t.Fatalf("DSP turn must retain dangerFullAccess sandbox; payload=%s", got)
+	}
+}
+
+func TestCodexProtocol_AdoptsEffectiveThreadApprovalPolicy(t *testing.T) {
+	p := NewProtocol(llm.ProtocolOpts{
+		WorkDir:        "/tmp/test",
+		Model:          "codex",
+		DSP:            true,
+		ApprovalPolicy: "never",
+	})
+	threadStarted := []byte(`{"id":2,"result":{"thread":{"id":"thread-123"},"approvalPolicy":"on-request","sandbox":{"type":"dangerFullAccess"}}}`)
+	if _, err := p.ParseLine(threadStarted); err != nil {
+		t.Fatalf("ParseLine(thread/start) error: %v", err)
+	}
+
+	var buf bytes.Buffer
+	p.SetStdin(&buf)
+	if err := p.startTurn("review the plan"); err != nil {
+		t.Fatalf("startTurn() error: %v", err)
+	}
+	got := buf.String()
+	if strings.Contains(got, `"approvalPolicy":"never"`) || !strings.Contains(got, `"approvalPolicy":"on-request"`) {
+		t.Fatalf("turn must adopt effective thread approval policy; payload=%s", got)
+	}
+	if !strings.Contains(got, `"type":"dangerFullAccess"`) {
+		t.Fatalf("effective policy adoption must not downgrade DSP sandbox; payload=%s", got)
+	}
+
+	buf.Reset()
+	if err := p.sendFollowUpTurn("continue"); err != nil {
+		t.Fatalf("sendFollowUpTurn() error: %v", err)
+	}
+	got = buf.String()
+	if strings.Contains(got, `"approvalPolicy":"never"`) || !strings.Contains(got, `"approvalPolicy":"on-request"`) {
+		t.Fatalf("follow-up must retain effective thread approval policy; payload=%s", got)
+	}
+	if !strings.Contains(got, `"type":"dangerFullAccess"`) {
+		t.Fatalf("follow-up must retain DSP sandbox; payload=%s", got)
 	}
 }
 

--- a/internal/llm/codex/types.go
+++ b/internal/llm/codex/types.go
@@ -96,7 +96,8 @@ type SandboxPolicy struct {
 
 // ThreadStartResult is the response to thread/start.
 type ThreadStartResult struct {
-	Thread Thread `json:"thread"`
+	Thread         Thread `json:"thread"`
+	ApprovalPolicy string `json:"approvalPolicy,omitempty"`
 }
 
 // Thread identifies a conversation thread.

--- a/internal/orchestrator/cycles.go
+++ b/internal/orchestrator/cycles.go
@@ -239,6 +239,7 @@ func (o *Orchestrator) restartRepoCycleImplement(featureID, repoName string, rc 
 		ReviewModel:                f.Models.Review,
 		ArtifactDir:                cycleBaseDir,
 		StateDir:                   filepath.Join(baseDir, featureID),
+		RunDir:                     agent.ActiveRunDir(baseDir, f),
 		RepoName:                   repoName,
 		DesignArtifactPath:         f.DesignArtifactPath(),
 		DangerouslySkipPermissions: pr.DangerouslySkipPermissions,

--- a/test/integration/phase_implement_unified_1repo_test.go
+++ b/test/integration/phase_implement_unified_1repo_test.go
@@ -44,7 +44,8 @@ import (
 //
 //   - PhaseScope correctly identifies the lone repo as the phase scope.
 //   - The inner ImplementConfig sees the cross-repo workspace shape:
-//     cwd = state dir (NOT repo dir), AdditionalDirs includes the repo,
+//     cwd = active run dir (NOT feature root or repo dir), AdditionalDirs
+//     includes the repo,
 //     ArtifactDir is at the flat phase level (no per-repo subdir).
 //   - AtomicPhaseStamp transitions the single repo to
 //     "awaiting_final_review".
@@ -118,22 +119,25 @@ func TestPhaseImplementUnified_1Repo_EndToEnd(t *testing.T) {
 	// verify that the unification cross-cuts (workspace setup, scope, atomic
 	// stamp) are correct for the N=1 degenerate case.
 	stubImpl := func(c agent.ImplementConfig, _ ports.SessionManager) (*agent.LoopResult, error) {
-		// The unified flow MUST set cwd to the state dir (NOT the repo
-		// dir) and pass the repo via --add-dir. This is the load-bearing
-		// invariant that distinguishes the unified flow from the legacy
-		// per-repo flow.
+		// The unified flow MUST set cwd to the active run dir (NOT the feature
+		// root or repo dir) and pass the repo via --add-dir. This keeps sealed
+		// predecessor runs outside the agent's granted state scope.
 		stateDirAbs, _ := filepath.Abs(filepath.Join(stateDir, f.ID))
+		activeRunDir := agent.ActiveRunDir(stateDir, f)
 		repoAAbs, _ := filepath.Abs(repoA)
-		if c.WorkDir != stateDirAbs {
-			t.Errorf("ImplementConfig.WorkDir = %q, want state dir %q (unified flow uses state dir as cwd)", c.WorkDir, stateDirAbs)
+		if c.WorkDir != activeRunDir {
+			t.Errorf("ImplementConfig.WorkDir = %q, want active run dir %q", c.WorkDir, activeRunDir)
 		}
-		// AdditionalDirs must NOT contain stateDir (already at WorkDir;
-		// the loop filters it out via additionalDirsExcludingStateDir).
+		if c.RunDir != activeRunDir {
+			t.Errorf("ImplementConfig.RunDir = %q, want active run dir %q", c.RunDir, activeRunDir)
+		}
+		// AdditionalDirs must NOT contain the feature state dir or active run
+		// dir (already at WorkDir and RunDir).
 		// AdditionalDirs MUST contain the repo path.
 		hasRepo := false
 		for _, d := range c.AdditionalDirs {
-			if d == stateDirAbs {
-				t.Errorf("ImplementConfig.AdditionalDirs leaked state dir %q (should be excluded)", d)
+			if d == stateDirAbs || d == activeRunDir {
+				t.Errorf("ImplementConfig.AdditionalDirs leaked state scope %q (should be excluded)", d)
 			}
 			if d == repoAAbs {
 				hasRepo = true


### PR DESCRIPTION
## Summary

- Restrict agent session working directories and provider roots to the active run, keeping sealed predecessor runs outside the agent-visible state scope.
- Keep Codex danger-full-access sandboxing compatible with managed approval policies and adopt the server's effective policy for later turns.
- Retry validator infrastructure failures within the same plan attempt, then fail cleanly instead of triggering a bogus plan revision.

## Verification

- Fast suite: `make test-fast`
- Isolated integration: `go test ./test/integration/... -count=1`
- E2E Go (process-launch / API-driven): `go test ./test/e2e/... -count=1 -race`
- E2E smoke shell: `bash test/e2e/smoke.sh`
- Static analysis: `go vet ./...`
- Build: `go build ./...`
- Skipped Race regression: the change does not alter concurrent state ownership, and the targeted E2E race gate passed.

Co-authored-by: Codex <noreply@openai.com>
