### PR TITLE
Wire Cross-Repo Verification into multi-repo testing contracts

### DIFF
--- a/internal/agent/testing_contract.go
+++ b/internal/agent/testing_contract.go
@@ -342,10 +342,11 @@ type MultiRepoContractInput struct {
 	BaselineProfile string
 	BaselineSteps   []VerificationStep
 	PlanLess        bool
-	// CrossRepoSteps are verification commands authored by the planner
-	// under a top-level "#### Cross-Repo Verification:" heading. The
-	// compiler emits these as `cross-repo` items separately from per-Task
-	// commands. May be nil.
+	// CrossRepoSteps are verification commands authored by the planner under a
+	// top-level "Cross-Repo Verification" heading. When PlanLess is false the
+	// compiler also parses that heading from PlanText and merges the results
+	// here (callers may still pass steps explicitly for tests). Emitted as
+	// `cross-repo` items separately from per-Task commands. May be nil.
 	CrossRepoSteps []VerificationStep
 }
 
@@ -518,8 +519,14 @@ func CompileTestingContractMultiRepo(in MultiRepoContractInput) TestingContract 
 		}
 	}
 
-	// 3) Cross-repo rows.
-	for _, step := range in.CrossRepoSteps {
+	// 3) Cross-repo rows: explicit CrossRepoSteps (tests / callers) plus
+	// planner-authored "Cross-Repo Verification" sections parsed from the
+	// plan when PlanLess is false. Dedup via addItem keeps overlaps unique.
+	crossRepoSteps := append([]VerificationStep(nil), in.CrossRepoSteps...)
+	if !in.PlanLess {
+		crossRepoSteps = append(crossRepoSteps, ParseCrossRepoVerification(in.PlanText)...)
+	}
+	for _, step := range crossRepoSteps {
 		addItem(testingContractCrossRepoSource, TestingContractCrossRepoTag, step)
 	}
 

--- a/internal/agent/testing_contract_multirepo_test.go
+++ b/internal/agent/testing_contract_multirepo_test.go
@@ -78,6 +78,46 @@ func TestCompileTestingContractMultiRepo_CrossRepoSteps(t *testing.T) {
 	}
 }
 
