### PR TITLE
Bound recovery scans to session state directories

### DIFF
--- a/internal/session/pidfile.go
+++ b/internal/session/pidfile.go
@@ -69,30 +69,78 @@ func RemovePIDFile(dir string, repoName string) error {
 	return os.Remove(filepath.Join(dir, PIDFileName(repoName)))
 }
 
-// FindPIDFiles scans all feature directories for session*.pid files.
+// FindPIDFiles scans the bounded set of directories where sessions persist PID
+// files: the state directory itself, each immediate feature directory, and the
+// feature's immediate child directories used by the legacy phase layout.
+//
+// Feature trees also contain arbitrary run artifacts, work products, and copied
+// fixtures. Recursing into those trees is both unbounded and incorrect: a copied
+// session PID fixture is not a live session owned by this runtime.
 func FindPIDFiles(featuresDir string) ([]PIDFile, error) {
 	var results []PIDFile
-
-	err := filepath.Walk(featuresDir, func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return nil
-		}
-		name := info.Name()
-		if strings.HasPrefix(name, "session") && strings.HasSuffix(name, ".pid") {
-			pf, err := ReadPIDFile(path)
-			if err != nil {
-				return nil
-			}
-			pf.Dir = filepath.Dir(path)
-			results = append(results, *pf)
-		}
-		return nil
-	})
+	entries, err := os.ReadDir(featuresDir)
 	if err != nil {
-		return nil, fmt.Errorf("scanning for PID files: %w", err)
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("reading session state directory: %w", err)
+	}
+
+	results = appendPIDFilesInDir(results, featuresDir, entries)
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		featureDir := filepath.Join(featuresDir, entry.Name())
+		featureEntries, err := os.ReadDir(featureDir)
+		if err != nil {
+			// Match the recovery scanner's best-effort behavior: one unreadable
+			// feature must not hide recoverable sessions from every other feature.
+			continue
+		}
+		results = appendPIDFilesInDir(results, featureDir, featureEntries)
+		for _, featureEntry := range featureEntries {
+			if !featureEntry.IsDir() || !isLegacyPhaseDir(featureEntry.Name()) {
+				continue
+			}
+			legacySessionDir := filepath.Join(featureDir, featureEntry.Name())
+			legacyEntries, err := os.ReadDir(legacySessionDir)
+			if err != nil {
+				continue
+			}
+			results = appendPIDFilesInDir(results, legacySessionDir, legacyEntries)
+		}
 	}
 
 	return results, nil
+}
+
+func appendPIDFilesInDir(results []PIDFile, dir string, entries []os.DirEntry) []PIDFile {
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if !strings.HasPrefix(name, "session") || !strings.HasSuffix(name, ".pid") {
+			continue
+		}
+		pf, err := ReadPIDFile(filepath.Join(dir, name))
+		if err != nil {
+			continue
+		}
+		pf.Dir = dir
+		results = append(results, *pf)
+	}
+	return results
+}
+
+func isLegacyPhaseDir(name string) bool {
+	switch name {
+	case "knowledgebase", "inquire", "research", "design", "plan", "implement", "review", "publish":
+		return true
+	default:
+		return false
+	}
 }
 
 // isProcessRunning checks if a process with the given PID is still running.

--- a/internal/session/pidfile_test.go
+++ b/internal/session/pidfile_test.go
@@ -73,9 +73,9 @@ func TestPIDFileRemove(t *testing.T) {
 func TestFindPIDFiles(t *testing.T) {
 	dir := t.TempDir()
 
-	// Create two feature dirs with PID files
-	feat1Dir := filepath.Join(dir, "feat-1", "implement")
-	feat2Dir := filepath.Join(dir, "feat-2", "research")
+	// Create two feature dirs with PID files.
+	feat1Dir := filepath.Join(dir, "feat-1")
+	feat2Dir := filepath.Join(dir, "feat-2")
 
 	WritePIDFile(feat1Dir, PIDFile{PID: 100, FeatureID: "feat-1", Phase: "implement"})
 	WritePIDFile(feat2Dir, PIDFile{PID: 200, FeatureID: "feat-2", Phase: "research"})
@@ -86,6 +86,37 @@ func TestFindPIDFiles(t *testing.T) {
 	}
 	if len(pids) != 2 {
 		t.Errorf("expected 2 PID files, got %d", len(pids))
+	}
+}
+
+// TestFindPIDFilesDoesNotDescendIntoFeatureArtifacts pins the runtime layout:
+// live session PID files belong directly under the state directory or one of
+// its feature directories. Nested run artifacts may contain copied fixtures
+// with session-like names and must not be surfaced as recoverable processes.
+func TestFindPIDFilesDoesNotDescendIntoFeatureArtifacts(t *testing.T) {
+	dir := t.TempDir()
+	featureDir := filepath.Join(dir, "feat-1")
+	if err := WritePIDFile(featureDir, PIDFile{PID: 100, FeatureID: "feat-1", RepoName: "live"}); err != nil {
+		t.Fatalf("write live PID file: %v", err)
+	}
+
+	artifactDir := filepath.Join(featureDir, "runs", "run-001", "review", "evidence", "fixture", "features", "copied")
+	if err := WritePIDFile(artifactDir, PIDFile{PID: 200, FeatureID: "copied", RepoName: "fixture"}); err != nil {
+		t.Fatalf("write fixture PID file: %v", err)
+	}
+	if err := WritePIDFile(filepath.Join(featureDir, "runs"), PIDFile{PID: 300, FeatureID: "copied", RepoName: "shallow-fixture"}); err != nil {
+		t.Fatalf("write shallow fixture PID file: %v", err)
+	}
+
+	pids, err := FindPIDFiles(dir)
+	if err != nil {
+		t.Fatalf("find PID files: %v", err)
+	}
+	if len(pids) != 1 {
+		t.Fatalf("PID files = %+v, want only the direct feature PID file", pids)
+	}
+	if pids[0].FeatureID != "feat-1" || pids[0].RepoName != "live" {
+		t.Fatalf("PID file = %+v, want feat-1/live", pids[0])
 	}
 }
 


### PR DESCRIPTION
## Summary

- replace the recursive recovery PID scan with a bounded scan of runtime-owned session locations
- preserve compatibility with the legacy phase-directory layout
- ignore copied PID fixtures and session-like files nested in run artifacts
- add regression coverage proving recovery does not descend into feature artifacts

## Why

Recovery previously walked the complete feature tree. Large run artifacts and build caches could make `/api/v1/recovery` exceed the API client's 10-second timeout, preventing the TUI from starting even though the server was healthy.

## Verification

- Fast suite: `make test-fast`
- Isolated integration: `go test ./test/integration/... -count=1`
- E2E Go (process-launch / API-driven): `go test ./test/e2e/... -count=1 -race`
- Static analysis: `go vet ./...`
- Build: `go build ./...`
- Focused regression: `go test ./internal/session -run 'TestFindPIDFiles' -count=1`

Co-authored-by: Codex <noreply@openai.com>
