### PR TITLE
Add pgrealey-roo to CLA contributors

### DIFF
--- a/.clabot
+++ b/.clabot
@@ -4,7 +4,8 @@
     "mranney-dd",
     "ltagliamonte-dd",
     "iscopetta",
-    "Abhishek21g"
+    "Abhishek21g",
+    "pgrealey-roo"
   ],
   "label": "cla-signed"
 }


### PR DESCRIPTION
## Summary
- Adds `pgrealey-roo` to `.clabot` contributors so CLA bot recognizes a signed CLA.

## Test plan
- [ ] Confirm `.clabot` JSON remains valid
- [ ] Confirm CLA bot applies `cla-signed` for future PRs from `pgrealey-roo`

Made with Cursor

Made with [Cursor](https://cursor.com)