### PR TITLE
Recover turns that stall after tool completion

### DIFF
--- a/internal/agent/phase.go
+++ b/internal/agent/phase.go
@@ -1066,21 +1066,22 @@ type BuildSessionOpts struct {
 // Used by TUI components and loop configs that need to create sessions.
 type BuildSessionFunc func(BuildSessionOpts) ([]string, []string, *ports.SessionOpts, error)
 
-var pendingToolWatchdogConfig = ports.SessionWatchdogConfig{
-	PendingToolIdleTimeout: 5 * time.Minute,
-	PollInterval:           time.Second,
+var sessionWatchdogConfig = ports.SessionWatchdogConfig{
+	PendingToolIdleTimeout:    5 * time.Minute,
+	TurnCompletionIdleTimeout: 5 * time.Minute,
+	PollInterval:              time.Second,
 }
 
-type pendingToolWatchdogProvider interface {
+type sessionWatchdogProvider interface {
 	EnablesPendingToolWatchdog() bool
 }
 
 func watchdogConfigForProvider(provider llm.LLMProvider) *ports.SessionWatchdogConfig {
-	p, ok := provider.(pendingToolWatchdogProvider)
+	p, ok := provider.(sessionWatchdogProvider)
 	if !ok || !p.EnablesPendingToolWatchdog() {
 		return nil
 	}
-	cfg := pendingToolWatchdogConfig
+	cfg := sessionWatchdogConfig
 	return &cfg
 }
 

--- a/internal/agent/phase_test.go
+++ b/internal/agent/phase_test.go
@@ -1454,6 +1454,8 @@ func TestWatchdogConfigForProviderCapability(t *testing.T) {
 	}
 	if got := watchdogConfigForProvider(&captureProvider{name: "watchdog", watchdog: true}); got == nil {
 		t.Fatal("watchdogConfigForProvider(enabled) = nil, want config")
+	} else if got.PendingToolIdleTimeout <= 0 || got.TurnCompletionIdleTimeout <= 0 {
+		t.Fatalf("watchdogConfigForProvider(enabled) = %#v, want both tool and turn-completion timeouts", got)
 	}
 }
 

--- a/internal/llm/opencode/provider.go
+++ b/internal/llm/opencode/provider.go
@@ -113,8 +113,10 @@ func NewWithRunner(runner clirun.CommandRunner) *Provider {
 func (p *Provider) Name() string { return providerName }
 
 // EnablesPendingToolWatchdog opts this adapter into the generic session
-// watchdog for providers that can report a tool as pending without surfacing a
-// permission request.
+// watchdog for providers that can report tool lifecycle updates without
+// necessarily completing the enclosing turn or surfacing a permission request.
+// The historical capability name is retained for compatibility; it enables
+// both the running-tool and post-tool turn-completion safety rails.
 func (p *Provider) EnablesPendingToolWatchdog() bool { return true }
 
 // UsesBoundedHelperSandbox opts bounded helper sessions into OS-level worktree

--- a/internal/ports/session.go
+++ b/internal/ports/session.go
@@ -160,12 +160,13 @@ type AskUserAutoPickConfig struct {
 }
 
 // SessionWatchdogConfig enables provider-specific lifecycle safety rails for a
-// session. The first watchdog watches for a provider that reports a pending or
-// in-progress tool call and then goes silent without emitting a permission
-// request, result, or process exit.
+// session. PendingToolIdleTimeout bounds silence while a tool is running.
+// TurnCompletionIdleTimeout bounds silence after a tool reaches a terminal
+// state but before the provider completes the enclosing turn.
 type SessionWatchdogConfig struct {
-	PendingToolIdleTimeout time.Duration
-	PollInterval           time.Duration
+	PendingToolIdleTimeout    time.Duration
+	TurnCompletionIdleTimeout time.Duration
+	PollInterval              time.Duration
 }
 
 // ToolPermissionRequest describes a pending tool-use permission check.

--- a/internal/session/control_protocol_test.go
+++ b/internal/session/control_protocol_test.go
@@ -787,6 +787,32 @@ func TestManagerOnMessage_BashToolPermission_SetsWaitingPermission(t *testing.T)
 	}
 }
 
+func TestRespondToControlReturnsToRunningAfterLastPendingPermission(t *testing.T) {
+	t.Parallel()
+
+	sess := NewSession("permission-response-status", "feat-1", feature.PhaseImplement)
+	sess.protocol = &interruptTrackingProtocol{}
+	sess.mu.Lock()
+	sess.status = SessionWaitingPermission
+	sess.recordPendingControlRequestLocked(&llm.ControlRequestMessage{RequestID: "permission-1"})
+	sess.recordPendingControlRequestLocked(&llm.ControlRequestMessage{RequestID: "permission-2"})
+	sess.mu.Unlock()
+
+	if err := sess.RespondToControl("permission-1", true, ""); err != nil {
+		t.Fatalf("RespondToControl(permission-1): %v", err)
+	}
+	if status := sess.Status(); status != SessionWaitingPermission {
+		t.Fatalf("status after first response = %v, want WaitingPermission while another request is pending", status)
+	}
+
+	if err := sess.RespondToControl("permission-2", true, ""); err != nil {
+		t.Fatalf("RespondToControl(permission-2): %v", err)
+	}
+	if status := sess.Status(); status != SessionRunning {
+		t.Fatalf("status after final response = %v, want Running", status)
+	}
+}
+
 // --- Codex provider session-level tests ---
 
 func TestSendUserMessage_CodexProvider_SendsTurnStart(t *testing.T) {

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -16,11 +16,14 @@ package session
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"sort"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/doordash-oss/agentic-orchestrator/internal/feature"
@@ -204,13 +207,18 @@ func (m *Manager) StartSession(id, featureID string, phase feature.Phase, comman
 			return nil, fmt.Errorf("protocol handshake: %w", err)
 		}
 	} else {
-		// Legacy path (no protocol set): Claude interactive
-		if err := s.SendInitialize(); err != nil {
+		// Legacy path (no protocol set): Claude interactive.
+		//
+		// A fast session can exit right after emitting its result without ever
+		// reading stdin (common with mock scripts in tests), closing the pipe
+		// before these writes land. That EPIPE/closed-pipe error is benign: the
+		// child already finished, so there is nothing left to hand off to.
+		if err := s.SendInitialize(); err != nil && !isChildExitedWriteError(err) {
 			_ = s.Stop()
 			return nil, fmt.Errorf("sending initialize handshake: %w", err)
 		}
 		if len(opts) > 0 && opts[0] != nil && opts[0].InitialPrompt != "" {
-			if err := s.SendUserMessage(opts[0].InitialPrompt); err != nil {
+			if err := s.SendUserMessage(opts[0].InitialPrompt); err != nil && !isChildExitedWriteError(err) {
 				_ = s.Stop()
 				return nil, fmt.Errorf("sending initial prompt: %w", err)
 			}
@@ -254,6 +262,13 @@ func (m *Manager) StartSession(id, featureID string, phase feature.Phase, comman
 	}()
 
 	return s, nil
+}
+
+// isChildExitedWriteError reports whether a stdin write failed because the
+// child process already closed its end of the pipe (it exited). Both EPIPE and
+// io.ErrClosedPipe surface this race.
+func isChildExitedWriteError(err error) bool {
+	return errors.Is(err, syscall.EPIPE) || errors.Is(err, io.ErrClosedPipe)
 }
 
 func (m *Manager) handleSessionMessage(s *Session, id, featureID string, phase feature.Phase, msg llm.SDKMessage) {

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -1435,6 +1435,9 @@ func (s *Session) RespondToControl(requestID string, allow bool, reason string) 
 		originalInput = cr.Request.Input
 		s.removePendingControlRequestLocked(requestID)
 	}
+	if s.status == SessionWaitingPermission && len(s.pendingControlRequests) == 0 {
+		s.status = SessionRunning
+	}
 	s.mu.Unlock()
 
 	if s.protocol != nil {

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -172,8 +172,9 @@ sleep 30
 		&SessionOpts{
 			ProviderName: "test-provider",
 			Watchdog: &ports.SessionWatchdogConfig{
-				PendingToolIdleTimeout: 25 * time.Millisecond,
-				PollInterval:           5 * time.Millisecond,
+				PendingToolIdleTimeout:    25 * time.Millisecond,
+				TurnCompletionIdleTimeout: 100 * time.Millisecond,
+				PollInterval:              5 * time.Millisecond,
 			},
 		},
 	)
@@ -226,8 +227,9 @@ sleep 30
 		&SessionOpts{
 			ProviderName: "test-provider",
 			Watchdog: &ports.SessionWatchdogConfig{
-				PendingToolIdleTimeout: 25 * time.Millisecond,
-				PollInterval:           5 * time.Millisecond,
+				PendingToolIdleTimeout:    25 * time.Millisecond,
+				TurnCompletionIdleTimeout: 25 * time.Millisecond,
+				PollInterval:              5 * time.Millisecond,
 			},
 		},
 	)
@@ -255,7 +257,7 @@ sleep 30
 	}
 }
 
-func TestPendingToolWatchdogIgnoresCompletedPendingTool(t *testing.T) {
+func TestPendingToolWatchdogAllowsPromptResultAfterCompletedTool(t *testing.T) {
 	tmpDir := t.TempDir()
 	scriptPath := filepath.Join(tmpDir, "pending-tool-completed.sh")
 	script := `#!/usr/bin/env bash
@@ -284,8 +286,9 @@ printf '%s\n' '{"type":"result","subtype":"success","result":"ok"}'
 		&SessionOpts{
 			ProviderName: "test-provider",
 			Watchdog: &ports.SessionWatchdogConfig{
-				PendingToolIdleTimeout: 25 * time.Millisecond,
-				PollInterval:           5 * time.Millisecond,
+				PendingToolIdleTimeout:    25 * time.Millisecond,
+				TurnCompletionIdleTimeout: 100 * time.Millisecond,
+				PollInterval:              5 * time.Millisecond,
 			},
 			ResultShutdownGrace: 20 * time.Millisecond,
 		},
@@ -301,6 +304,204 @@ printf '%s\n' '{"type":"result","subtype":"success","result":"ok"}'
 		}
 	case <-time.After(500 * time.Millisecond):
 		t.Fatal("timeout waiting for success status")
+	}
+}
+
+func TestWatchdogToolProgressTransitions(t *testing.T) {
+	t.Parallel()
+
+	running := watchdogTool{phase: watchdogToolRunning, id: "tool-1", name: "Write"}
+	tests := []struct {
+		name     string
+		current  watchdogTool
+		progress llm.ToolProgressMessage
+		want     watchdogTool
+	}{
+		{
+			name:     "pending arms running tool",
+			progress: llm.ToolProgressMessage{ToolUseID: "tool-1", ToolName: "Write", Data: "pending"},
+			want:     running,
+		},
+		{
+			name:     "completed awaits enclosing turn result",
+			current:  running,
+			progress: llm.ToolProgressMessage{ToolUseID: "tool-1", ToolName: "Write", Data: "Status: completed"},
+			want:     watchdogTool{phase: watchdogToolAwaitingTurnResult, id: "tool-1", name: "Write"},
+		},
+		{
+			name:     "failed awaits enclosing turn result",
+			current:  running,
+			progress: llm.ToolProgressMessage{ToolUseID: "tool-1", ToolName: "Write", Data: "failed"},
+			want:     watchdogTool{phase: watchdogToolAwaitingTurnResult, id: "tool-1", name: "Write"},
+		},
+		{
+			name:     "terminal update for another tool cannot clear running tool",
+			current:  running,
+			progress: llm.ToolProgressMessage{ToolUseID: "tool-2", ToolName: "Read", Data: "completed"},
+			want:     running,
+		},
+		{
+			name:     "unrecognized progress keeps current state",
+			current:  running,
+			progress: llm.ToolProgressMessage{ToolUseID: "tool-1", ToolName: "Write", Data: "Status: running"},
+			want:     running,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := observeWatchdogToolProgress(tt.current, tt.progress); got != tt.want {
+				t.Fatalf("observeWatchdogToolProgress() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWatchdogControlWaitPausesAndRefreshesTurnTimer(t *testing.T) {
+	sess := NewSession("watchdog-control-wait", "feat-1", feature.PhaseImplement)
+	watchdog := newSessionWatchdog(sess, &ports.SessionWatchdogConfig{
+		PendingToolIdleTimeout:    20 * time.Millisecond,
+		TurnCompletionIdleTimeout: 20 * time.Millisecond,
+		PollInterval:              5 * time.Millisecond,
+	})
+	watchdog.Observe(llm.SDKMessage{ToolProgress: &llm.ToolProgressMessage{
+		ToolUseID: "tool-1",
+		ToolName:  "Write",
+		Data:      "completed",
+	}})
+
+	sess.mu.Lock()
+	sess.status = SessionWaitingPermission
+	sess.recordPendingControlRequestLocked(&llm.ControlRequestMessage{RequestID: "permission-1"})
+	sess.mu.Unlock()
+	watchdog.mu.Lock()
+	watchdog.lastActivityAt = time.Now().Add(-time.Second)
+	watchdog.mu.Unlock()
+
+	if _, _, _, stalled := watchdog.toolStall(); stalled {
+		t.Fatal("watchdog reported a stall while a real control request was pending")
+	}
+
+	sess.mu.Lock()
+	sess.removePendingControlRequestLocked("permission-1")
+	sess.status = SessionRunning
+	sess.mu.Unlock()
+	if _, _, _, stalled := watchdog.toolStall(); stalled {
+		t.Fatal("watchdog reused pre-permission idle time after the control wait ended")
+	}
+
+	watchdog.mu.Lock()
+	watchdog.lastActivityAt = time.Now().Add(-time.Second)
+	watchdog.mu.Unlock()
+	if tool, _, _, stalled := watchdog.toolStall(); !stalled || tool.phase != watchdogToolAwaitingTurnResult {
+		t.Fatalf("toolStall() = (%+v, stalled=%v), want awaiting-turn-result stall after refreshed timeout", tool, stalled)
+	}
+}
+
+func TestWatchdogDoesNotPauseForWaitingPermissionWithoutPendingControl(t *testing.T) {
+	sess := NewSession("watchdog-stale-permission-status", "feat-1", feature.PhaseImplement)
+	sess.SetStatus(SessionWaitingPermission)
+	watchdog := newSessionWatchdog(sess, &ports.SessionWatchdogConfig{
+		PendingToolIdleTimeout:    20 * time.Millisecond,
+		TurnCompletionIdleTimeout: 20 * time.Millisecond,
+		PollInterval:              5 * time.Millisecond,
+	})
+	watchdog.Observe(llm.SDKMessage{ToolProgress: &llm.ToolProgressMessage{
+		ToolUseID: "tool-1",
+		ToolName:  "Write",
+		Data:      "completed",
+	}})
+	watchdog.mu.Lock()
+	watchdog.lastActivityAt = time.Now().Add(-time.Second)
+	watchdog.mu.Unlock()
+
+	if tool, _, _, stalled := watchdog.toolStall(); !stalled || tool.phase != watchdogToolAwaitingTurnResult {
+		t.Fatalf("toolStall() = (%+v, stalled=%v), want stale WaitingPermission status not to mask the stall", tool, stalled)
+	}
+}
+
+func TestWatchdogActivityRefreshesAwaitingTurnTimerAndResultDisarmsIt(t *testing.T) {
+	sess := NewSession("watchdog-activity", "feat-1", feature.PhaseImplement)
+	watchdog := newSessionWatchdog(sess, &ports.SessionWatchdogConfig{
+		PendingToolIdleTimeout:    20 * time.Millisecond,
+		TurnCompletionIdleTimeout: 20 * time.Millisecond,
+		PollInterval:              5 * time.Millisecond,
+	})
+	watchdog.Observe(llm.SDKMessage{ToolProgress: &llm.ToolProgressMessage{
+		ToolUseID: "tool-1",
+		ToolName:  "Write",
+		Data:      "completed",
+	}})
+	watchdog.mu.Lock()
+	watchdog.lastActivityAt = time.Now().Add(-time.Second)
+	watchdog.mu.Unlock()
+
+	watchdog.Observe(llm.SDKMessage{Assistant: &llm.AssistantMessage{}})
+	if tool, _, _, stalled := watchdog.toolStall(); stalled || tool.phase != watchdogToolAwaitingTurnResult {
+		t.Fatalf("toolStall() after assistant activity = (%+v, stalled=%v), want refreshed awaiting-turn state", tool, stalled)
+	}
+
+	watchdog.Observe(llm.SDKMessage{Result: &llm.ResultMessage{Subtype: "success"}})
+	if tool, _, _, stalled := watchdog.toolStall(); stalled || tool.phase != watchdogToolInactive {
+		t.Fatalf("toolStall() after Result = (%+v, stalled=%v), want inactive watchdog", tool, stalled)
+	}
+}
+
+func TestPendingToolWatchdogFailsWhenTurnStallsAfterCompletedTool(t *testing.T) {
+	tmpDir := t.TempDir()
+	scriptPath := filepath.Join(tmpDir, "completed-tool-turn-stall.sh")
+	script := `#!/usr/bin/env bash
+printf '%s\n' '{"type":"tool_progress","tool_use_id":"chatcmpl-tool-write","tool_name":"Write","data":"pending"}'
+printf '%s\n' '{"type":"tool_progress","tool_use_id":"chatcmpl-tool-write","tool_name":"Write","data":"in_progress"}'
+printf '%s\n' '{"type":"tool_progress","tool_use_id":"chatcmpl-tool-write","tool_name":"Write","data":"completed"}'
+sleep 30
+`
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+
+	mgr := NewManager(nil)
+	defer mgr.Shutdown()
+
+	sess, err := mgr.StartSession(
+		"completed-tool-turn-watchdog-stall",
+		"feat-1",
+		feature.PhaseImplement,
+		[]string{"bash", scriptPath},
+		tmpDir,
+		nil,
+		&SessionOpts{
+			ProviderName: "test-provider",
+			Watchdog: &ports.SessionWatchdogConfig{
+				PendingToolIdleTimeout:    25 * time.Millisecond,
+				TurnCompletionIdleTimeout: 25 * time.Millisecond,
+				PollInterval:              5 * time.Millisecond,
+			},
+		},
+	)
+	if err != nil {
+		t.Fatalf("StartSession() error: %v", err)
+	}
+
+	select {
+	case status := <-sess.StatusCh():
+		if status != "FAILED" {
+			t.Fatalf("StatusCh = %q, want FAILED", status)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("timeout waiting for watchdog to fail a turn stalled after a completed tool")
+	}
+
+	select {
+	case <-sess.Done():
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for watchdog to stop session")
+	}
+
+	if got := sess.ErrorDetail(); !strings.Contains(got, "provider watchdog stalled awaiting turn completion after tool Write") {
+		t.Fatalf("ErrorDetail() = %q, want post-tool turn-completion watchdog detail", got)
 	}
 }
 
@@ -326,6 +527,32 @@ func TestWatchdogPendingToolDataMatchesStatusLine(t *testing.T) {
 			t.Parallel()
 			if got := isWatchdogPendingToolData(tt.data); got != tt.want {
 				t.Fatalf("isWatchdogPendingToolData(%q) = %v, want %v", tt.data, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWatchdogTerminalToolDataMatchesStatusLine(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		data string
+		want bool
+	}{
+		{name: "bare completed status", data: "completed", want: true},
+		{name: "multi-line completed status", data: "File: report.md\nStatus: completed", want: true},
+		{name: "bare failed status", data: "failed", want: true},
+		{name: "multi-line failed status", data: "command\nStatus: failed", want: true},
+		{name: "command mentions completed", data: "echo completed\nStatus: in_progress", want: false},
+		{name: "path mentions failed", data: "File: failed-report.md\nStatus: in_progress", want: false},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := isWatchdogTerminalToolData(tt.data); got != tt.want {
+				t.Fatalf("isWatchdogTerminalToolData(%q) = %v, want %v", tt.data, got, tt.want)
 			}
 		})
 	}

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -380,7 +380,7 @@ func TestWatchdogControlWaitPausesAndRefreshesTurnTimer(t *testing.T) {
 	watchdog.lastActivityAt = time.Now().Add(-time.Second)
 	watchdog.mu.Unlock()
 
-	if _, _, _, stalled := watchdog.toolStall(); stalled {
+	if _, _, stalled := watchdog.toolStall(); stalled {
 		t.Fatal("watchdog reported a stall while a real control request was pending")
 	}
 
@@ -388,14 +388,14 @@ func TestWatchdogControlWaitPausesAndRefreshesTurnTimer(t *testing.T) {
 	sess.removePendingControlRequestLocked("permission-1")
 	sess.status = SessionRunning
 	sess.mu.Unlock()
-	if _, _, _, stalled := watchdog.toolStall(); stalled {
+	if _, _, stalled := watchdog.toolStall(); stalled {
 		t.Fatal("watchdog reused pre-permission idle time after the control wait ended")
 	}
 
 	watchdog.mu.Lock()
 	watchdog.lastActivityAt = time.Now().Add(-time.Second)
 	watchdog.mu.Unlock()
-	if tool, _, _, stalled := watchdog.toolStall(); !stalled || tool.phase != watchdogToolAwaitingTurnResult {
+	if tool, _, stalled := watchdog.toolStall(); !stalled || tool.phase != watchdogToolAwaitingTurnResult {
 		t.Fatalf("toolStall() = (%+v, stalled=%v), want awaiting-turn-result stall after refreshed timeout", tool, stalled)
 	}
 }
@@ -417,7 +417,7 @@ func TestWatchdogDoesNotPauseForWaitingPermissionWithoutPendingControl(t *testin
 	watchdog.lastActivityAt = time.Now().Add(-time.Second)
 	watchdog.mu.Unlock()
 
-	if tool, _, _, stalled := watchdog.toolStall(); !stalled || tool.phase != watchdogToolAwaitingTurnResult {
+	if tool, _, stalled := watchdog.toolStall(); !stalled || tool.phase != watchdogToolAwaitingTurnResult {
 		t.Fatalf("toolStall() = (%+v, stalled=%v), want stale WaitingPermission status not to mask the stall", tool, stalled)
 	}
 }
@@ -439,12 +439,12 @@ func TestWatchdogActivityRefreshesAwaitingTurnTimerAndResultDisarmsIt(t *testing
 	watchdog.mu.Unlock()
 
 	watchdog.Observe(llm.SDKMessage{Assistant: &llm.AssistantMessage{}})
-	if tool, _, _, stalled := watchdog.toolStall(); stalled || tool.phase != watchdogToolAwaitingTurnResult {
+	if tool, _, stalled := watchdog.toolStall(); stalled || tool.phase != watchdogToolAwaitingTurnResult {
 		t.Fatalf("toolStall() after assistant activity = (%+v, stalled=%v), want refreshed awaiting-turn state", tool, stalled)
 	}
 
 	watchdog.Observe(llm.SDKMessage{Result: &llm.ResultMessage{Subtype: "success"}})
-	if tool, _, _, stalled := watchdog.toolStall(); stalled || tool.phase != watchdogToolInactive {
+	if tool, _, stalled := watchdog.toolStall(); stalled || tool.phase != watchdogToolInactive {
 		t.Fatalf("toolStall() after Result = (%+v, stalled=%v), want inactive watchdog", tool, stalled)
 	}
 }

--- a/internal/session/watchdog.go
+++ b/internal/session/watchdog.go
@@ -36,7 +36,6 @@ type sessionWatchdog struct {
 	lastActivityAt time.Time
 
 	startOnce sync.Once
-	failOnce  sync.Once
 }
 
 type watchdogToolPhase uint8
@@ -179,7 +178,7 @@ func (w *sessionWatchdog) run() {
 		case <-ticker.C:
 		}
 
-		if tool, timeout, _, ok := w.toolStall(); ok {
+		if tool, timeout, ok := w.toolStall(); ok {
 			if w.failTool(tool, timeout) {
 				return
 			}
@@ -187,18 +186,18 @@ func (w *sessionWatchdog) run() {
 	}
 }
 
-func (w *sessionWatchdog) toolStall() (watchdogTool, time.Duration, time.Duration, bool) {
+func (w *sessionWatchdog) toolStall() (watchdogTool, time.Duration, bool) {
 	if len(w.session.PendingControlRequests()) > 0 || w.session.HasPendingAskUserQuestion() {
 		w.refreshActivity()
-		return watchdogTool{}, 0, 0, false
+		return watchdogTool{}, 0, false
 	}
 	status := w.session.Status()
 	if status == SessionWaitingHelp {
 		w.refreshActivity()
-		return watchdogTool{}, 0, 0, false
+		return watchdogTool{}, 0, false
 	}
 	if status == SessionDone || status == SessionFailed {
-		return watchdogTool{}, 0, 0, false
+		return watchdogTool{}, 0, false
 	}
 
 	w.mu.Lock()
@@ -207,13 +206,13 @@ func (w *sessionWatchdog) toolStall() (watchdogTool, time.Duration, time.Duratio
 	w.mu.Unlock()
 	timeout := w.timeoutFor(tool.phase)
 	if timeout <= 0 {
-		return watchdogTool{}, 0, 0, false
+		return watchdogTool{}, 0, false
 	}
 	if stdoutAt := w.session.LastStdoutAt(); stdoutAt.After(lastActivityAt) {
 		lastActivityAt = stdoutAt
 	}
 	idleFor := time.Since(lastActivityAt)
-	return tool, timeout, idleFor, idleFor >= timeout
+	return tool, timeout, idleFor >= timeout
 }
 
 func (w *sessionWatchdog) refreshActivity() {
@@ -237,6 +236,8 @@ func (w *sessionWatchdog) failTool(tool watchdogTool, timeout time.Duration) boo
 	// Observe and the poller race at the timeout boundary. Linearize the
 	// decision under the watchdog lock: if a Result or any stdout arrived after
 	// the poll snapshot, that activity wins and the watchdog keeps waiting.
+	// Clearing w.tool here also guarantees a single fire: the only caller is
+	// run(), which returns as soon as this reports true.
 	w.mu.Lock()
 	if w.tool != tool {
 		w.mu.Unlock()
@@ -254,18 +255,14 @@ func (w *sessionWatchdog) failTool(tool watchdogTool, timeout time.Duration) boo
 	w.tool = watchdogTool{}
 	w.mu.Unlock()
 
-	failed := false
-	w.failOnce.Do(func() {
-		failed = true
-		var reason string
-		if tool.phase == watchdogToolAwaitingTurnResult {
-			reason = fmt.Sprintf("provider watchdog stalled awaiting turn completion after tool %s for %s (idle %s)", tool.displayName(), timeout, idleFor.Round(time.Millisecond))
-		} else {
-			reason = fmt.Sprintf("provider watchdog stalled with pending tool %s for %s (idle %s)", tool.displayName(), timeout, idleFor.Round(time.Millisecond))
-		}
-		w.session.failFromWatchdog(reason)
-	})
-	return failed
+	var reason string
+	if tool.phase == watchdogToolAwaitingTurnResult {
+		reason = fmt.Sprintf("provider watchdog stalled awaiting turn completion after tool %s for %s (idle %s)", tool.displayName(), timeout, idleFor.Round(time.Millisecond))
+	} else {
+		reason = fmt.Sprintf("provider watchdog stalled with pending tool %s for %s (idle %s)", tool.displayName(), timeout, idleFor.Round(time.Millisecond))
+	}
+	w.session.failFromWatchdog(reason)
+	return true
 }
 
 func (p watchdogTool) displayName() string {

--- a/internal/session/watchdog.go
+++ b/internal/session/watchdog.go
@@ -26,43 +26,67 @@ import (
 )
 
 type sessionWatchdog struct {
-	session                *Session
-	pendingToolIdleTimeout time.Duration
-	pollInterval           time.Duration
+	session                   *Session
+	pendingToolIdleTimeout    time.Duration
+	turnCompletionIdleTimeout time.Duration
+	pollInterval              time.Duration
 
 	mu             sync.Mutex
-	pendingTool    watchdogPendingTool
+	tool           watchdogTool
 	lastActivityAt time.Time
 
 	startOnce sync.Once
 	failOnce  sync.Once
 }
 
-type watchdogPendingTool struct {
-	pending bool
-	id      string
-	name    string
+type watchdogToolPhase uint8
+
+const (
+	watchdogToolInactive watchdogToolPhase = iota
+	watchdogToolRunning
+	watchdogToolAwaitingTurnResult
+)
+
+type watchdogTool struct {
+	phase watchdogToolPhase
+	id    string
+	name  string
 }
 
 func newSessionWatchdog(sess *Session, cfg *ports.SessionWatchdogConfig) *sessionWatchdog {
-	if sess == nil || cfg == nil || cfg.PendingToolIdleTimeout <= 0 {
+	if sess == nil || cfg == nil || (cfg.PendingToolIdleTimeout <= 0 && cfg.TurnCompletionIdleTimeout <= 0) {
 		return nil
 	}
+	shortestTimeout := shortestPositiveDuration(cfg.PendingToolIdleTimeout, cfg.TurnCompletionIdleTimeout)
 	interval := cfg.PollInterval
-	if interval <= 0 || interval > cfg.PendingToolIdleTimeout {
-		interval = cfg.PendingToolIdleTimeout / 4
+	if interval <= 0 || interval > shortestTimeout {
+		interval = shortestTimeout / 4
 		if interval <= 0 {
-			interval = cfg.PendingToolIdleTimeout
+			interval = shortestTimeout
 		}
 		if interval > time.Second {
 			interval = time.Second
 		}
 	}
 	return &sessionWatchdog{
-		session:                sess,
-		pendingToolIdleTimeout: cfg.PendingToolIdleTimeout,
-		pollInterval:           interval,
-		lastActivityAt:         time.Now(),
+		session:                   sess,
+		pendingToolIdleTimeout:    cfg.PendingToolIdleTimeout,
+		turnCompletionIdleTimeout: cfg.TurnCompletionIdleTimeout,
+		pollInterval:              interval,
+		lastActivityAt:            time.Now(),
+	}
+}
+
+func shortestPositiveDuration(a, b time.Duration) time.Duration {
+	switch {
+	case a <= 0:
+		return b
+	case b <= 0:
+		return a
+	case a < b:
+		return a
+	default:
+		return b
 	}
 }
 
@@ -84,31 +108,41 @@ func (w *sessionWatchdog) Observe(msg llm.SDKMessage) {
 	w.lastActivityAt = now
 	switch {
 	case msg.Result != nil:
-		w.pendingTool = watchdogPendingTool{}
+		w.tool = watchdogTool{}
 	case msg.ToolProgress != nil:
-		w.pendingTool = observeWatchdogToolProgress(w.pendingTool, *msg.ToolProgress)
+		w.tool = observeWatchdogToolProgress(w.tool, *msg.ToolProgress)
 	}
 	w.mu.Unlock()
 }
 
-func observeWatchdogToolProgress(current watchdogPendingTool, progress llm.ToolProgressMessage) watchdogPendingTool {
+func observeWatchdogToolProgress(current watchdogTool, progress llm.ToolProgressMessage) watchdogTool {
 	data := strings.TrimSpace(progress.Data)
 	id := strings.TrimSpace(progress.ToolUseID)
 	name := strings.TrimSpace(progress.ToolName)
 	if isWatchdogPendingToolData(data) {
-		return watchdogPendingTool{
-			pending: true,
-			id:      id,
-			name:    name,
+		return watchdogTool{
+			phase: watchdogToolRunning,
+			id:    id,
+			name:  name,
 		}
 	}
-	if !current.pending {
-		return watchdogPendingTool{}
-	}
-	if id != "" && current.id != "" && id != current.id {
+	if !isWatchdogTerminalToolData(data) {
 		return current
 	}
-	return watchdogPendingTool{}
+	if current.phase == watchdogToolRunning && id != "" && current.id != "" && id != current.id {
+		return current
+	}
+	if id == "" {
+		id = current.id
+	}
+	if name == "" {
+		name = current.name
+	}
+	return watchdogTool{
+		phase: watchdogToolAwaitingTurnResult,
+		id:    id,
+		name:  name,
+	}
 }
 
 func isWatchdogPendingToolData(data string) bool {
@@ -118,6 +152,17 @@ func isWatchdogPendingToolData(data string) bool {
 		// statuses are non-terminal and must remain watchdog-eligible.
 		if line == "pending" || line == "status: pending" ||
 			line == "in_progress" || line == "status: in_progress" {
+			return true
+		}
+	}
+	return false
+}
+
+func isWatchdogTerminalToolData(data string) bool {
+	for _, line := range strings.Split(data, "\n") {
+		line = strings.ToLower(strings.TrimSpace(line))
+		if line == "completed" || line == "status: completed" ||
+			line == "failed" || line == "status: failed" {
 			return true
 		}
 	}
@@ -134,44 +179,96 @@ func (w *sessionWatchdog) run() {
 		case <-ticker.C:
 		}
 
-		if pending, idleFor, ok := w.pendingToolStall(); ok {
-			w.failPendingTool(pending, idleFor)
-			return
+		if tool, timeout, _, ok := w.toolStall(); ok {
+			if w.failTool(tool, timeout) {
+				return
+			}
 		}
 	}
 }
 
-func (w *sessionWatchdog) pendingToolStall() (watchdogPendingTool, time.Duration, bool) {
+func (w *sessionWatchdog) toolStall() (watchdogTool, time.Duration, time.Duration, bool) {
 	if len(w.session.PendingControlRequests()) > 0 || w.session.HasPendingAskUserQuestion() {
-		return watchdogPendingTool{}, 0, false
+		w.refreshActivity()
+		return watchdogTool{}, 0, 0, false
 	}
 	status := w.session.Status()
-	if status == SessionWaitingPermission || status == SessionWaitingHelp || status == SessionDone || status == SessionFailed {
-		return watchdogPendingTool{}, 0, false
+	if status == SessionWaitingHelp {
+		w.refreshActivity()
+		return watchdogTool{}, 0, 0, false
+	}
+	if status == SessionDone || status == SessionFailed {
+		return watchdogTool{}, 0, 0, false
 	}
 
 	w.mu.Lock()
-	pending := w.pendingTool
+	tool := w.tool
 	lastActivityAt := w.lastActivityAt
 	w.mu.Unlock()
-	if !pending.pending {
-		return watchdogPendingTool{}, 0, false
+	timeout := w.timeoutFor(tool.phase)
+	if timeout <= 0 {
+		return watchdogTool{}, 0, 0, false
 	}
 	if stdoutAt := w.session.LastStdoutAt(); stdoutAt.After(lastActivityAt) {
 		lastActivityAt = stdoutAt
 	}
 	idleFor := time.Since(lastActivityAt)
-	return pending, idleFor, idleFor >= w.pendingToolIdleTimeout
+	return tool, timeout, idleFor, idleFor >= timeout
 }
 
-func (w *sessionWatchdog) failPendingTool(pending watchdogPendingTool, idleFor time.Duration) {
+func (w *sessionWatchdog) refreshActivity() {
+	w.mu.Lock()
+	w.lastActivityAt = time.Now()
+	w.mu.Unlock()
+}
+
+func (w *sessionWatchdog) timeoutFor(phase watchdogToolPhase) time.Duration {
+	switch phase {
+	case watchdogToolRunning:
+		return w.pendingToolIdleTimeout
+	case watchdogToolAwaitingTurnResult:
+		return w.turnCompletionIdleTimeout
+	default:
+		return 0
+	}
+}
+
+func (w *sessionWatchdog) failTool(tool watchdogTool, timeout time.Duration) bool {
+	// Observe and the poller race at the timeout boundary. Linearize the
+	// decision under the watchdog lock: if a Result or any stdout arrived after
+	// the poll snapshot, that activity wins and the watchdog keeps waiting.
+	w.mu.Lock()
+	if w.tool != tool {
+		w.mu.Unlock()
+		return false
+	}
+	lastActivityAt := w.lastActivityAt
+	if stdoutAt := w.session.LastStdoutAt(); stdoutAt.After(lastActivityAt) {
+		lastActivityAt = stdoutAt
+	}
+	idleFor := time.Since(lastActivityAt)
+	if idleFor < timeout {
+		w.mu.Unlock()
+		return false
+	}
+	w.tool = watchdogTool{}
+	w.mu.Unlock()
+
+	failed := false
 	w.failOnce.Do(func() {
-		reason := fmt.Sprintf("provider watchdog stalled with pending tool %s for %s (idle %s)", pending.displayName(), w.pendingToolIdleTimeout, idleFor.Round(time.Millisecond))
+		failed = true
+		var reason string
+		if tool.phase == watchdogToolAwaitingTurnResult {
+			reason = fmt.Sprintf("provider watchdog stalled awaiting turn completion after tool %s for %s (idle %s)", tool.displayName(), timeout, idleFor.Round(time.Millisecond))
+		} else {
+			reason = fmt.Sprintf("provider watchdog stalled with pending tool %s for %s (idle %s)", tool.displayName(), timeout, idleFor.Round(time.Millisecond))
+		}
 		w.session.failFromWatchdog(reason)
 	})
+	return failed
 }
 
-func (p watchdogPendingTool) displayName() string {
+func (p watchdogTool) displayName() string {
 	switch {
 	case p.name != "":
 		return p.name


### PR DESCRIPTION
## Summary
- extend the session watchdog to keep tracking provider silence after a tool reaches a terminal state but before the turn result arrives
- refresh and pause watchdog timing around real permission waits, assistant output, and result delivery to avoid false positives
- add regression coverage for post-tool stalls, stale waiting-permission state, timeout revalidation, and control-response status recovery

## Root Cause
The existing watchdog only observed pending and in-progress tool states. Once a provider emitted a terminal tool update like completed, the watchdog disarmed even if the provider never delivered the enclosing turn result, leaving the session stuck indefinitely.

## Impact
OpenCode-backed sessions now fail deterministically when a turn stalls after tool completion instead of hanging behind an early phase marker or stale waiting-permission state.

## Verification
- Fast suite: `make test-fast`
- Isolated integration: `go test ./test/integration/... -count=1`
- E2E Go (process-launch / API-driven): `go test ./test/e2e/... -count=1 -race`
- Race regression: `go test ./... -count=1 -race`
- Static analysis: `go vet ./...`
- Build: `go build ./...`

## Follow-up
The crash-resume branch should treat watchdog-triggered failures as resumable even if an early `phase_complete` marker exists, because the marker can be created before the ACP returns the terminal turn result.

Co-authored-by: Codex <noreply@openai.com>