+func TestCompileTestingContractMultiRepo_CrossRepoStepsFromPlan(t *testing.T) {
+	plan := strings.Join([]string{
+		"## Tasks",
+		"### Task 1: api work",
+		"**Repo:** `api`",
+		"#### Automated Verification:",
+		"- [ ] api tests: `go test ./api/... -count=1`",
+		"### Task 2: web work",
+		"**Repo:** `web`",
+		"#### Automated Verification:",
+		"- [ ] web tests: `npm test`",
+		"## Cross-Repo Verification",
+		"- e2e smoke: `scripts/e2e.sh`",
+		"- [ ] contract test: `scripts/contract-test.sh`",
+	}, "\n")
+	c := CompileTestingContractMultiRepo(MultiRepoContractInput{
+		Repos:    []string{testRepoNameAPI, testRepoNameWeb},
+		PlanText: plan,
+	})
+	if got := countItems(c.Items, testingContractCrossRepoSource, TestingContractCrossRepoTag); got != 2 {
+		t.Fatalf("cross-repo rows = %d, want 2", got)
+	}
+	wantCmds := map[string]bool{"scripts/e2e.sh": false, "scripts/contract-test.sh": false}
+	for _, it := range c.Items {
+		if it.Source != testingContractCrossRepoSource {
+			continue
+		}
+		if _, ok := wantCmds[it.Command]; !ok {
+			t.Errorf("unexpected cross-repo command %q", it.Command)
+			continue
+		}
+		wantCmds[it.Command] = true
+	}
+	for cmd, seen := range wantCmds {
+		if !seen {
+			t.Errorf("missing cross-repo command %q", cmd)
+		}
+	}
+}
+
 func TestCompileTestingContractMultiRepo_PlanLessNoPlanItems(t *testing.T) {
 	plan := strings.Join([]string{
 		"## Tasks",

--- a/internal/agent/verify.go
+++ b/internal/agent/verify.go
@@ -48,6 +48,22 @@ type EvidenceRequirement struct {
 //   - [ ] `command`
 //   - [ ] Description (`command`)
 func ParsePlanVerification(planText string) []VerificationStep {
+	return parseVerificationSection(planText, isAutomatedVerificationHeader, parseChecklistItem)
+}
+
+// ParseCrossRepoVerification extracts cross-repo verification commands from a
+// plan's "Cross-Repo Verification" section. Accepts both checklist items
+// ("- [ ] Description: `command`") and plain bullets ("- Description: `command`")
+// so planner-authored ## Cross-Repo Verification blocks match production plans.
+func ParseCrossRepoVerification(planText string) []VerificationStep {
+	return parseVerificationSection(planText, isCrossRepoVerificationHeader, parseCrossRepoItem)
+}
+
+func parseVerificationSection(
+	planText string,
+	isSectionHeader func(string) bool,
+	parseItem func(string) (VerificationStep, bool),
+) []VerificationStep {
 	var steps []VerificationStep
 	lines := strings.Split(planText, "\n")
 	inSection := false
@@ -69,8 +85,7 @@ func ParsePlanVerification(planText string) []VerificationStep {
 			continue
 		}
 
-		// Detect start of an Automated Verification section
-		if isAutomatedVerificationHeader(trimmed) {
+		if isSectionHeader(trimmed) {
 			inSection = true
 			continue
 		}
@@ -81,13 +96,11 @@ func ParsePlanVerification(planText string) []VerificationStep {
 			continue
 		}
 
-		// Skip non-checklist lines within section
 		if !inSection {
 			continue
 		}
 
-		// Parse checklist items
-		if step, ok := parseChecklistItem(trimmed); ok {
+		if step, ok := parseItem(trimmed); ok {
 			steps = append(steps, step)
 		}
 	}
@@ -198,6 +211,15 @@ func isAutomatedVerificationHeader(line string) bool {
 	return automatedVerificationRe.MatchString(line)
 }
 
+// Cross-Repo Verification headers appear as ## / ### / #### with an optional
+// trailing colon — matching both the struct docs ("#### Cross-Repo Verification:")
+// and the multi-repo integration fixture ("## Cross-Repo Verification").
+var crossRepoVerificationRe = regexp.MustCompile(`^#{2,5}\s+Cross-Repo Verification`)
+
+func isCrossRepoVerificationHeader(line string) bool {
+	return crossRepoVerificationRe.MatchString(line)
+}
+
 var manualVerificationRe = regexp.MustCompile(`^#{2,5}\s+Manual Verification`)
 
 func isManualVerificationHeader(line string) bool {
@@ -248,7 +270,22 @@ func parseChecklistItem(line string) (VerificationStep, bool) {
 	if !strings.HasPrefix(line, "- [") {
 		return VerificationStep{}, false
 	}
+	return parseBacktickVerificationItem(line)
+}
 
+// parseCrossRepoItem accepts checklist items and plain markdown bullets so
+// Cross-Repo Verification sections authored either way yield VerificationSteps.
+func parseCrossRepoItem(line string) (VerificationStep, bool) {
+	if strings.HasPrefix(line, "- [") {
+		return parseBacktickVerificationItem(line)
+	}
+	if !strings.HasPrefix(line, "- ") {
+		return VerificationStep{}, false
+	}
+	return parseBacktickVerificationItem(line)
+}
+
+func parseBacktickVerificationItem(line string) (VerificationStep, bool) {
 	matches := findBacktickSpans(line)
 	if len(matches) == 0 {
 		return VerificationStep{}, false
@@ -420,6 +457,9 @@ func extractDescription(line, commandWithBackticks string) string {
 	desc := line
 	if idx := strings.Index(desc, "] "); idx >= 0 {
 		desc = desc[idx+2:]
+	} else if strings.HasPrefix(desc, "- ") {
+		// Plain markdown bullet (Cross-Repo Verification plans).
+		desc = strings.TrimSpace(desc[2:])
 	}
 	// Inverted format: command is the first non-whitespace content.
 	if strings.HasPrefix(strings.TrimLeft(desc, " \t"), commandWithBackticks) {

--- a/internal/agent/verify.go
+++ b/internal/agent/verify.go
@@ -275,14 +275,17 @@ func parseChecklistItem(line string) (VerificationStep, bool) {
 
 // parseCrossRepoItem accepts checklist items and plain markdown bullets so
 // Cross-Repo Verification sections authored either way yield VerificationSteps.
+// Plain bullets require a command-shaped backtick span (no last-span fallback)
+// so prose notes like `- Keep `service-a` and `service-b` schemas in sync`
+// do not become fabricated contract rows.
 func parseCrossRepoItem(line string) (VerificationStep, bool) {
-	if strings.HasPrefix(line, "- [") {
-		return parseBacktickVerificationItem(line)
-	}
 	if !strings.HasPrefix(line, "- ") {
 		return VerificationStep{}, false
 	}
-	return parseBacktickVerificationItem(line)
+	if strings.HasPrefix(line, "- [") {
+		return parseBacktickVerificationItem(line)
+	}
+	return parsePlainCrossRepoBullet(line)
 }
 
 func parseBacktickVerificationItem(line string) (VerificationStep, bool) {
@@ -295,6 +298,26 @@ func parseBacktickVerificationItem(line string) (VerificationStep, bool) {
 	if chosen == nil {
 		return VerificationStep{}, false
 	}
+	return verificationStepFromSpan(line, chosen)
+}
+
+// parsePlainCrossRepoBullet parses "- description: `cmd`" lines. Unlike
+// checklist parsing, it rejects lines whose backtick spans are only bare
+// identifiers (no looksLikeShellCommand match).
+func parsePlainCrossRepoBullet(line string) (VerificationStep, bool) {
+	matches := findBacktickSpans(line)
+	if len(matches) == 0 {
+		return VerificationStep{}, false
+	}
+	for _, m := range matches {
+		if looksLikeShellCommand(line[m[2]:m[3]]) {
+			return verificationStepFromSpan(line, m)
+		}
+	}
+	return VerificationStep{}, false
+}
+
+func verificationStepFromSpan(line string, chosen []int) (VerificationStep, bool) {
 	command := strings.TrimSpace(line[chosen[2]:chosen[3]])
 	if command == "" {
 		return VerificationStep{}, false
@@ -436,6 +459,14 @@ func looksLikeShellCommand(s string) bool {
 	}
 	// Relative-path invocations like `./bin/agentic` or `./scripts/foo.sh`.
 	if strings.Contains(s, "./") {
+		return true
+	}
+	// Script-path invocations without ./, e.g. `scripts/e2e.sh`.
+	lower := strings.ToLower(s)
+	if strings.HasSuffix(lower, ".sh") ||
+		strings.HasSuffix(lower, ".bash") ||
+		strings.HasSuffix(lower, ".py") ||
+		strings.HasSuffix(lower, ".rb") {
 		return true
 	}
 	return false

--- a/internal/agent/verify_test.go
+++ b/internal/agent/verify_test.go
@@ -15,6 +15,7 @@
 package agent
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -375,5 +376,31 @@ func TestParseChecklistItem(t *testing.T) {
 				t.Errorf("command = %q, want %q", step.Command, tt.wantCmd)
 			}
 		})
+	}
+}
+
+func TestParseCrossRepoVerification(t *testing.T) {
+	plan := strings.Join([]string{
+		"## Tasks",
+		"### Task 1",
+		"**Repo:** api",
+		"## Cross-Repo Verification",
+		"- e2e smoke: `scripts/e2e.sh`",
+		"- [ ] contract test: `scripts/contract-test.sh`",
+		"## Manual Verification",
+		"- [ ] UI looks fine",
+	}, "\n")
+	got := ParseCrossRepoVerification(plan)
+	want := []VerificationStep{
+		{Description: "e2e smoke", Command: "scripts/e2e.sh"},
+		{Description: "contract test", Command: "scripts/contract-test.sh"},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("len = %d, want %d (%+v)", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("[%d] = %+v, want %+v", i, got[i], want[i])
+		}
 	}
 }

--- a/internal/agent/verify_test.go
+++ b/internal/agent/verify_test.go
@@ -387,6 +387,7 @@ func TestParseCrossRepoVerification(t *testing.T) {
 		"## Cross-Repo Verification",
 		"- e2e smoke: `scripts/e2e.sh`",
 		"- [ ] contract test: `scripts/contract-test.sh`",
+		"- Keep `service-a` and `service-b` schemas in sync",
 		"## Manual Verification",
 		"- [ ] UI looks fine",
 	}, "\n")
@@ -402,5 +403,25 @@ func TestParseCrossRepoVerification(t *testing.T) {
 		if got[i] != want[i] {
 			t.Errorf("[%d] = %+v, want %+v", i, got[i], want[i])
 		}
+	}
+}
+
+func TestParseCrossRepoItem_PlainBulletRequiresCommandShape(t *testing.T) {
+	if _, ok := parseCrossRepoItem("- Keep `service-a` and `service-b` schemas in sync"); ok {
+		t.Fatal("prose bullet with identifier backticks must not become a verification step")
+	}
+	step, ok := parseCrossRepoItem("- e2e smoke: `scripts/e2e.sh`")
+	if !ok {
+		t.Fatal("plain bullet with script path should parse")
+	}
+	if step.Command != "scripts/e2e.sh" {
+		t.Fatalf("command = %q, want scripts/e2e.sh", step.Command)
+	}
+	step, ok = parseCrossRepoItem("- [ ] single word: `make`")
+	if !ok {
+		t.Fatal("checklist items still allow last-span fallback for single-word commands")
+	}
+	if step.Command != "make" {
+		t.Fatalf("command = %q, want make", step.Command)
 	}
 }

--- a/test/integration/phase_implement_unified_3repo_cross_repo_test.go
+++ b/test/integration/phase_implement_unified_3repo_cross_repo_test.go
@@ -139,23 +139,13 @@ func TestPhaseImplementUnified_3Repo_CrossRepoVerification(t *testing.T) {
 
 	// --- Part B: TestingContractCompiler emits per-repo baseline +
 	// plan-source items + `cross-repo` items, every item tagged with
-	// `repo:`.
-	//
-	// CrossRepoSteps are synthesized directly here. Production cross-
-	// repo extraction from the plan body is not yet wired (the
-	// implement/refactor loops construct MultiRepoContractInput without
-	// CrossRepoSteps today); the unit tests at testing_contract_multirepo_test.go
-	// pass them in directly via this same shape.
-	crossRepoSteps := []agent.VerificationStep{
-		{Description: "e2e smoke", Command: "scripts/e2e.sh"},
-		{Description: "contract test", Command: "scripts/contract-test.sh"},
-	}
+	// `repo:`. Cross-repo rows are extracted from the plan's
+	// `## Cross-Repo Verification` section (production path).
 	contract := agent.CompileTestingContractMultiRepo(agent.MultiRepoContractInput{
-		Repos:          scope.Repos,
-		PlanText:       planText,
-		PlanPath:       planPath,
-		PhaseType:      "tracer-bullet",
-		CrossRepoSteps: crossRepoSteps,
+		Repos:     scope.Repos,
+		PlanText:  planText,
+		PlanPath:  planPath,
+		PhaseType: "tracer-bullet",
 	})
 
 	// Every item must carry a `repo:` field — the unification invariant.


### PR DESCRIPTION
## Summary

Planner-authored `Cross-Repo Verification` sections are documented on `MultiRepoContractInput.CrossRepoSteps` and the compiler already emits `source: cross-repo` rows from that field — but production implement/refactor paths never populated it. Multi-repo phases could therefore go green without running the cross-repo checks the plan required.

This wires plan parsing into `CompileTestingContractMultiRepo` so Cross-Repo Verification bullets (checklist or plain `- description: \`cmd\``) become contract rows automatically. Explicit `CrossRepoSteps` still work for tests and merge via the existing dedup.

Related: the 3-repo integration test previously hand-injected steps and noted extraction was not wired; it now relies on plan parsing.

CLA: https://github.com/doordash-oss/agentic-orchestrator/pull/99

## Repro (before)

A plan with:

```markdown
## Cross-Repo Verification
- e2e smoke: `scripts/e2e.sh`
```

compiled through `CompileTestingContractMultiRepo` without explicit `CrossRepoSteps` produced no `source: cross-repo` items.

## Fix

- `ParseCrossRepoVerification` for `##`/`###`/`#### Cross-Repo Verification` headers
- Parse plain bullets and `- [ ]` checklist items with backtick commands
- Merge parsed steps in `CompileTestingContractMultiRepo` when `PlanLess` is false
- Unit + integration coverage

## Verification

- `make test-fast` (32s, green)
- `go test ./internal/agent/ -count=1 -run 'ParseCrossRepo|CrossRepoSteps|MultiRepo_CrossRepo'`

Intentionally skipped: full race sweep / live eval (unchanged surface; short-mode suite covers the contract compiler path).