### PR TITLE
Make Design converge through focused critique

### DIFF
--- a/cmd/agentico/autoreview_merge_test.go
+++ b/cmd/agentico/autoreview_merge_test.go
@@ -110,6 +110,21 @@ func TestMergeRuntimeDefaultsModelsOmittedDoesNotMerge(t *testing.T) {
 	}
 }
 
+func TestMergeRuntimeDefaultsMaxDesignIterations(t *testing.T) {
+	dst := config.DefaultsConfig{MaxDesignIterations: 5}
+	changed := mergeRuntimeDefaultsMutation(&dst, serverruntime.RuntimeDefaultsMutation{
+		MaxDesignIterations: 7,
+	})
+	if !changed || dst.MaxDesignIterations != 7 {
+		t.Fatalf("MaxDesignIterations merge = (%v, %d), want (true, 7)", changed, dst.MaxDesignIterations)
+	}
+
+	changed = mergeRuntimeDefaultsMutation(&dst, serverruntime.RuntimeDefaultsMutation{})
+	if changed || dst.MaxDesignIterations != 7 {
+		t.Fatalf("omitted MaxDesignIterations merge = (%v, %d), want (false, 7)", changed, dst.MaxDesignIterations)
+	}
+}
+
 func TestMergeRuntimeDefaultsAutomaticReviewModelUnsetWhenAllEmpty(t *testing.T) {
 	// A Models patch with all fields empty/nil and AutomaticReview explicitly
 	// set to empty should clear the model without touching phase-role models.

--- a/cmd/agentico/main.go
+++ b/cmd/agentico/main.go
@@ -2060,6 +2060,9 @@ func mergeRuntimeDefaultsMutation(dst *config.DefaultsConfig, patch serverruntim
 	if patch.MaxConsecutiveNoProgress > 0 && setIfChanged(&dst.MaxConsecutiveNoProgress, patch.MaxConsecutiveNoProgress) {
 		changed = true
 	}
+	if patch.MaxDesignIterations > 0 && setIfChanged(&dst.MaxDesignIterations, patch.MaxDesignIterations) {
+		changed = true
+	}
 	if patch.MaxPhasePlanIterations > 0 && setIfChanged(&dst.MaxPhasePlanIterations, patch.MaxPhasePlanIterations) {
 		changed = true
 	}

--- a/cmd/agentico/server_mutation_target_test.go
+++ b/cmd/agentico/server_mutation_target_test.go
@@ -678,9 +678,10 @@ func TestServerMutationTargetRuntimeConfigPersistsAllowedDefaultsChanges(t *test
 				Research:       testResearchModelNew,
 				Implementation: testImplementationModelNew,
 			},
-			Inquireness:   testInquirenessHigh,
-			MaxIterations: 8,
-			Checkpoints:   &checkpoints,
+			Inquireness:         testInquirenessHigh,
+			MaxIterations:       8,
+			MaxDesignIterations: 6,
+			Checkpoints:         &checkpoints,
 		},
 	})
 	if err != nil {
@@ -693,7 +694,7 @@ func TestServerMutationTargetRuntimeConfigPersistsAllowedDefaultsChanges(t *test
 	if cfg.Defaults.Models.Implementation != testImplementationModelNew {
 		t.Fatalf("in-memory implementation model = %q, want new-implementation", cfg.Defaults.Models.Implementation)
 	}
-	if cfg.Defaults.MaxIterations != 8 || cfg.Defaults.Inquireness != testInquirenessHigh || !cfg.Defaults.Checkpoints.RoadmapReview || !cfg.Defaults.Checkpoints.PhasePlanReview {
+	if cfg.Defaults.MaxIterations != 8 || cfg.Defaults.MaxDesignIterations != 6 || cfg.Defaults.Inquireness != testInquirenessHigh || !cfg.Defaults.Checkpoints.RoadmapReview || !cfg.Defaults.Checkpoints.PhasePlanReview {
 		t.Fatalf("in-memory defaults = %+v, want requested changes", cfg.Defaults)
 	}
 
@@ -704,6 +705,7 @@ func TestServerMutationTargetRuntimeConfigPersistsAllowedDefaultsChanges(t *test
 	if loaded.Defaults.Models.Research != testResearchModelNew ||
 		loaded.Defaults.Models.Implementation != testImplementationModelNew ||
 		loaded.Defaults.MaxIterations != 8 ||
+		loaded.Defaults.MaxDesignIterations != 6 ||
 		loaded.Defaults.Inquireness != testInquirenessHigh ||
 		!loaded.Defaults.Checkpoints.RoadmapReview ||
 		!loaded.Defaults.Checkpoints.PhasePlanReview {

--- a/internal/agent/contract_test.go
+++ b/internal/agent/contract_test.go
@@ -634,10 +634,6 @@ func TestContractRegistryArtifactPhaseRolesRequireMarkdown(t *testing.T) {
 	}{
 		{"inquire", feature.PhaseInquire, RoleInquirer, "2026-05-07-inquire.md"},
 		{"research", feature.PhaseResearch, RoleResearcher, "2026-05-07-research.md"},
-		{"design", feature.PhaseDesign, RoleDesigner, "2026-05-07-design.md"},
-		// Legacy Design role still resolves and validates the same
-		// markdown artifact behavior so older runs continue to complete.
-		{"design", feature.PhaseDesign, RoleDesigner, "2026-05-07-design.md"},
 	}
 
 	for _, tt := range tests {
@@ -680,8 +676,6 @@ func TestContractRegistryArtifactPhaseRolesReportMissingMarkdown(t *testing.T) {
 	}{
 		{feature.PhaseInquire, RoleInquirer},
 		{feature.PhaseResearch, RoleResearcher},
-		{feature.PhaseDesign, RoleDesigner},
-		{feature.PhaseDesign, RoleDesigner},
 	}
 
 	for _, tt := range tests {
@@ -719,10 +713,14 @@ func TestContractRegistryArtifactPhaseRolesIgnoreExcludedMarkdown(t *testing.T) 
 	}
 }
 
-func TestContractRegistryArtifactPhaseRolesSelectNewestMarkdown(t *testing.T) {
-	dir := t.TempDir()
-	oldPath := filepath.Join(dir, "old.md")
-	newPath := filepath.Join(dir, "new.md")
+func TestContractRegistryDesignRoleUsesCanonicalMarkdown(t *testing.T) {
+	artifactDir := t.TempDir()
+	attemptDir := filepath.Join(artifactDir, "attempt-01")
+	if err := os.MkdirAll(attemptDir, 0o755); err != nil {
+		t.Fatalf("mkdir attempt dir: %v", err)
+	}
+	oldPath := filepath.Join(artifactDir, "old.md")
+	newPath := filepath.Join(artifactDir, "design.md")
 	if err := os.WriteFile(oldPath, []byte("# old\n"), 0o644); err != nil {
 		t.Fatalf("write old artifact: %v", err)
 	}
@@ -733,8 +731,15 @@ func TestContractRegistryArtifactPhaseRolesSelectNewestMarkdown(t *testing.T) {
 	if err := os.Chtimes(oldPath, oldTime, oldTime); err != nil {
 		t.Fatalf("chtimes old artifact: %v", err)
 	}
+	if err := WritePlanAttemptMeta(artifactDir, PlanAttemptMeta{
+		Attempt:      1,
+		AgentStatus:  agentStatusSuccess,
+		ReviewStatus: "VALIDATION_PENDING",
+	}); err != nil {
+		t.Fatalf("WritePlanAttemptMeta(): %v", err)
+	}
 
-	out, violations, err := Validate(feature.PhaseDesign, RoleDesigner, dir)
+	out, violations, err := Validate(feature.PhaseDesign, RoleDesigner, attemptDir)
 	if err != nil {
 		t.Fatalf("Validate() error = %v", err)
 	}
@@ -743,6 +748,40 @@ func TestContractRegistryArtifactPhaseRolesSelectNewestMarkdown(t *testing.T) {
 	}
 	if out.PhaseArtifactPath != newPath {
 		t.Fatalf("PhaseArtifactPath = %q, want %q", out.PhaseArtifactPath, newPath)
+	}
+}
+
+func TestContractRegistryDesignRolesUseSharedArtifactAndAttemptMetadata(t *testing.T) {
+	for _, role := range []Role{RoleDesigner, RoleDesignReviser} {
+		t.Run(string(role), func(t *testing.T) {
+			artifactDir := t.TempDir()
+			attemptDir := filepath.Join(artifactDir, "attempt-01")
+			if err := os.MkdirAll(attemptDir, 0o755); err != nil {
+				t.Fatalf("mkdir attempt dir: %v", err)
+			}
+			designPath := filepath.Join(artifactDir, "design.md")
+			if err := os.WriteFile(designPath, []byte("# Design\n"), 0o644); err != nil {
+				t.Fatalf("write design: %v", err)
+			}
+			if err := WritePlanAttemptMeta(artifactDir, PlanAttemptMeta{
+				Attempt:      1,
+				AgentStatus:  agentStatusSuccess,
+				ReviewStatus: "VALIDATION_PENDING",
+			}); err != nil {
+				t.Fatalf("WritePlanAttemptMeta(): %v", err)
+			}
+
+			out, violations, err := Validate(feature.PhaseDesign, role, attemptDir)
+			if err != nil {
+				t.Fatalf("Validate() error = %v", err)
+			}
+			if !out.OK || len(violations) != 0 {
+				t.Fatalf("Validate() = (%+v, %v), want OK", out, violations)
+			}
+			if out.PhaseArtifactPath != designPath {
+				t.Fatalf("PhaseArtifactPath = %q, want %q", out.PhaseArtifactPath, designPath)
+			}
+		})
 	}
 }
 

--- a/internal/agent/contract_test.go
+++ b/internal/agent/contract_test.go
@@ -727,9 +727,17 @@ func TestContractRegistryDesignRoleUsesCanonicalMarkdown(t *testing.T) {
 	if err := os.WriteFile(newPath, []byte("# new\n"), 0o644); err != nil {
 		t.Fatalf("write new artifact: %v", err)
 	}
+	ledgerPath := filepath.Join(artifactDir, designDecisionLedgerFile)
+	if err := os.WriteFile(ledgerPath, []byte("# Design Decision Ledger\n"), 0o644); err != nil {
+		t.Fatalf("write decision ledger: %v", err)
+	}
 	oldTime := time.Now().Add(-1 * time.Hour)
 	if err := os.Chtimes(oldPath, oldTime, oldTime); err != nil {
 		t.Fatalf("chtimes old artifact: %v", err)
+	}
+	newTime := time.Now().Add(-30 * time.Minute)
+	if err := os.Chtimes(newPath, newTime, newTime); err != nil {
+		t.Fatalf("chtimes canonical design: %v", err)
 	}
 	if err := WritePlanAttemptMeta(artifactDir, PlanAttemptMeta{
 		Attempt:      1,

--- a/internal/agent/design.go
+++ b/internal/agent/design.go
@@ -26,7 +26,7 @@ import (
 //
 // skillsDir, guidelinesDir, and kbInfos are retained for caller compatibility.
 // The RoleSpec system prompt now owns primary skill discovery and Useful Resources.
-func BuildDesignPrompt(f *feature.Feature, skillsDir, guidelinesDir, researchArtifactPath string, qaFilePaths []string, kbInfos ...KBInfo) string {
+func BuildDesignPrompt(f *feature.Feature, skillsDir, guidelinesDir, researchArtifactPath, decisionLedgerPath string, qaFilePaths []string, kbInfos ...KBInfo) string {
 	_, _, _ = skillsDir, guidelinesDir, kbInfos
 	repos, images, attachments := researchFeatureViews(f)
 
@@ -38,6 +38,7 @@ func BuildDesignPrompt(f *feature.Feature, skillsDir, guidelinesDir, researchArt
 		Repos:                repos,
 		MultiRepo:            len(repos) > 1,
 		ResearchArtifactPath: researchArtifactPath,
+		DecisionLedgerPath:   decisionLedgerPath,
 		QAFiles: prompts.QAFilesInput{
 			Paths: append([]string(nil), qaFilePaths...),
 			Lead:  "Read these Q&A files for important context about their intent and preferences:",
@@ -48,12 +49,16 @@ func BuildDesignPrompt(f *feature.Feature, skillsDir, guidelinesDir, researchArt
 
 // BuildDesignRevisionPrompt constructs the autonomous revision prompt used
 // after one or both Design critics request changes.
-func BuildDesignRevisionPrompt(previousDesignPath, mockupManifestPath, criticFeedback string, attempt int) string {
+func BuildDesignRevisionPrompt(f *feature.Feature, previousDesignPath, mockupManifestPath, researchPath, decisionLedgerPath, criticFeedback string, attempt int) string {
 	return roles.BuildDesignRevisionPrompt(roles.DesignRevisionUserInput{
+		Name:               f.Name,
+		Description:        f.EffectiveDescription(),
+		ExitCriteria:       f.ExitCriteria,
 		Attempt:            attempt,
 		CriticFeedback:     criticFeedback,
 		PreviousDesignPath: previousDesignPath,
 		MockupManifestPath: mockupManifestPath,
-		Inquireness:        prompts.AutonomousInquirenessInput{},
+		ResearchPath:       researchPath,
+		DecisionLedgerPath: decisionLedgerPath,
 	})
 }

--- a/internal/agent/design.go
+++ b/internal/agent/design.go
@@ -45,3 +45,15 @@ func BuildDesignPrompt(f *feature.Feature, skillsDir, guidelinesDir, researchArt
 		Inquireness: prompts.GrillMeInquirenessInput{Level: string(f.Inquireness)},
 	})
 }
+
+// BuildDesignRevisionPrompt constructs the autonomous revision prompt used
+// after one or both Design critics request changes.
+func BuildDesignRevisionPrompt(previousDesignPath, mockupManifestPath, criticFeedback string, attempt int) string {
+	return roles.BuildDesignRevisionPrompt(roles.DesignRevisionUserInput{
+		Attempt:            attempt,
+		CriticFeedback:     criticFeedback,
+		PreviousDesignPath: previousDesignPath,
+		MockupManifestPath: mockupManifestPath,
+		Inquireness:        prompts.AutonomousInquirenessInput{},
+	})
+}

--- a/internal/agent/design_decisions.go
+++ b/internal/agent/design_decisions.go
@@ -1,0 +1,336 @@
+// Copyright 2026 DoorDash, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agent
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/doordash-oss/agentic-orchestrator/internal/feature"
+)
+
+const designDecisionLedgerFile = "decision-ledger.md"
+const designHumanDirectionQAFile = "human-direction-qa.md"
+
+type designDecision struct {
+	Question string
+	Answer   string
+	Notes    string
+	Source   string
+}
+
+// WriteDesignDecisionLedger renders the harness-owned, stable-ID authority
+// record consumed by every Design author, critic, and reviser.
+func WriteDesignDecisionLedger(artifactDir string, f *feature.Feature, qaFilePaths []string) (string, error) {
+	if f == nil {
+		return "", fmt.Errorf("writing Design decision ledger: feature is nil")
+	}
+	var decisions []designDecision
+	for _, qaPath := range qaFilePaths {
+		data, err := os.ReadFile(qaPath)
+		if err != nil {
+			return "", fmt.Errorf("reading Design decision source %s: %w", qaPath, err)
+		}
+		decisions = append(decisions, parseDesignDecisions(string(data), qaPath)...)
+	}
+
+	var b strings.Builder
+	b.WriteString("# Design Decision Ledger\n\n")
+	b.WriteString("This file is generated and owned by the Agentico harness. It is the authoritative record of feature requirements and binding human decisions for every Design author, critic, and reviser. IDs remain stable while the ordered source inputs remain unchanged.\n\n")
+	b.WriteString("## Requirements\n\n")
+	b.WriteString("### REQ-001 — Feature request\n\n")
+	b.WriteString("**Source:** original feature description\n\n")
+	fmt.Fprintf(&b, "%s\n\n", strings.TrimSpace(f.EffectiveDescription()))
+	if exitCriteria := strings.TrimSpace(f.ExitCriteria); exitCriteria != "" {
+		b.WriteString("### REQ-002 — Exit criteria\n\n")
+		b.WriteString("**Source:** feature exit criteria\n\n")
+		fmt.Fprintf(&b, "%s\n\n", exitCriteria)
+	}
+	b.WriteString("## Binding Decisions\n\n")
+	if len(decisions) == 0 {
+		b.WriteString("- None recorded yet.\n")
+	} else {
+		for i, decision := range decisions {
+			fmt.Fprintf(&b, "### DEC-%03d — %s\n\n", i+1, decision.Question)
+			fmt.Fprintf(&b, "**Source:** %s\n\n", decision.Source)
+			fmt.Fprintf(&b, "**Decision:** %s\n\n", decision.Answer)
+			if decision.Notes != "" {
+				fmt.Fprintf(&b, "**Notes:** %s\n\n", decision.Notes)
+			}
+		}
+	}
+
+	path := filepath.Join(artifactDir, designDecisionLedgerFile)
+	if err := os.WriteFile(path, []byte(b.String()), 0o644); err != nil {
+		return "", fmt.Errorf("writing Design decision ledger: %w", err)
+	}
+	return path, nil
+}
+
+func parseDesignDecisions(contents, source string) []designDecision {
+	lines := strings.Split(strings.ReplaceAll(contents, "\r\n", "\n"), "\n")
+	var out []designDecision
+	for i := 0; i < len(lines); {
+		question, ok := strings.CutPrefix(strings.TrimSpace(lines[i]), "## Q:")
+		if !ok {
+			i++
+			continue
+		}
+		question = strings.TrimSpace(question)
+		i++
+		var answerLines []string
+		var notesLines []string
+		capture := ""
+		for i < len(lines) {
+			trimmed := strings.TrimSpace(lines[i])
+			if strings.HasPrefix(trimmed, "## Q:") {
+				break
+			}
+			if answer, found := strings.CutPrefix(trimmed, "**A:**"); found {
+				capture = "answer"
+				answerLines = append(answerLines, strings.TrimSpace(answer))
+				i++
+				continue
+			}
+			if notes, found := strings.CutPrefix(trimmed, "**Notes:**"); found {
+				capture = "notes"
+				notesLines = append(notesLines, strings.TrimSpace(notes))
+				i++
+				continue
+			}
+			if strings.HasPrefix(trimmed, "_(auto-picked,") {
+				capture = ""
+			}
+			switch capture {
+			case "answer":
+				answerLines = append(answerLines, strings.TrimSpace(lines[i]))
+			case "notes":
+				notesLines = append(notesLines, strings.TrimSpace(lines[i]))
+			}
+			i++
+		}
+		answer := strings.TrimSpace(strings.Join(answerLines, "\n"))
+		if question != "" && answer != "" {
+			out = append(out, designDecision{
+				Question: question,
+				Answer:   answer,
+				Notes:    strings.TrimSpace(strings.Join(notesLines, "\n")),
+				Source:   source,
+			})
+		}
+	}
+	return out
+}
+
+// designDecisionSourcePaths appends Q&A captured during the initial Design
+// interview and later revision attempts after upstream decision sources.
+// Duplicate paths are removed.
+func designDecisionSourcePaths(upstream []string, artifactDir string) []string {
+	out := make([]string, 0, len(upstream)+1)
+	seen := make(map[string]struct{}, len(upstream)+1)
+	appendPath := func(path string) {
+		if path == "" {
+			return
+		}
+		if _, ok := seen[path]; ok {
+			return
+		}
+		seen[path] = struct{}{}
+		out = append(out, path)
+	}
+	for _, path := range upstream {
+		appendPath(path)
+	}
+	current := filepath.Join(artifactDir, "qa-answers.md")
+	if info, err := os.Stat(current); err == nil && info.Mode().IsRegular() {
+		appendPath(current)
+	}
+	attemptDirs, _ := filepath.Glob(filepath.Join(artifactDir, "attempt-*"))
+	for _, attemptDir := range attemptDirs {
+		for _, name := range []string{"qa-answers.md", designHumanDirectionQAFile} {
+			path := filepath.Join(attemptDir, name)
+			if info, err := os.Stat(path); err == nil && info.Mode().IsRegular() {
+				appendPath(path)
+			}
+		}
+	}
+	return out
+}
+
+// RecordDesignHumanDirection persists review-gate feedback as a binding Q&A
+// source so the next Design attempt receives it through the decision ledger.
+func RecordDesignHumanDirection(attemptDir, feedback string) (string, error) {
+	feedback = strings.TrimSpace(feedback)
+	if feedback == "" {
+		return "", fmt.Errorf("recording Design human direction: feedback is empty")
+	}
+	var b strings.Builder
+	b.WriteString("# User Q&A — Human Design Review\n\n")
+	b.WriteString("## Q: Which direction did the human give after reviewing this Design attempt?\n\n")
+	fmt.Fprintf(&b, "**A:** %s\n", feedback)
+
+	path := filepath.Join(attemptDir, designHumanDirectionQAFile)
+	if err := os.WriteFile(path, []byte(b.String()), 0o644); err != nil {
+		return "", fmt.Errorf("recording Design human direction: %w", err)
+	}
+	return path, nil
+}
+
+func archiveDesignAttempt(designPath, attemptDir string) (string, error) {
+	data, err := os.ReadFile(designPath)
+	if err != nil {
+		return "", err
+	}
+	path := filepath.Join(attemptDir, "design.md")
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
+type designReviewDispositionResult struct {
+	RequiresHuman bool
+	Reason        string
+}
+
+// designReviewDisposition prevents critic preferences or unresolved material
+// choices from entering the autonomous reviser. Only decision-referenced,
+// observable contract defects and grounding errors may revise automatically.
+func designReviewDisposition(results []ValidatorResult, decisionIDs map[string]struct{}) designReviewDispositionResult {
+	for _, result := range results {
+		if result.Status != ReviewChangesRequested {
+			continue
+		}
+		findings := strings.TrimSpace(extractMarkdownSection(result.Feedback, "## Findings"))
+		if findings == "" || findings == "- (none)" {
+			return designReviewDispositionResult{
+				RequiresHuman: true,
+				Reason:        fmt.Sprintf("%s critic requested changes without a classified blocking finding", result.Domain),
+			}
+		}
+		foundBlocking := false
+		for _, line := range strings.Split(findings, "\n") {
+			trimmed := strings.TrimSpace(line)
+			var body string
+			switch {
+			case strings.HasPrefix(trimmed, "- **Critical**:"):
+				body = strings.TrimSpace(strings.TrimPrefix(trimmed, "- **Critical**:"))
+			case strings.HasPrefix(trimmed, "- **High**:"):
+				body = strings.TrimSpace(strings.TrimPrefix(trimmed, "- **High**:"))
+			default:
+				continue
+			}
+			foundBlocking = true
+			class, rest, ok := cutBracketToken(body)
+			if !ok {
+				return designReviewDispositionResult{
+					RequiresHuman: true,
+					Reason:        fmt.Sprintf("%s critic emitted an unclassified blocking finding", result.Domain),
+				}
+			}
+			reference, detail, ok := cutBracketToken(rest)
+			if !ok || !validDesignDecisionReference(reference) {
+				return designReviewDispositionResult{
+					RequiresHuman: true,
+					Reason:        fmt.Sprintf("%s critic finding must cite a REQ-### or DEC-### decision-ledger ID", result.Domain),
+				}
+			}
+			if _, exists := decisionIDs[reference]; !exists {
+				return designReviewDispositionResult{
+					RequiresHuman: true,
+					Reason:        fmt.Sprintf("%s critic cited %s, which is not present in the decision ledger", result.Domain, reference),
+				}
+			}
+			if !strings.Contains(detail, "Observable failure:") {
+				return designReviewDispositionResult{
+					RequiresHuman: true,
+					Reason:        fmt.Sprintf("%s critic finding for %s must state an Observable failure", result.Domain, reference),
+				}
+			}
+			switch class {
+			case "CONTRACT_DEFECT", "GROUNDING_ERROR":
+				// Safe for autonomous revision when the remaining contract is
+				// satisfied.
+			case "DECISION_CONFLICT", "MISSING_DECISION":
+				return designReviewDispositionResult{
+					RequiresHuman: true,
+					Reason:        fmt.Sprintf("%s critic reported %s for %s", result.Domain, class, reference),
+				}
+			default:
+				return designReviewDispositionResult{
+					RequiresHuman: true,
+					Reason:        fmt.Sprintf("%s critic emitted unknown finding classification %q", result.Domain, class),
+				}
+			}
+		}
+		if !foundBlocking {
+			return designReviewDispositionResult{
+				RequiresHuman: true,
+				Reason:        fmt.Sprintf("%s critic requested changes without a Critical or High finding", result.Domain),
+			}
+		}
+	}
+	return designReviewDispositionResult{}
+}
+
+func readDesignDecisionIDs(path string) (map[string]struct{}, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading Design decision ledger IDs: %w", err)
+	}
+	ids := make(map[string]struct{})
+	for _, line := range strings.Split(string(data), "\n") {
+		heading, ok := strings.CutPrefix(strings.TrimSpace(line), "### ")
+		if !ok {
+			continue
+		}
+		id, _, _ := strings.Cut(heading, " ")
+		if validDesignDecisionReference(id) {
+			ids[id] = struct{}{}
+		}
+	}
+	if len(ids) == 0 {
+		return nil, fmt.Errorf("Design decision ledger %s contains no requirement or decision IDs", path)
+	}
+	return ids, nil
+}
+
+func cutBracketToken(s string) (token, rest string, ok bool) {
+	if !strings.HasPrefix(s, "[") {
+		return "", s, false
+	}
+	end := strings.IndexByte(s, ']')
+	if end <= 1 {
+		return "", s, false
+	}
+	return s[1:end], strings.TrimSpace(s[end+1:]), true
+}
+
+func validDesignDecisionReference(reference string) bool {
+	if len(reference) != 7 || reference[3] != '-' {
+		return false
+	}
+	if reference[:3] != "REQ" && reference[:3] != "DEC" {
+		return false
+	}
+	for _, ch := range reference[4:] {
+		if ch < '0' || ch > '9' {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/agent/design_test.go
+++ b/internal/agent/design_test.go
@@ -15,6 +15,8 @@
 package agent
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -31,7 +33,7 @@ func TestBuildDesignPrompt(t *testing.T) {
 		Inquireness: feature.InquirenessHigh,
 	}
 
-	prompt := BuildDesignPrompt(f, "", "", "/tmp/research/doc.md", nil)
+	prompt := BuildDesignPrompt(f, "", "", "/tmp/research/doc.md", "/tmp/design/decision-ledger.md", nil)
 
 	checks := []string{
 		"# Feature Context",
@@ -40,6 +42,8 @@ func TestBuildDesignPrompt(t *testing.T) {
 		"> Implement user authentication",
 		"## Research Findings",
 		"/tmp/research/doc.md",
+		"## Authoritative Decision Ledger",
+		"/tmp/design/decision-ledger.md",
 		"Ambiguity Resolution",
 	}
 
@@ -56,7 +60,7 @@ func TestBuildDesignPromptNoResearch(t *testing.T) {
 		Description: "A feature",
 		Inquireness: feature.InquirenessMedium,
 	}
-	prompt := BuildDesignPrompt(f, "", "", "", nil)
+	prompt := BuildDesignPrompt(f, "", "", "", "", nil)
 	if strings.Contains(prompt, "## Research Findings") {
 		t.Error("expected no research section when path is empty")
 	}
@@ -69,7 +73,7 @@ func TestBuildDesignPromptWithImages(t *testing.T) {
 		Images:      []string{"/tmp/images/image-1.png"},
 		Inquireness: feature.InquirenessMedium,
 	}
-	prompt := BuildDesignPrompt(f, "", "", "/tmp/research.md", nil)
+	prompt := BuildDesignPrompt(f, "", "", "/tmp/research.md", "", nil)
 	if !strings.Contains(prompt, "Attached Images:") {
 		t.Error("expected 'Attached Images' section")
 	}
@@ -82,7 +86,7 @@ func TestBuildDesignPromptWithQAPaths(t *testing.T) {
 		Inquireness: feature.InquirenessMedium,
 	}
 	qaFiles := []string{"/tmp/features/abc/inquire/qa-answers.md", "/tmp/features/abc/research/qa-answers.md"}
-	prompt := BuildDesignPrompt(f, "", "", "/tmp/research.md", qaFiles)
+	prompt := BuildDesignPrompt(f, "", "", "/tmp/research.md", "/tmp/features/abc/design/decision-ledger.md", qaFiles)
 
 	if !strings.Contains(prompt, "## User Decisions") {
 		t.Error("expected '## User Decisions' section")
@@ -95,6 +99,9 @@ func TestBuildDesignPromptWithQAPaths(t *testing.T) {
 	if !strings.Contains(prompt, "intent and preferences") {
 		t.Error("expected guidance language about user decisions")
 	}
+	if !strings.Contains(prompt, "/tmp/features/abc/design/decision-ledger.md") {
+		t.Error("expected authoritative decision ledger path")
+	}
 }
 
 func TestBuildDesignPromptNoQAPaths(t *testing.T) {
@@ -103,14 +110,152 @@ func TestBuildDesignPromptNoQAPaths(t *testing.T) {
 		Description: "A feature without Q&A",
 		Inquireness: feature.InquirenessMedium,
 	}
-	prompt := BuildDesignPrompt(f, "", "", "/tmp/research.md", nil)
+	prompt := BuildDesignPrompt(f, "", "", "/tmp/research.md", "", nil)
 	if strings.Contains(prompt, "## User Decisions") {
 		t.Error("expected no User Decisions section when qaFilePaths is nil")
 	}
 
-	prompt2 := BuildDesignPrompt(f, "", "", "/tmp/research.md", []string{})
+	prompt2 := BuildDesignPrompt(f, "", "", "/tmp/research.md", "", []string{})
 	if strings.Contains(prompt2, "## User Decisions") {
 		t.Error("expected no User Decisions section when qaFilePaths is empty")
+	}
+}
+
+func TestWriteDesignDecisionLedgerAssignsStableRequirementAndDecisionIDs(t *testing.T) {
+	artifactDir := t.TempDir()
+	firstQA := filepath.Join(t.TempDir(), "qa-answers.md")
+	secondQA := filepath.Join(t.TempDir(), "qa-answers.md")
+	if err := os.WriteFile(firstQA, []byte(`# User Q&A
+
+## Q: Which storage?
+
+**A:** Reuse the customer table.
+
+## Q: Which delivery semantics?
+
+**A:** Publish the freshest state.
+
+**Notes:** Intermediate mutations do not matter, but dropping the newest committed state is fatal.
+`), 0o644); err != nil {
+		t.Fatalf("write first Q&A: %v", err)
+	}
+	if err := os.WriteFile(secondQA, []byte(`# User Q&A
+
+## Q: Which performance gate?
+
+**A:** Correctness-only acceptance.
+`), 0o644); err != nil {
+		t.Fatalf("write second Q&A: %v", err)
+	}
+	f := &feature.Feature{
+		Name:         "Linearizable CDC",
+		Description:  "Support CDC without dropping committed state.",
+		ExitCriteria: "Preserve state-convergent delivery.",
+	}
+
+	path, err := WriteDesignDecisionLedger(artifactDir, f, []string{firstQA, secondQA})
+	if err != nil {
+		t.Fatalf("WriteDesignDecisionLedger() error = %v", err)
+	}
+	first, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read decision ledger: %v", err)
+	}
+	for _, want := range []string{
+		"### REQ-001 — Feature request",
+		"### REQ-002 — Exit criteria",
+		"### DEC-001 — Which storage?",
+		"### DEC-002 — Which delivery semantics?",
+		"### DEC-003 — Which performance gate?",
+		"**Decision:** Reuse the customer table.",
+		"**Notes:** Intermediate mutations do not matter, but dropping the newest committed state is fatal.",
+		"**Decision:** Correctness-only acceptance.",
+	} {
+		if !strings.Contains(string(first), want) {
+			t.Errorf("decision ledger missing %q:\n%s", want, first)
+		}
+	}
+
+	secondPath, err := WriteDesignDecisionLedger(artifactDir, f, []string{firstQA, secondQA})
+	if err != nil {
+		t.Fatalf("second WriteDesignDecisionLedger() error = %v", err)
+	}
+	second, err := os.ReadFile(secondPath)
+	if err != nil {
+		t.Fatalf("read second decision ledger: %v", err)
+	}
+	if string(second) != string(first) {
+		t.Fatalf("decision ledger IDs/content changed across identical regeneration:\n--- first ---\n%s\n--- second ---\n%s", first, second)
+	}
+}
+
+func TestDesignDecisionSourcePathsIncludesCurrentDesignAnswersLast(t *testing.T) {
+	artifactDir := t.TempDir()
+	current := filepath.Join(artifactDir, "qa-answers.md")
+	if err := os.WriteFile(current, []byte("# current design answers\n"), 0o644); err != nil {
+		t.Fatalf("write current design answers: %v", err)
+	}
+	firstAttemptDir := filepath.Join(artifactDir, "attempt-01")
+	if err := os.MkdirAll(firstAttemptDir, 0o755); err != nil {
+		t.Fatalf("create first attempt: %v", err)
+	}
+	humanDirection, err := RecordDesignHumanDirection(firstAttemptDir, "Keep the selected delivery semantics.")
+	if err != nil {
+		t.Fatalf("RecordDesignHumanDirection(): %v", err)
+	}
+	revisionDir := filepath.Join(artifactDir, "attempt-02")
+	if err := os.MkdirAll(revisionDir, 0o755); err != nil {
+		t.Fatalf("create revision attempt: %v", err)
+	}
+	revision := filepath.Join(revisionDir, "qa-answers.md")
+	if err := os.WriteFile(revision, []byte("# revision answers\n"), 0o644); err != nil {
+		t.Fatalf("write revision answers: %v", err)
+	}
+
+	got := designDecisionSourcePaths([]string{"/upstream/inquire.md", "/upstream/research.md"}, artifactDir)
+	want := []string{"/upstream/inquire.md", "/upstream/research.md", current, humanDirection, revision}
+	if len(got) != len(want) {
+		t.Fatalf("designDecisionSourcePaths() = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("designDecisionSourcePaths()[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestRecordDesignHumanDirectionBecomesBindingLedgerDecision(t *testing.T) {
+	artifactDir := t.TempDir()
+	attemptDir := filepath.Join(artifactDir, "attempt-01")
+	if err := os.MkdirAll(attemptDir, 0o755); err != nil {
+		t.Fatalf("create attempt: %v", err)
+	}
+	if _, err := RecordDesignHumanDirection(attemptDir, "Preserve watermark-first resolution."); err != nil {
+		t.Fatalf("RecordDesignHumanDirection(): %v", err)
+	}
+	f := &feature.Feature{
+		Name:        "Human-reviewed Design",
+		Description: "Preserve reviewed decisions.",
+	}
+	ledgerPath, err := WriteDesignDecisionLedger(
+		artifactDir,
+		f,
+		designDecisionSourcePaths(nil, artifactDir),
+	)
+	if err != nil {
+		t.Fatalf("WriteDesignDecisionLedger(): %v", err)
+	}
+	ledger, err := os.ReadFile(ledgerPath)
+	if err != nil {
+		t.Fatalf("read decision ledger: %v", err)
+	}
+	for _, want := range []string{
+		"### DEC-001 — Which direction did the human give after reviewing this Design attempt?",
+		"**Decision:** Preserve watermark-first resolution.",
+	} {
+		if !strings.Contains(string(ledger), want) {
+			t.Fatalf("decision ledger missing %q:\n%s", want, ledger)
+		}
 	}
 }
 
@@ -168,7 +313,7 @@ func TestBuildDesignPromptUsesEffectiveDescription(t *testing.T) {
 			{Name: "repo", Path: "/tmp/test"},
 		},
 	}
-	prompt := BuildDesignPrompt(f, "", "", "some research output", nil)
+	prompt := BuildDesignPrompt(f, "", "", "some research output", "", nil)
 	if !strings.Contains(prompt, "improve performance") {
 		t.Error("expected refactor prompt in design output")
 	}
@@ -187,7 +332,7 @@ func TestBuildDesignPrompt_MultiRepo(t *testing.T) {
 				{Name: "repo-b", Path: "/path/b"},
 			},
 		}
-		prompt := BuildDesignPrompt(f, "", "", "/tmp/research.md", nil)
+		prompt := BuildDesignPrompt(f, "", "", "/tmp/research.md", "", nil)
 		if !strings.Contains(prompt, "Target Repositories") {
 			t.Error("expected 'Target Repositories' section for multi-repo feature")
 		}
@@ -200,7 +345,7 @@ func TestBuildDesignPrompt_MultiRepo(t *testing.T) {
 			Name:  "test-feature",
 			Repos: []feature.FeatureRepo{{Name: "repo-a", Path: "/path/a"}},
 		}
-		prompt := BuildDesignPrompt(f, "", "", "/tmp/research.md", nil)
+		prompt := BuildDesignPrompt(f, "", "", "/tmp/research.md", "", nil)
 		if strings.Contains(prompt, "Target Repositories") {
 			t.Error("single-repo feature should not have 'Target Repositories' section")
 		}
@@ -213,7 +358,7 @@ func TestBuildDesignPrompt_MultiRepo(t *testing.T) {
 				{Name: "repo-b", Path: "/path/b", WorktreePath: "/wt/b"},
 			},
 		}
-		prompt := BuildDesignPrompt(f, "", "", "/tmp/research.md", nil)
+		prompt := BuildDesignPrompt(f, "", "", "/tmp/research.md", "", nil)
 		if !strings.Contains(prompt, "/wt/a") {
 			t.Error("expected worktree path /wt/a in prompt")
 		}

--- a/internal/agent/design_validation.go
+++ b/internal/agent/design_validation.go
@@ -1,0 +1,572 @@
+// Copyright 2026 DoorDash, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agent
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/doordash-oss/agentic-orchestrator/internal/feature"
+	"github.com/doordash-oss/agentic-orchestrator/internal/observe"
+	"github.com/doordash-oss/agentic-orchestrator/internal/ports"
+)
+
+const defaultMaxDesignAttempts = 5
+
+// DefaultMaxDesignAttempts is the initial autonomous Design revision budget.
+const DefaultMaxDesignAttempts = defaultMaxDesignAttempts
+
+// DesignLoopConfig configures the Design author/reviser and critic loop.
+type DesignLoopConfig struct {
+	PlanLoopConfig
+}
+
+// DesignLoopResult is the terminal result consumed by the orchestrator.
+type DesignLoopResult struct {
+	FinalStatus string
+	Iterations  int
+	LastError   string
+}
+
+func designRoleForAttempt(attempt int) Role {
+	if attempt <= 1 {
+		return RoleDesigner
+	}
+	return RoleDesignReviser
+}
+
+func designSpecForAttempt(attempt int) RoleSpec {
+	if attempt <= 1 {
+		return DesignerRoleSpec()
+	}
+	return DesignReviserRoleSpec()
+}
+
+func designValidators(manifestPath string) []validatorDomain {
+	validators := []validatorDomain{{
+		Name:     "Integrity",
+		Template: "validate-design-integrity",
+	}}
+	if manifestPath != "" {
+		validators = append(validators, validatorDomain{
+			Name:     "Visual",
+			Template: "validate-design-visual",
+		})
+	}
+	return validators
+}
+
+// RunDesignValidationLoop creates a Design artifact, conditionally creates its
+// mockup bundle through the companion skill, and iterates over two focused
+// critics until approved or escalated.
+func RunDesignValidationLoop(cfg DesignLoopConfig, sm ports.SessionManager) (result *DesignLoopResult, retErr error) {
+	featureCtx := observe.SpanContextForFeature(
+		cfg.Feature.ID,
+		cfg.Feature.TraceID,
+		cfg.Feature.Name,
+		cfg.Feature.FeatureSpanID,
+	).WithRun(cfg.Feature.ActiveRun)
+	cfg.PhaseSpanCtx = featureCtx.Child()
+	cfg.PlanLoopConfig.PhaseSpanCtx = cfg.PhaseSpanCtx
+	phaseStart := time.Now()
+	cfg.Observer.PhaseStarted(cfg.PhaseSpanCtx, feature.PhaseDesign.String())
+	defer func() {
+		var phaseErr error
+		if retErr != nil {
+			phaseErr = retErr
+		} else if result != nil && result.FinalStatus != "approved" {
+			phaseErr = errors.New(result.FinalStatus)
+		}
+		cfg.Observer.PhaseCompleted(cfg.PhaseSpanCtx, feature.PhaseDesign.String(), time.Since(phaseStart), phaseErr)
+	}()
+
+	artifactDir := filepath.Join(
+		ActiveRunDir(cfg.StateDir, cfg.Feature),
+		cfg.Feature.RefactorPrefix(),
+		feature.PhaseDesign.DirName(),
+	)
+	if err := os.MkdirAll(artifactDir, 0o755); err != nil {
+		return nil, fmt.Errorf("creating Design artifact directory: %w", err)
+	}
+
+	maxAttempts := cfg.MaxAttempts
+	if maxAttempts <= 0 {
+		maxAttempts = defaultMaxDesignAttempts
+	}
+
+	startAttempt := LatestCompletedPlanAttempt(artifactDir)
+	resumeValidation := false
+	var criticFeedback string
+	feedbackAttempt, feedback := latestPlanRevisionFeedbackAttempt(artifactDir)
+	if feedbackAttempt > startAttempt {
+		startAttempt = feedbackAttempt
+		criticFeedback = feedback
+	} else if startAttempt > 0 {
+		meta, err := readPlanAttemptMeta(artifactDir, startAttempt)
+		if err == nil {
+			switch meta.ReviewStatus {
+			case agentStatusApproved:
+				return &DesignLoopResult{FinalStatus: "approved", Iterations: startAttempt}, nil
+			case "VALIDATION_PENDING":
+				resumeValidation = true
+			case agentStatusChangesRequested:
+				feedbackPath := filepath.Join(artifactDir, fmt.Sprintf("attempt-%02d", startAttempt), "validation-feedback.md")
+				if data, readErr := os.ReadFile(feedbackPath); readErr == nil {
+					criticFeedback = strings.TrimSpace(string(data))
+				}
+			}
+		}
+	}
+
+	loopStart := startAttempt + 1
+	if resumeValidation {
+		loopStart = startAttempt
+	}
+	stalls := loadAxisStallState(artifactDir)
+
+designAttemptLoop:
+	for attempt := loopStart; attempt <= maxAttempts; attempt++ {
+		if isFeatureInterrupted(cfg.FeatureStore, cfg.Feature.ID) {
+			return &DesignLoopResult{FinalStatus: "interrupted", Iterations: attempt - 1}, nil
+		}
+
+		attemptDir := filepath.Join(artifactDir, fmt.Sprintf("attempt-%02d", attempt))
+		if err := os.MkdirAll(attemptDir, 0o755); err != nil {
+			return nil, fmt.Errorf("creating Design attempt directory: %w", err)
+		}
+		setDesignIteration(cfg, attempt)
+
+		if resumeValidation {
+			resumeValidation = false
+		} else {
+			designPath := resolveDesignArtifactPath(cfg.FeatureStore, cfg.Feature.ID, artifactDir)
+			manifestPath := existingMockupManifestPath(artifactDir)
+			prompt := BuildDesignPrompt(
+				cfg.Feature,
+				cfg.SkillsDir,
+				cfg.GuidelinesDir,
+				cfg.ResearchArtifactPath,
+				cfg.QAFilePaths,
+				cfg.KBInfos...,
+			)
+			if attempt > 1 {
+				prompt = BuildDesignRevisionPrompt(
+					designPath,
+					manifestPath,
+					criticFeedback,
+					attempt,
+				)
+			}
+
+			spec := designSpecForAttempt(attempt)
+			systemPrompt := BuildRoleSystemPrompt(BuildRoleSystemPromptInput{
+				Spec:          spec,
+				IterationDir:  attemptDir,
+				SkillsDir:     cfg.SkillsDir,
+				GuidelinesDir: cfg.GuidelinesDir,
+				KBInfos:       cfg.KBInfos,
+				AskingClause:  cfg.AskingClause,
+			})
+			addDirs := cfg.AdditionalDirs
+			if len(addDirs) == 0 {
+				addDirs = []string{ActiveRunDir(cfg.StateDir, cfg.Feature)}
+			}
+			sessionAttempt := nextPlanSessionAttempt(artifactDir, attempt)
+			for {
+				RemovePhaseComplete(attemptDir)
+				cmd, env, sessOpts, err := cfg.BuildSession(BuildSessionOpts{
+					Model:                          cfg.Feature.Models.Planning,
+					Prompt:                         prompt,
+					SystemPrompt:                   systemPrompt,
+					AdditionalDirs:                 addDirs,
+					PIDDir:                         filepath.Join(cfg.StateDir, cfg.Feature.ID),
+					PermHandler:                    permHandlerFor(cfg.DangerouslySkipPermissions, cfg.PermissionCache, cfg.RepoName),
+					WorkDir:                        cfg.WorkDir,
+					EffortLevel:                    planEffortLevel(cfg.PlanLoopConfig),
+					Phase:                          feature.PhaseDesign,
+					SystemPromptHasUsefulResources: true,
+					MarkerPath:                     filepath.Join(attemptDir, PhaseCompleteFile),
+				})
+				if err != nil {
+					return nil, fmt.Errorf("building Design session (attempt %d): %w", attempt, err)
+				}
+				sessOpts = enableTruncatedTurnAutoResume(sessOpts)
+				if cfg.EffectiveEffort != "" {
+					sessOpts.EffectiveEffort = cfg.EffectiveEffort
+					sessOpts.EffortSource = cfg.EffortSource
+				}
+				if cfg.FinishOrViolateNudge {
+					sessOpts.TurnMode = ports.TurnModeInteractive
+				}
+				WriteDebugPrompts(attemptDir, sessOpts.DebugSystemPrompt, prompt)
+				sessOpts.PermCacheScope = cfg.RepoName
+
+				sessionID := planAttemptSessionID(fmt.Sprintf("%s-design-%02d", cfg.Feature.ID, attempt), sessionAttempt)
+				sessionCtx := cfg.PhaseSpanCtx.Child()
+				if attempt == 1 {
+					sessOpts.AskUserAutoPick = askUserAutoPickConfig(
+						cfg.FeatureStore,
+						cfg.Observer,
+						cfg.Feature,
+						ports.AskUserAutoPickPurposeDesign,
+						sessionCtx,
+						sessionID,
+						cfg.RepoName,
+						0,
+					)
+				}
+				startSession := resolveSessionStartFunc(cfg.SessionStartFunc, sm)
+				sess, err := startSession(sessionID, cfg.Feature.ID, feature.PhaseDesign, cmd, cfg.WorkDir, env, sessOpts)
+				if err != nil {
+					if errors.Is(err, ports.ErrSessionShuttingDown) {
+						return &DesignLoopResult{FinalStatus: "interrupted", Iterations: attempt - 1}, nil
+					}
+					return nil, fmt.Errorf("starting Design session (attempt %d): %w", attempt, err)
+				}
+
+				providerName := ""
+				if sessOpts != nil {
+					providerName = sessOpts.ProviderName
+				}
+				cfg.Observer.SessionStarted(
+					sessionCtx,
+					feature.PhaseDesign.String(),
+					sessionID,
+					providerName,
+					cfg.Feature.Models.Planning,
+					cfg.RepoName,
+					string(cfg.EffectiveEffort),
+					string(cfg.EffortSource),
+				)
+				sessionStart := time.Now()
+				logPath := filepath.Join(attemptDir, "output.txt")
+				if logFile, createErr := os.Create(logPath); createErr == nil {
+					sess.SetLogFile(logFile)
+				}
+
+				agentStatus := waitForStatusDetailed(sess, sm, sessionID, waitForStatusOptions{
+					ReadyCheck: func() bool {
+						if HasPhaseComplete(attemptDir) {
+							sess.SetHasUnansweredQuestion(false)
+							return true
+						}
+						return false
+					},
+					FinishOrViolateNudge: cfg.FinishOrViolateNudge,
+					MissingArtifacts:     []string{"design markdown"},
+				}).Status
+				cost := ExtractSessionCost(sess)
+				cfg.Observer.SessionEnded(
+					sessionCtx,
+					feature.PhaseDesign.String(),
+					sessionID,
+					cfg.RepoName,
+					toSessionUsage(cost),
+					time.Since(sessionStart),
+					sessionErrFromAgentStatus(agentStatus),
+				)
+				_ = os.WriteFile(logPath, []byte(sess.MessageLog().Text()), 0o644)
+				recordDesignSessionCost(cfg, sessionID, cost)
+
+				if agentStatus == agentStatusSuccess {
+					if attempt == 1 {
+						if _, err := WriteQAFile(sess.QALog(), artifactDir); err != nil {
+							return nil, fmt.Errorf("writing Design Q&A: %w", err)
+						}
+					}
+					meta := PlanAttemptMeta{
+						Attempt:      attempt,
+						AgentStatus:  agentStatusSuccess,
+						ReviewStatus: "VALIDATION_PENDING",
+					}
+					if sessionAttempt > 1 {
+						meta.SessionAttempt = sessionAttempt
+					}
+					_ = WritePlanAttemptMeta(artifactDir, meta)
+					break
+				}
+				if agentStatus == "FAILED" && sm != nil && sm.IsShuttingDown() {
+					return &DesignLoopResult{FinalStatus: "interrupted", Iterations: attempt - 1}, nil
+				}
+				if agentStatus == agentStatusMissingMarker {
+					criticFeedback = formatPlanContractViolationFeedback(spec.Role, missingPhaseCompleteViolations())
+					_ = writeDesignAttemptFeedback(artifactDir, attempt, criticFeedback)
+					if attempt >= maxAttempts {
+						return &DesignLoopResult{
+							FinalStatus: BoundedHelperStatusProtocolViolation,
+							Iterations:  attempt,
+							LastError:   criticFeedback,
+						}, nil
+					}
+					continue designAttemptLoop
+				}
+				_ = WritePlanAttemptMeta(artifactDir, PlanAttemptMeta{
+					Attempt:        attempt,
+					SessionAttempt: sessionAttempt,
+					AgentStatus:    "FAILED",
+				})
+				if shouldRetryPlanInfrastructureSession(agentStatus, sess, cost, time.Since(sessionStart), sessionAttempt) {
+					sessionAttempt++
+					continue
+				}
+				return &DesignLoopResult{
+					FinalStatus: "failed",
+					Iterations:  attempt,
+					LastError:   "Design session did not complete successfully",
+				}, nil
+			}
+		}
+
+		role := designRoleForAttempt(attempt)
+		outcome, violations, err := Validate(feature.PhaseDesign, role, attemptDir)
+		if err != nil {
+			return nil, fmt.Errorf("validating Design contract (attempt %d): %w", attempt, err)
+		}
+		if !outcome.OK {
+			criticFeedback = formatPlanContractViolationFeedback(role, violations)
+			_ = writeDesignAttemptFeedback(artifactDir, attempt, criticFeedback)
+			if attempt >= maxAttempts {
+				return &DesignLoopResult{
+					FinalStatus: BoundedHelperStatusProtocolViolation,
+					Iterations:  attempt,
+					LastError:   criticFeedback,
+				}, nil
+			}
+			continue
+		}
+
+		designPath := resolveDesignArtifactPath(cfg.FeatureStore, cfg.Feature.ID, artifactDir)
+		if designPath == "" {
+			return nil, fmt.Errorf("Design attempt %d produced no design markdown", attempt)
+		}
+		manifestPath := existingMockupManifestPath(artifactDir)
+		validators := designValidators(manifestPath)
+		setValidatingDesign(cfg, true)
+		results, reviewStatus, feedback, reviewErr := runValidatorSet(
+			cfg.PlanLoopConfig,
+			sm,
+			attempt,
+			attemptDir,
+			designPath,
+			validators,
+			validationArtifactDesign,
+			planValidationExtras{MockupManifestPath: manifestPath},
+		)
+		setValidatingDesign(cfg, false)
+
+		if isFeatureInterrupted(cfg.FeatureStore, cfg.Feature.ID) {
+			return &DesignLoopResult{FinalStatus: "interrupted", Iterations: attempt}, nil
+		}
+		if reviewErr != nil {
+			if isProtocolViolationError(reviewErr) {
+				criticFeedback = feedback
+				if strings.TrimSpace(criticFeedback) == "" {
+					criticFeedback = fmt.Sprintf("Design validation failed: %v", reviewErr)
+				}
+				_ = writeDesignAttemptFeedback(artifactDir, attempt, criticFeedback)
+				if attempt >= maxAttempts {
+					return &DesignLoopResult{
+						FinalStatus: BoundedHelperStatusProtocolViolation,
+						Iterations:  attempt,
+						LastError:   reviewErr.Error(),
+					}, nil
+				}
+				continue
+			}
+			_ = WritePlanAttemptMeta(artifactDir, PlanAttemptMeta{
+				Attempt:      attempt,
+				AgentStatus:  agentStatusSuccess,
+				ReviewStatus: "FAILED",
+			})
+			return &DesignLoopResult{
+				FinalStatus: "failed",
+				Iterations:  attempt,
+				LastError:   reviewErr.Error(),
+			}, nil
+		}
+
+		stallResults := make([]ValidatorResult, 0, len(results))
+		for _, validatorResult := range results {
+			if !strings.EqualFold(validatorResult.Domain, "Visual") {
+				stallResults = append(stallResults, validatorResult)
+			}
+		}
+		stalled, axis, count, verdicts, digests := stalls.observe(attempt, designPath, stallResults)
+		for _, validatorResult := range results {
+			axisName := strings.ToLower(validatorResult.Domain)
+			if _, tracked := verdicts[axisName]; !tracked {
+				verdicts[axisName] = validatorResult.Status.String()
+			}
+		}
+		meta := PlanAttemptMeta{
+			Attempt:      attempt,
+			AgentStatus:  agentStatusSuccess,
+			ReviewStatus: reviewStatus.String(),
+			AxisVerdicts: verdicts,
+			AxisDigests:  digests,
+		}
+		_ = WritePlanAttemptMeta(artifactDir, meta)
+
+		switch reviewStatus {
+		case ReviewApproved:
+			if err := recordDesignArtifacts(cfg, designPath, manifestPath); err != nil {
+				return nil, err
+			}
+			return &DesignLoopResult{FinalStatus: "approved", Iterations: attempt}, nil
+		case ReviewChangesRequested:
+			criticFeedback = feedback
+			_ = os.WriteFile(filepath.Join(attemptDir, "validation-feedback.md"), []byte(feedback), 0o644)
+			if stalled {
+				if err := recordDesignArtifacts(cfg, designPath, manifestPath); err != nil {
+					return nil, err
+				}
+				return &DesignLoopResult{
+					FinalStatus: "needs_human_review",
+					Iterations:  attempt,
+					LastError:   fmt.Sprintf("%s critic stalled for %d attempts", axis, count),
+				}, nil
+			}
+		default:
+			criticFeedback = "Design validation produced no clear result."
+			_ = os.WriteFile(filepath.Join(attemptDir, "validation-feedback.md"), []byte(criticFeedback), 0o644)
+		}
+	}
+
+	designPath := resolveDesignArtifactPath(cfg.FeatureStore, cfg.Feature.ID, artifactDir)
+	if designPath != "" {
+		if err := recordDesignArtifacts(cfg, designPath, existingMockupManifestPath(artifactDir)); err != nil {
+			return nil, err
+		}
+	}
+	return &DesignLoopResult{
+		FinalStatus: "needs_human_review",
+		Iterations:  maxAttempts,
+		LastError:   fmt.Sprintf("Design not approved after %d attempts", maxAttempts),
+	}, nil
+}
+
+func existingMockupManifestPath(artifactDir string) string {
+	path := filepath.Join(artifactDir, "mockups", "manifest.yaml")
+	info, err := os.Stat(path)
+	if err != nil || info.IsDir() || info.Size() == 0 {
+		return ""
+	}
+	return path
+}
+
+func resolveDesignArtifactPath(store ports.FeatureStore, featureID, artifactDir string) string {
+	if store != nil {
+		if f, err := store.Load(featureID); err == nil && f.Artifacts != nil {
+			if path := f.Artifacts[feature.DesignArtifactKey]; path != "" {
+				if filepath.IsAbs(path) {
+					if _, statErr := os.Stat(path); statErr == nil {
+						return path
+					}
+				}
+			}
+		}
+	}
+	canonical := filepath.Join(artifactDir, "design.md")
+	if info, err := os.Stat(canonical); err == nil && info.Mode().IsRegular() {
+		return canonical
+	}
+	var bestPath string
+	var bestModTime int64
+	matches, _ := filepath.Glob(filepath.Join(artifactDir, "*.md"))
+	for _, match := range matches {
+		if IsArtifactExcluded(filepath.Base(match)) {
+			continue
+		}
+		info, err := os.Stat(match)
+		if err != nil || info.IsDir() {
+			continue
+		}
+		if modified := info.ModTime().UnixNano(); bestPath == "" || modified > bestModTime {
+			bestPath = match
+			bestModTime = modified
+		}
+	}
+	return bestPath
+}
+
+func writeDesignAttemptFeedback(artifactDir string, attempt int, feedback string) error {
+	attemptDir := filepath.Join(artifactDir, fmt.Sprintf("attempt-%02d", attempt))
+	if err := os.WriteFile(filepath.Join(attemptDir, "validation-feedback.md"), []byte(feedback), 0o644); err != nil {
+		return err
+	}
+	return WritePlanAttemptMeta(artifactDir, PlanAttemptMeta{
+		Attempt:      attempt,
+		AgentStatus:  agentStatusSuccess,
+		ReviewStatus: agentStatusChangesRequested,
+	})
+}
+
+func setDesignIteration(cfg DesignLoopConfig, attempt int) {
+	if cfg.FeatureStore == nil {
+		return
+	}
+	_ = cfg.FeatureStore.Modify(cfg.Feature.ID, func(f *feature.Feature) error {
+		f.DesignIteration = attempt
+		return nil
+	})
+}
+
+func setValidatingDesign(cfg DesignLoopConfig, validating bool) {
+	if cfg.FeatureStore == nil {
+		return
+	}
+	_ = cfg.FeatureStore.Modify(cfg.Feature.ID, func(f *feature.Feature) error {
+		f.ValidatingDesign = validating
+		return nil
+	})
+}
+
+func recordDesignSessionCost(cfg DesignLoopConfig, sessionID string, cost SessionCost) {
+	if cfg.FeatureStore == nil || cost.TotalCostUSD <= 0 {
+		return
+	}
+	_ = cfg.FeatureStore.Modify(cfg.Feature.ID, func(f *feature.Feature) error {
+		f.RecordSessionCost(feature.SessionCostRecord{
+			SessionID:     sessionID,
+			PhaseKey:      feature.PhaseDesign.DirName(),
+			ObserverPhase: feature.PhaseDesign.String(),
+			RepoName:      cfg.RepoName,
+			CostUSD:       cost.TotalCostUSD,
+		})
+		return nil
+	})
+}
+
+func recordDesignArtifacts(cfg DesignLoopConfig, designPath, manifestPath string) error {
+	if cfg.FeatureStore == nil {
+		return nil
+	}
+	return cfg.FeatureStore.Modify(cfg.Feature.ID, func(f *feature.Feature) error {
+		if f.Artifacts == nil {
+			f.Artifacts = make(map[string]string)
+		}
+		f.Artifacts[feature.DesignArtifactKey] = designPath
+		if manifestPath != "" {
+			f.Artifacts[feature.DesignMockupsArtifactKey] = manifestPath
+		} else {
+			delete(f.Artifacts, feature.DesignMockupsArtifactKey)
+		}
+		return nil
+	})
+}

--- a/internal/agent/design_validation.go
+++ b/internal/agent/design_validation.go
@@ -104,6 +104,14 @@ func RunDesignValidationLoop(cfg DesignLoopConfig, sm ports.SessionManager) (res
 	if err := os.MkdirAll(artifactDir, 0o755); err != nil {
 		return nil, fmt.Errorf("creating Design artifact directory: %w", err)
 	}
+	decisionLedgerPath, err := WriteDesignDecisionLedger(
+		artifactDir,
+		cfg.Feature,
+		designDecisionSourcePaths(cfg.QAFilePaths, artifactDir),
+	)
+	if err != nil {
+		return nil, err
+	}
 
 	maxAttempts := cfg.MaxAttempts
 	if maxAttempts <= 0 {
@@ -162,13 +170,17 @@ designAttemptLoop:
 				cfg.SkillsDir,
 				cfg.GuidelinesDir,
 				cfg.ResearchArtifactPath,
+				decisionLedgerPath,
 				cfg.QAFilePaths,
 				cfg.KBInfos...,
 			)
 			if attempt > 1 {
 				prompt = BuildDesignRevisionPrompt(
+					cfg.Feature,
 					designPath,
 					manifestPath,
+					cfg.ResearchArtifactPath,
+					decisionLedgerPath,
 					criticFeedback,
 					attempt,
 				)
@@ -285,10 +297,23 @@ designAttemptLoop:
 				recordDesignSessionCost(cfg, sessionID, cost)
 
 				if agentStatus == agentStatusSuccess {
-					if attempt == 1 {
-						if _, err := WriteQAFile(sess.QALog(), artifactDir); err != nil {
+					qaLog := sess.QALog()
+					if len(qaLog) > 0 {
+						qaDir := attemptDir
+						if attempt == 1 {
+							qaDir = artifactDir
+						}
+						if _, err := WriteQAFile(qaLog, qaDir); err != nil {
 							return nil, fmt.Errorf("writing Design Q&A: %w", err)
 						}
+					}
+					decisionLedgerPath, err = WriteDesignDecisionLedger(
+						artifactDir,
+						cfg.Feature,
+						designDecisionSourcePaths(cfg.QAFilePaths, artifactDir),
+					)
+					if err != nil {
+						return nil, err
 					}
 					meta := PlanAttemptMeta{
 						Attempt:      attempt,
@@ -355,6 +380,9 @@ designAttemptLoop:
 		if designPath == "" {
 			return nil, fmt.Errorf("Design attempt %d produced no design markdown", attempt)
 		}
+		if _, err := archiveDesignAttempt(designPath, attemptDir); err != nil {
+			return nil, fmt.Errorf("archiving Design attempt %d: %w", attempt, err)
+		}
 		manifestPath := existingMockupManifestPath(artifactDir)
 		validators := designValidators(manifestPath)
 		setValidatingDesign(cfg, true)
@@ -366,7 +394,10 @@ designAttemptLoop:
 			designPath,
 			validators,
 			validationArtifactDesign,
-			planValidationExtras{MockupManifestPath: manifestPath},
+			planValidationExtras{
+				MockupManifestPath: manifestPath,
+				DecisionLedgerPath: decisionLedgerPath,
+			},
 		)
 		setValidatingDesign(cfg, false)
 
@@ -398,6 +429,33 @@ designAttemptLoop:
 				FinalStatus: "failed",
 				Iterations:  attempt,
 				LastError:   reviewErr.Error(),
+			}, nil
+		}
+
+		decisionIDs, err := readDesignDecisionIDs(decisionLedgerPath)
+		if err != nil {
+			return nil, err
+		}
+		disposition := designReviewDisposition(results, decisionIDs)
+		if disposition.RequiresHuman {
+			_ = os.WriteFile(filepath.Join(attemptDir, "validation-feedback.md"), []byte(feedback), 0o644)
+			verdicts := make(map[string]string, len(results))
+			for _, validatorResult := range results {
+				verdicts[strings.ToLower(validatorResult.Domain)] = validatorResult.Status.String()
+			}
+			_ = WritePlanAttemptMeta(artifactDir, PlanAttemptMeta{
+				Attempt:      attempt,
+				AgentStatus:  agentStatusSuccess,
+				ReviewStatus: "NEEDS_HUMAN_REVIEW",
+				AxisVerdicts: verdicts,
+			})
+			if err := recordDesignArtifacts(cfg, designPath, manifestPath); err != nil {
+				return nil, err
+			}
+			return &DesignLoopResult{
+				FinalStatus: "needs_human_review",
+				Iterations:  attempt,
+				LastError:   disposition.Reason,
 			}, nil
 		}
 

--- a/internal/agent/design_validation_test.go
+++ b/internal/agent/design_validation_test.go
@@ -115,9 +115,12 @@ Use the existing boundary.
 ## Out of Scope
 - Unrelated work.
 DESIGNEOF
+cat > %q <<'LEDGEREOF'
+# Poisoned agent-authored ledger
+LEDGEREOF
 %s
 %s
-`, testutil.JSONLInit, filepath.Join(designDir, "design.md"), testutil.TouchPhaseCompleteInLatestAttemptDir(designDir), testutil.JSONLSuccess))
+`, testutil.JSONLInit, filepath.Join(designDir, "design.md"), filepath.Join(designDir, designDecisionLedgerFile), testutil.TouchPhaseCompleteInLatestAttemptDir(designDir), testutil.JSONLSuccess))
 	criticScript := testutil.WriteScript(
 		t,
 		scriptsDir,
@@ -157,29 +160,379 @@ DESIGNEOF
 	if got := loaded.DesignMockupsArtifactPath(); got != "" {
 		t.Fatalf("DesignMockupsArtifactPath() = %q, want empty", got)
 	}
+	ledger, err := os.ReadFile(filepath.Join(designDir, designDecisionLedgerFile))
+	if err != nil {
+		t.Fatalf("read regenerated decision ledger: %v", err)
+	}
+	if strings.Contains(string(ledger), "Poisoned") || !strings.Contains(string(ledger), "### REQ-001") {
+		t.Fatalf("agent modification of harness-owned decision ledger survived regeneration:\n%s", ledger)
+	}
 }
 
-func TestBuildDesignRevisionPromptCarriesFeedbackWithoutStickyApprovals(t *testing.T) {
+func TestRunDesignValidationLoopEscalatesMaterialCriticFindingBeforeRevision(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping process-backed Design loop test in short mode")
+	}
+
+	tmpDir := t.TempDir()
+	workDir := filepath.Join(tmpDir, "work")
+	scriptsDir := filepath.Join(tmpDir, "scripts")
+	f := newTestDesignFeature(workDir)
+	designDir := filepath.Join(ActiveRunDir(tmpDir, f), feature.PhaseDesign.DirName())
+	for _, dir := range []string{workDir, scriptsDir, designDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("MkdirAll(%q): %v", dir, err)
+		}
+	}
+
+	designScript := testutil.WriteScript(t, scriptsDir, "design.sh", fmt.Sprintf(`%s
+cat > %q <<'DESIGNEOF'
+# Design
+
+## Problem and Outcomes
+Deliver the requested behavior.
+
+## Final Design
+Use the selected existing boundary.
+
+## Contracts
+- None
+
+## User Experience
+**Visual mockups:** not-required — no rendered surface changes.
+
+## Conditional Concerns
+- None beyond repository defaults
+
+## Testing Strategy
+- Verify observable behavior.
+
+## Implementation Latitude
+- Routine private details.
+
+## Out of Scope
+- Unrelated work.
+DESIGNEOF
+%s
+%s
+`, testutil.JSONLInit, filepath.Join(designDir, "design.md"), testutil.TouchPhaseCompleteInLatestAttemptDir(designDir), testutil.JSONLSuccess))
+	criticScript := testutil.WriteScript(
+		t,
+		scriptsDir,
+		"critic.sh",
+		testutil.JSONLInit+"\n"+
+			testutil.WriteAnyValidatorChangesRequested(
+				tmpDir,
+				"- **High**: [DECISION_CONFLICT] [REQ-001] Observable failure: satisfying the proposed replacement would contradict the selected delivery semantics.",
+			)+"\n"+
+			testutil.JSONLSuccess+"\n",
+	)
+	buildSession, captured := capturingBuildSession(designScript, criticScript)
+	store := feature.NewStore(tmpDir)
+	if err := store.Save(f); err != nil {
+		t.Fatalf("Save(feature): %v", err)
+	}
+	sm := session.NewManager(make(chan interface{}, 100))
+	defer sm.Shutdown()
+
+	result, err := RunDesignValidationLoop(DesignLoopConfig{PlanLoopConfig: PlanLoopConfig{
+		Feature:                    f,
+		FeatureStore:               store,
+		StateDir:                   tmpDir,
+		WorkDir:                    workDir,
+		MaxAttempts:                2,
+		DangerouslySkipPermissions: true,
+		BuildSession:               buildSession,
+	}}, sm)
+	if err != nil {
+		t.Fatalf("RunDesignValidationLoop() error = %v", err)
+	}
+	if result.FinalStatus != "needs_human_review" || result.Iterations != 1 {
+		t.Fatalf("RunDesignValidationLoop() = %+v, want needs_human_review after attempt 1", result)
+	}
+	if !strings.Contains(result.LastError, "DECISION_CONFLICT") {
+		t.Fatalf("LastError = %q, want DECISION_CONFLICT", result.LastError)
+	}
+	if len(*captured) != 2 {
+		t.Fatalf("BuildSession calls = %d, want one designer and one validator with no autonomous reviser", len(*captured))
+	}
+	if _, err := os.Stat(filepath.Join(designDir, "attempt-02")); !os.IsNotExist(err) {
+		t.Fatalf("attempt-02 should not exist after material escalation; stat error = %v", err)
+	}
+	history, err := os.ReadFile(filepath.Join(designDir, "attempt-01", "design.md"))
+	if err != nil {
+		t.Fatalf("read attempt-01 historical design: %v", err)
+	}
+	if !strings.Contains(string(history), "Use the selected existing boundary.") {
+		t.Fatalf("historical design snapshot does not contain attempt-01 content:\n%s", history)
+	}
+}
+
+func TestBuildDesignRevisionPromptCarriesAuthorityAndMaterialChangeGuard(t *testing.T) {
+	f := newTestDesignFeature("/work")
+	f.ExitCriteria = "No committed mutation is dropped."
 	prompt := BuildDesignRevisionPrompt(
+		f,
 		"/design/design.md",
 		"/design/mockups/manifest.yaml",
+		"/research/research.md",
+		"/design/decision-ledger.md",
 		"Clarify the error contract.",
 		3,
 	)
 	for _, want := range []string{
 		"revision attempt 3",
+		"Test Design Feature",
+		"Exercise the Design validation loop",
+		"No committed mutation is dropped.",
 		"/design/design.md",
 		"/design/mockups/manifest.yaml",
+		"/research/research.md",
+		"/design/decision-ledger.md",
 		"Clarify the error contract.",
+		"binding product behavior",
+		"AskUserQuestion",
+		"Human Direction",
 	} {
 		if !strings.Contains(prompt, want) {
 			t.Errorf("BuildDesignRevisionPrompt() missing %q:\n%s", want, prompt)
 		}
 	}
-	for _, unwanted := range []string{"Prior Axis Approvals", "Sticky Approval", "frozen_sections"} {
+	for _, unwanted := range []string{
+		"Prior Axis Approvals",
+		"Sticky Approval",
+		"frozen_sections",
+		"Resolve all ambiguity autonomously",
+		"Do NOT ask the user",
+	} {
 		if strings.Contains(prompt, unwanted) {
 			t.Errorf("BuildDesignRevisionPrompt() unexpectedly contains %q:\n%s", unwanted, prompt)
 		}
+	}
+}
+
+func TestDesignReviewDispositionAllowsOnlyClassifiedNonMaterialCorrections(t *testing.T) {
+	decisionIDs := map[string]struct{}{
+		"REQ-001": {},
+		"DEC-002": {},
+		"DEC-003": {},
+		"DEC-004": {},
+	}
+	tests := []struct {
+		name           string
+		findings       string
+		wantHuman      bool
+		wantReasonPart string
+	}{
+		{
+			name:      "contract defect can revise",
+			findings:  "- **High**: [CONTRACT_DEFECT] [DEC-003] Observable failure: the state table contradicts the selected watermark rule.",
+			wantHuman: false,
+		},
+		{
+			name:      "grounding error can revise",
+			findings:  "- **High**: [GROUNDING_ERROR] [REQ-001] Observable failure: the named API does not exist at the cited repository path.",
+			wantHuman: false,
+		},
+		{
+			name:           "decision conflict escalates",
+			findings:       "- **High**: [DECISION_CONFLICT] [DEC-004] Observable failure: the selected retention cannot satisfy the binding replay horizon.",
+			wantHuman:      true,
+			wantReasonPart: "DECISION_CONFLICT",
+		},
+		{
+			name:           "missing material decision escalates",
+			findings:       "- **High**: [MISSING_DECISION] [REQ-001] Observable failure: no owner is selected for a new persisted cross-service schema.",
+			wantHuman:      true,
+			wantReasonPart: "MISSING_DECISION",
+		},
+		{
+			name:           "unclassified finding cannot drive autonomous revision",
+			findings:       "- **High**: Add a dedicated outcome table and HMAC proof.",
+			wantHuman:      true,
+			wantReasonPart: "unclassified",
+		},
+		{
+			name:           "missing decision reference cannot drive autonomous revision",
+			findings:       "- **High**: [CONTRACT_DEFECT] Observable failure: the design is inconsistent.",
+			wantHuman:      true,
+			wantReasonPart: "REQ-### or DEC-###",
+		},
+		{
+			name:           "missing observable failure cannot drive autonomous revision",
+			findings:       "- **High**: [CONTRACT_DEFECT] [DEC-002] Prefer a different schema.",
+			wantHuman:      true,
+			wantReasonPart: "Observable failure",
+		},
+		{
+			name:           "unknown decision reference cannot drive autonomous revision",
+			findings:       "- **High**: [CONTRACT_DEFECT] [DEC-999] Observable failure: the design contradicts a decision that is not in the ledger.",
+			wantHuman:      true,
+			wantReasonPart: "not present",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			feedback := FormatStructuredReviewFeedback(
+				"Integrity Validation",
+				tt.findings,
+				"",
+				ReviewChangesRequested,
+			)
+			got := designReviewDisposition([]ValidatorResult{{
+				Domain:   "Integrity",
+				Status:   ReviewChangesRequested,
+				Feedback: feedback,
+			}}, decisionIDs)
+			if got.RequiresHuman != tt.wantHuman {
+				t.Fatalf("designReviewDisposition().RequiresHuman = %v, want %v (reason=%q)", got.RequiresHuman, tt.wantHuman, got.Reason)
+			}
+			if tt.wantReasonPart != "" && !strings.Contains(got.Reason, tt.wantReasonPart) {
+				t.Fatalf("designReviewDisposition().Reason = %q, want substring %q", got.Reason, tt.wantReasonPart)
+			}
+		})
+	}
+}
+
+func TestLinearizableCDCRegressionRoutesAttemptsToReopenHumanDecisionsToReview(t *testing.T) {
+	t.Parallel()
+
+	decisionIDs := map[string]struct{}{
+		"DEC-001": {},
+		"DEC-002": {},
+		"DEC-003": {},
+		"DEC-004": {},
+		"DEC-005": {},
+	}
+	cases := []struct {
+		name      string
+		reference string
+		failure   string
+	}{
+		{
+			name:      "replace watermark proof with applied receipts",
+			reference: "DEC-001",
+			failure:   "requiring exact APPLIED outcomes would replace the selected state-convergent delivery semantics",
+		},
+		{
+			name:      "reuse customer idempotency UUID as attempt identity",
+			reference: "DEC-002",
+			failure:   "reusing the customer idempotency UUID would contradict the selected per-proxy-invocation attempt identity",
+		},
+		{
+			name:      "move receipts to a dedicated outcome table",
+			reference: "DEC-003",
+			failure:   "moving rejection receipts out of the customer K/V table would replace the selected persistence placement",
+		},
+		{
+			name:      "look up receipt before the watermark",
+			reference: "DEC-004",
+			failure:   "consulting the rejection receipt first would reverse the selected watermark-first resolution order",
+		},
+		{
+			name:      "reinstate waived acceptance requirements",
+			reference: "DEC-005",
+			failure:   "requiring a composed E2E harness or performance gate would reinstate explicitly waived acceptance requirements",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			feedback := fmt.Sprintf(
+				"## Findings\n- **High**: [DECISION_CONFLICT] [%s] Observable failure: %s.\n\n## Suggestions\n- (none)\n\n## Verdict\nCHANGES_REQUESTED\n",
+				tc.reference,
+				tc.failure,
+			)
+			got := designReviewDisposition([]ValidatorResult{{
+				Domain:   "Integrity",
+				Status:   ReviewChangesRequested,
+				Feedback: feedback,
+			}}, decisionIDs)
+			if !got.RequiresHuman {
+				t.Fatalf("designReviewDisposition() = %+v, want human review before any CDC redesign", got)
+			}
+		})
+	}
+}
+
+func TestArchiveDesignAttemptKeepsHistoryWithoutReplacingCanonicalArtifact(t *testing.T) {
+	artifactDir := t.TempDir()
+	canonical := filepath.Join(artifactDir, "design.md")
+	attemptOne := filepath.Join(artifactDir, "attempt-01")
+	attemptTwo := filepath.Join(artifactDir, "attempt-02")
+	for _, dir := range []string{attemptOne, attemptTwo} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("MkdirAll(%q): %v", dir, err)
+		}
+	}
+	if err := os.WriteFile(canonical, []byte("version one\n"), 0o644); err != nil {
+		t.Fatalf("write canonical v1: %v", err)
+	}
+	if _, err := archiveDesignAttempt(canonical, attemptOne); err != nil {
+		t.Fatalf("archive attempt one: %v", err)
+	}
+	if err := os.WriteFile(canonical, []byte("version two\n"), 0o644); err != nil {
+		t.Fatalf("write canonical v2: %v", err)
+	}
+	if _, err := archiveDesignAttempt(canonical, attemptTwo); err != nil {
+		t.Fatalf("archive attempt two: %v", err)
+	}
+
+	for path, want := range map[string]string{
+		filepath.Join(attemptOne, "design.md"): "version one\n",
+		filepath.Join(attemptTwo, "design.md"): "version two\n",
+		canonical:                              "version two\n",
+	} {
+		got, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %q: %v", path, err)
+		}
+		if string(got) != want {
+			t.Fatalf("%s = %q, want %q", path, got, want)
+		}
+	}
+
+	if err := WritePlanAttemptMeta(artifactDir, PlanAttemptMeta{
+		Attempt:      2,
+		AgentStatus:  agentStatusSuccess,
+		ReviewStatus: "VALIDATION_PENDING",
+	}); err != nil {
+		t.Fatalf("WritePlanAttemptMeta(): %v", err)
+	}
+	outcome, violations, err := Validate(feature.PhaseDesign, RoleDesignReviser, attemptTwo)
+	if err != nil {
+		t.Fatalf("Validate() error = %v", err)
+	}
+	if !outcome.OK || len(violations) != 0 {
+		t.Fatalf("Validate() = (%+v, %v), want canonical artifact accepted while historical designs are ignored", outcome, violations)
+	}
+	if outcome.PhaseArtifactPath != canonical {
+		t.Fatalf("Validate() PhaseArtifactPath = %q, want canonical %q", outcome.PhaseArtifactPath, canonical)
+	}
+}
+
+func TestResolveDesignArtifactPathFallbackIgnoresLedgerAndAttemptHistory(t *testing.T) {
+	artifactDir := t.TempDir()
+	fallback := filepath.Join(artifactDir, "legacy-design.md")
+	if err := os.WriteFile(fallback, []byte("# Legacy Design\n"), 0o644); err != nil {
+		t.Fatalf("write fallback design: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(artifactDir, designDecisionLedgerFile), []byte("# Design Decision Ledger\n"), 0o644); err != nil {
+		t.Fatalf("write decision ledger: %v", err)
+	}
+	attemptDir := filepath.Join(artifactDir, "attempt-01")
+	if err := os.MkdirAll(attemptDir, 0o755); err != nil {
+		t.Fatalf("create attempt history: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(attemptDir, "design.md"), []byte("# Historical Design\n"), 0o644); err != nil {
+		t.Fatalf("write historical design: %v", err)
+	}
+
+	if got := resolveDesignArtifactPath(nil, "", artifactDir); got != fallback {
+		t.Fatalf("resolveDesignArtifactPath() = %q, want fallback %q; ledger and attempt history must be ignored", got, fallback)
 	}
 }
 

--- a/internal/agent/design_validation_test.go
+++ b/internal/agent/design_validation_test.go
@@ -1,0 +1,207 @@
+// Copyright 2026 DoorDash, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agent
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/doordash-oss/agentic-orchestrator/internal/config"
+	"github.com/doordash-oss/agentic-orchestrator/internal/feature"
+	"github.com/doordash-oss/agentic-orchestrator/internal/session"
+	"github.com/doordash-oss/agentic-orchestrator/test/testutil"
+)
+
+func TestDesignValidatorsVisualAxisIsConditional(t *testing.T) {
+	withoutMockups := designValidators("")
+	if len(withoutMockups) != 1 || withoutMockups[0].Template != "validate-design-integrity" {
+		t.Fatalf("designValidators(no manifest) = %+v, want integrity only", withoutMockups)
+	}
+
+	withMockups := designValidators("/design/mockups/manifest.yaml")
+	if len(withMockups) != 2 ||
+		withMockups[0].Template != "validate-design-integrity" ||
+		withMockups[1].Template != "validate-design-visual" {
+		t.Fatalf("designValidators(manifest) = %+v, want integrity + visual", withMockups)
+	}
+}
+
+func TestRunDesignValidationLoopResumesApprovedAttempt(t *testing.T) {
+	stateDir := t.TempDir()
+	f := newTestDesignFeature(filepath.Join(stateDir, "work"))
+	designDir := filepath.Join(ActiveRunDir(stateDir, f), feature.PhaseDesign.DirName())
+	if err := os.MkdirAll(designDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(design dir): %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(designDir, "design.md"), []byte("# Design\n"), 0o644); err != nil {
+		t.Fatalf("write design: %v", err)
+	}
+	if err := WritePlanAttemptMeta(designDir, PlanAttemptMeta{
+		Attempt:      2,
+		AgentStatus:  agentStatusSuccess,
+		ReviewStatus: agentStatusApproved,
+	}); err != nil {
+		t.Fatalf("WritePlanAttemptMeta(): %v", err)
+	}
+
+	result, err := RunDesignValidationLoop(DesignLoopConfig{PlanLoopConfig: PlanLoopConfig{
+		Feature:  f,
+		StateDir: stateDir,
+	}}, nil)
+	if err != nil {
+		t.Fatalf("RunDesignValidationLoop() error = %v", err)
+	}
+	if result.FinalStatus != "approved" || result.Iterations != 2 {
+		t.Fatalf("RunDesignValidationLoop() = %+v, want resumed approval at attempt 2", result)
+	}
+}
+
+func TestRunDesignValidationLoopApprovesIntegrityOnlyDesign(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping process-backed Design loop test in short mode")
+	}
+
+	tmpDir := t.TempDir()
+	workDir := filepath.Join(tmpDir, "work")
+	scriptsDir := filepath.Join(tmpDir, "scripts")
+	f := newTestDesignFeature(workDir)
+	designDir := filepath.Join(ActiveRunDir(tmpDir, f), feature.PhaseDesign.DirName())
+	for _, dir := range []string{workDir, scriptsDir, designDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("MkdirAll(%q): %v", dir, err)
+		}
+	}
+
+	designScript := testutil.WriteScript(t, scriptsDir, "design.sh", fmt.Sprintf(`%s
+cat > %q <<'DESIGNEOF'
+# Design
+
+## Problem and Outcomes
+Deliver the requested behavior.
+
+## Final Design
+Use the existing boundary.
+
+## Contracts
+- None
+
+## User Experience
+**Visual mockups:** not-required — no rendered surface changes.
+
+## Conditional Concerns
+- None beyond repository defaults
+
+## Testing Strategy
+- Verify observable behavior.
+
+## Implementation Latitude
+- Routine private details.
+
+## Out of Scope
+- Unrelated work.
+DESIGNEOF
+%s
+%s
+`, testutil.JSONLInit, filepath.Join(designDir, "design.md"), testutil.TouchPhaseCompleteInLatestAttemptDir(designDir), testutil.JSONLSuccess))
+	criticScript := testutil.WriteScript(
+		t,
+		scriptsDir,
+		"critic.sh",
+		testutil.JSONLInit+"\n"+testutil.WriteAnyValidatorApproved(tmpDir)+"\n"+testutil.JSONLSuccess+"\n",
+	)
+
+	store := feature.NewStore(tmpDir)
+	if err := store.Save(f); err != nil {
+		t.Fatalf("Save(feature): %v", err)
+	}
+	sm := session.NewManager(make(chan interface{}, 100))
+	defer sm.Shutdown()
+
+	result, err := RunDesignValidationLoop(DesignLoopConfig{PlanLoopConfig: PlanLoopConfig{
+		Feature:                    f,
+		FeatureStore:               store,
+		StateDir:                   tmpDir,
+		WorkDir:                    workDir,
+		MaxAttempts:                1,
+		DangerouslySkipPermissions: true,
+		BuildSession:               mockBuildSession(designScript, criticScript),
+	}}, sm)
+	if err != nil {
+		t.Fatalf("RunDesignValidationLoop() error = %v", err)
+	}
+	if result.FinalStatus != "approved" {
+		t.Fatalf("FinalStatus = %q, want approved (LastError=%q)", result.FinalStatus, result.LastError)
+	}
+	loaded, err := store.Load(f.ID)
+	if err != nil {
+		t.Fatalf("Load(feature): %v", err)
+	}
+	if got := loaded.DesignArtifactPath(); got != filepath.Join(designDir, "design.md") {
+		t.Fatalf("DesignArtifactPath() = %q, want canonical design path", got)
+	}
+	if got := loaded.DesignMockupsArtifactPath(); got != "" {
+		t.Fatalf("DesignMockupsArtifactPath() = %q, want empty", got)
+	}
+}
+
+func TestBuildDesignRevisionPromptCarriesFeedbackWithoutStickyApprovals(t *testing.T) {
+	prompt := BuildDesignRevisionPrompt(
+		"/design/design.md",
+		"/design/mockups/manifest.yaml",
+		"Clarify the error contract.",
+		3,
+	)
+	for _, want := range []string{
+		"revision attempt 3",
+		"/design/design.md",
+		"/design/mockups/manifest.yaml",
+		"Clarify the error contract.",
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Errorf("BuildDesignRevisionPrompt() missing %q:\n%s", want, prompt)
+		}
+	}
+	for _, unwanted := range []string{"Prior Axis Approvals", "Sticky Approval", "frozen_sections"} {
+		if strings.Contains(prompt, unwanted) {
+			t.Errorf("BuildDesignRevisionPrompt() unexpectedly contains %q:\n%s", unwanted, prompt)
+		}
+	}
+}
+
+func newTestDesignFeature(repoPath string) *feature.Feature {
+	return &feature.Feature{
+		ID:            "test-design-001",
+		Name:          "Test Design Feature",
+		Slug:          "test-design-feature",
+		Description:   "Exercise the Design validation loop",
+		Status:        feature.StatusDesigning,
+		CurrentPhase:  feature.PhaseDesign,
+		ActiveRun:     1,
+		RunCount:      1,
+		Pipeline:      feature.PipelineLarge,
+		SchemaVersion: feature.SchemaVersionCurrent,
+		Repos: []feature.FeatureRepo{{
+			Name: "test-repo",
+			Path: repoPath,
+		}},
+		Models: config.ModelConfig{
+			Planning: "planner",
+			Review:   "reviewer",
+		},
+	}
+}

--- a/internal/agent/final_review_helpers.go
+++ b/internal/agent/final_review_helpers.go
@@ -41,6 +41,7 @@ type FinalFixPromptOpts struct {
 	Publishable        bool
 	DesignArtifactPath string   // retained for caller compatibility; no longer re-injected
 	Images             []string // user-attached visual references, re-injected per iteration
+	VisualReferences   prompts.VisualReferencesInput
 }
 
 // BuildFinalFixPrompt constructs the prompt for the fix agent session.
@@ -49,11 +50,15 @@ type FinalFixPromptOpts struct {
 // The prose lives in internal/agent/prompts/templates/final_fix.user.tmpl
 // (with the manual-verification-outcomes partial branched on a flag).
 func BuildFinalFixPrompt(opts FinalFixPromptOpts) string {
-	return roles.BuildFinalFixPrompt(roles.FinalFixUserInput{
-		VisualReferences: prompts.VisualReferencesInput{
+	references := opts.VisualReferences
+	if len(references.Images) == 0 && len(references.Mockups) == 0 {
+		references = prompts.VisualReferencesInput{
 			Images: opts.Images,
 			Label:  "applying this fix",
-		},
+		}
+	}
+	return roles.BuildFinalFixPrompt(roles.FinalFixUserInput{
+		VisualReferences:                  references,
 		Iteration:                         opts.Iteration,
 		ExitCriteria:                      opts.ExitCriteria,
 		Feedback:                          opts.Feedback,

--- a/internal/agent/final_review_loop.go
+++ b/internal/agent/final_review_loop.go
@@ -620,7 +620,7 @@ func (s *featureFinalReviewLoopState) runFinalReviewAxis(iteration int, iterDir 
 		PriorImplementationEvidenceArtifacts: priorEvidence.EvidenceArtifactPaths,
 	})
 	if cfg.Feature != nil {
-		if block := visualReferencesSection(cfg.Feature.Images, "conducting this final review"); block != "" {
+		if block := visualReferencesSectionForFeature(cfg.Feature, cfg.Feature.DesignArtifactPath(), "conducting this final review"); block != "" {
 			prompt = block + prompt
 		}
 	}
@@ -720,6 +720,7 @@ func (s *featureFinalReviewLoopState) runFix(iteration int, iterDir, feedback st
 		Publishable:        cfg.Feature.IsPublishable(),
 		DesignArtifactPath: cfg.Feature.DesignArtifactPath(),
 		Images:             cfg.Feature.Images,
+		VisualReferences:   visualReferencesForFeature(cfg.Feature, cfg.Feature.DesignArtifactPath(), "applying this fix"),
 	})
 
 	_ = os.WriteFile(filepath.Join(iterDir, "fix-prompt.md"), []byte(prompt), 0o644)

--- a/internal/agent/grill_me_fanout_test.go
+++ b/internal/agent/grill_me_fanout_test.go
@@ -41,7 +41,7 @@ func TestBuildDesignPrompt_UsesGrillMeDirective(t *testing.T) {
 				},
 				Inquireness: level,
 			}
-			prompt := BuildDesignPrompt(f, "", "", "/tmp/research.md", nil)
+			prompt := BuildDesignPrompt(f, "", "", "/tmp/research.md", "", nil)
 
 			if first == "" {
 				first = prompt

--- a/internal/agent/implement.go
+++ b/internal/agent/implement.go
@@ -385,7 +385,7 @@ func RunImplementationLoop(cfg ImplementConfig, sm ports.SessionManager) (result
 			// iteration. They communicate intent that text-only phase
 			// plans can't carry; without this they die at Design.
 			if cfg.Feature != nil {
-				if block := visualReferencesSection(cfg.Feature.Images, "implementing this iteration"); block != "" {
+				if block := visualReferencesSectionForFeature(cfg.Feature, cfg.Feature.DesignArtifactPath(), "implementing this iteration"); block != "" {
 					prompt = block + prompt
 				}
 			}

--- a/internal/agent/implementation_review.go
+++ b/internal/agent/implementation_review.go
@@ -268,7 +268,7 @@ func runImplementationReviewAxis(cfg ImplementConfig, sm ports.SessionManager, i
 		FeedbackPath:           feedbackPath,
 	})
 	if cfg.Feature != nil {
-		if block := visualReferencesSection(cfg.Feature.Images, "reviewing this iteration"); block != "" {
+		if block := visualReferencesSectionForFeature(cfg.Feature, cfg.Feature.DesignArtifactPath(), "reviewing this iteration"); block != "" {
 			reviewPrompt = block + reviewPrompt
 		}
 	}

--- a/internal/agent/phase.go
+++ b/internal/agent/phase.go
@@ -412,6 +412,64 @@ func (pr *PhaseRunner) RunDesign(f *feature.Feature, researchOutput string, qaFi
 	})
 }
 
+// RunDesignWithValidation starts the iterative Design author/critic loop.
+func (pr *PhaseRunner) RunDesignWithValidation(f *feature.Feature, researchOutput string, qaFilePaths []string, kbInfos ...KBInfo) (chan *DesignLoopResult, error) {
+	workDir, additionalDirs := resolveUnifiedWorkDir(f, pr.StateDir)
+	var repoName string
+	if len(f.Repos) > 0 {
+		repoName = f.Repos[0].Name
+	}
+
+	designModel := pr.modelForRole(f.Models.Planning, llm.PhasePlanning)
+	designEffort, designEffortSource := pr.resolveEffortForRole(f, llm.PhasePlanning, designModel)
+	reviewModel := pr.modelForRole(f.Models.Review, llm.PhaseReview)
+	validatorEffort, validatorEffortSource := pr.resolveEffortForRole(f, llm.PhaseReview, reviewModel)
+
+	maxAttempts := f.MaxDesignIterations
+	if maxAttempts <= 0 && pr.Config != nil {
+		maxAttempts = pr.Config.Defaults.MaxDesignIterations
+	}
+	if maxAttempts <= 0 {
+		maxAttempts = DefaultMaxDesignAttempts
+	}
+	cfg := DesignLoopConfig{PlanLoopConfig: PlanLoopConfig{
+		Feature:                    f,
+		FeatureStore:               pr.FeatureStore,
+		StateDir:                   pr.StateDir,
+		ResearchArtifactPath:       researchOutput,
+		QAFilePaths:                qaFilePaths,
+		KBInfos:                    kbInfos,
+		WorkDir:                    workDir,
+		AdditionalDirs:             additionalDirs,
+		MaxAttempts:                maxAttempts,
+		DangerouslySkipPermissions: pr.DangerouslySkipPermissions,
+		PermissionCache:            pr.PermissionCache,
+		RepoName:                   repoName,
+		BuildSession:               pr.buildSessionForFeature(f),
+		AskingClause:               pr.askingQuestionsClauseForModel(designModel),
+		EffortLevel:                f.EffectivePipeline().EffortLevel(),
+		EffectiveEffort:            designEffort,
+		EffortSource:               designEffortSource,
+		ValidatorEffectiveEffort:   validatorEffort,
+		ValidatorEffortSource:      validatorEffortSource,
+		SkillsDir:                  pr.SkillsDir,
+		GuidelinesDir:              pr.GuidelinesDir,
+		FinishOrViolateNudge:       pr.finishOrViolateNudgeForModel(designModel),
+		Observer:                   pr.Observer,
+	}}
+
+	resultCh := make(chan *DesignLoopResult, 1)
+	go func() {
+		result, err := RunDesignValidationLoop(cfg, pr.SessionManager)
+		if err != nil {
+			resultCh <- &DesignLoopResult{FinalStatus: "failed", LastError: err.Error()}
+			return
+		}
+		resultCh <- result
+	}()
+	return resultCh, nil
+}
+
 // RunCodebaseIndex builds structural codebase indexes for all repos in a feature.
 // This is pure Go (no LLM) and runs quickly. It checks freshness first and
 // skips repos whose indexes are already up-to-date with HEAD.

--- a/internal/agent/phase.go
+++ b/internal/agent/phase.go
@@ -397,8 +397,24 @@ func explorationAgentNames() []string {
 // subdirectory remains "design" so legacy run state stays readable in
 // place; the session identity, skill, and prompt template are Design-facing.
 func (pr *PhaseRunner) RunDesign(f *feature.Feature, researchOutput string, qaFilePaths []string, kbInfos ...KBInfo) (string, error) {
+	artifactDir := filepath.Join(
+		ActiveRunDir(pr.StateDir, f),
+		f.RefactorPrefix(),
+		feature.PhaseDesign.DirName(),
+	)
+	if err := os.MkdirAll(artifactDir, 0o755); err != nil {
+		return "", fmt.Errorf("creating Design artifact directory: %w", err)
+	}
+	decisionLedgerPath, err := WriteDesignDecisionLedger(
+		artifactDir,
+		f,
+		designDecisionSourcePaths(qaFilePaths, artifactDir),
+	)
+	if err != nil {
+		return "", err
+	}
 	return pr.runInteractivePhase(f, interactivePhaseConfig{
-		Prompt:          BuildDesignPrompt(f, pr.SkillsDir, pr.GuidelinesDir, researchOutput, qaFilePaths, kbInfos...),
+		Prompt:          BuildDesignPrompt(f, pr.SkillsDir, pr.GuidelinesDir, researchOutput, decisionLedgerPath, qaFilePaths, kbInfos...),
 		Spec:            DesignerRoleSpec(),
 		DirName:         feature.PhaseDesign.DirName(),
 		SkillName:       "design",

--- a/internal/agent/plan_validation.go
+++ b/internal/agent/plan_validation.go
@@ -685,6 +685,7 @@ func runSpecializedPlanValidation(cfg PlanLoopConfig, sm ports.SessionManager, a
 type planValidationExtras struct {
 	PriorPhasePlanPaths []string
 	MockupManifestPath  string
+	DecisionLedgerPath  string
 }
 
 func runSpecializedPlanValidationForArtifact(cfg PlanLoopConfig, sm ports.SessionManager, attempt int, attemptDir, planArtifactPath string, domain validatorDomain, kind validationArtifactKind, extras planValidationExtras, parentCtx observe.SpanContext) (ReviewStatus, string, ValidatorMarkers, error) {
@@ -1187,6 +1188,7 @@ func buildSpecializedValidationPromptForArtifact(f *feature.Feature, planPath, r
 		IsDesignKind:              kind == validationArtifactDesign,
 		ResearchPath:              researchPath,
 		MockupManifestPath:        extras.MockupManifestPath,
+		DecisionLedgerPath:        extras.DecisionLedgerPath,
 		FeedbackPath:              feedbackPath,
 		AxisLabel:                 strings.ToLower(domain.Name),
 		AutomatedVerificationOnly: kind == validationArtifactPhasePlan && !f.EffectivePipeline().ShouldContractAgentEvidence(),
@@ -2497,7 +2499,7 @@ func IsArtifactExcluded(name string) bool {
 		return true
 	case strings.HasSuffix(lower, "-prompt.md"):
 		return true
-	case lower == "qa-answers.md" || lower == ProtocolRetrySidecarFile:
+	case lower == "qa-answers.md" || lower == designDecisionLedgerFile || lower == ProtocolRetrySidecarFile:
 		return true
 	case strings.HasPrefix(lower, ".protocol-retry-") && strings.HasSuffix(lower, ".yaml"):
 		return true

--- a/internal/agent/plan_validation.go
+++ b/internal/agent/plan_validation.go
@@ -407,6 +407,9 @@ func frozenSectionsDigest(planPath string, frozen []string) string {
 	any := false
 	for _, heading := range frozen {
 		section := extractPlanSection(planPath, heading)
+		if len(section) == 0 && !strings.HasPrefix(strings.TrimSpace(heading), "#") {
+			section = extractPlanSection(planPath, "## "+strings.TrimSpace(heading))
+		}
 		h.Write([]byte(heading))
 		h.Write([]byte{0})
 		h.Write(section)
@@ -619,6 +622,7 @@ type validationArtifactKind string
 const (
 	validationArtifactRoadmap   validationArtifactKind = "roadmap"
 	validationArtifactPhasePlan validationArtifactKind = "phase-plan"
+	validationArtifactDesign    validationArtifactKind = "design"
 )
 
 // phasePlanValidatorsForRisk returns the axis validator set for per-phase
@@ -680,6 +684,7 @@ func runSpecializedPlanValidation(cfg PlanLoopConfig, sm ports.SessionManager, a
 // worktree.
 type planValidationExtras struct {
 	PriorPhasePlanPaths []string
+	MockupManifestPath  string
 }
 
 func runSpecializedPlanValidationForArtifact(cfg PlanLoopConfig, sm ports.SessionManager, attempt int, attemptDir, planArtifactPath string, domain validatorDomain, kind validationArtifactKind, extras planValidationExtras, parentCtx observe.SpanContext) (ReviewStatus, string, ValidatorMarkers, error) {
@@ -707,7 +712,7 @@ func runSpecializedPlanValidationForArtifact(cfg PlanLoopConfig, sm ports.Sessio
 	parentFeedbackPath := filepath.Join(attemptDir, fmt.Sprintf("validation-%s-feedback.md", domainLower))
 
 	validationPrompt := buildSpecializedValidationPromptForArtifact(cfg.Feature, planArtifactPath, cfg.ResearchArtifactPath, cfg.SkillsDir, feedbackPath, domain, kind, extras)
-	validatorSpec, ok := PlanValidatorRoleForSkill(domain.Template)
+	validatorSpec, ok := validatorRoleForArtifact(kind, domain.Template)
 	if !ok {
 		return ReviewFailed, "", ValidatorMarkers{}, fmt.Errorf("missing validator RoleSpec for skill %q", domain.Template)
 	}
@@ -719,7 +724,7 @@ func runSpecializedPlanValidationForArtifact(cfg PlanLoopConfig, sm ports.Sessio
 	if len(addDirs) == 0 {
 		addDirs = []string{ActiveRunDir(cfg.StateDir, cfg.Feature)}
 	}
-	reviewID := fmt.Sprintf("%s-planreview-%s-%02d", cfg.Feature.ID, domainLower, attempt)
+	reviewID := fmt.Sprintf("%s-%sreview-%s-%02d", cfg.Feature.ID, validationPhaseName(kind), domainLower, attempt)
 	helper := &PhaseRunner{
 		SessionManager: sm,
 		FeatureStore:   cfg.FeatureStore,
@@ -740,7 +745,7 @@ func runSpecializedPlanValidationForArtifact(cfg PlanLoopConfig, sm ports.Sessio
 		helperResult, err = helper.RunReadOnlyReviewHelper(context.Background(), ReviewHelperConfig{
 			SessionID:              retrySessionID(reviewID, sessionAttempt),
 			FeatureID:              cfg.Feature.ID,
-			Phase:                  feature.PhasePlan,
+			Phase:                  validationPhase(kind),
 			ParentSpanCtx:          parentCtx,
 			Model:                  validatorModel,
 			Prompt:                 validationPrompt,
@@ -788,7 +793,7 @@ func runSpecializedPlanValidationForArtifact(cfg PlanLoopConfig, sm ports.Sessio
 		if strings.TrimSpace(feedback) != "" {
 			_ = os.WriteFile(parentFeedbackPath, []byte(feedback), 0o644)
 		}
-		if markers.AxisApproved != "" {
+		if kind != validationArtifactDesign && markers.AxisApproved != "" {
 			writeAxisApprovalArtifact(attemptDir, attempt, markers, planArtifactPath)
 		}
 		return ReviewFailed, feedback, markers, fmt.Errorf("running %s validation session: %w", domain.Name, err)
@@ -812,11 +817,29 @@ func runSpecializedPlanValidationForArtifact(cfg PlanLoopConfig, sm ports.Sessio
 	// contract). Persisting that anyway would leave a stale approval for
 	// an axis that is actively rejecting — forcing the reviser to treat
 	// sections it needs to edit as no-touch — so we require IsApproved() here.
-	if status.IsApproved() && markers.AxisApproved != "" {
+	if kind != validationArtifactDesign && status.IsApproved() && markers.AxisApproved != "" {
 		writeAxisApprovalArtifact(attemptDir, attempt, markers, planArtifactPath)
 	}
 
 	return status, feedback, markers, nil
+}
+
+func validatorRoleForArtifact(kind validationArtifactKind, skillName string) (RoleSpec, bool) {
+	if kind == validationArtifactDesign {
+		return DesignValidatorRoleForSkill(skillName)
+	}
+	return PlanValidatorRoleForSkill(skillName)
+}
+
+func validationPhase(kind validationArtifactKind) feature.Phase {
+	if kind == validationArtifactDesign {
+		return feature.PhaseDesign
+	}
+	return feature.PhasePlan
+}
+
+func validationPhaseName(kind validationArtifactKind) string {
+	return validationPhase(kind).DirName()
 }
 
 // runGroundingPreCheck runs the deterministic Grounding-table check before the
@@ -917,7 +940,10 @@ func groundingRootsForFeature(f *feature.Feature) []GroundingRoot {
 var axisFrozenHeading = map[string]string{
 	"structural": "## Tasks",
 	"scope":      "## Tasks",
+	"integrity":  wholeArtifactDigestHeading,
 }
+
+const wholeArtifactDigestHeading = "<whole-artifact>"
 
 // axisStallLimit is the number of consecutive identical-section failures on
 // the same axis that cause the phase-planning loop to escalate to
@@ -1058,6 +1084,14 @@ func loadAxisStallState(artifactDir string) axisStallState {
 // the Markdown section whose heading exactly matches the given string.
 // Returns "" when the file cannot be read or the section is absent.
 func planSectionDigest(planPath, heading string) string {
+	if heading == wholeArtifactDigestHeading {
+		data, err := os.ReadFile(planPath)
+		if err != nil || len(data) == 0 {
+			return ""
+		}
+		sum := sha256.Sum256(data)
+		return hex.EncodeToString(sum[:])
+	}
 	section := extractPlanSection(planPath, heading)
 	if len(section) == 0 {
 		return ""
@@ -1114,7 +1148,8 @@ func writeAxisApprovalArtifact(attemptDir string, attempt int, markers Validator
 	var b strings.Builder
 	fmt.Fprintf(&b, "# AxisApproved: %s\n", markers.AxisApproved)
 	fmt.Fprintf(&b, "Attempt: %d\n", attempt)
-	if digest := frozenSectionsDigest(planPath, markers.FrozenSections); digest != "" {
+	digest := frozenSectionsDigest(planPath, markers.FrozenSections)
+	if digest != "" {
 		fmt.Fprintf(&b, "Approved-Digest: %s\n", digest)
 	}
 	b.WriteString("\n## Frozen Sections\n")
@@ -1149,10 +1184,12 @@ func buildSpecializedValidationPromptForArtifact(f *feature.Feature, planPath, r
 		IncludePriorPhaseContext:  includePriorPhase,
 		PriorPhasePlanPaths:       append([]string(nil), extras.PriorPhasePlanPaths...),
 		IsRoadmapKind:             kind == validationArtifactRoadmap,
+		IsDesignKind:              kind == validationArtifactDesign,
 		ResearchPath:              researchPath,
+		MockupManifestPath:        extras.MockupManifestPath,
 		FeedbackPath:              feedbackPath,
 		AxisLabel:                 strings.ToLower(domain.Name),
-		AutomatedVerificationOnly: kind != validationArtifactRoadmap && !f.EffectivePipeline().ShouldContractAgentEvidence(),
+		AutomatedVerificationOnly: kind == validationArtifactPhasePlan && !f.EffectivePipeline().ShouldContractAgentEvidence(),
 	})
 }
 
@@ -1204,26 +1241,30 @@ func runValidatorSet(cfg PlanLoopConfig, sm ports.SessionManager, attempt int, a
 	// Validation span — child of phase span
 	validationCtx := cfg.PhaseSpanCtx.Child()
 	validationStart := time.Now()
-	cfg.Observer.ValidationStarted(validationCtx, "plan", len(validators))
+	phaseName := validationPhaseName(kind)
+	cfg.Observer.ValidationStarted(validationCtx, phaseName, len(validators))
 
 	results := make([]ValidatorResult, len(validators))
 
 	// Initialize validator statuses for TUI display
 	setValidatorStatuses(cfg, validators, nil)
 
-	// Sticky-approval short-circuit: for each validator whose axis already
-	// approved on a prior attempt, compare the stored frozen-section digest
+	// Plan-only sticky-approval short-circuit: for each validator whose axis
+	// already approved on a prior attempt, compare the stored frozen-section digest
 	// against the current plan. When they match, the reviser cannot have
 	// changed anything this axis would re-reject, so re-launching the
 	// validator only exposes the approval to nondeterminism. Skip it and
 	// synthesize an APPROVED result. A missing digest (artifacts written by
 	// older binaries, or an empty FrozenSections list) returns "" from
 	// frozenSectionsDigest and disables short-circuiting for that axis —
-	// strictly safer.
+	// strictly safer. Design critics always re-run against the complete revised
+	// design and optional mockup bundle.
 	priorApprovals := make(map[string]AxisApproval, len(validators))
-	if parent := filepath.Dir(attemptDir); parent != "" && parent != "." {
-		for _, a := range LoadPriorAxisApprovals(parent) {
-			priorApprovals[strings.ToLower(a.Axis)] = a
+	if kind != validationArtifactDesign {
+		if parent := filepath.Dir(attemptDir); parent != "" && parent != "." {
+			for _, a := range LoadPriorAxisApprovals(parent) {
+				priorApprovals[strings.ToLower(a.Axis)] = a
+			}
 		}
 	}
 
@@ -1292,7 +1333,7 @@ func runValidatorSet(cfg PlanLoopConfig, sm ports.SessionManager, attempt int, a
 	clearValidatorStatuses(cfg)
 
 	if isFeatureInterrupted(cfg.FeatureStore, cfg.Feature.ID) {
-		cfg.Observer.ValidationCompleted(validationCtx, "plan", "interrupted", time.Since(validationStart), len(validators))
+		cfg.Observer.ValidationCompleted(validationCtx, phaseName, "interrupted", time.Since(validationStart), len(validators))
 		return results, ReviewFailed, "", fmt.Errorf("feature interrupted during multi-validator validation")
 	}
 
@@ -1308,7 +1349,7 @@ func runValidatorSet(cfg PlanLoopConfig, sm ports.SessionManager, attempt int, a
 	if aggErr != nil {
 		aggVerdict = "error"
 	}
-	cfg.Observer.ValidationCompleted(validationCtx, "plan", aggVerdict, time.Since(validationStart), len(validators))
+	cfg.Observer.ValidationCompleted(validationCtx, phaseName, aggVerdict, time.Since(validationStart), len(validators))
 
 	return results, aggStatus, aggFeedback, aggErr
 }

--- a/internal/agent/plan_validation_test.go
+++ b/internal/agent/plan_validation_test.go
@@ -1443,6 +1443,7 @@ func TestIsArtifactExcluded(t *testing.T) {
 		{"plan.md", false},
 		{"research.md", false},
 		{"qa-answers.md", true},
+		{"decision-ledger.md", true},
 		{".protocol-retry.yaml", true},
 		{".protocol-retry-feat-abc123.yaml", true},
 		{"protocol-retry.yaml", false},
@@ -3095,6 +3096,37 @@ func TestBuildSpecializedValidationPrompt_NonGroundingOmitsPriorPhaseContext(t *
 				t.Errorf("%s prompt should NOT contain prior-phase path %q:\n%s", template, priorPath, prompt)
 			}
 		})
+	}
+}
+
+func TestBuildSpecializedDesignValidationPromptIncludesAuthoritativeDecisionLedger(t *testing.T) {
+	f := &feature.Feature{
+		Name:          "Decision-preserving design",
+		Description:   "Keep human decisions authoritative.",
+		SchemaVersion: feature.SchemaVersionCurrent,
+	}
+	domain := validatorDomain{Name: "Integrity", Template: "validate-design-integrity"}
+	extras := planValidationExtras{DecisionLedgerPath: "/design/decision-ledger.md"}
+
+	prompt := buildSpecializedValidationPromptForArtifact(
+		f,
+		"/design/design.md",
+		"/research/research.md",
+		"",
+		"",
+		domain,
+		validationArtifactDesign,
+		extras,
+	)
+
+	for _, want := range []string{
+		"## Authoritative Decision Ledger",
+		"/design/decision-ledger.md",
+		"binding source of product and architectural decisions",
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Errorf("specialized Design validation prompt missing %q:\n%s", want, prompt)
+		}
 	}
 }
 

--- a/internal/agent/prompts/helpers.go
+++ b/internal/agent/prompts/helpers.go
@@ -54,10 +54,10 @@ func AutoReviewUserPrompt(in AutoReviewUserInput) string {
 }
 
 // VisualReferences renders the visual_references partial. Returns "" when
-// Images is empty so callers can drop the result into a prompt
-// unconditionally.
+// both Images and Mockups are empty so callers can drop the result into a
+// prompt unconditionally.
 func VisualReferences(in VisualReferencesInput) string {
-	if len(in.Images) == 0 {
+	if len(in.Images) == 0 && len(in.Mockups) == 0 {
 		return ""
 	}
 	if in.Label == "" {
@@ -108,6 +108,12 @@ func KBBuildUserPrompt(in any) string {
 // (design.user.tmpl).
 func DesignUserPrompt(in any) string {
 	return MustRender("design.user", in)
+}
+
+// DesignRevisionUserPrompt renders the Design revision user prompt
+// (design_revision.user.tmpl).
+func DesignRevisionUserPrompt(in any) string {
+	return MustRender("design_revision.user", in)
 }
 
 // RefactorPlanUserPrompt renders the refactor-plan step user prompt

--- a/internal/agent/prompts/partials/visual_references.tmpl
+++ b/internal/agent/prompts/partials/visual_references.tmpl
@@ -1,18 +1,23 @@
 {{- /*
-  visual_references: re-injects user-attached images (mockups, design
-  comps, annotated whiteboards, bug repros) so phases downstream of
-  Design don't lose visual specification. Tag-gated per phase by the
-  caller (no-op when Images is empty).
+  visual_references: re-injects user-attached images and approved generated
+  mockups so phases downstream of Design don't lose visual specification.
+  Tag-gated per phase by the caller (no-op when both collections are empty).
 
   Label is a short phase-specific noun woven into the imperative so each
   phase's prompt reads naturally — "implementing", "reviewing",
   "planning". Defaults to "working on this feature".
 */ -}}
 {{- define "visual_references" -}}
-{{ if .Images }}## Visual References
+{{ if or .Images .Mockups }}## Visual References
 
-IMPORTANT: The user attached the image(s) below when creating this feature. They communicate intent that text alone cannot — mockups, desired-state screenshots, annotated whiteboards, bug repros, or reference designs. Before {{ .Label }}, Read each image via tool-use and treat its visual information as a binding specification for what the output should look like. If an image shows a specific layout, palette, typography, or interaction, match it; do not substitute generic defaults.
-
+{{ if .Mockups }}IMPORTANT: These references communicate approved intent that text alone cannot. Before {{ .Label }}, read every applicable reference via tool-use and treat its visual information as a binding specification. If a reference shows a specific layout, palette, typography, content, or interaction, match it; do not substitute generic defaults.
+{{ else }}IMPORTANT: The user attached the image(s) below when creating this feature. They communicate intent that text alone cannot — mockups, desired-state screenshots, annotated whiteboards, bug repros, or reference designs. Before {{ .Label }}, Read each image via tool-use and treat its visual information as a binding specification for what the output should look like. If an image shows a specific layout, palette, typography, or interaction, match it; do not substitute generic defaults.
+{{ end }}
 {{ range $i, $p := .Images }}- [Image #{{ inc $i }}]: {{ $p }}
+{{ end }}{{ if .Mockups }}Approved generated mockups:
+{{ range .Mockups }}- [{{ .ID }}]
+  - HTML: {{ .HTMLPath }}
+  - PNG: {{ .PNGPath }}
+{{ end }}Read both representations: inspect the PNG for pixel-level appearance and the self-contained HTML for structure and interaction details.
 {{ end }}
 {{ end }}{{- end -}}

--- a/internal/agent/prompts/prompt_branch_iteration_test.go
+++ b/internal/agent/prompts/prompt_branch_iteration_test.go
@@ -274,6 +274,7 @@ func TestValidateSpecializedPromptBranches(t *testing.T) {
 func TestGoldenSnapshotsNoOrphanFiles(t *testing.T) {
 	retained := map[string]bool{
 		"autoreview_user":                                      true,
+		"design_revision_user":                                 true,
 		"design_system_rolespec":                               true,
 		"design_user_multi_repo":                               true,
 		"final_fix_user_with_manual":                           true,
@@ -294,6 +295,8 @@ func TestGoldenSnapshotsNoOrphanFiles(t *testing.T) {
 		"roadmap_user_multi_repo":                              true,
 		"scout_user":                                           true,
 		"summary_user":                                         true,
+		"validate_design_integrity_user":                       true,
+		"validate_design_visual_user":                          true,
 		"validate_specialized_grounding":                       true,
 		"validate_specialized_automated_verification_only":     true,
 	}

--- a/internal/agent/prompts/prompts_test.go
+++ b/internal/agent/prompts/prompts_test.go
@@ -122,17 +122,22 @@ type DesignUserInput struct {
 
 	MultiRepo            bool
 	ResearchArtifactPath string
+	DecisionLedgerPath   string
 
 	QAFiles     QAFilesInput
 	Inquireness GrillMeInquirenessInput
 }
 
 type DesignRevisionUserInput struct {
+	Name               string
+	Description        string
+	ExitCriteria       string
 	Attempt            int
 	CriticFeedback     string
 	PreviousDesignPath string
 	MockupManifestPath string
-	Inquireness        AutonomousInquirenessInput
+	ResearchPath       string
+	DecisionLedgerPath string
 }
 
 type RefactorPlanUserInput struct {
@@ -286,6 +291,7 @@ type ValidateSpecializedUserInput struct {
 
 	ResearchPath       string
 	MockupManifestPath string
+	DecisionLedgerPath string
 
 	FeedbackPath string
 	AxisLabel    string
@@ -375,6 +381,7 @@ func TestGoldenSnapshots(t *testing.T) {
 					},
 					MultiRepo:            true,
 					ResearchArtifactPath: "/state/feat-x/run-1/research/research.md",
+					DecisionLedgerPath:   "/state/feat-x/run-1/design/decision-ledger.md",
 					QAFiles: QAFilesInput{
 						Paths: []string{"/state/feat-x/run-1/inquire/qa.md"},
 						Lead:  "Read these Q&A files for important context about their intent and preferences:",
@@ -388,11 +395,15 @@ func TestGoldenSnapshots(t *testing.T) {
 			name: "design_revision_user",
 			render: func() string {
 				return DesignRevisionUserPrompt(DesignRevisionUserInput{
+					Name:               "OAuth login",
+					Description:        "Sign in with Google.",
+					ExitCriteria:       "PKCE succeeds and errors are actionable.",
 					Attempt:            2,
 					CriticFeedback:     "Clarify callback errors and refresh the mobile error state.",
 					PreviousDesignPath: "/state/feat-x/run-1/design/design.md",
 					MockupManifestPath: "/state/feat-x/run-1/design/mockups/manifest.yaml",
-					Inquireness:        AutonomousInquirenessInput{},
+					ResearchPath:       "/state/feat-x/run-1/research/research.md",
+					DecisionLedgerPath: "/state/feat-x/run-1/design/decision-ledger.md",
 				})
 			},
 		},
@@ -400,13 +411,14 @@ func TestGoldenSnapshots(t *testing.T) {
 			name: "validate_design_integrity_user",
 			render: func() string {
 				return ValidateSpecializedUserPrompt(ValidateSpecializedUserInput{
-					Name:         "OAuth login",
-					Description:  "Sign in with Google.",
-					ExitCriteria: "PKCE succeeds and errors are actionable.",
-					DomainName:   "Integrity",
-					PlanPath:     "/state/feat-x/run-1/design/design.md",
-					IsDesignKind: true,
-					ResearchPath: "/state/feat-x/run-1/research/research.md",
+					Name:               "OAuth login",
+					Description:        "Sign in with Google.",
+					ExitCriteria:       "PKCE succeeds and errors are actionable.",
+					DomainName:         "Integrity",
+					PlanPath:           "/state/feat-x/run-1/design/design.md",
+					IsDesignKind:       true,
+					ResearchPath:       "/state/feat-x/run-1/research/research.md",
+					DecisionLedgerPath: "/state/feat-x/run-1/design/decision-ledger.md",
 				})
 			},
 		},
@@ -420,6 +432,7 @@ func TestGoldenSnapshots(t *testing.T) {
 					PlanPath:           "/state/feat-x/run-1/design/design.md",
 					IsDesignKind:       true,
 					MockupManifestPath: "/state/feat-x/run-1/design/mockups/manifest.yaml",
+					DecisionLedgerPath: "/state/feat-x/run-1/design/decision-ledger.md",
 				})
 			},
 		},

--- a/internal/agent/prompts/prompts_test.go
+++ b/internal/agent/prompts/prompts_test.go
@@ -127,6 +127,14 @@ type DesignUserInput struct {
 	Inquireness GrillMeInquirenessInput
 }
 
+type DesignRevisionUserInput struct {
+	Attempt            int
+	CriticFeedback     string
+	PreviousDesignPath string
+	MockupManifestPath string
+	Inquireness        AutonomousInquirenessInput
+}
+
 type RefactorPlanUserInput struct {
 	Request        string
 	FeatureContext string
@@ -150,8 +158,9 @@ type RoadmapUserInput struct {
 }
 
 type RoadmapRevisionUserInput struct {
-	Attempt        int
-	CriticFeedback string
+	Attempt          int
+	VisualReferences VisualReferencesInput
+	CriticFeedback   string
 
 	PriorAxisApprovals  PriorAxisApprovalsInput
 	PreviousRoadmapPath string
@@ -174,7 +183,8 @@ type PhasePlanUserInput struct {
 	RoadmapPath          string
 	ResearchArtifactPath string
 
-	QAFiles QAFilesInput
+	VisualReferences VisualReferencesInput
+	QAFiles          QAFilesInput
 
 	Inquireness GrillMeInquirenessInput
 
@@ -185,7 +195,8 @@ type PhasePlanRevisionUserInput struct {
 	Attempt int
 	Phase   PhasePlanView
 
-	Feedback string
+	VisualReferences VisualReferencesInput
+	Feedback         string
 
 	PriorAxisApprovals PriorAxisApprovalsInput
 	PhasePlanPath      string
@@ -203,6 +214,7 @@ type VerificationItemView struct {
 }
 
 type ImplementUserInput struct {
+	VisualReferences      VisualReferencesInput
 	PlanPath              string
 	ExitCriteria          string
 	Feedback              string
@@ -213,6 +225,8 @@ type ImplementUserInput struct {
 }
 
 type ReviewUserInput struct {
+	VisualReferences VisualReferencesInput
+
 	Iteration int
 	IterDir   string
 	AxisLabel string
@@ -268,8 +282,10 @@ type ValidateSpecializedUserInput struct {
 	PriorPhasePlanPaths      []string
 
 	IsRoadmapKind bool
+	IsDesignKind  bool
 
-	ResearchPath string
+	ResearchPath       string
+	MockupManifestPath string
 
 	FeedbackPath string
 	AxisLabel    string
@@ -366,6 +382,45 @@ func TestGoldenSnapshots(t *testing.T) {
 					Inquireness: GrillMeInquirenessInput{Level: "medium"},
 				}
 				return DesignUserPrompt(in)
+			},
+		},
+		{
+			name: "design_revision_user",
+			render: func() string {
+				return DesignRevisionUserPrompt(DesignRevisionUserInput{
+					Attempt:            2,
+					CriticFeedback:     "Clarify callback errors and refresh the mobile error state.",
+					PreviousDesignPath: "/state/feat-x/run-1/design/design.md",
+					MockupManifestPath: "/state/feat-x/run-1/design/mockups/manifest.yaml",
+					Inquireness:        AutonomousInquirenessInput{},
+				})
+			},
+		},
+		{
+			name: "validate_design_integrity_user",
+			render: func() string {
+				return ValidateSpecializedUserPrompt(ValidateSpecializedUserInput{
+					Name:         "OAuth login",
+					Description:  "Sign in with Google.",
+					ExitCriteria: "PKCE succeeds and errors are actionable.",
+					DomainName:   "Integrity",
+					PlanPath:     "/state/feat-x/run-1/design/design.md",
+					IsDesignKind: true,
+					ResearchPath: "/state/feat-x/run-1/research/research.md",
+				})
+			},
+		},
+		{
+			name: "validate_design_visual_user",
+			render: func() string {
+				return ValidateSpecializedUserPrompt(ValidateSpecializedUserInput{
+					Name:               "OAuth login",
+					Description:        "Sign in with Google.",
+					DomainName:         "Visual",
+					PlanPath:           "/state/feat-x/run-1/design/design.md",
+					IsDesignKind:       true,
+					MockupManifestPath: "/state/feat-x/run-1/design/mockups/manifest.yaml",
+				})
 			},
 		},
 		{

--- a/internal/agent/prompts/templates/design.user.tmpl
+++ b/internal/agent/prompts/templates/design.user.tmpl
@@ -35,5 +35,12 @@ Read the research document produced by the previous phase at:
 
 Read this file completely before proceeding.
 
+{{ end }}{{ if .DecisionLedgerPath }}## Authoritative Decision Ledger
+
+Read the harness-owned decision ledger at:
+{{ .DecisionLedgerPath }}
+
+Treat every `REQ-###` requirement and `DEC-###` human decision as binding. Preserve these IDs when reasoning about conflicts or asking follow-up questions.
+
 {{ end }}{{ template "qa_files" .QAFiles }}{{ template "grillme_inquireness" .Inquireness }}
 {{ end -}}

--- a/internal/agent/prompts/templates/design_revision.user.tmpl
+++ b/internal/agent/prompts/templates/design_revision.user.tmpl
@@ -1,11 +1,32 @@
 {{- /*
   design_revision.user: Design revision after automated critic feedback.
-  Revisions are autonomous and preserve the final-decision-only artifact.
+  Revisions preserve the final-decision-only artifact and stop for material
+  changes that the authoritative decision ledger does not settle.
 */ -}}
 {{- define "design_revision.user" -}}
 # Design Revision
 
 This is revision attempt {{ .Attempt }}.
+
+## Feature Authority
+
+**Name**: {{ .Name }}
+
+**Description**:
+> {{ blockquote .Description }}
+
+{{ if .ExitCriteria }}**Exit Criteria**:
+> {{ blockquote .ExitCriteria }}
+
+{{ end }}{{ if .ResearchPath }}## Research Findings
+
+Read the research findings at: {{ .ResearchPath }}
+
+{{ end }}## Authoritative Decision Ledger
+
+Read the harness-owned decision ledger at: {{ .DecisionLedgerPath }}
+
+Every `REQ-###` requirement and `DEC-###` human decision is binding and supersedes critic preferences.
 
 ## Design to Revise
 
@@ -21,5 +42,9 @@ Update the manifest, prototype, and rendered states when the feedback changes a 
 
 {{ .CriticFeedback }}
 
-{{ template "autonomous_inquireness" .Inquireness }}
+## Material Change Guard
+
+Apply only classified `CONTRACT_DEFECT` and `GROUNDING_ERROR` corrections that preserve the decision ledger. An explicit `## Human Direction` block is direct human authority and may be applied when that direction is also recorded in the decision ledger. Do not treat other critic feedback as product or architecture authority.
+
+If any requested correction would change binding product behavior, architecture, persistence, operational cost, rollout, or testing commitments; conflicts with a `REQ-###` or `DEC-###` entry; or exposes a consequential choice absent from the ledger, stop and use `AskUserQuestion`. Do not resolve such a material change autonomously.
 {{ end -}}

--- a/internal/agent/prompts/templates/design_revision.user.tmpl
+++ b/internal/agent/prompts/templates/design_revision.user.tmpl
@@ -1,0 +1,25 @@
+{{- /*
+  design_revision.user: Design revision after automated critic feedback.
+  Revisions are autonomous and preserve the final-decision-only artifact.
+*/ -}}
+{{- define "design_revision.user" -}}
+# Design Revision
+
+This is revision attempt {{ .Attempt }}.
+
+## Design to Revise
+
+Read and update the design at: {{ .PreviousDesignPath }}
+
+{{ if .MockupManifestPath }}## Existing Mockup Bundle
+
+Read the mockup manifest at: {{ .MockupManifestPath }}
+
+Update the manifest, prototype, and rendered states when the feedback changes a binding UI decision.
+
+{{ end }}## Critic Feedback
+
+{{ .CriticFeedback }}
+
+{{ template "autonomous_inquireness" .Inquireness }}
+{{ end -}}

--- a/internal/agent/prompts/templates/implement.user.tmpl
+++ b/internal/agent/prompts/templates/implement.user.tmpl
@@ -6,7 +6,7 @@
   implement SKILL.md. This template carries only per-call arguments.
 */ -}}
 {{- define "implement.user" -}}
-# Implementation Context
+{{ template "visual_references" .VisualReferences }}# Implementation Context
 
 **Plan**: {{ .PlanPath }}
 

--- a/internal/agent/prompts/templates/implementation_review_axis.user.tmpl
+++ b/internal/agent/prompts/templates/implementation_review_axis.user.tmpl
@@ -4,7 +4,7 @@
   selected axis label.
 */ -}}
 {{- define "implementation_review_axis.user" -}}
-Axis under review: {{ .AxisLabel }}
+{{ template "visual_references" .VisualReferences }}Axis under review: {{ .AxisLabel }}
 {{ if .GateLabel }}Gate under review: {{ .GateLabel }}
 {{ end -}}
 Review feedback output: {{ .FeedbackPath }}

--- a/internal/agent/prompts/templates/phase_plan.user.tmpl
+++ b/internal/agent/prompts/templates/phase_plan.user.tmpl
@@ -12,7 +12,7 @@
   skills/plan-phase/SKILL.md, not the prompt.
 */ -}}
 {{- define "phase_plan.user" -}}
-# Phase {{ .Phase.Number }}: {{ .Phase.Name }}
+{{ template "visual_references" .VisualReferences }}# Phase {{ .Phase.Number }}: {{ .Phase.Name }}
 
 {{ if .RoadmapPath }}## Approved Roadmap
 

--- a/internal/agent/prompts/templates/phase_plan_revision.user.tmpl
+++ b/internal/agent/prompts/templates/phase_plan_revision.user.tmpl
@@ -2,12 +2,12 @@
   phase_plan_revision.user: the per-phase plan revision user prompt.
   Always strict-inquireness=none (revisions don't re-open decisions).
 
-  Feature name, visual references, and prior phase plan paths are
-  intentionally omitted: a revision is a text-level edit driven by critic
-  feedback against the prior plan, not a fresh design pass.
+  Feature name and prior phase plan paths are omitted. Approved visual
+  references remain in scope because critic-driven task revisions must not
+  drift from the Design contract.
 */ -}}
 {{- define "phase_plan_revision.user" -}}
-{{ if .PhasePlanFormatPath }}The methodology references the plan output format at: {{ .PhasePlanFormatPath }} — read this file in addition to the SKILL.md before producing the revised plan.
+{{ template "visual_references" .VisualReferences }}{{ if .PhasePlanFormatPath }}The methodology references the plan output format at: {{ .PhasePlanFormatPath }} — read this file in addition to the SKILL.md before producing the revised plan.
 
 {{ end }}# Revision Context
 

--- a/internal/agent/prompts/templates/review.user.tmpl
+++ b/internal/agent/prompts/templates/review.user.tmpl
@@ -5,7 +5,7 @@
   preserving budget for the reasoning step.
 */ -}}
 {{- define "review.user" -}}
-Iteration under review: {{ .Iteration }}
+{{ template "visual_references" .VisualReferences }}Iteration under review: {{ .Iteration }}
 Iteration artifacts directory: {{ .IterDir }}
 
 {{ if .RoadmapPath }}## Approved Roadmap

--- a/internal/agent/prompts/templates/roadmap.user.tmpl
+++ b/internal/agent/prompts/templates/roadmap.user.tmpl
@@ -3,10 +3,10 @@
   creation.
 
   When a design/design artifact is present, the design doc is the
-  authoritative spec — its contents already cover the feature
-  description and visual references, so we only point at the path and
-  suppress the redundant Feature / Visual References blocks. In Medium
-  mode (no design doc) those blocks ARE the spec, so they render.
+  authoritative text spec, so we point at the path and suppress the
+  redundant Feature block. Visual references still render because approved
+  mockups carry information that a text document cannot preserve. In Medium
+  mode (no design doc), the Feature block remains the text spec.
 
   Repo-task routing lives in the later phase plan, where `**Repo:** <name>`
   task tags are the source of truth. The roadmap prompt only signals the
@@ -27,7 +27,7 @@
 **Description**:
 > {{ blockquote .Description }}
 
-{{ template "visual_references" .VisualReferences }}{{ end }}{{ template "qa_files" .QAFiles }}{{ if .Repos }}## Target Repositories
+{{ end }}{{ template "visual_references" .VisualReferences }}{{ template "qa_files" .QAFiles }}{{ if .Repos }}## Target Repositories
 
 This feature targets the repositories below. Treat this list as authoritative; ignore sibling directories that are not listed here.
 {{ range .Repos }}- **{{ .Name }}** ({{ .Path }})

--- a/internal/agent/prompts/templates/roadmap_revision.user.tmpl
+++ b/internal/agent/prompts/templates/roadmap_revision.user.tmpl
@@ -4,7 +4,7 @@
   never re-open the human-decision loop).
 */ -}}
 {{- define "roadmap_revision.user" -}}
-{{ if .RoadmapFormatPath }}The methodology references the roadmap output format at: {{ .RoadmapFormatPath }} — read this file in addition to the SKILL.md before producing the revised roadmap.
+{{ template "visual_references" .VisualReferences }}{{ if .RoadmapFormatPath }}The methodology references the roadmap output format at: {{ .RoadmapFormatPath }} — read this file in addition to the SKILL.md before producing the revised roadmap.
 
 {{ end }}# Revision Context
 

--- a/internal/agent/prompts/templates/validate_specialized.user.tmpl
+++ b/internal/agent/prompts/templates/validate_specialized.user.tmpl
@@ -42,9 +42,15 @@ Read the research findings at: {{ .ResearchPath }}
 
 Use the research to verify that the plan respects discovered constraints, existing patterns, and integration requirements.
 
+{{ end }}{{ if .MockupManifestPath }}## Mockup Bundle
+
+Read the mockup manifest and every referenced prototype and rendered state at: {{ .MockupManifestPath }}
+
 {{ end }}{{ if .AutomatedVerificationOnly }}Note: this feature verifies through automated tests only. The plan's Manual Verification, Visual Evidence, and Behavioral Evidence sections are required to be `None required:` markers; do not request evidence matrices, screenshots, or manual observation steps.
 
-{{ end }}## Plan to Evaluate
+{{ end }}{{ if .IsDesignKind }}## Design to Evaluate
+{{ else }}## Plan to Evaluate
+{{ end }}
 
 Read the plan at: {{ .PlanPath }}
 {{ end -}}

--- a/internal/agent/prompts/templates/validate_specialized.user.tmpl
+++ b/internal/agent/prompts/templates/validate_specialized.user.tmpl
@@ -42,6 +42,12 @@ Read the research findings at: {{ .ResearchPath }}
 
 Use the research to verify that the plan respects discovered constraints, existing patterns, and integration requirements.
 
+{{ end }}{{ if .DecisionLedgerPath }}## Authoritative Decision Ledger
+
+Read the harness-owned decision ledger at: {{ .DecisionLedgerPath }}
+
+This ledger is the binding source of product and architectural decisions. Every blocking Design finding must cite the relevant `REQ-###` or `DEC-###` ID. Do not replace a recorded decision with a critic preference.
+
 {{ end }}{{ if .MockupManifestPath }}## Mockup Bundle
 
 Read the mockup manifest and every referenced prototype and rendered state at: {{ .MockupManifestPath }}

--- a/internal/agent/prompts/testdata/design_revision_user.golden
+++ b/internal/agent/prompts/testdata/design_revision_user.golden
@@ -2,6 +2,26 @@
 
 This is revision attempt 2.
 
+## Feature Authority
+
+**Name**: OAuth login
+
+**Description**:
+> Sign in with Google.
+
+**Exit Criteria**:
+> PKCE succeeds and errors are actionable.
+
+## Research Findings
+
+Read the research findings at: /state/feat-x/run-1/research/research.md
+
+## Authoritative Decision Ledger
+
+Read the harness-owned decision ledger at: /state/feat-x/run-1/design/decision-ledger.md
+
+Every `REQ-###` requirement and `DEC-###` human decision is binding and supersedes critic preferences.
+
 ## Design to Revise
 
 Read and update the design at: /state/feat-x/run-1/design/design.md
@@ -16,5 +36,8 @@ Update the manifest, prototype, and rendered states when the feedback changes a 
 
 Clarify callback errors and refresh the mobile error state.
 
-## Ambiguity Resolution [none]
-Resolve all ambiguity autonomously. Do NOT ask the user any questions or request clarification. Make your best judgment on all decisions and proceed.
+## Material Change Guard
+
+Apply only classified `CONTRACT_DEFECT` and `GROUNDING_ERROR` corrections that preserve the decision ledger. An explicit `## Human Direction` block is direct human authority and may be applied when that direction is also recorded in the decision ledger. Do not treat other critic feedback as product or architecture authority.
+
+If any requested correction would change binding product behavior, architecture, persistence, operational cost, rollout, or testing commitments; conflicts with a `REQ-###` or `DEC-###` entry; or exposes a consequential choice absent from the ledger, stop and use `AskUserQuestion`. Do not resolve such a material change autonomously.

--- a/internal/agent/prompts/testdata/design_revision_user.golden
+++ b/internal/agent/prompts/testdata/design_revision_user.golden
@@ -1,0 +1,20 @@
+# Design Revision
+
+This is revision attempt 2.
+
+## Design to Revise
+
+Read and update the design at: /state/feat-x/run-1/design/design.md
+
+## Existing Mockup Bundle
+
+Read the mockup manifest at: /state/feat-x/run-1/design/mockups/manifest.yaml
+
+Update the manifest, prototype, and rendered states when the feedback changes a binding UI decision.
+
+## Critic Feedback
+
+Clarify callback errors and refresh the mobile error state.
+
+## Ambiguity Resolution [none]
+Resolve all ambiguity autonomously. Do NOT ask the user any questions or request clarification. Make your best judgment on all decisions and proceed.

--- a/internal/agent/prompts/testdata/design_user_multi_repo.golden
+++ b/internal/agent/prompts/testdata/design_user_multi_repo.golden
@@ -21,6 +21,13 @@ Read the research document produced by the previous phase at:
 
 Read this file completely before proceeding.
 
+## Authoritative Decision Ledger
+
+Read the harness-owned decision ledger at:
+/state/feat-x/run-1/design/decision-ledger.md
+
+Treat every `REQ-###` requirement and `DEC-###` human decision as binding. Preserve these IDs when reasoning about conflicts or asking follow-up questions.
+
 ## User Decisions
 
 The user answered clarifying questions during earlier phases. Read these Q&A files for important context about their intent and preferences:

--- a/internal/agent/prompts/testdata/roadmap_user_multi_repo.golden
+++ b/internal/agent/prompts/testdata/roadmap_user_multi_repo.golden
@@ -2,6 +2,12 @@
 
 Design Document: /state/feat-x/run-1/design/design.md
 
+## Visual References
+
+IMPORTANT: The user attached the image(s) below when creating this feature. They communicate intent that text alone cannot — mockups, desired-state screenshots, annotated whiteboards, bug repros, or reference designs. Before producing the roadmap, Read each image via tool-use and treat its visual information as a binding specification for what the output should look like. If an image shows a specific layout, palette, typography, or interaction, match it; do not substitute generic defaults.
+
+- [Image #1]: /tmp/login.png
+
 ## User Decisions
 
 The user answered clarifying questions during earlier phases. Read these Q&A files for important context about their intent and preferences — do not re-ask questions that have already been answered:

--- a/internal/agent/prompts/testdata/validate_design_integrity_user.golden
+++ b/internal/agent/prompts/testdata/validate_design_integrity_user.golden
@@ -1,0 +1,20 @@
+## Feature Under Review
+
+**Name**: OAuth login
+
+**Description**:
+> Sign in with Google.
+
+**Exit Criteria**:
+> PKCE succeeds and errors are actionable.
+
+## Research Findings
+
+Read the research findings at: /state/feat-x/run-1/research/research.md
+
+Use the research to verify that the plan respects discovered constraints, existing patterns, and integration requirements.
+
+## Design to Evaluate
+
+
+Read the plan at: /state/feat-x/run-1/design/design.md

--- a/internal/agent/prompts/testdata/validate_design_integrity_user.golden
+++ b/internal/agent/prompts/testdata/validate_design_integrity_user.golden
@@ -14,6 +14,12 @@ Read the research findings at: /state/feat-x/run-1/research/research.md
 
 Use the research to verify that the plan respects discovered constraints, existing patterns, and integration requirements.
 
+## Authoritative Decision Ledger
+
+Read the harness-owned decision ledger at: /state/feat-x/run-1/design/decision-ledger.md
+
+This ledger is the binding source of product and architectural decisions. Every blocking Design finding must cite the relevant `REQ-###` or `DEC-###` ID. Do not replace a recorded decision with a critic preference.
+
 ## Design to Evaluate
 
 

--- a/internal/agent/prompts/testdata/validate_design_visual_user.golden
+++ b/internal/agent/prompts/testdata/validate_design_visual_user.golden
@@ -1,0 +1,15 @@
+## Feature Under Review
+
+**Name**: OAuth login
+
+**Description**:
+> Sign in with Google.
+
+## Mockup Bundle
+
+Read the mockup manifest and every referenced prototype and rendered state at: /state/feat-x/run-1/design/mockups/manifest.yaml
+
+## Design to Evaluate
+
+
+Read the plan at: /state/feat-x/run-1/design/design.md

--- a/internal/agent/prompts/testdata/validate_design_visual_user.golden
+++ b/internal/agent/prompts/testdata/validate_design_visual_user.golden
@@ -5,6 +5,12 @@
 **Description**:
 > Sign in with Google.
 
+## Authoritative Decision Ledger
+
+Read the harness-owned decision ledger at: /state/feat-x/run-1/design/decision-ledger.md
+
+This ledger is the binding source of product and architectural decisions. Every blocking Design finding must cite the relevant `REQ-###` or `DEC-###` ID. Do not replace a recorded decision with a critic preference.
+
 ## Mockup Bundle
 
 Read the mockup manifest and every referenced prototype and rendered state at: /state/feat-x/run-1/design/mockups/manifest.yaml

--- a/internal/agent/prompts/testdata/validate_specialized_automated_verification_only.golden
+++ b/internal/agent/prompts/testdata/validate_specialized_automated_verification_only.golden
@@ -14,4 +14,5 @@ Note: this feature verifies through automated tests only. The plan's Manual Veri
 
 ## Plan to Evaluate
 
+
 Read the plan at: /state/feat-x/run-1/phase-2/plan.md

--- a/internal/agent/prompts/testdata/validate_specialized_grounding.golden
+++ b/internal/agent/prompts/testdata/validate_specialized_grounding.golden
@@ -24,4 +24,5 @@ Use the research to verify that the plan respects discovered constraints, existi
 
 ## Plan to Evaluate
 
+
 Read the plan at: /state/feat-x/run-1/phase-2/plan.md

--- a/internal/agent/prompts/types.go
+++ b/internal/agent/prompts/types.go
@@ -143,13 +143,22 @@ type GrillMeInquirenessInput struct {
 // from grill-me at the type level.
 type AutonomousInquirenessInput struct{}
 
+// MockupReference is one approved generated mockup. HTMLPath is the
+// self-contained interactive rendering and PNGPath is its visual snapshot.
+type MockupReference struct {
+	ID       string
+	HTMLPath string
+	PNGPath  string
+}
+
 // VisualReferencesInput is the data passed to the visual_references partial.
 // Label is the phase-specific verb woven into the imperative (e.g.
 // "implementing this iteration", "producing the roadmap"). Returns "" when
-// Images is empty.
+// both Images and Mockups are empty.
 type VisualReferencesInput struct {
-	Images []string
-	Label  string
+	Images  []string
+	Mockups []MockupReference
+	Label   string
 }
 
 // QAFilesInput is the data passed to the qa_files partial. Lead is the

--- a/internal/agent/roadmap_prompt.go
+++ b/internal/agent/roadmap_prompt.go
@@ -124,10 +124,7 @@ func BuildRoadmapPromptWithResearch(f *feature.Feature, skillsDir, guidelinesDir
 		Repos:                repos,
 		DesignArtifactPath:   designArtifactPath,
 		ResearchArtifactPath: researchArtifactPath,
-		VisualReferences: prompts.VisualReferencesInput{
-			Images: append([]string(nil), f.Images...),
-			Label:  "producing the roadmap",
-		},
+		VisualReferences:     visualReferencesForFeature(f, designArtifactPath, "producing the roadmap"),
 		QAFiles: prompts.QAFilesInput{
 			Paths:         append([]string(nil), qaFilePaths...),
 			Lead:          "Read these Q&A files for important context about their intent and preferences — do not re-ask questions that have already been answered:",
@@ -150,16 +147,17 @@ func BuildRoadmapPromptWithResearch(f *feature.Feature, skillsDir, guidelinesDir
 // The prose lives in
 // internal/agent/prompts/templates/roadmap_revision.user.tmpl.
 //
-// f is currently unused by the template; retained on the signature for
-// caller stability. roadmapPath is similarly unused (the path is implicit
-// via previousRoadmapPath).
+// roadmapPath is retained for caller stability; the path to revise is supplied
+// separately as previousRoadmapPath.
 func BuildRoadmapRevisionPrompt(f *feature.Feature, skillsDir, roadmapPath, previousRoadmapPath, criticFeedback, designArtifactPath string, attempt int, approvals []AxisApproval) string {
-	_ = f
 	_ = roadmapPath
-	_ = designArtifactPath
+	if designArtifactPath == "" {
+		designArtifactPath = f.DesignArtifactPath()
+	}
 	return roles.BuildRoadmapRevisionPrompt(roles.RoadmapRevisionUserInput{
-		Attempt:        attempt,
-		CriticFeedback: criticFeedback,
+		Attempt:          attempt,
+		VisualReferences: visualReferencesForFeature(f, designArtifactPath, "revising the roadmap"),
+		CriticFeedback:   criticFeedback,
 		PriorAxisApprovals: prompts.PriorAxisApprovalsInput{
 			ArtifactName: "roadmap",
 			Approvals:    axisApprovalViews(approvals),
@@ -178,8 +176,8 @@ func BuildRoadmapRevisionPrompt(f *feature.Feature, skillsDir, roadmapPath, prev
 // (inquire/research/design/roadmap qa-answers.md) collected by
 // the orchestrator. Phase-Plan re-injects them under a "User Decisions"
 // section so the planner reads the user's prior answers verbatim and
-// does not re-litigate them. Visual references are intentionally
-// omitted — the approved roadmap already incorporates them. Phase-Plan's
+// does not re-litigate them. Approved generated mockups are re-injected
+// because they carry pixel-level contracts the roadmap cannot preserve. Phase-Plan's
 // own qa-answers.md is NOT propagated to Implement (Implement reads
 // the phase-plan markdown artifact, which already encodes all decisions).
 //
@@ -197,6 +195,7 @@ func BuildPhasePlanPromptWithResearch(f *feature.Feature, skillsDir, guidelinesD
 	_ = guidelinesDir
 	_ = kbInfos
 	return roles.BuildPhasePlanPrompt(roles.PhasePlanUserInput{
+		VisualReferences: visualReferencesForFeature(f, f.DesignArtifactPath(), "planning this phase"),
 		Phase: roles.PhasePlanView{
 			Number:        phase.Number,
 			Name:          phase.Name,
@@ -228,9 +227,12 @@ func BuildPhasePlanPromptWithResearch(f *feature.Feature, skillsDir, guidelinesD
 // The prose lives in
 // internal/agent/prompts/templates/phase_plan_revision.user.tmpl.
 func BuildPhasePlanRevisionPrompt(f *feature.Feature, skillsDir, phasePlanPath, feedback, designArtifactPath string, phase RoadmapPhase, attempt int, approvals []AxisApproval) string {
-	_ = designArtifactPath
+	if designArtifactPath == "" {
+		designArtifactPath = f.DesignArtifactPath()
+	}
 	return roles.BuildPhasePlanRevisionPrompt(roles.PhasePlanRevisionUserInput{
-		Attempt: attempt,
+		Attempt:          attempt,
+		VisualReferences: visualReferencesForFeature(f, designArtifactPath, "revising this phase plan"),
 		Phase: roles.PhasePlanView{
 			Number: phase.Number,
 			Name:   phase.Name,

--- a/internal/agent/roles/design_reviser.go
+++ b/internal/agent/roles/design_reviser.go
@@ -1,0 +1,61 @@
+// Copyright 2026 DoorDash, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package roles
+
+import (
+	"github.com/doordash-oss/agentic-orchestrator/internal/agent/prompts"
+	"github.com/doordash-oss/agentic-orchestrator/internal/feature"
+)
+
+// RoleDesignReviser revises a Design artifact after automated critic feedback.
+const RoleDesignReviser Role = "design_reviser"
+
+var designReviserRoleSpec = RoleSpec{
+	Phase:        feature.PhaseDesign,
+	Role:         RoleDesignReviser,
+	SkillName:    "revise-design",
+	UserTemplate: "design_revision.user",
+	Required:     []feature.Phase{feature.PhaseResearch},
+	OutputRoots: []OutputRootSpec{
+		artifactDirOutputRoot("Shared Design artifact root. Revisions update the design and optional mockup bundle here across attempts."),
+		attemptDirOutputRoot("Active Design revision attempt directory. Debug prompts, attempt metadata, validator output, and phase_complete are written here."),
+	},
+	MarkerRoot: "attempt_dir",
+	Artifacts: []RoleArtifactSpec{
+		designMarkdownRoleArtifact(),
+		designMockupManifestRoleArtifact(),
+		planAttemptMetaRoleArtifact(),
+	},
+	ReadOnlyOutsideRoots: true,
+}
+
+// DesignReviserRoleSpec returns the Design revision RoleSpec.
+func DesignReviserRoleSpec() RoleSpec {
+	return CloneRoleSpec(designReviserRoleSpec)
+}
+
+// DesignRevisionUserInput is the data passed to design_revision.user.tmpl.
+type DesignRevisionUserInput struct {
+	Attempt            int
+	CriticFeedback     string
+	PreviousDesignPath string
+	MockupManifestPath string
+	Inquireness        prompts.AutonomousInquirenessInput
+}
+
+// BuildDesignRevisionPrompt renders the Design revision prompt.
+func BuildDesignRevisionPrompt(in DesignRevisionUserInput) string {
+	return prompts.DesignRevisionUserPrompt(in)
+}

--- a/internal/agent/roles/design_reviser.go
+++ b/internal/agent/roles/design_reviser.go
@@ -48,11 +48,15 @@ func DesignReviserRoleSpec() RoleSpec {
 
 // DesignRevisionUserInput is the data passed to design_revision.user.tmpl.
 type DesignRevisionUserInput struct {
+	Name               string
+	Description        string
+	ExitCriteria       string
 	Attempt            int
 	CriticFeedback     string
 	PreviousDesignPath string
 	MockupManifestPath string
-	Inquireness        prompts.AutonomousInquirenessInput
+	ResearchPath       string
+	DecisionLedgerPath string
 }
 
 // BuildDesignRevisionPrompt renders the Design revision prompt.

--- a/internal/agent/roles/design_validators.go
+++ b/internal/agent/roles/design_validators.go
@@ -1,0 +1,76 @@
+// Copyright 2026 DoorDash, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package roles
+
+import (
+	"fmt"
+
+	"github.com/doordash-oss/agentic-orchestrator/internal/feature"
+)
+
+const (
+	// RoleValidateDesignIntegrity validates objective alignment, coherence, and implementation readiness.
+	RoleValidateDesignIntegrity Role = "validate_design_integrity"
+	// RoleValidateDesignVisual validates an applicable UI mockup bundle.
+	RoleValidateDesignVisual Role = "validate_design_visual"
+)
+
+var designValidatorRoleSpecs = []RoleSpec{
+	designValidatorRoleSpec(RoleValidateDesignIntegrity, "validate-design-integrity", "integrity"),
+	designValidatorRoleSpec(RoleValidateDesignVisual, "validate-design-visual", "visual"),
+}
+
+// DesignValidatorRoleSpecs returns the Design critic RoleSpecs.
+func DesignValidatorRoleSpecs() []RoleSpec {
+	out := make([]RoleSpec, 0, len(designValidatorRoleSpecs))
+	for _, spec := range designValidatorRoleSpecs {
+		out = append(out, CloneRoleSpec(spec))
+	}
+	return out
+}
+
+// DesignValidatorRoleForSkill returns the critic RoleSpec for a Design critic skill.
+func DesignValidatorRoleForSkill(skillName string) (RoleSpec, bool) {
+	for _, spec := range designValidatorRoleSpecs {
+		if spec.SkillName == skillName {
+			return CloneRoleSpec(spec), true
+		}
+	}
+	return RoleSpec{}, false
+}
+
+func designValidatorRoleSpec(role Role, skillName, axis string) RoleSpec {
+	return reviewFeedbackAxisRoleSpec(reviewFeedbackAxisRoleSpecConfig{
+		Phase:        feature.PhaseDesign,
+		Role:         role,
+		SkillName:    skillName,
+		UserTemplate: "validate_specialized.user",
+		OutputRoots: []OutputRootSpec{
+			validatorAttemptDirOutputRoot(),
+			validatorHelperDirOutputRoot(),
+		},
+		MarkerRoot: "helper_dir",
+		Artifact: RoleArtifactSpec{
+			Name:         "design_validator_feedback",
+			DisplayPath:  fmt.Sprintf("validation-%s-feedback.md", axis),
+			RootName:     "helper_dir",
+			RelativePath: fmt.Sprintf("validation-%s-feedback.md", axis),
+			Presence:     ArtifactRequired,
+			Description:  "structured Design validation feedback with findings, suggestions, and verdict",
+			Validate:     ValidatorReviewFeedback,
+		},
+		ReadOnlyOutsideRoots: true,
+	})
+}

--- a/internal/agent/roles/designer.go
+++ b/internal/agent/roles/designer.go
@@ -60,6 +60,7 @@ type DesignUserInput struct {
 
 	MultiRepo            bool
 	ResearchArtifactPath string
+	DecisionLedgerPath   string
 
 	QAFiles     prompts.QAFilesInput
 	Inquireness prompts.GrillMeInquirenessInput

--- a/internal/agent/roles/designer.go
+++ b/internal/agent/roles/designer.go
@@ -31,11 +31,14 @@ var designerRoleSpec = RoleSpec{
 	UserTemplate: "design.user",
 	Required:     []feature.Phase{feature.PhaseResearch},
 	OutputRoots: []OutputRootSpec{
-		singleShotPhaseDirOutputRoot("Design phase artifact directory."),
+		artifactDirOutputRoot("Shared Design artifact root. The approved design and optional mockup bundle are updated here across attempts."),
+		attemptDirOutputRoot("Active Design attempt directory. Debug prompts, attempt metadata, validator output, and phase_complete are written here."),
 	},
-	MarkerRoot: "phase_dir",
+	MarkerRoot: "attempt_dir",
 	Artifacts: []RoleArtifactSpec{
-		phaseMarkdownRoleArtifact("design markdown artifact"),
+		designMarkdownRoleArtifact(),
+		designMockupManifestRoleArtifact(),
+		planAttemptMetaRoleArtifact(),
 	},
 	ReadOnlyOutsideRoots: true,
 }

--- a/internal/agent/roles/implement.go
+++ b/internal/agent/roles/implement.go
@@ -78,6 +78,7 @@ func ImplementRoleSpec() RoleSpec {
 
 // ImplementUserInput is the data passed to implement.user.tmpl.
 type ImplementUserInput struct {
+	VisualReferences      prompts.VisualReferencesInput
 	PlanPath              string
 	ExitCriteria          string
 	Feedback              string

--- a/internal/agent/roles/iteration_reviewer.go
+++ b/internal/agent/roles/iteration_reviewer.go
@@ -24,6 +24,8 @@ type VerificationItemView struct {
 
 // ReviewUserInput is the data passed to review.user.tmpl.
 type ReviewUserInput struct {
+	VisualReferences prompts.VisualReferencesInput
+
 	Iteration int
 	IterDir   string
 

--- a/internal/agent/roles/phase_plan_creator.go
+++ b/internal/agent/roles/phase_plan_creator.go
@@ -59,7 +59,8 @@ type PhasePlanUserInput struct {
 	RoadmapPath          string
 	ResearchArtifactPath string
 
-	QAFiles prompts.QAFilesInput
+	VisualReferences prompts.VisualReferencesInput
+	QAFiles          prompts.QAFilesInput
 
 	Inquireness prompts.GrillMeInquirenessInput
 

--- a/internal/agent/roles/phase_plan_reviser.go
+++ b/internal/agent/roles/phase_plan_reviser.go
@@ -49,7 +49,8 @@ type PhasePlanRevisionUserInput struct {
 	Attempt int
 	Phase   PhasePlanView
 
-	Feedback string
+	VisualReferences prompts.VisualReferencesInput
+	Feedback         string
 
 	PriorAxisApprovals prompts.PriorAxisApprovalsInput
 	PhasePlanPath      string

--- a/internal/agent/roles/plan_validators.go
+++ b/internal/agent/roles/plan_validators.go
@@ -109,8 +109,10 @@ type ValidateSpecializedUserInput struct {
 	PriorPhasePlanPaths      []string
 
 	IsRoadmapKind bool
+	IsDesignKind  bool
 
-	ResearchPath string
+	ResearchPath       string
+	MockupManifestPath string
 
 	FeedbackPath string
 	AxisLabel    string

--- a/internal/agent/roles/plan_validators.go
+++ b/internal/agent/roles/plan_validators.go
@@ -113,6 +113,7 @@ type ValidateSpecializedUserInput struct {
 
 	ResearchPath       string
 	MockupManifestPath string
+	DecisionLedgerPath string
 
 	FeedbackPath string
 	AxisLabel    string

--- a/internal/agent/roles/registry.go
+++ b/internal/agent/roles/registry.go
@@ -17,19 +17,23 @@ package roles
 import "github.com/doordash-oss/agentic-orchestrator/internal/feature"
 
 var roleSpecs = append(
-	append([]RoleSpec{
-		implementRoleSpec,
-		roadmapCreatorRoleSpec,
-		roadmapReviserRoleSpec,
-		phasePlanCreatorRoleSpec,
-		phasePlanReviserRoleSpec,
-		knowledgeBaseBuilderRoleSpec,
-		inquirerRoleSpec,
-		researcherRoleSpec,
-		designerRoleSpec,
-		refactorPlanRoleSpec,
-		finalReviewFixerRoleSpec,
-	}, planValidatorRoleSpecs...),
+	append(
+		append([]RoleSpec{
+			implementRoleSpec,
+			roadmapCreatorRoleSpec,
+			roadmapReviserRoleSpec,
+			phasePlanCreatorRoleSpec,
+			phasePlanReviserRoleSpec,
+			knowledgeBaseBuilderRoleSpec,
+			inquirerRoleSpec,
+			researcherRoleSpec,
+			designerRoleSpec,
+			designReviserRoleSpec,
+			refactorPlanRoleSpec,
+			finalReviewFixerRoleSpec,
+		}, planValidatorRoleSpecs...),
+		designValidatorRoleSpecs...,
+	),
 	implementationReviewAxisRoleSpecs...,
 )
 

--- a/internal/agent/roles/roadmap_reviser.go
+++ b/internal/agent/roles/roadmap_reviser.go
@@ -47,8 +47,9 @@ func RoadmapReviserRoleSpec() RoleSpec {
 
 // RoadmapRevisionUserInput is the data passed to roadmap_revision.user.tmpl.
 type RoadmapRevisionUserInput struct {
-	Attempt        int
-	CriticFeedback string
+	Attempt          int
+	VisualReferences prompts.VisualReferencesInput
+	CriticFeedback   string
 
 	PriorAxisApprovals  prompts.PriorAxisApprovalsInput
 	PreviousRoadmapPath string

--- a/internal/agent/roles/types.go
+++ b/internal/agent/roles/types.go
@@ -414,7 +414,7 @@ func artifactExcluded(name string) bool {
 		return true
 	case strings.HasSuffix(lower, "-prompt.md"):
 		return true
-	case lower == "qa-answers.md":
+	case lower == "qa-answers.md" || lower == "decision-ledger.md":
 		return true
 	default:
 		return false

--- a/internal/agent/roles/types.go
+++ b/internal/agent/roles/types.go
@@ -53,6 +53,8 @@ const (
 	ValidatorPlanAttemptMeta           ArtifactValidator = "plan_attempt_meta"
 	ValidatorKnowledgeBaseIndex        ArtifactValidator = "knowledge_base_index"
 	ValidatorPhaseMarkdown             ArtifactValidator = "phase_markdown"
+	ValidatorDesignMarkdown            ArtifactValidator = "design_markdown"
+	ValidatorDesignMockupManifest      ArtifactValidator = "design_mockup_manifest"
 	ValidatorRefactorPlanMarkdown      ArtifactValidator = "refactor_plan_markdown"
 	ValidatorReviewFeedback            ArtifactValidator = "review_feedback"
 	ValidatorPlanValidatorAxisApproval ArtifactValidator = "plan_validator_axis_approval"
@@ -261,6 +263,31 @@ func roadmapMarkdownRoleArtifact() RoleArtifactSpec {
 		Description:  "roadmap markdown matching the create-roadmap format contract",
 		ResolvePath:  resolvePlanMarkdownRoleArtifact("roadmap.md"),
 		Validate:     ValidatorRoadmap,
+	}
+}
+
+func designMarkdownRoleArtifact() RoleArtifactSpec {
+	return RoleArtifactSpec{
+		Name:         "design_markdown",
+		DisplayPath:  "design markdown",
+		RootName:     "artifact_dir",
+		RelativePath: "design.md",
+		Presence:     ArtifactRequired,
+		Description:  "final-decision design markdown matching the Design skill contract",
+		Validate:     ValidatorDesignMarkdown,
+	}
+}
+
+func designMockupManifestRoleArtifact() RoleArtifactSpec {
+	return RoleArtifactSpec{
+		Name:         "design_mockup_manifest",
+		DisplayPath:  "mockup manifest",
+		RootName:     "artifact_dir",
+		RelativePath: "mockups/manifest.yaml",
+		Presence:     ArtifactOptional,
+		Condition:    "required for material UI changes",
+		Description:  "versioned manifest for self-contained HTML and rendered PNG mockups",
+		Validate:     ValidatorDesignMockupManifest,
 	}
 }
 

--- a/internal/agent/rolespec.go
+++ b/internal/agent/rolespec.go
@@ -51,6 +51,9 @@ const (
 	RoleInquirer                                  = roles.RoleInquirer
 	RoleResearcher                                = roles.RoleResearcher
 	RoleDesigner                                  = roles.RoleDesigner
+	RoleDesignReviser                             = roles.RoleDesignReviser
+	RoleValidateDesignIntegrity                   = roles.RoleValidateDesignIntegrity
+	RoleValidateDesignVisual                      = roles.RoleValidateDesignVisual
 )
 
 type ArtifactPresence = roles.ArtifactPresence
@@ -114,6 +117,22 @@ func ResearcherRoleSpec() RoleSpec {
 // DesignerRoleSpec returns the canonical Design RoleSpec wrapper.
 func DesignerRoleSpec() RoleSpec {
 	return wrapRoleSpec(roles.DesignerRoleSpec())
+}
+
+// DesignReviserRoleSpec returns the Design revision RoleSpec wrapper.
+func DesignReviserRoleSpec() RoleSpec {
+	return wrapRoleSpec(roles.DesignReviserRoleSpec())
+}
+
+// DesignValidatorRoleSpecs returns the Design critic RoleSpecs.
+func DesignValidatorRoleSpecs() []RoleSpec {
+	return wrapRoleSpecs(roles.DesignValidatorRoleSpecs())
+}
+
+// DesignValidatorRoleForSkill returns the Design critic RoleSpec for a skill.
+func DesignValidatorRoleForSkill(skillName string) (RoleSpec, bool) {
+	spec, ok := roles.DesignValidatorRoleForSkill(skillName)
+	return wrapRoleSpec(spec), ok
 }
 
 // RefactorPlanRoleSpec returns the RoleSpec-backed refactor-plan role.
@@ -264,6 +283,30 @@ func validatorForRoleArtifact(artifact RoleArtifactSpec) func(iterDir, path stri
 				return []ProtocolViolation{{Artifact: display, Reason: missingArtifactReason(display, dir)}}, nil
 			}
 			out.PhaseArtifactPath = path
+			return nil, nil
+		}
+	case roles.ValidatorDesignMarkdown:
+		display := artifact.DisplayPath
+		return func(_ string, path string, out *Outcome) ([]ProtocolViolation, error) {
+			info, err := os.Stat(path)
+			if err != nil {
+				return []ProtocolViolation{{Artifact: display, Reason: missingArtifactReason(display, path)}}, nil
+			}
+			if !info.Mode().IsRegular() {
+				return []ProtocolViolation{{Artifact: display, Reason: fmt.Sprintf("%s is not a regular file", path)}}, nil
+			}
+			out.PhaseArtifactPath = path
+			return nil, nil
+		}
+	case roles.ValidatorDesignMockupManifest:
+		display := artifact.DisplayPath
+		return func(_ string, path string, _ *Outcome) ([]ProtocolViolation, error) {
+			if err := ValidateDesignMockupManifest(path); err != nil {
+				return []ProtocolViolation{{
+					Artifact: display,
+					Reason:   err.Error(),
+				}}, nil
+			}
 			return nil, nil
 		}
 	case roles.ValidatorRefactorPlanMarkdown:

--- a/internal/agent/rolespec_test.go
+++ b/internal/agent/rolespec_test.go
@@ -362,29 +362,6 @@ func TestSingleShotProducerRoleSpecsDeriveContractPaths(t *testing.T) {
 			wantMarker: filepath.Join(base, "runs", "run-001", "research", "phase_complete"),
 		},
 		{
-			name:       "design",
-			spec:       DesignerRoleSpec(),
-			phaseDir:   filepath.Join(base, "runs", "run-001", "design"),
-			wantPhase:  feature.PhaseDesign,
-			wantRole:   RoleDesigner,
-			wantSkill:  "design",
-			wantPath:   filepath.Join(base, "runs", "run-001", "design"),
-			wantMarker: filepath.Join(base, "runs", "run-001", "design", "phase_complete"),
-		},
-		{
-			// Legacy alias: resumed/older runs that still resolve the role as
-			// RoleDesigner must validate the same markdown artifact in the
-			// same phase directory.
-			name:       "design",
-			spec:       DesignerRoleSpec(),
-			phaseDir:   filepath.Join(base, "runs", "run-001", "design"),
-			wantPhase:  feature.PhaseDesign,
-			wantRole:   RoleDesigner,
-			wantSkill:  "design",
-			wantPath:   filepath.Join(base, "runs", "run-001", "design"),
-			wantMarker: filepath.Join(base, "runs", "run-001", "design", "phase_complete"),
-		},
-		{
 			name:       "refactor plan",
 			spec:       RefactorPlanRoleSpec(),
 			phaseDir:   filepath.Join(base, "runs", "run-001", "refactor-1"),
@@ -437,7 +414,7 @@ func TestSingleShotProducerRoleSpecsDeriveContractPaths(t *testing.T) {
 func TestBuildSingleShotSystemPromptFromRoleSpec(t *testing.T) {
 	got := BuildRoleSystemPrompt(BuildRoleSystemPromptInput{
 		Spec:          DesignerRoleSpec(),
-		IterationDir:  "/state/feat-x/runs/run-001/design",
+		IterationDir:  "/state/feat-x/runs/run-001/design/attempt-01",
 		SkillsDir:     "/skills",
 		GuidelinesDir: "/guidelines",
 		KBInfos: []KBInfo{
@@ -447,8 +424,9 @@ func TestBuildSingleShotSystemPromptFromRoleSpec(t *testing.T) {
 	})
 
 	for _, want := range []string{
-		"`phase_dir`: /state/feat-x/runs/run-001/design",
-		"/state/feat-x/runs/run-001/design/phase_complete",
+		"`artifact_dir`: /state/feat-x/runs/run-001/design",
+		"`attempt_dir`: /state/feat-x/runs/run-001/design/attempt-01",
+		"/state/feat-x/runs/run-001/design/attempt-01/phase_complete",
 		"/skills/design/SKILL.md",
 		"# Useful Resources",
 		"/kb/agentic/index.md",

--- a/internal/agent/visual_references.go
+++ b/internal/agent/visual_references.go
@@ -15,8 +15,406 @@
 package agent
 
 import (
+	"errors"
+	"fmt"
+	"image"
+	_ "image/png"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
 	"github.com/doordash-oss/agentic-orchestrator/internal/agent/prompts"
+	"github.com/doordash-oss/agentic-orchestrator/internal/feature"
+	"gopkg.in/yaml.v3"
 )
+
+const (
+	// DesignMockupManifestVersion is the only manifest schema version accepted
+	// by ResolveVisualReferences.
+	DesignMockupManifestVersion = 1
+	designMockupManifestPath    = "mockups/manifest.yaml"
+)
+
+// ApprovedMockup is one generated visual artifact approved during Design.
+// Paths are absolute, validated paths beneath the Design artifact root.
+type ApprovedMockup struct {
+	ID       string
+	HTMLPath string
+	PNGPath  string
+}
+
+// ResolvedVisualReferences combines original feature images with generated,
+// approved Design mockups. A missing manifest produces an empty Mockups slice.
+type ResolvedVisualReferences struct {
+	Images  []string
+	Mockups []ApprovedMockup
+}
+
+// Paths returns every reference path in prompt order: original images, then
+// each generated mockup's HTML and PNG representations.
+func (r ResolvedVisualReferences) Paths() []string {
+	paths := make([]string, 0, len(r.Images)+len(r.Mockups)*2)
+	paths = append(paths, r.Images...)
+	for _, mockup := range r.Mockups {
+		paths = append(paths, mockup.HTMLPath, mockup.PNGPath)
+	}
+	return paths
+}
+
+// PromptInput projects resolved references into the shared prompt partial.
+func (r ResolvedVisualReferences) PromptInput(label string) prompts.VisualReferencesInput {
+	mockups := make([]prompts.MockupReference, 0, len(r.Mockups))
+	for _, mockup := range r.Mockups {
+		mockups = append(mockups, prompts.MockupReference{
+			ID:       mockup.ID,
+			HTMLPath: mockup.HTMLPath,
+			PNGPath:  mockup.PNGPath,
+		})
+	}
+	return prompts.VisualReferencesInput{
+		Images:  append([]string(nil), r.Images...),
+		Mockups: mockups,
+		Label:   label,
+	}
+}
+
+// ResolveVisualReferencesInput resolves and projects references in one call.
+// Roadmap, phase-plan, implementation, implementation-review, and final-review
+// callers can supply their phase-specific label without duplicating plumbing.
+func ResolveVisualReferencesInput(
+	f *feature.Feature,
+	designArtifactPath string,
+	label string,
+) (prompts.VisualReferencesInput, error) {
+	resolved, err := ResolveVisualReferences(f, designArtifactPath)
+	if err != nil {
+		return prompts.VisualReferencesInput{}, err
+	}
+	return resolved.PromptInput(label), nil
+}
+
+// ResolveVisualReferences merges the feature's original images with approved
+// generated mockups declared by mockups/manifest.yaml beside the Design
+// artifact. Missing manifests are accepted for backward compatibility.
+func ResolveVisualReferences(f *feature.Feature, designArtifactPath string) (ResolvedVisualReferences, error) {
+	var resolved ResolvedVisualReferences
+	if f != nil {
+		resolved.Images = append([]string(nil), f.Images...)
+	}
+	if designArtifactPath == "" {
+		return resolved, nil
+	}
+
+	designRoot := filepath.Dir(designArtifactPath)
+	manifestPath := filepath.Join(designRoot, filepath.FromSlash(designMockupManifestPath))
+	if err := validateManifestConfinement(designRoot, manifestPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return ResolvedVisualReferences{}, err
+	}
+	manifest, err := readDesignMockupManifest(manifestPath)
+	if errors.Is(err, os.ErrNotExist) {
+		return resolved, nil
+	}
+	if err != nil {
+		return ResolvedVisualReferences{}, err
+	}
+
+	mockupRoot := filepath.Dir(manifestPath)
+	if err := validateManifestDesignArtifact(designRoot, mockupRoot, designArtifactPath, manifest.DesignArtifact); err != nil {
+		return ResolvedVisualReferences{}, fmt.Errorf("validating %s: %w", manifestPath, err)
+	}
+	htmlPath, err := validateMockupFile(designRoot, mockupRoot, manifest.HTML, ".html")
+	if err != nil {
+		return ResolvedVisualReferences{}, fmt.Errorf("validating %s: html: %w", manifestPath, err)
+	}
+	seenIDs := make(map[string]struct{}, len(manifest.States))
+	seenSources := make(map[string]string, len(manifest.States))
+	seenPNGs := make(map[string]string, len(manifest.States))
+	for i, entry := range manifest.States {
+		mockup, err := validateDesignMockup(
+			designRoot, mockupRoot, htmlPath, entry, i, seenIDs, seenSources, seenPNGs,
+		)
+		if err != nil {
+			return ResolvedVisualReferences{}, fmt.Errorf("validating %s: %w", manifestPath, err)
+		}
+		resolved.Mockups = append(resolved.Mockups, mockup)
+	}
+	if err := validateDesignMockupMetadata(manifest, resolved.Mockups); err != nil {
+		return ResolvedVisualReferences{}, fmt.Errorf("validating %s: %w", manifestPath, err)
+	}
+	return resolved, nil
+}
+
+// ValidateDesignMockupManifest validates a manifest and every artifact it
+// references without requiring the caller to know the design markdown path.
+func ValidateDesignMockupManifest(manifestPath string) error {
+	manifest, err := readDesignMockupManifest(manifestPath)
+	if err != nil {
+		return err
+	}
+	mockupRoot := filepath.Dir(manifestPath)
+	designRoot := filepath.Dir(mockupRoot)
+	designPath, err := validateMockupFile(designRoot, mockupRoot, manifest.DesignArtifact, ".md")
+	if err != nil {
+		return fmt.Errorf("validating %s: design_artifact: %w", manifestPath, err)
+	}
+	_, err = ResolveVisualReferences(nil, designPath)
+	return err
+}
+
+func validateManifestConfinement(designRoot, manifestPath string) error {
+	realManifest, err := filepath.EvalSymlinks(manifestPath)
+	if err != nil {
+		return err
+	}
+	realRoot, err := filepath.EvalSymlinks(designRoot)
+	if err != nil {
+		return fmt.Errorf("resolve Design artifact root %q: %w", designRoot, err)
+	}
+	confined, err := pathWithinRoot(realRoot, realManifest)
+	if err != nil {
+		return err
+	}
+	if !confined {
+		return fmt.Errorf("design mockup manifest %q resolves outside the Design artifact root", manifestPath)
+	}
+	return nil
+}
+
+type designMockupManifest struct {
+	SchemaVersion          int                 `yaml:"schema_version"`
+	DesignArtifact         string              `yaml:"design_artifact"`
+	HTML                   string              `yaml:"html"`
+	ResponsiveExpectations []string            `yaml:"responsive_expectations,omitempty"`
+	BindingDecisions       []string            `yaml:"binding_decisions,omitempty"`
+	IllustrativeDetails    []string            `yaml:"illustrative_details,omitempty"`
+	States                 []designMockupEntry `yaml:"states"`
+}
+
+type designMockupEntry struct {
+	ID             string               `yaml:"id"`
+	Title          string               `yaml:"title"`
+	Source         string               `yaml:"source"`
+	PNG            string               `yaml:"png"`
+	Viewport       designMockupViewport `yaml:"viewport"`
+	DesignSections []string             `yaml:"design_sections"`
+	Description    string               `yaml:"description"`
+}
+
+type designMockupViewport struct {
+	Width             int `yaml:"width"`
+	Height            int `yaml:"height"`
+	DeviceScaleFactor int `yaml:"device_scale_factor"`
+}
+
+func readDesignMockupManifest(path string) (designMockupManifest, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return designMockupManifest{}, fmt.Errorf("opening design mockup manifest: %w", err)
+	}
+	defer file.Close()
+
+	var manifest designMockupManifest
+	decoder := yaml.NewDecoder(file)
+	decoder.KnownFields(true)
+	if err := decoder.Decode(&manifest); err != nil {
+		return designMockupManifest{}, fmt.Errorf("decoding design mockup manifest %s: %w", path, err)
+	}
+	var extra any
+	if err := decoder.Decode(&extra); err != io.EOF {
+		if err == nil {
+			return designMockupManifest{}, fmt.Errorf("decoding design mockup manifest %s: multiple YAML documents", path)
+		}
+		return designMockupManifest{}, fmt.Errorf("decoding design mockup manifest %s: %w", path, err)
+	}
+	if manifest.SchemaVersion != DesignMockupManifestVersion {
+		return designMockupManifest{}, fmt.Errorf(
+			"design mockup manifest %s has schema_version %d; want %d",
+			path, manifest.SchemaVersion, DesignMockupManifestVersion,
+		)
+	}
+	if strings.TrimSpace(manifest.DesignArtifact) == "" {
+		return designMockupManifest{}, fmt.Errorf("design mockup manifest %s has no design_artifact", path)
+	}
+	if strings.TrimSpace(manifest.HTML) == "" {
+		return designMockupManifest{}, fmt.Errorf("design mockup manifest %s has no html", path)
+	}
+	if len(manifest.States) == 0 {
+		return designMockupManifest{}, fmt.Errorf("design mockup manifest %s has no states", path)
+	}
+	return manifest, nil
+}
+
+func validateManifestDesignArtifact(designRoot, mockupRoot, designArtifactPath, declaredPath string) error {
+	resolved, err := validateMockupFile(designRoot, mockupRoot, strings.TrimSpace(declaredPath), ".md")
+	if err != nil {
+		return fmt.Errorf("design_artifact: %w", err)
+	}
+	expected, err := filepath.Abs(designArtifactPath)
+	if err != nil {
+		return fmt.Errorf("resolve Design artifact path %q: %w", designArtifactPath, err)
+	}
+	if resolved != filepath.Clean(expected) {
+		return fmt.Errorf("design_artifact resolves to %q; want %q", resolved, filepath.Clean(expected))
+	}
+	return nil
+}
+
+func validateDesignMockup(
+	designRoot string,
+	mockupRoot string,
+	manifestHTMLPath string,
+	entry designMockupEntry,
+	index int,
+	seenIDs map[string]struct{},
+	seenSources map[string]string,
+	seenPNGs map[string]string,
+) (ApprovedMockup, error) {
+	entry.ID = strings.TrimSpace(entry.ID)
+	entry.Source = strings.TrimSpace(entry.Source)
+	entry.PNG = strings.TrimSpace(entry.PNG)
+	if entry.ID == "" {
+		return ApprovedMockup{}, fmt.Errorf("states[%d].id is required", index)
+	}
+	if entry.Source == "" {
+		return ApprovedMockup{}, fmt.Errorf("mockup state %q source is required", entry.ID)
+	}
+	if entry.PNG == "" {
+		return ApprovedMockup{}, fmt.Errorf("mockup state %q png is required", entry.ID)
+	}
+	if _, exists := seenIDs[entry.ID]; exists {
+		return ApprovedMockup{}, fmt.Errorf("duplicate mockup id %q", entry.ID)
+	}
+	seenIDs[entry.ID] = struct{}{}
+
+	sourceFile, fragment, hasFragment := strings.Cut(entry.Source, "#")
+	if !hasFragment || strings.TrimSpace(fragment) == "" {
+		return ApprovedMockup{}, fmt.Errorf("mockup state %q source %q requires a fragment", entry.ID, entry.Source)
+	}
+	htmlPath, err := validateMockupFile(designRoot, mockupRoot, sourceFile, ".html")
+	if err != nil {
+		return ApprovedMockup{}, fmt.Errorf("mockup state %q source: %w", entry.ID, err)
+	}
+	if htmlPath != manifestHTMLPath {
+		return ApprovedMockup{}, fmt.Errorf(
+			"mockup state %q source resolves to %q; want manifest html %q",
+			entry.ID, htmlPath, manifestHTMLPath,
+		)
+	}
+	pngPath, err := validateMockupFile(designRoot, mockupRoot, entry.PNG, ".png")
+	if err != nil {
+		return ApprovedMockup{}, fmt.Errorf("mockup state %q png: %w", entry.ID, err)
+	}
+	sourcePath := htmlPath + "#" + fragment
+	if owner, exists := seenSources[sourcePath]; exists {
+		return ApprovedMockup{}, fmt.Errorf("duplicate source path %q used by mockups %q and %q", sourcePath, owner, entry.ID)
+	}
+	seenSources[sourcePath] = entry.ID
+	if owner, exists := seenPNGs[pngPath]; exists {
+		return ApprovedMockup{}, fmt.Errorf("duplicate png path %q used by mockups %q and %q", pngPath, owner, entry.ID)
+	}
+	seenPNGs[pngPath] = entry.ID
+	return ApprovedMockup{ID: entry.ID, HTMLPath: sourcePath, PNGPath: pngPath}, nil
+}
+
+func validateDesignMockupMetadata(manifest designMockupManifest, mockups []ApprovedMockup) error {
+	if len(manifest.ResponsiveExpectations) == 0 {
+		return errors.New("responsive_expectations must contain at least one decision")
+	}
+	if len(manifest.BindingDecisions) == 0 {
+		return errors.New("binding_decisions must contain at least one decision")
+	}
+	if manifest.IllustrativeDetails == nil {
+		return errors.New("illustrative_details must be present (use [] when none apply)")
+	}
+	for i, entry := range manifest.States {
+		if strings.TrimSpace(entry.Title) == "" {
+			return fmt.Errorf("mockup state %q title is required", entry.ID)
+		}
+		if entry.Viewport.Width <= 0 || entry.Viewport.Height <= 0 || entry.Viewport.DeviceScaleFactor <= 0 {
+			return fmt.Errorf("mockup state %q viewport values must be positive", entry.ID)
+		}
+		if len(entry.DesignSections) == 0 {
+			return fmt.Errorf("mockup state %q design_sections is required", entry.ID)
+		}
+		if strings.TrimSpace(entry.Description) == "" {
+			return fmt.Errorf("mockup state %q description is required", entry.ID)
+		}
+		file, err := os.Open(mockups[i].PNGPath)
+		if err != nil {
+			return fmt.Errorf("open mockup state %q PNG: %w", entry.ID, err)
+		}
+		cfg, _, decodeErr := image.DecodeConfig(file)
+		closeErr := file.Close()
+		if decodeErr != nil {
+			return fmt.Errorf("mockup state %q PNG is not decodable: %w", entry.ID, decodeErr)
+		}
+		if closeErr != nil {
+			return fmt.Errorf("close mockup state %q PNG: %w", entry.ID, closeErr)
+		}
+		expectedWidth := entry.Viewport.Width * entry.Viewport.DeviceScaleFactor
+		expectedHeight := entry.Viewport.Height * entry.Viewport.DeviceScaleFactor
+		if cfg.Width != expectedWidth || cfg.Height != expectedHeight {
+			return fmt.Errorf(
+				"mockup state %q PNG dimensions are %dx%d; want %dx%d from viewport",
+				entry.ID, cfg.Width, cfg.Height, expectedWidth, expectedHeight,
+			)
+		}
+	}
+	return nil
+}
+
+func validateMockupFile(designRoot, mockupRoot, manifestPath, extension string) (string, error) {
+	if filepath.IsAbs(manifestPath) {
+		return "", fmt.Errorf("path %q must be relative", manifestPath)
+	}
+	path := filepath.Clean(filepath.Join(mockupRoot, filepath.FromSlash(manifestPath)))
+	confined, err := pathWithinRoot(designRoot, path)
+	if err != nil {
+		return "", err
+	}
+	if !confined {
+		return "", fmt.Errorf("path %q escapes the Design artifact root", manifestPath)
+	}
+	if !strings.EqualFold(filepath.Ext(path), extension) {
+		return "", fmt.Errorf("path %q must use the %s extension", manifestPath, extension)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return "", fmt.Errorf("stat %q: %w", path, err)
+	}
+	if !info.Mode().IsRegular() {
+		return "", fmt.Errorf("path %q is not a regular file", path)
+	}
+	if info.Size() == 0 {
+		return "", fmt.Errorf("path %q is empty", path)
+	}
+
+	realRoot, err := filepath.EvalSymlinks(designRoot)
+	if err != nil {
+		return "", fmt.Errorf("resolve Design artifact root %q: %w", designRoot, err)
+	}
+	realPath, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return "", fmt.Errorf("resolve path %q: %w", path, err)
+	}
+	confined, err = pathWithinRoot(realRoot, realPath)
+	if err != nil {
+		return "", err
+	}
+	if !confined {
+		return "", fmt.Errorf("path %q resolves outside the Design artifact root", manifestPath)
+	}
+	return path, nil
+}
+
+func pathWithinRoot(root, path string) (bool, error) {
+	relative, err := filepath.Rel(filepath.Clean(root), filepath.Clean(path))
+	if err != nil {
+		return false, fmt.Errorf("compare path %q with root %q: %w", path, root, err)
+	}
+	return relative != ".." && !strings.HasPrefix(relative, ".."+string(filepath.Separator)), nil
+}
 
 // visualReferencesSection renders user-attached images (mockups, design
 // comps, screenshots of desired state, annotated whiteboards, bug
@@ -41,4 +439,26 @@ func visualReferencesSection(images []string, label string) string {
 		Images: images,
 		Label:  label,
 	})
+}
+
+// resolvedVisualReferencesSection renders original images and approved
+// generated mockups through the same shared prompt partial.
+func resolvedVisualReferencesSection(references ResolvedVisualReferences, label string) string {
+	return prompts.VisualReferences(references.PromptInput(label))
+}
+
+func visualReferencesForFeature(f *feature.Feature, designArtifactPath, label string) prompts.VisualReferencesInput {
+	resolved, err := ResolveVisualReferences(f, designArtifactPath)
+	if err != nil {
+		images := []string(nil)
+		if f != nil {
+			images = append(images, f.Images...)
+		}
+		return prompts.VisualReferencesInput{Images: images, Label: label}
+	}
+	return resolved.PromptInput(label)
+}
+
+func visualReferencesSectionForFeature(f *feature.Feature, designArtifactPath, label string) string {
+	return prompts.VisualReferences(visualReferencesForFeature(f, designArtifactPath, label))
 }

--- a/internal/agent/visual_references_test.go
+++ b/internal/agent/visual_references_test.go
@@ -15,11 +15,429 @@
 package agent
 
 import (
+	"image"
+	"image/color"
+	"image/png"
+	"os"
+	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
+	"github.com/doordash-oss/agentic-orchestrator/internal/agent/roles"
 	"github.com/doordash-oss/agentic-orchestrator/internal/feature"
 )
+
+func TestResolveVisualReferences_MergesFeatureImagesAndApprovedMockups(t *testing.T) {
+	designRoot := t.TempDir()
+	designPath := filepath.Join(designRoot, "design.md")
+	writeVisualReferenceTestFile(t, designPath, "# Design")
+	writeVisualReferenceTestFile(t, filepath.Join(designRoot, "mockups", "index.html"), "<html>checkout</html>")
+	writeVisualReferenceTestPNG(t, filepath.Join(designRoot, "mockups", "states", "checkout.png"), color.RGBA{R: 0xff, A: 0xff})
+	writeVisualReferenceTestFile(t, filepath.Join(designRoot, "mockups", "manifest.yaml"), `schema_version: 1
+design_artifact: ../design.md
+html: index.html
+responsive_expectations: [Responsive layout remains usable.]
+binding_decisions: [Primary action remains visible.]
+illustrative_details: []
+states:
+  - id: checkout
+    title: Checkout
+    source: index.html#state=checkout
+    png: states/checkout.png
+    viewport:
+      width: 2
+      height: 2
+      device_scale_factor: 1
+    design_sections: [User Experience, Contracts]
+    description: Approved checkout state.
+`)
+
+	got, err := ResolveVisualReferences(
+		&feature.Feature{Images: []string{"/tmp/user-reference.png"}},
+		designPath,
+	)
+	if err != nil {
+		t.Fatalf("ResolveVisualReferences() error = %v", err)
+	}
+	if !slices.Equal(got.Images, []string{"/tmp/user-reference.png"}) {
+		t.Fatalf("ResolveVisualReferences().Images = %v", got.Images)
+	}
+	if len(got.Mockups) != 1 {
+		t.Fatalf("ResolveVisualReferences().Mockups = %v, want one mockup", got.Mockups)
+	}
+	mockup := got.Mockups[0]
+	if mockup.ID != "checkout" ||
+		mockup.HTMLPath != filepath.Join(designRoot, "mockups", "index.html")+"#state=checkout" ||
+		mockup.PNGPath != filepath.Join(designRoot, "mockups", "states", "checkout.png") {
+		t.Errorf("ResolveVisualReferences().Mockups[0] = %+v", mockup)
+	}
+}
+
+func TestResolveVisualReferences_MissingManifestPreservesFeatureImages(t *testing.T) {
+	images := []string{"/tmp/one.png", "/tmp/two.png"}
+	got, err := ResolveVisualReferences(
+		&feature.Feature{Images: images},
+		filepath.Join(t.TempDir(), "design.md"),
+	)
+	if err != nil {
+		t.Fatalf("ResolveVisualReferences() error = %v", err)
+	}
+	if !slices.Equal(got.Images, images) || len(got.Mockups) != 0 {
+		t.Errorf("ResolveVisualReferences() = %+v, want only original images", got)
+	}
+}
+
+func TestResolveVisualReferences_RejectsInvalidManifestArtifacts(t *testing.T) {
+	tests := []struct {
+		name       string
+		manifest   string
+		beforeLoad func(t *testing.T, designRoot string)
+		wantError  string
+	}{
+		{
+			name: "unsupported version",
+			manifest: `schema_version: 2
+design_artifact: ../design.md
+html: index.html
+states:
+  - id: checkout
+    source: index.html#state=checkout
+    png: states/checkout.png
+`,
+			wantError: "schema_version 2",
+		},
+		{
+			name: "missing required id",
+			manifest: `schema_version: 1
+design_artifact: ../design.md
+html: index.html
+states:
+  - source: index.html#state=checkout
+    png: states/checkout.png
+`,
+			wantError: "id is required",
+		},
+		{
+			name: "missing required html",
+			manifest: `schema_version: 1
+design_artifact: ../design.md
+states:
+  - id: checkout
+    source: index.html#state=checkout
+    png: states/checkout.png
+`,
+			wantError: "has no html",
+		},
+		{
+			name: "missing required design artifact",
+			manifest: `schema_version: 1
+html: index.html
+states:
+  - id: checkout
+    source: index.html#state=checkout
+    png: states/checkout.png
+`,
+			wantError: "has no design_artifact",
+		},
+		{
+			name: "missing required states",
+			manifest: `schema_version: 1
+design_artifact: ../design.md
+html: index.html
+`,
+			wantError: "has no states",
+		},
+		{
+			name: "missing required png",
+			manifest: `schema_version: 1
+design_artifact: ../design.md
+html: index.html
+states:
+  - id: checkout
+    source: index.html#state=checkout
+`,
+			wantError: "png is required",
+		},
+		{
+			name: "missing required source",
+			manifest: `schema_version: 1
+design_artifact: ../design.md
+html: index.html
+states:
+  - id: checkout
+    png: states/checkout.png
+`,
+			wantError: "source is required",
+		},
+		{
+			name: "duplicate ids",
+			manifest: `schema_version: 1
+design_artifact: ../design.md
+html: index.html
+states:
+  - id: checkout
+    source: index.html#state=checkout
+    png: states/checkout.png
+  - id: checkout
+    source: index.html#state=confirmation
+    png: states/confirmation.png
+`,
+			wantError: `duplicate mockup id "checkout"`,
+		},
+		{
+			name: "source requires fragment",
+			manifest: `schema_version: 1
+design_artifact: ../design.md
+html: index.html
+states:
+  - id: checkout
+    source: index.html
+    png: states/checkout.png
+`,
+			wantError: "requires a fragment",
+		},
+		{
+			name: "duplicate source paths",
+			manifest: `schema_version: 1
+design_artifact: ../design.md
+html: index.html
+states:
+  - id: checkout
+    source: index.html#state=checkout
+    png: states/checkout.png
+  - id: confirmation
+    source: index.html#state=checkout
+    png: states/confirmation.png
+`,
+			wantError: "duplicate source path",
+		},
+		{
+			name: "duplicate png paths",
+			manifest: `schema_version: 1
+design_artifact: ../design.md
+html: index.html
+states:
+  - id: checkout
+    source: index.html#state=checkout
+    png: states/checkout.png
+  - id: confirmation
+    source: index.html#state=confirmation
+    png: states/checkout.png
+`,
+			wantError: "duplicate png path",
+		},
+		{
+			name: "path escapes design root",
+			manifest: `schema_version: 1
+design_artifact: ../design.md
+html: index.html
+states:
+  - id: checkout
+    source: ../../outside.html#state=checkout
+    png: states/checkout.png
+`,
+			wantError: "escapes the Design artifact root",
+		},
+		{
+			name: "absolute path",
+			manifest: `schema_version: 1
+design_artifact: ../design.md
+html: index.html
+states:
+  - id: checkout
+    source: index.html#state=checkout
+    png: /tmp/outside.png
+`,
+			wantError: "must be relative",
+		},
+		{
+			name: "missing file",
+			manifest: `schema_version: 1
+design_artifact: ../design.md
+html: missing.html
+states:
+  - id: checkout
+    source: missing.html#state=checkout
+    png: states/checkout.png
+`,
+			wantError: "no such file",
+		},
+		{
+			name: "empty file",
+			manifest: `schema_version: 1
+design_artifact: ../design.md
+html: index.html
+states:
+  - id: checkout
+    source: index.html#state=checkout
+    png: states/empty.png
+`,
+			beforeLoad: func(t *testing.T, designRoot string) {
+				writeVisualReferenceTestFile(t, filepath.Join(designRoot, "mockups", "states", "empty.png"), "")
+			},
+			wantError: "is empty",
+		},
+		{
+			name: "wrong extension",
+			manifest: `schema_version: 1
+design_artifact: ../design.md
+html: index.txt
+states:
+  - id: checkout
+    source: index.txt#state=checkout
+    png: states/checkout.png
+`,
+			wantError: "must use the .html extension",
+		},
+		{
+			name: "missing visual authority metadata",
+			manifest: `schema_version: 1
+design_artifact: ../design.md
+html: index.html
+states:
+  - id: checkout
+    title: Checkout
+    source: index.html#checkout
+    png: states/checkout.png
+    viewport:
+      width: 2
+      height: 2
+      device_scale_factor: 1
+    design_sections: [User Experience]
+    description: Checkout state.
+`,
+			wantError: "responsive_expectations",
+		},
+		{
+			name: "render dimensions disagree with viewport",
+			manifest: `schema_version: 1
+design_artifact: ../design.md
+html: index.html
+responsive_expectations: [Responsive layout remains usable.]
+binding_decisions: [Primary action remains visible.]
+illustrative_details: []
+states:
+  - id: checkout
+    title: Checkout
+    source: index.html#checkout
+    png: states/checkout.png
+    viewport:
+      width: 4
+      height: 4
+      device_scale_factor: 1
+    design_sections: [User Experience]
+    description: Checkout state.
+`,
+			wantError: "PNG dimensions are 2x2; want 4x4",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			designRoot := t.TempDir()
+			writeVisualReferenceTestFile(t, filepath.Join(designRoot, "design.md"), "# Design")
+			writeVisualReferenceTestFile(t, filepath.Join(designRoot, "mockups", "index.html"), "<html>checkout</html>")
+			writeVisualReferenceTestPNG(t, filepath.Join(designRoot, "mockups", "states", "checkout.png"), color.RGBA{R: 0xff, A: 0xff})
+			writeVisualReferenceTestPNG(t, filepath.Join(designRoot, "mockups", "states", "confirmation.png"), color.RGBA{G: 0xff, A: 0xff})
+			writeVisualReferenceTestFile(t, filepath.Join(designRoot, "mockups", "manifest.yaml"), tt.manifest)
+			if tt.beforeLoad != nil {
+				tt.beforeLoad(t, designRoot)
+			}
+
+			_, err := ResolveVisualReferences(nil, filepath.Join(designRoot, "design.md"))
+			if err == nil || !strings.Contains(err.Error(), tt.wantError) {
+				t.Fatalf("ResolveVisualReferences() error = %v, want containing %q", err, tt.wantError)
+			}
+		})
+	}
+}
+
+func TestResolvedVisualReferences_PropagateAcrossDownstreamPromptSurfaces(t *testing.T) {
+	references := ResolvedVisualReferences{
+		Images: []string{"/tmp/user.png"},
+		Mockups: []ApprovedMockup{{
+			ID:       "checkout",
+			HTMLPath: "/design/mockups/checkout.html",
+			PNGPath:  "/design/mockups/checkout.png",
+		}},
+	}
+
+	promptsByCaller := map[string]string{
+		"roadmap": roles.BuildRoadmapPrompt(roles.RoadmapUserInput{
+			DesignArtifactPath: "/design/design.md",
+			VisualReferences:   references.PromptInput("producing the roadmap"),
+		}),
+		"phase plan": roles.BuildPhasePlanPrompt(roles.PhasePlanUserInput{
+			VisualReferences: references.PromptInput("planning this phase"),
+		}),
+		"implementation": roles.BuildImplementPrompt(roles.ImplementUserInput{
+			VisualReferences: references.PromptInput("implementing this iteration"),
+		}),
+		"implementation review": roles.BuildImplementationReviewAxisPrompt(roles.ImplementationReviewAxisUserInput{
+			ReviewUserInput: roles.ReviewUserInput{
+				VisualReferences: references.PromptInput("reviewing this iteration"),
+			},
+			AxisLabel: "Visual fidelity",
+		}),
+		"final review": roles.BuildImplementationReviewAxisPrompt(roles.ImplementationReviewAxisUserInput{
+			ReviewUserInput: roles.ReviewUserInput{
+				VisualReferences: references.PromptInput("conducting this final review"),
+				FinalGate:        true,
+			},
+			AxisLabel: "Final visual fidelity",
+		}),
+	}
+
+	for caller, prompt := range promptsByCaller {
+		t.Run(caller, func(t *testing.T) {
+			for _, want := range []string{
+				"/tmp/user.png",
+				"checkout",
+				"/design/mockups/checkout.html",
+				"/design/mockups/checkout.png",
+			} {
+				if !strings.Contains(prompt, want) {
+					t.Errorf("%s prompt missing %q:\n%s", caller, want, prompt)
+				}
+			}
+		})
+	}
+}
+
+func writeVisualReferenceTestFile(t *testing.T, path, contents string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q): %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", path, err)
+	}
+}
+
+func writeVisualReferenceTestPNG(t *testing.T, path string, fill color.Color) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q): %v", filepath.Dir(path), err)
+	}
+	file, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("Create(%q): %v", path, err)
+	}
+	canvas := image.NewRGBA(image.Rect(0, 0, 2, 2))
+	for y := 0; y < 2; y++ {
+		for x := 0; x < 2; x++ {
+			canvas.Set(x, y, fill)
+		}
+	}
+	if err := png.Encode(file, canvas); err != nil {
+		_ = file.Close()
+		t.Fatalf("png.Encode(%q): %v", path, err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatalf("Close(%q): %v", path, err)
+	}
+}
 
 func TestVisualReferencesSection_EmptyImagesNoBlock(t *testing.T) {
 	if got := visualReferencesSection(nil, "implementing"); got != "" {
@@ -71,24 +489,18 @@ func TestBuildRoadmapPrompt_EmitsVisualReferences(t *testing.T) {
 	}
 }
 
-// TestBuildRoadmapPrompt_SuppressesVisualReferencesWhenDesignDocPresent
-// asserts the inverse path: when a design/design artifact exists,
-// the design doc is the authoritative spec and already incorporates the
-// user's visual references. Re-injecting them in the roadmap prompt
-// would create two competing sources of truth, so the prompt suppresses
-// the block and points the planner at the design doc instead.
-func TestBuildRoadmapPrompt_SuppressesVisualReferencesWhenDesignDocPresent(t *testing.T) {
+func TestBuildRoadmapPrompt_CarriesVisualReferencesWhenDesignDocPresent(t *testing.T) {
 	f := &feature.Feature{
 		Name:        "X",
 		Description: "do a thing",
 		Images:      []string{"/tmp/mockup.png"},
 	}
 	prompt := BuildRoadmapPrompt(f, "", "", "/tmp/design.md", nil)
-	if strings.Contains(prompt, "Visual References") {
-		t.Errorf("roadmap prompt should suppress Visual References when a design doc is present:\n%s", prompt)
+	if !strings.Contains(prompt, "Visual References") {
+		t.Errorf("roadmap prompt missing Visual References when a design doc is present:\n%s", prompt)
 	}
-	if strings.Contains(prompt, "/tmp/mockup.png") {
-		t.Errorf("roadmap prompt should not list mockup paths when a design doc is present:\n%s", prompt)
+	if !strings.Contains(prompt, "/tmp/mockup.png") {
+		t.Errorf("roadmap prompt missing mockup path when a design doc is present:\n%s", prompt)
 	}
 }
 
@@ -100,61 +512,46 @@ func TestBuildRoadmapPrompt_NoImagesNoBlock(t *testing.T) {
 	}
 }
 
-// TestBuildPhasePlanPrompt_OmitsVisualReferences pins the deliberate
-// decision that the per-phase plan prompt does NOT carry visual
-// references. The approved roadmap is the authoritative input at this
-// stage and already incorporates the user's mockups; re-injecting them
-// here would create two competing sources of truth.
-func TestBuildPhasePlanPrompt_OmitsVisualReferences(t *testing.T) {
+func TestBuildPhasePlanPrompt_CarriesVisualReferences(t *testing.T) {
 	f := &feature.Feature{
 		Name:        "X",
 		Description: "build a screen",
 		Images:      []string{"/tmp/screen.png"},
 	}
 	prompt := BuildPhasePlanPrompt(f, "", "", "/tmp/roadmap.md", RoadmapPhase{Number: 1, Type: "tracer-bullet", Name: "Setup"}, nil)
-	if strings.Contains(prompt, "Visual References") {
-		t.Errorf("phase plan prompt should NOT carry Visual References, got:\n%s", prompt)
+	if !strings.Contains(prompt, "Visual References") {
+		t.Errorf("phase plan prompt missing Visual References:\n%s", prompt)
 	}
-	if strings.Contains(prompt, "/tmp/screen.png") {
-		t.Errorf("phase plan prompt should NOT carry mockup paths, got:\n%s", prompt)
+	if !strings.Contains(prompt, "/tmp/screen.png") {
+		t.Errorf("phase plan prompt missing visual reference path:\n%s", prompt)
 	}
 }
 
-// TestBuildPhasePlanRevisionPrompt_OmitsVisualReferences pins the
-// deliberate decision that the per-phase plan revision prompt does NOT
-// carry visual references. A revision is a text-level edit driven by
-// critic feedback against the prior plan, not a fresh design pass —
-// mockups belong on the create-roadmap surface.
-func TestBuildPhasePlanRevisionPrompt_OmitsVisualReferences(t *testing.T) {
+func TestBuildPhasePlanRevisionPrompt_CarriesVisualReferences(t *testing.T) {
 	f := &feature.Feature{
 		Name:   "X",
 		Images: []string{"/tmp/screen.png"},
 	}
 	prompt := BuildPhasePlanRevisionPrompt(f, "", "/tmp/prev.md", "feedback", "", RoadmapPhase{Number: 1, Type: "tdd-fill-in", Name: "Fill"}, 2, nil)
-	if strings.Contains(prompt, "Visual References") {
-		t.Errorf("phase plan revision prompt should NOT carry Visual References, got:\n%s", prompt)
+	if !strings.Contains(prompt, "Visual References") {
+		t.Errorf("phase plan revision prompt missing Visual References:\n%s", prompt)
 	}
-	if strings.Contains(prompt, "/tmp/screen.png") {
-		t.Errorf("phase plan revision prompt should NOT carry mockup paths, got:\n%s", prompt)
+	if !strings.Contains(prompt, "/tmp/screen.png") {
+		t.Errorf("phase plan revision prompt missing visual reference path:\n%s", prompt)
 	}
 }
 
-// TestBuildRoadmapRevisionPrompt_OmitsVisualReferences pins the deliberate
-// decision that the roadmap revision prompt does NOT carry visual references.
-// A revision is a text-level edit driven by critic feedback, not a fresh
-// design pass; mockups belong on the create-roadmap and per-phase plan
-// prompts, not here.
-func TestBuildRoadmapRevisionPrompt_OmitsVisualReferences(t *testing.T) {
+func TestBuildRoadmapRevisionPrompt_CarriesVisualReferences(t *testing.T) {
 	f := &feature.Feature{
 		Name:   "X",
 		Images: []string{"/tmp/screen.png"},
 	}
 	prompt := BuildRoadmapRevisionPrompt(f, "", "/tmp/r.md", "/tmp/p.md", "feedback", "", 2, nil)
-	if strings.Contains(prompt, "Visual References") {
-		t.Errorf("roadmap revision prompt should NOT carry Visual References, got:\n%s", prompt)
+	if !strings.Contains(prompt, "Visual References") {
+		t.Errorf("roadmap revision prompt missing Visual References:\n%s", prompt)
 	}
-	if strings.Contains(prompt, "/tmp/screen.png") {
-		t.Errorf("roadmap revision prompt should NOT carry image paths, got:\n%s", prompt)
+	if !strings.Contains(prompt, "/tmp/screen.png") {
+		t.Errorf("roadmap revision prompt missing image path:\n%s", prompt)
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -25,6 +25,8 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+const defaultMaxDesignIterations = 5
+
 // validKeyboardLayouts defines the set of accepted keyboard_layout values.
 // An empty string means "use default (US) behaviour".
 var validKeyboardLayouts = map[string]bool{
@@ -106,6 +108,7 @@ type DefaultsConfig struct {
 	MaxIterations            int                           `yaml:"max_iterations" json:"max_iterations,omitempty"`
 	MaxConsecutiveFailures   int                           `yaml:"max_consecutive_failures" json:"max_consecutive_failures,omitempty"`
 	MaxConsecutiveNoProgress int                           `yaml:"max_consecutive_no_progress" json:"max_consecutive_no_progress,omitempty"`
+	MaxDesignIterations      int                           `yaml:"max_design_iterations,omitempty" json:"max_design_iterations,omitempty"`
 	MaxPhasePlanIterations   int                           `yaml:"max_phase_plan_iterations,omitempty" json:"max_phase_plan_iterations,omitempty"`
 	Checkpoints              Checkpoints                   `yaml:"checkpoints" json:"checkpoints"`
 	// AutomaticReviewEnabled controls the default-off workspace behavior that
@@ -403,6 +406,9 @@ func applyDefaults(cfg *Config) {
 	}
 	if cfg.Defaults.MaxConsecutiveNoProgress == 0 {
 		cfg.Defaults.MaxConsecutiveNoProgress = d.Defaults.MaxConsecutiveNoProgress
+	}
+	if cfg.Defaults.MaxDesignIterations == 0 {
+		cfg.Defaults.MaxDesignIterations = defaultMaxDesignIterations
 	}
 	if cfg.Defaults.MaxPhasePlanIterations == 0 {
 		cfg.Defaults.MaxPhasePlanIterations = 10

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -498,6 +498,39 @@ func TestMaxPhasePlanIterationsDefault(t *testing.T) {
 	}
 }
 
+func TestMaxDesignIterationsDefault(t *testing.T) {
+	cfg := NewDefault()
+	applyDefaults(cfg)
+	if cfg.Defaults.MaxDesignIterations != 5 {
+		t.Fatalf("MaxDesignIterations = %d, want 5", cfg.Defaults.MaxDesignIterations)
+	}
+}
+
+func TestMaxDesignIterationsPreserved(t *testing.T) {
+	cfg := Config{Defaults: DefaultsConfig{MaxDesignIterations: 3}}
+	applyDefaults(&cfg)
+	if cfg.Defaults.MaxDesignIterations != 3 {
+		t.Fatalf("MaxDesignIterations = %d, want preserved value 3", cfg.Defaults.MaxDesignIterations)
+	}
+}
+
+func TestMaxDesignIterationsRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	original := NewDefault()
+	original.Defaults.MaxDesignIterations = 4
+	if err := Save(path, original); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+	loaded, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if loaded.Defaults.MaxDesignIterations != 4 {
+		t.Fatalf("MaxDesignIterations = %d, want 4 after round trip", loaded.Defaults.MaxDesignIterations)
+	}
+}
+
 func TestMaxPhasePlanIterationsPreserved(t *testing.T) {
 	cfg := &Config{}
 	cfg.Defaults.MaxPhasePlanIterations = 5

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -45,6 +45,7 @@ func NewDefault() *Config {
 			Inquireness:              "high",
 			Pipeline:                 "large",
 			MaxIterations:            10,
+			MaxDesignIterations:      defaultMaxDesignIterations,
 			MaxConsecutiveFailures:   3,
 			MaxConsecutiveNoProgress: 3,
 		},

--- a/internal/feature/carry_forward_test.go
+++ b/internal/feature/carry_forward_test.go
@@ -44,10 +44,10 @@ func TestRewindToPhase_CarryForwardArtifactPathEdges(t *testing.T) {
 
 	if err := mgr.Store.Modify(f.ID, func(ff *feature.Feature) error {
 		ff.Artifacts = map[string]string{
-			"inquire":    relInquire,
-			"research":   outsideResearch,
-			"design": absDesign,
-			"pr_url":     "https://github.com/o/r/pull/42",
+			"inquire":  relInquire,
+			"research": outsideResearch,
+			"design":   absDesign,
+			"pr_url":   "https://github.com/o/r/pull/42",
 		}
 		return nil
 	}); err != nil {
@@ -63,9 +63,9 @@ func TestRewindToPhase_CarryForwardArtifactPathEdges(t *testing.T) {
 		t.Fatalf("Get: %v", err)
 	}
 	want := map[string]string{
-		"inquire":    relInquire,
-		"research":   outsideResearch,
-		"design": filepath.Join("design", "design.md"),
+		"inquire":  relInquire,
+		"research": outsideResearch,
+		"design":   filepath.Join("design", "design.md"),
 	}
 	if len(got.Artifacts) != len(want) {
 		t.Fatalf("Artifacts len = %d, want %d: %v", len(got.Artifacts), len(want), got.Artifacts)

--- a/internal/feature/feature.go
+++ b/internal/feature/feature.go
@@ -46,6 +46,9 @@ const (
 // DesignArtifactKey is the artifact-map key for the Design phase output.
 const DesignArtifactKey = "design"
 
+// DesignMockupsArtifactKey is the artifact-map key for an approved mockup manifest.
+const DesignMockupsArtifactKey = "design-mockups"
+
 // ResearchArtifactKey is the artifact-map key for the Research phase output.
 const ResearchArtifactKey = "research"
 
@@ -55,6 +58,14 @@ func (f *Feature) DesignArtifactPath() string {
 		return ""
 	}
 	return f.Artifacts[DesignArtifactKey]
+}
+
+// DesignMockupsArtifactPath returns the approved mockup manifest path, when present.
+func (f *Feature) DesignMockupsArtifactPath() string {
+	if f == nil || f.Artifacts == nil {
+		return ""
+	}
+	return f.Artifacts[DesignMockupsArtifactKey]
 }
 
 // ResearchArtifactPath returns the recorded path of the Research artifact for a feature.
@@ -671,6 +682,7 @@ type Feature struct {
 	HelpQueue            []HelpRequest       `yaml:"help_queue"`
 	MaxIterations        int                 `yaml:"max_iterations,omitempty"`
 	MaxPlanIterations    int                 `yaml:"max_plan_iterations,omitempty"`
+	MaxDesignIterations  int                 `yaml:"max_design_iterations,omitempty"`
 	RiskLevel            RiskLevel           `yaml:"risk_level,omitempty"`
 	Pipeline             PipelineProfile     `yaml:"pipeline,omitempty"`
 	PipelineUpgradedFrom PipelineProfile     `yaml:"pipeline_upgraded_from,omitempty"` // original profile before UpgradePipeline; used to enforce KB restart on rewind
@@ -718,11 +730,13 @@ type Feature struct {
 	ReviewingGate     bool              `yaml:"-"`
 	ReviewFixing      bool              `yaml:"-"`
 	ValidatingPlan    bool              `yaml:"-"`
+	ValidatingDesign  bool              `yaml:"-"`
 	ValidatorStatuses map[string]string `yaml:"-"`
 	// VerificationItems is the ordered live progress of harness-executed
 	// testing-contract commands while CurrentPhaseStatus is "verifying".
 	VerificationItems []VerificationItemStatus `yaml:"-"`
 	PlanIteration     int                      `yaml:"-"`
+	DesignIteration   int                      `yaml:"-"`
 	ReviewIteration   int                      `yaml:"-"`
 	Artifacts         map[string]string        `yaml:"-"`
 	// RepoStates is the per-repo state map. agent.AtomicPhaseStamp writes it
@@ -840,9 +854,11 @@ func (f *Feature) syncShadowsToRun() {
 	r.ReviewingGate = f.ReviewingGate
 	r.ReviewFixing = f.ReviewFixing
 	r.ValidatingPlan = f.ValidatingPlan
+	r.ValidatingDesign = f.ValidatingDesign
 	r.ValidatorStatuses = f.ValidatorStatuses
 	r.VerificationItems = f.VerificationItems
 	r.PlanIteration = f.PlanIteration
+	r.DesignIteration = f.DesignIteration
 	r.ReviewIteration = f.ReviewIteration
 	r.Artifacts = f.Artifacts
 	if f.RoadmapPhaseFrontendByPhase != nil {
@@ -872,6 +888,7 @@ func (f *Feature) syncShadowsToRun() {
 	r.TotalRoadmapPhases = f.TotalRoadmapPhases
 	r.RoadmapPhaseType = f.RoadmapPhaseType
 	r.MaxPlanIterations = f.MaxPlanIterations
+	r.MaxDesignIterations = f.MaxDesignIterations
 	r.PendingNeedUserInputPath = f.PendingNeedUserInputPath
 	r.CurrentPhaseStatus = f.CurrentPhaseStatus
 }
@@ -889,9 +906,11 @@ func (f *Feature) syncRunToShadows() {
 	f.ReviewingGate = r.ReviewingGate
 	f.ReviewFixing = r.ReviewFixing
 	f.ValidatingPlan = r.ValidatingPlan
+	f.ValidatingDesign = r.ValidatingDesign
 	f.ValidatorStatuses = r.ValidatorStatuses
 	f.VerificationItems = r.VerificationItems
 	f.PlanIteration = r.PlanIteration
+	f.DesignIteration = r.DesignIteration
 	f.ReviewIteration = r.ReviewIteration
 	f.Artifacts = r.Artifacts
 	f.RoadmapPhaseFrontendByPhase = r.RoadmapPhaseFrontendByPhase
@@ -917,6 +936,7 @@ func (f *Feature) syncRunToShadows() {
 	f.TotalRoadmapPhases = r.TotalRoadmapPhases
 	f.RoadmapPhaseType = r.RoadmapPhaseType
 	f.MaxPlanIterations = r.MaxPlanIterations
+	f.MaxDesignIterations = r.MaxDesignIterations
 	f.PendingNeedUserInputPath = r.PendingNeedUserInputPath
 	f.CurrentPhaseStatus = r.CurrentPhaseStatus
 }

--- a/internal/feature/manager.go
+++ b/internal/feature/manager.go
@@ -472,7 +472,14 @@ func (m *Manager) StartDesign(featureID string) error {
 
 // CompleteDesign transitions a feature to PlanReady.
 func (m *Manager) CompleteDesign(featureID string) error {
-	return m.Transition(featureID, StatusPlanReady)
+	return m.Store.Modify(featureID, func(f *Feature) error {
+		if err := f.Transition(StatusPlanReady); err != nil {
+			return err
+		}
+		f.ValidatingDesign = false
+		f.ValidatorStatuses = nil
+		return nil
+	})
 }
 
 // StartResearch transitions a feature to Researching status and sets CurrentPhase.
@@ -583,6 +590,7 @@ func (m *Manager) StartPlanning(featureID string) error {
 		}
 		f.CurrentPhase = PhasePlan
 		f.ValidatingPlan = false
+		f.ValidatingDesign = false
 		f.ValidatorStatuses = nil
 		// Accumulate any in-flight time under the old key before switching.
 		// Without this, an interrupt → restart cycle for a roadmap-phase plan

--- a/internal/feature/run.go
+++ b/internal/feature/run.go
@@ -91,6 +91,7 @@ type Run struct {
 	// Iteration counters (moved from Feature).
 	CurrentIteration int `yaml:"current_iteration,omitempty"`
 	PlanIteration    int `yaml:"plan_iteration,omitempty"`
+	DesignIteration  int `yaml:"design_iteration,omitempty"`
 	ReviewIteration  int `yaml:"review_iteration,omitempty"`
 	RebaseCount      int `yaml:"rebase_count,omitempty"`
 	RefactorCount    int `yaml:"refactor_count,omitempty"`
@@ -150,6 +151,7 @@ type Run struct {
 
 	// Plan validation + gate state (moved from Feature).
 	ValidatingPlan    bool              `yaml:"validating_plan,omitempty"`
+	ValidatingDesign  bool              `yaml:"validating_design,omitempty"`
 	ValidatorStatuses map[string]string `yaml:"validator_statuses,omitempty"`
 	// VerificationItems is the ordered live progress of harness-executed
 	// testing-contract commands while CurrentPhaseStatus is "verifying".
@@ -169,7 +171,8 @@ type Run struct {
 	// MaxPlanIterations is a per-run ceiling. The feature-level
 	// MaxPlanIterations is a user-set config ceiling; this per-run counter
 	// tracks the reset-on-phase-boundary limit that the plan loop consults.
-	MaxPlanIterations int `yaml:"max_plan_iterations,omitempty"`
+	MaxPlanIterations   int `yaml:"max_plan_iterations,omitempty"`
+	MaxDesignIterations int `yaml:"max_design_iterations,omitempty"`
 
 	// Error state (moved from Feature).
 	LastError   string `yaml:"last_error,omitempty"`

--- a/internal/orchestrator/completion.go
+++ b/internal/orchestrator/completion.go
@@ -604,6 +604,92 @@ func (o *Orchestrator) validateArtifactPhaseCompletionContract(
 }
 
 // ---------------------------------------------------------------------------
+// Design loop completion
+// ---------------------------------------------------------------------------
+
+func (o *Orchestrator) onDesignLoopDone(featureID string, result *agent.DesignLoopResult) error {
+	f, err := o.deps.Lifecycle.Get(featureID)
+	if err != nil {
+		return fmt.Errorf("load feature: %w", err)
+	}
+	if isTerminalForCompletion(f) {
+		return nil
+	}
+	if result == nil {
+		errMsg := "Design loop returned no result"
+		o.emitPhaseCompleted(featureID, feature.PhaseDesign, errors.New(errMsg))
+		return o.markFailedWithEvent(featureID, feature.FailureInfrastructure, errMsg)
+	}
+
+	designDir := o.artifactReadOnlyGuardDir(f, feature.PhaseDesign.DirName())
+	violations, err := agent.EnforceReadOnlyRepoMutations(context.Background(), o.deps.CmdRunner, f, feature.PhaseDesign, designDir)
+	if err != nil {
+		return fmt.Errorf("enforce Design read-only repo guard: %w", err)
+	}
+	if len(violations) > 0 {
+		errMsg := formatSingleShotProtocolViolationError(agent.RoleDesigner, designDir, violations)
+		o.emitPhaseCompleted(featureID, feature.PhaseDesign, errors.New(errMsg))
+		return o.markFailedWithEvent(featureID, feature.FailureProtocolViolation, errMsg)
+	}
+
+	clearProgress := func() {
+		_ = o.deps.Store.Modify(featureID, func(ff *feature.Feature) error {
+			ff.ValidatingDesign = false
+			ff.ValidatorStatuses = nil
+			return nil
+		})
+	}
+	switch result.FinalStatus {
+	case "approved":
+		clearProgress()
+		if err := o.deps.Lifecycle.CompleteDesign(featureID); err != nil {
+			return fmt.Errorf("complete Design: %w", err)
+		}
+		o.emitPhaseCompleted(featureID, feature.PhaseDesign, nil)
+		return o.advanceToNextPhase(featureID, feature.PhaseDesign)
+	case "needs_human_review":
+		clearProgress()
+		if err := o.EnterReviewGate(featureID, feature.PhasePlan); err != nil {
+			return fmt.Errorf("enter Design review gate: %w", err)
+		}
+		o.emitPhaseCompleted(featureID, feature.PhaseDesign, nil)
+		o.emitEventBlocking(ports.Event{
+			Type:      ports.ReviewRequired,
+			FeatureID: featureID,
+			Phase:     feature.PhaseDesign,
+		})
+		if o.hooks.OnReviewRequired != nil {
+			o.hooks.OnReviewRequired(featureID, feature.PhaseDesign)
+		}
+		return nil
+	case "failed":
+		clearProgress()
+		errMsg := result.LastError
+		if errMsg == "" {
+			errMsg = "Design loop failed"
+		}
+		o.emitPhaseCompleted(featureID, feature.PhaseDesign, errors.New(errMsg))
+		return o.markFailedWithEvent(featureID, feature.FailureInfrastructure, errMsg)
+	case agent.BoundedHelperStatusProtocolViolation:
+		clearProgress()
+		errMsg := result.LastError
+		if errMsg == "" {
+			errMsg = "Design loop protocol violation"
+		}
+		o.emitPhaseCompleted(featureID, feature.PhaseDesign, errors.New(errMsg))
+		return o.markFailedWithEvent(featureID, feature.FailureProtocolViolation, errMsg)
+	case finalStatusInterrupted:
+		clearProgress()
+		return nil
+	default:
+		clearProgress()
+		errMsg := fmt.Sprintf("unknown Design FinalStatus %q", result.FinalStatus)
+		o.emitPhaseCompleted(featureID, feature.PhaseDesign, errors.New(errMsg))
+		return o.markFailedWithEvent(featureID, feature.FailureInfrastructure, errMsg)
+	}
+}
+
+// ---------------------------------------------------------------------------
 // Plan loop completion
 // ---------------------------------------------------------------------------
 

--- a/internal/orchestrator/completion_test.go
+++ b/internal/orchestrator/completion_test.go
@@ -712,7 +712,7 @@ func TestOrchestrator_HandlePhaseCompletion_KB_Failure(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// Category B — Artifact phase completion (Inquire / Research / Design)
+// Category B — Single-shot artifact phase completion (Inquire / Research)
 // ---------------------------------------------------------------------------
 
 type artifactPhaseCase struct {
@@ -727,9 +727,6 @@ func artifactPhaseCases() []artifactPhaseCase {
 	return []artifactPhaseCase{
 		{"inquire", feature.PhaseInquire, "inquire", "inquire", feature.StatusInquiring},
 		{"research", feature.PhaseResearch, "research", "research", feature.StatusResearching},
-		// The Design phase keeps the legacy "design" on-disk subdir for
-		// compat but persists under the canonical Design artifact key.
-		{"design", feature.PhaseDesign, "design", feature.DesignArtifactKey, feature.StatusDesigning},
 	}
 }
 
@@ -1649,6 +1646,125 @@ func TestOrchestrator_HandlePhaseCompletion_Inquire_Terminal(t *testing.T) {
 	}
 
 	refuteLifecycleCall(t, lc, "CompleteInquire")
+}
+
+func TestOrchestrator_HandlePhaseCompletion_DesignApprovedAdvancesToPlan(t *testing.T) {
+	o, store, lc := newDesignLoopCompletionFixture(t, feature.Checkpoints{})
+
+	if err := o.HandlePhaseCompletion("feat-design-loop", orchestrator.PhaseCompletionInput{
+		Phase:        feature.PhaseDesign,
+		DesignResult: &agent.DesignLoopResult{FinalStatus: "approved", Iterations: 2},
+	}); err != nil {
+		t.Fatalf("HandlePhaseCompletion(): %v", err)
+	}
+
+	assertLifecycleCall(t, lc, "CompleteDesign")
+	assertLifecycleCall(t, lc, "StartPlanning")
+	got := loadStoredFeature(t, store, "feat-design-loop")
+	if got.Status != feature.StatusPlanning {
+		t.Fatalf("Status = %s, want Planning", got.Status)
+	}
+	if got.ValidatingDesign || len(got.ValidatorStatuses) != 0 {
+		t.Fatalf("Design validation progress was not cleared: %+v", got)
+	}
+}
+
+func TestOrchestrator_HandlePhaseCompletion_DesignNeedsHumanReviewAlwaysGates(t *testing.T) {
+	o, store, lc := newDesignLoopCompletionFixture(t, feature.Checkpoints{})
+
+	if err := o.HandlePhaseCompletion("feat-design-loop", orchestrator.PhaseCompletionInput{
+		Phase: feature.PhaseDesign,
+		DesignResult: &agent.DesignLoopResult{
+			FinalStatus: "needs_human_review",
+			Iterations:  5,
+		},
+	}); err != nil {
+		t.Fatalf("HandlePhaseCompletion(): %v", err)
+	}
+
+	refuteLifecycleCall(t, lc, "CompleteDesign")
+	got := loadStoredFeature(t, store, "feat-design-loop")
+	if got.Status != feature.StatusDesignNeedsReview {
+		t.Fatalf("Status = %s, want DesignNeedsReview", got.Status)
+	}
+	if got.PendingReviewPhase == nil || *got.PendingReviewPhase != feature.PhasePlan {
+		t.Fatalf("PendingReviewPhase = %v, want Plan", got.PendingReviewPhase)
+	}
+}
+
+func TestOrchestrator_HandlePhaseCompletion_DesignFailureMarksFailed(t *testing.T) {
+	o, store, _ := newDesignLoopCompletionFixture(t, feature.Checkpoints{})
+
+	if err := o.HandlePhaseCompletion("feat-design-loop", orchestrator.PhaseCompletionInput{
+		Phase: feature.PhaseDesign,
+		DesignResult: &agent.DesignLoopResult{
+			FinalStatus: "failed",
+			LastError:   "critic infrastructure failed",
+		},
+	}); err != nil {
+		t.Fatalf("HandlePhaseCompletion(): %v", err)
+	}
+
+	got := loadStoredFeature(t, store, "feat-design-loop")
+	if got.Status != feature.StatusFailed || got.FailureType != feature.FailureInfrastructure {
+		t.Fatalf("failure state = (%s, %s), want Failed/infrastructure", got.Status, got.FailureType)
+	}
+}
+
+func newDesignLoopCompletionFixture(t *testing.T, checkpoints feature.Checkpoints) (*orchestrator.Orchestrator, *feature.Store, *mocks.MockFeatureLifecycle) {
+	t.Helper()
+	stateDir := t.TempDir()
+	designPath := filepath.Join(stateDir, "design.md")
+	if err := os.WriteFile(designPath, []byte("# Design\n"), 0o644); err != nil {
+		t.Fatalf("write design artifact: %v", err)
+	}
+	f := &feature.Feature{
+		ID:                "feat-design-loop",
+		Status:            feature.StatusDesigning,
+		CurrentPhase:      feature.PhaseDesign,
+		Pipeline:          feature.PipelineLarge,
+		ActiveRun:         1,
+		RunCount:          1,
+		SchemaVersion:     feature.SchemaVersionCurrent,
+		Checkpoints:       checkpoints,
+		ValidatingDesign:  true,
+		ValidatorStatuses: map[string]string{"Integrity": "running"},
+		Artifacts:         map[string]string{feature.DesignArtifactKey: designPath},
+	}
+	store := feature.NewStore(stateDir)
+	if err := store.Save(f); err != nil {
+		t.Fatalf("Save(feature): %v", err)
+	}
+	lc := lifecycleForFeature(f)
+	lc.GetFn = func(id string) (*feature.Feature, error) {
+		return store.Load(id)
+	}
+	lc.CompleteDesignFn = func(id string) error {
+		return store.Modify(id, func(ff *feature.Feature) error {
+			ff.Status = feature.StatusPlanReady
+			return nil
+		})
+	}
+	lc.StartPlanningFn = func(id string) error {
+		return store.Modify(id, func(ff *feature.Feature) error {
+			ff.Status = feature.StatusPlanning
+			ff.CurrentPhase = feature.PhasePlan
+			return nil
+		})
+	}
+	lc.MarkFailedFn = func(id, failureType, message string) error {
+		return store.Modify(id, func(ff *feature.Feature) error {
+			ff.Status = feature.StatusFailed
+			ff.FailureType = failureType
+			ff.LastError = message
+			return nil
+		})
+	}
+	o := orchestrator.New(orchestrator.Deps{
+		Lifecycle: lc,
+		Store:     store,
+	}, orchestrator.Hooks{})
+	return o, store, lc
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/orchestrator/grill_me_fanout_integration_test.go
+++ b/internal/orchestrator/grill_me_fanout_integration_test.go
@@ -176,18 +176,14 @@ func TestRunPhasePlanning_HighInquireness_GrillMePromptInvariant(t *testing.T) {
 }
 
 // TestGrillMeFanout_PrimaryBuilders_EndToEnd is the table-driven fan-out
-// integration test for the three primary grill-me builders. For each row:
+// integration test for the iterative planning builders. For each row:
 //
 //	(i) the test pre-writes a stale qa-answers.md at the canonical phase
 //	    directory;
 //	(ii) drives HandlePhaseCompletion with the input shape the production
-//	    code uses for that phase (SessionID-based for Design, PlanResult-
-//	    based for Roadmap and Phase-Plan);
-//	(iii) asserts Design is replaced from the session Q&A log, while
-//	    Roadmap and Phase-Plan preserve transcripts already written by their
-//	    planner loops;
-//	(iv) for Design and Roadmap (which have downstream consumers of
-//	    collectQAFilePaths), asserts the path is surfaced to the next phase.
+//	    code uses for Roadmap and Phase-Plan;
+//	(iii) asserts transcripts already written by their planner loops survive;
+//	(iv) for Roadmap, asserts the path is surfaced to the next phase.
 //
 // Phase-Plan deliberately does not propagate qa-answers.md downstream
 // (see plan §`What We're NOT Doing`), so the phase-plan row asserts
@@ -202,43 +198,6 @@ func TestGrillMeFanout_PrimaryBuilders_EndToEnd(t *testing.T) {
 		assertCollectQA  bool
 		expectedQAPathFn func(stateDir string, f *feature.Feature) string
 	}{
-		{
-			name: "design",
-			phaseDirRel: func(stateDir string, f *feature.Feature) string {
-				return filepath.Join(agent.ActiveRunDir(stateDir, f), "design")
-			},
-			setupFeature: func() *feature.Feature {
-				return &feature.Feature{
-					ID:           "feat-fanout-design",
-					ActiveRun:    1,
-					RunCount:     1,
-					Status:       feature.StatusDesigning,
-					CurrentPhase: feature.PhaseDesign,
-					Pipeline:     feature.PipelineLarge,
-					Checkpoints: feature.Checkpoints{
-						InquiryReview:   true,
-						ResearchReview:  true,
-						DesignReview:    true,
-						RoadmapReview:   true,
-						PhasePlanReview: true,
-					},
-				}
-			},
-			invoke: func(t *testing.T, o *Orchestrator, featureID string) {
-				if err := o.HandlePhaseCompletion(featureID, PhaseCompletionInput{
-					Phase:     feature.PhaseDesign,
-					SessionID: "sess-1",
-					Success:   true,
-				}); err != nil {
-					t.Fatalf("HandlePhaseCompletion design: %v", err)
-				}
-			},
-			wantQAFile:      sampleHarnessOwnedQA,
-			assertCollectQA: true,
-			expectedQAPathFn: func(stateDir string, f *feature.Feature) string {
-				return filepath.Join(agent.ActiveRunDir(stateDir, f), "design", "qa-answers.md")
-			},
-		},
 		{
 			name: "roadmap",
 			phaseDirRel: func(stateDir string, f *feature.Feature) string {
@@ -405,61 +364,6 @@ func TestGrillMeFanout_StartPaths_DriveEntryPath(t *testing.T) {
 		mustContain          []string
 		mustNotContain       []string
 	}{
-		{
-			name: "design",
-			setupFeature: func(stateDir string) *feature.Feature {
-				return &feature.Feature{
-					ID:           "feat-entry-design",
-					ActiveRun:    1,
-					RunCount:     1,
-					Status:       feature.StatusDesignReady,
-					CurrentPhase: feature.PhaseDesign,
-					Pipeline:     feature.PipelineLarge,
-					Inquireness:  feature.InquirenessMedium,
-					Repos: []feature.FeatureRepo{
-						{Name: "repo1", Path: stateDir},
-					},
-				}
-			},
-			seedUpstreamArtifact: func(t *testing.T, stateDir string, f *feature.Feature) {
-				researchDir := filepath.Join(agent.ActiveRunDir(stateDir, f), "research")
-				if err := os.MkdirAll(researchDir, 0o755); err != nil {
-					t.Fatalf("mkdir research: %v", err)
-				}
-				researchPath := filepath.Join(researchDir, "research.md")
-				if err := os.WriteFile(researchPath, []byte("# research\n"), 0o644); err != nil {
-					t.Fatalf("write research: %v", err)
-				}
-				if f.Artifacts == nil {
-					f.Artifacts = map[string]string{}
-				}
-				f.Artifacts["research"] = researchPath
-			},
-			invoke: func(t *testing.T, o *Orchestrator, f *feature.Feature) {
-				if _, err := o.startDesign(f.ID); err == nil {
-					// startDesign fans through PhaseRunner.RunDesign,
-					// which returns the BuildSessionFn error. A nil error
-					// means the capture path was not exercised.
-					t.Fatalf("expected startDesign to surface BuildSession ErrShuttingDown")
-				}
-			},
-			expectDispatchFail: false,
-			mustContain: []string{
-				"## Ambiguity Resolution [grill-me]",
-			},
-			mustNotContain: []string{
-				"strictly greater than",
-				"auto-pick",
-				"auto-resolve",
-				"silent",
-				"qa-answers.md",
-				"threshold",
-				"strictly greater than 0.5",
-				"Do not auto-pick any answer",
-				"## Ambiguity Resolution: [autonomous]",
-				"## Ambiguity Resolution [autonomous]",
-			},
-		},
 		{
 			name: "roadmap",
 			setupFeature: func(stateDir string) *feature.Feature {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -94,7 +94,7 @@ type Hooks struct {
 
 // PhaseCompletionInput is a sum-type describing a phase completion. Exactly
 // one of the pointer result fields is non-nil for loop-driven phases; for
-// session-parser-driven phases (KB/Inquire/Research/Design) all pointer
+// session-parser-driven phases (KB/Inquire/Research) all pointer
 // fields are nil and the handler uses Success + ErrorDetail + SessionID.
 type PhaseCompletionInput struct {
 	Phase       feature.Phase
@@ -102,6 +102,7 @@ type PhaseCompletionInput struct {
 	Success     bool
 	ErrorDetail string
 
+	DesignResult    *agent.DesignLoopResult
 	PlanResult      *agent.PlanLoopResult
 	ImplementResult *agent.LoopResult
 	MultiRepoResult *agent.OrchestratorResult
@@ -1017,13 +1018,18 @@ func (o *Orchestrator) startDesign(featureID string) (PhaseStartResult, error) {
 		}
 	}
 	kbInfos := o.computeKBInfos(f)
-	return o.runSingleShotArtifactPhase(featureID, f, feature.PhaseDesign, "design", nil, func() (string, error) {
-		sessionID, err := o.deps.PhaseRunner.RunDesign(f, researchPath, qaFilePaths, kbInfos...)
-		if err != nil {
-			return "", fmt.Errorf("run design: %w", err)
-		}
-		return sessionID, nil
-	})
+	if o.deps.PhaseRunner == nil {
+		return PhaseStartResult{Outcome: PhaseStarted}, nil
+	}
+	if err := agent.RecordReadOnlyRepoBaseline(context.Background(), o.deps.CmdRunner, f, o.artifactReadOnlyGuardDir(f, "design")); err != nil {
+		return PhaseStartResult{}, fmt.Errorf("record design read-only repo baseline: %w", err)
+	}
+	resultCh, err := o.deps.PhaseRunner.RunDesignWithValidation(f, researchPath, qaFilePaths, kbInfos...)
+	if err != nil {
+		return PhaseStartResult{}, fmt.Errorf("run design: %w", err)
+	}
+	o.phaseSupervisor().superviseDesignLoop(featureID, resultCh)
+	return PhaseStartResult{Outcome: PhaseStarted}, nil
 }
 
 // startPlan starts the Plan phase. Delegates to startRoadmapPhasePlan when
@@ -1488,10 +1494,7 @@ func (o *Orchestrator) HandlePhaseCompletion(featureID string, input PhaseComple
 	case feature.PhaseResearch:
 		return o.onArtifactPhaseCompleted(featureID, input, "research", o.deps.Lifecycle.CompleteResearch)
 	case feature.PhaseDesign:
-		// Validate against the legacy "design" on-disk subdirectory but
-		// persist the canonical Design artifact key so downstream consumers
-		// resolve it through feature.Feature.DesignArtifactPath().
-		return o.onArtifactPhaseCompletedWithKey(featureID, input, "design", feature.DesignArtifactKey, o.deps.Lifecycle.CompleteDesign)
+		return o.onDesignLoopDone(featureID, input.DesignResult)
 	case feature.PhasePlan:
 		return o.onPlanLoopDone(featureID, input.PlanResult)
 	case feature.PhaseImplement:
@@ -1535,6 +1538,14 @@ func (o *Orchestrator) HandleReviewDecision(featureID string, d ReviewDecision) 
 // follow-up phase so the orchestrator owns the full unwind.
 func (o *Orchestrator) reviewProceed(featureID string, f *feature.Feature, d ReviewDecision) error {
 	if err := o.clearReviewGate(featureID); err != nil {
+		return err
+	}
+
+	if f.Status == feature.StatusDesignNeedsReview && f.CurrentPhase == feature.PhaseDesign {
+		if err := o.deps.Lifecycle.CompleteDesign(featureID); err != nil {
+			return fmt.Errorf("complete human-approved Design: %w", err)
+		}
+		_, _, err := o.startPhase(featureID, feature.PhasePlan)
 		return err
 	}
 
@@ -1632,6 +1643,36 @@ func (o *Orchestrator) reviewProceed(featureID string, f *feature.Feature, d Rev
 // safe for every path.
 func (o *Orchestrator) reviewIterate(featureID string, f *feature.Feature, d ReviewDecision) error {
 	if err := o.clearReviewGate(featureID); err != nil {
+		return err
+	}
+	if f.Status == feature.StatusDesignNeedsReview && f.CurrentPhase == feature.PhaseDesign {
+		if err := o.deps.Store.Modify(featureID, func(ff *feature.Feature) error {
+			if ff.MaxDesignIterations <= 0 {
+				ff.MaxDesignIterations = agent.DefaultMaxDesignAttempts
+			}
+			ff.MaxDesignIterations += 2
+			ff.Status = feature.StatusDesigning
+			ff.CurrentPhase = feature.PhaseDesign
+			return nil
+		}); err != nil {
+			return fmt.Errorf("extend Design iteration budget: %w", err)
+		}
+		designDir := o.artifactReadOnlyGuardDir(f, feature.PhaseDesign.DirName())
+		attempt := agent.LatestCompletedPlanAttempt(designDir)
+		if attempt > 0 {
+			feedback := strings.TrimSpace(d.Comment)
+			if feedback == "" {
+				feedback = "Human review requested another Design iteration."
+			}
+			attemptDir := filepath.Join(designDir, fmt.Sprintf("attempt-%02d", attempt))
+			_ = os.WriteFile(filepath.Join(attemptDir, "validation-feedback.md"), []byte(feedback+"\n"), 0o644)
+			_ = agent.WritePlanAttemptMeta(designDir, agent.PlanAttemptMeta{
+				Attempt:      attempt,
+				AgentStatus:  "SUCCESS",
+				ReviewStatus: "CHANGES_REQUESTED",
+			})
+		}
+		_, _, err := o.startPhase(featureID, feature.PhaseDesign)
 		return err
 	}
 	// Roadmap reject path: reset PlanStatus back to PlanReady, record rejection

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -138,9 +138,9 @@ type ReviewDecision struct {
 	IsRewind    bool
 	PhasePlan   bool
 	Roadmap     bool
-	// Comment carries free-text rejection feedback from a roadmap review
-	// menu. Only meaningful when Roadmap == true && Decision == "iterate"
-	// (the roadmap reject path). Mirrors RoadmapReviewDecisionMsg.Comment.
+	// Comment carries free-text rejection feedback from roadmap and Design
+	// review menus when Decision == "iterate". Design feedback is persisted as
+	// a binding decision before the next revision attempt.
 	Comment string
 }
 
@@ -1665,7 +1665,11 @@ func (o *Orchestrator) reviewIterate(featureID string, f *feature.Feature, d Rev
 				feedback = "Human review requested another Design iteration."
 			}
 			attemptDir := filepath.Join(designDir, fmt.Sprintf("attempt-%02d", attempt))
-			_ = os.WriteFile(filepath.Join(attemptDir, "validation-feedback.md"), []byte(feedback+"\n"), 0o644)
+			if _, err := agent.RecordDesignHumanDirection(attemptDir, feedback); err != nil {
+				return fmt.Errorf("record Design human direction: %w", err)
+			}
+			humanFeedback := "## Human Direction\n\n" + feedback + "\n"
+			_ = os.WriteFile(filepath.Join(attemptDir, "validation-feedback.md"), []byte(humanFeedback), 0o644)
 			_ = agent.WritePlanAttemptMeta(designDir, agent.PlanAttemptMeta{
 				Attempt:      attempt,
 				AgentStatus:  "SUCCESS",

--- a/internal/orchestrator/orchestrator_phaserunner_test.go
+++ b/internal/orchestrator/orchestrator_phaserunner_test.go
@@ -154,6 +154,7 @@ type capturingPhaseRunner struct {
 	stateDir     string
 	mu           sync.Mutex
 	capturedOpts []agent.BuildSessionOpts
+	startCalls   []mocks.MockStartSessionCall
 }
 
 func newCapturingPhaseRunner(t *testing.T) *capturingPhaseRunner {
@@ -198,6 +199,14 @@ func newCapturingPhaseRunner(t *testing.T) *capturingPhaseRunner {
 	sm.StartSessionFn = func(id, featureID string, phase feature.Phase,
 		command []string, workdir string, env []string,
 		opts ...*session.SessionOpts) (ports.SessionHandle, error) {
+		cpr.mu.Lock()
+		cpr.startCalls = append(cpr.startCalls, mocks.MockStartSessionCall{
+			ID:        id,
+			FeatureID: featureID,
+			Phase:     phase,
+			Command:   append([]string(nil), command...),
+		})
+		cpr.mu.Unlock()
 		repoName := ""
 		if len(opts) > 0 && opts[0] != nil {
 			repoName = opts[0].RepoName
@@ -226,8 +235,10 @@ func (c *capturingPhaseRunner) capturedByPhase(want feature.Phase) []agent.Build
 // startSessionsByPhase returns MockStartSessionCall entries whose Phase
 // matches want.
 func (c *capturingPhaseRunner) startSessionsByPhase(want feature.Phase) []mocks.MockStartSessionCall {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	var out []mocks.MockStartSessionCall
-	for _, call := range c.sm.StartSessionCalls {
+	for _, call := range c.startCalls {
 		if call.Phase == want {
 			out = append(out, call)
 		}
@@ -514,6 +525,13 @@ func TestOrchestrator_StartPhase_PhaseRunnerDispatch_Sync(t *testing.T) {
 			tt.setup(t, f, cpr.stateDir)
 
 			lc := lifecycleForFeature(f)
+			if tt.phase == feature.PhaseDesign {
+				lc.StartDesignFn = func(id string) error {
+					f.Status = feature.StatusDesigning
+					f.CurrentPhase = feature.PhaseDesign
+					return nil
+				}
+			}
 			fs := newFeatureStore(f)
 			cpr.pr.FeatureStore = fs
 			o := orchestrator.New(orchestrator.Deps{
@@ -533,6 +551,9 @@ func TestOrchestrator_StartPhase_PhaseRunnerDispatch_Sync(t *testing.T) {
 			}
 
 			captured := cpr.capturedByPhase(tt.phase)
+			if tt.phase == feature.PhaseDesign {
+				captured = waitForCapturedPhase(t, cpr, tt.phase, 3*time.Second)
+			}
 			if len(captured) == 0 {
 				t.Fatalf("BuildSession was not called with Phase=%v; all captures: %v",
 					tt.phase, cpr.capturedOpts)

--- a/internal/orchestrator/phase_supervisor.go
+++ b/internal/orchestrator/phase_supervisor.go
@@ -209,6 +209,22 @@ func (s *phaseSupervisor) supervisePlanLoop(featureID string, resultCh <-chan *a
 	}()
 }
 
+func (s *phaseSupervisor) superviseDesignLoop(featureID string, resultCh <-chan *agent.DesignLoopResult) {
+	if s == nil || resultCh == nil {
+		return
+	}
+	go func() {
+		result, ok := <-resultCh
+		if !ok {
+			return
+		}
+		s.complete(featureID, PhaseCompletionInput{
+			Phase:        feature.PhaseDesign,
+			DesignResult: result,
+		})
+	}()
+}
+
 func (s *phaseSupervisor) superviseImplementationLoop(featureID string, resultCh <-chan *agent.OrchestratorResult) {
 	if s == nil || resultCh == nil {
 		return

--- a/internal/orchestrator/phase_supervisor_test.go
+++ b/internal/orchestrator/phase_supervisor_test.go
@@ -180,6 +180,21 @@ func TestPhaseSupervisorPlanLoopRoutesPlanResult(t *testing.T) {
 	}
 }
 
+func TestPhaseSupervisorDesignLoopRoutesDesignResult(t *testing.T) {
+	sink := newRecordingPhaseCompletionSink()
+	supervisor := newPhaseSupervisor(phaseSupervisorConfig{Completion: sink})
+	resultCh := make(chan *agent.DesignLoopResult, 1)
+	want := &agent.DesignLoopResult{FinalStatus: "approved", Iterations: 2}
+
+	supervisor.superviseDesignLoop("feat-design", resultCh)
+	resultCh <- want
+
+	call := sink.wait(t)
+	if call.featureID != "feat-design" || call.input.Phase != feature.PhaseDesign || call.input.DesignResult != want {
+		t.Fatalf("completion call = %+v, want Design result", call)
+	}
+}
+
 func TestPhaseSupervisorImplementationLoopRoutesFirstTerminalResult(t *testing.T) {
 	sink := newRecordingPhaseCompletionSink()
 	supervisor := newPhaseSupervisor(phaseSupervisorConfig{Completion: sink})

--- a/internal/orchestrator/qa_persistence_gate_test.go
+++ b/internal/orchestrator/qa_persistence_gate_test.go
@@ -106,8 +106,8 @@ func sessionManagerWithQALog(sessionID string) *mocks.MockSessionManager {
 // TestOrchestrator_OnArtifactPhaseCompleted_QAWritesForInteractivePlanningPhases is the
 // table-driven persistence-whitelist regression. It calls onArtifactPhaseCompleted
 // directly with each interactive planning phase plus roadmap/phase-plan
-// sentinel keys. Inquire, Research, and Design persist the session Q&A log;
-// Roadmap and Phase-Plan transcripts are owned by the plan loops instead.
+// sentinel keys. Inquire and Research persist the session Q&A log; Design,
+// Roadmap, and Phase-Plan transcripts are owned by their iterative loops.
 func TestOrchestrator_OnArtifactPhaseCompleted_QAWritesForInteractivePlanningPhases(t *testing.T) {
 	cases := []struct {
 		phaseKey       string
@@ -117,9 +117,6 @@ func TestOrchestrator_OnArtifactPhaseCompleted_QAWritesForInteractivePlanningPha
 	}{
 		{"inquire", feature.PhaseInquire, true, func(lc *mocks.MockFeatureLifecycle) func(string) error {
 			return lc.CompleteInquire
-		}},
-		{"design", feature.PhaseDesign, true, func(lc *mocks.MockFeatureLifecycle) func(string) error {
-			return lc.CompleteDesign
 		}},
 		{"roadmap", feature.PhaseInquire /* unused */, false, func(lc *mocks.MockFeatureLifecycle) func(string) error {
 			return func(string) error { return nil }

--- a/internal/orchestrator/review_decision_test.go
+++ b/internal/orchestrator/review_decision_test.go
@@ -301,6 +301,88 @@ func TestOrchestrator_HandleReviewDecision_Iterate_BumpsIterations(t *testing.T)
 	}
 }
 
+func TestOrchestrator_HandleReviewDecision_IterateDesignExtendsDesignBudget(t *testing.T) {
+	researchPath := filepath.Join(t.TempDir(), "research.md")
+	if err := os.WriteFile(researchPath, []byte("# Research\n"), 0o644); err != nil {
+		t.Fatalf("write research artifact: %v", err)
+	}
+	planGate := feature.PhasePlan
+	f := &feature.Feature{
+		ID:                  "feat-rd-design-iter",
+		Status:              feature.StatusDesignNeedsReview,
+		CurrentPhase:        feature.PhaseDesign,
+		Pipeline:            feature.PipelineLarge,
+		PendingReviewPhase:  &planGate,
+		MaxDesignIterations: 0,
+		Artifacts:           map[string]string{feature.ResearchArtifactKey: researchPath},
+	}
+	lc := lifecycleForFeature(f)
+	fs := newFeatureStore(f)
+	o := orchestrator.New(orchestrator.Deps{Lifecycle: lc, Store: fs}, orchestrator.Hooks{})
+
+	if err := o.HandleReviewDecision(f.ID, orchestrator.ReviewDecision{
+		Decision: "iterate",
+		Comment:  "Clarify the event contract.",
+	}); err != nil {
+		t.Fatalf("HandleReviewDecision(): %v", err)
+	}
+
+	if f.MaxDesignIterations != agent.DefaultMaxDesignAttempts+2 {
+		t.Fatalf("MaxDesignIterations = %d, want %d", f.MaxDesignIterations, agent.DefaultMaxDesignAttempts+2)
+	}
+	if f.Status != feature.StatusDesigning || f.CurrentPhase != feature.PhaseDesign {
+		t.Fatalf("Design iteration state = (%s, %s), want Designing/Design", f.Status, f.CurrentPhase)
+	}
+	if f.PendingReviewPhase != nil {
+		t.Fatalf("PendingReviewPhase = %v, want nil", f.PendingReviewPhase)
+	}
+}
+
+func TestOrchestrator_HandleReviewDecision_ProceedDesignCompletesBeforePlanning(t *testing.T) {
+	planGate := feature.PhasePlan
+	f := &feature.Feature{
+		ID:                 "feat-rd-design-proceed",
+		Status:             feature.StatusDesignNeedsReview,
+		CurrentPhase:       feature.PhaseDesign,
+		Pipeline:           feature.PipelineLarge,
+		PendingReviewPhase: &planGate,
+	}
+	lc := lifecycleForFeature(f)
+	lc.CompleteDesignFn = func(string) error {
+		f.Status = feature.StatusPlanReady
+		return nil
+	}
+	lc.StartPlanningFn = func(string) error {
+		f.Status = feature.StatusPlanning
+		return nil
+	}
+	fs := newFeatureStore(f)
+	o := orchestrator.New(orchestrator.Deps{Lifecycle: lc, Store: fs}, orchestrator.Hooks{})
+
+	_ = o.HandleReviewDecision(f.ID, orchestrator.ReviewDecision{
+		Decision:    "proceed",
+		TargetPhase: feature.PhasePlan,
+	})
+
+	assertLifecycleCall(t, lc, "CompleteDesign")
+	assertLifecycleCall(t, lc, "StartPlanning")
+	completeIndex, startIndex := -1, -1
+	for i, call := range lc.Calls {
+		switch call.Method {
+		case "CompleteDesign":
+			completeIndex = i
+		case "StartPlanning":
+			startIndex = i
+		}
+	}
+	if completeIndex < 0 || startIndex < 0 || completeIndex >= startIndex {
+		t.Fatalf("lifecycle call order = %v; want CompleteDesign before StartPlanning", lifecycleCallNames(lc))
+	}
+	if f.PendingReviewPhase != nil {
+		t.Fatalf("PendingReviewPhase = %v, want nil", f.PendingReviewPhase)
+	}
+}
+
 // Iterate with MaxPlanIterations==0 (the default for fresh features): the
 // effective planning budget at runtime is agent.DefaultMaxPlanAttempts, so
 // "iterate" must promote 0 → DefaultMaxPlanAttempts before adding 3.

--- a/internal/server/mutation.go
+++ b/internal/server/mutation.go
@@ -253,6 +253,7 @@ type RuntimeDefaultsMutation struct {
 	MaxIterations            int                                  `json:"max_iterations,omitempty"`
 	MaxConsecutiveFailures   int                                  `json:"max_consecutive_failures,omitempty"`
 	MaxConsecutiveNoProgress int                                  `json:"max_consecutive_no_progress,omitempty"`
+	MaxDesignIterations      int                                  `json:"max_design_iterations,omitempty"`
 	MaxPhasePlanIterations   int                                  `json:"max_phase_plan_iterations,omitempty"`
 	Checkpoints              *config.Checkpoints                  `json:"checkpoints,omitempty"`
 	AutomaticReviewEnabled   *bool                                `json:"automatic_review_enabled,omitempty"`

--- a/internal/skilldef/skilldef_test.go
+++ b/internal/skilldef/skilldef_test.go
@@ -27,7 +27,7 @@ import (
 	skillsFS "github.com/doordash-oss/agentic-orchestrator/skills"
 )
 
-const expectedEmbeddedSkillCount = 30
+const expectedEmbeddedSkillCount = 34
 
 func TestParseSkillFile(t *testing.T) {
 	tests := []struct {

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -1410,6 +1410,9 @@ func formatStatus(f *feature.Feature) string {
 		if f.IsRefactoring() {
 			label = "Refactoring: Designing"
 		}
+		if len(f.ValidatorStatuses) > 0 {
+			return ReviewStyle.Render("Validating Design") + elapsed
+		}
 		if needsInput {
 			return WarningStyle.Render(label+" | waiting input") + elapsed
 		}

--- a/internal/tui/live_preview.go
+++ b/internal/tui/live_preview.go
@@ -1127,7 +1127,9 @@ func livePreviewValidationTitle(f *feature.Feature, sess session.SessionView) st
 }
 
 func livePreviewHasValidationContext(f *feature.Feature, sess session.SessionView) bool {
-	if f != nil && (f.ValidatingPlan || f.ReviewingGate) && len(f.ValidatorStatuses) > 0 {
+	if f != nil &&
+		(f.ValidatingPlan || f.ReviewingGate || f.CurrentPhase == feature.PhaseDesign) &&
+		len(f.ValidatorStatuses) > 0 {
 		return true
 	}
 	if livePreviewIsVerifying(f) {
@@ -1181,6 +1183,9 @@ func livePreviewVerificationLogLines(f *feature.Feature, width int) []string {
 }
 
 func livePreviewValidationTarget(f *feature.Feature) string {
+	if f != nil && f.CurrentPhase == feature.PhaseDesign {
+		return "Validating Design"
+	}
 	if f != nil && f.CurrentPhase == feature.PhaseImplement && f.ReviewingGate {
 		return "Reviewing implementation"
 	}

--- a/skills/chat/user-guide/configuration.md
+++ b/skills/chat/user-guide/configuration.md
@@ -258,6 +258,7 @@ In the TUI, Roadmap Review controls the planning review group and Phase Plan Rev
 | `max_iterations` | `10` | Maximum iterations per phase before failing |
 | `max_consecutive_failures` | `3` | Consecutive failures before aborting a phase |
 | `max_consecutive_no_progress` | `3` | Consecutive no-progress signals before aborting |
+| `max_design_iterations` | `5` | Maximum Design author/critic attempts before human review |
 | `max_phase_plan_iterations` | `10` | Maximum iterations for plan creation/validation |
 
 ## Inquireness

--- a/skills/chat/user-guide/feature-lifecycle.md
+++ b/skills/chat/user-guide/feature-lifecycle.md
@@ -30,7 +30,7 @@ Explores the problem space by analyzing the codebase and gathering context. The 
 Deep dives into the codebase to understand relevant code paths, existing patterns, and technical constraints. Produces research artifacts that inform planning.
 
 ### Design
-Produces a final-decision implementation contract from the feature request, Q&A, and research. The author resolves consequential ambiguity with the user, spells out architecture and changed schemas/APIs/events, and separates binding decisions from implementation latitude. An Integrity critic always reviews the artifact; when the design requires UI mockups, the author also produces a self-contained HTML prototype, rendered PNG states, and a manifest, and a Visual critic reviews that bundle. Critic feedback drives bounded revision attempts before approval or human escalation.
+Produces a final-decision implementation contract from the feature request, Q&A, and research. Agentico generates an authoritative decision ledger with stable `REQ-###` and `DEC-###` IDs for the author, critics, and reviser. Critics must tie blocking findings to that ledger and may trigger autonomous revision only for a classified contract defect or grounding error; decision conflicts, missing consequential decisions, and malformed findings pause for human review. The canonical `design.md` always represents the latest attempt, while `attempt-NN/design.md` snapshots retain older designs for manual history and are ignored by artifact selection and validation. When the design requires UI mockups, the author also produces a self-contained HTML prototype, rendered PNG states, and a manifest, and a Visual critic reviews that bundle.
 
 ### Plan
 Creates a detailed implementation plan. Uses **two-tier planning**:

--- a/skills/chat/user-guide/feature-lifecycle.md
+++ b/skills/chat/user-guide/feature-lifecycle.md
@@ -30,7 +30,7 @@ Explores the problem space by analyzing the codebase and gathering context. The 
 Deep dives into the codebase to understand relevant code paths, existing patterns, and technical constraints. Produces research artifacts that inform planning.
 
 ### Design
-Generates and evaluates implementation approaches. Considers trade-offs, risks, and alternatives before committing to a design direction. (Older docs and persisted state may refer to this phase as "Design" — it is the same phase under its legacy name and continues to load without migration.)
+Produces a final-decision implementation contract from the feature request, Q&A, and research. The author resolves consequential ambiguity with the user, spells out architecture and changed schemas/APIs/events, and separates binding decisions from implementation latitude. An Integrity critic always reviews the artifact; when the design requires UI mockups, the author also produces a self-contained HTML prototype, rendered PNG states, and a manifest, and a Visual critic reviews that bundle. Critic feedback drives bounded revision attempts before approval or human escalation.
 
 ### Plan
 Creates a detailed implementation plan. Uses **two-tier planning**:

--- a/skills/design-mockups/SKILL.md
+++ b/skills/design-mockups/SKILL.md
@@ -1,0 +1,100 @@
+---
+description: Artifact contract for frontend-design HTML and PNG mockup bundles
+license: Apache-2.0
+provenance: agentic-orchestrator-original
+---
+
+# Design Mockups
+
+This skill is a companion contract for `@skills/frontend-design/`. Before creating or revising mockups, locate `frontend-design` in the system prompt's Additional Skills catalog, read its listed `SKILL.md`, and follow it for visual direction, design process, content, accessibility, responsiveness, implementation quality, and self-critique.
+
+Do not introduce a separate visual methodology here. `frontend-design` owns how the interface is designed; this skill only adds the artifact and validation contract required by the Design workflow.
+
+The bundle is design evidence, not production implementation.
+
+## Output Files
+
+Write the bundle only under the shared Design artifact root (`{artifact_dir}`) supplied by the role contract:
+
+| Artifact | Path | Requirement | Purpose |
+|----------|------|-------------|---------|
+| HTML prototype | `{artifact_dir}/mockups/prototype.html` | required | self-contained rendering with one addressable fragment per state |
+| PNG states | `{artifact_dir}/mockups/states/<state-id>.png` | one or more required | real browser-rendered image paired with each prototype state |
+| manifest | `{artifact_dir}/mockups/manifest.yaml` | required | exact machine-readable inventory consumed by the orchestrator |
+
+Do not write to the repository worktree, source directories, generic temporary directories, `{attempt_dir}`, or any path outside `{artifact_dir}`. Temporary browser profiles, downloaded assets, and intermediate screenshots must also remain inside `{artifact_dir}/mockups/.work/`; remove `.work/` before completion.
+
+## Bundle Contract
+
+### Self-contained HTML
+
+Every manifest-referenced HTML file must:
+
+- contain all HTML, CSS, and JavaScript needed to render its declared state
+- work from `file://` without a build, package install, local server, or network access
+- use inline CSS and JavaScript
+- embed fonts and raster/vector assets as data URLs when they are necessary
+- render deterministically at the viewport required by the design
+- include visible keyboard focus and reduced-motion behavior when interaction or motion is represented
+
+Do not use external URLs, CDNs, remote fonts, framework imports, repository assets by relative path, or generated placeholders.
+
+### Real PNG states
+
+Each PNG must be captured from the manifest-referenced HTML prototype in a real browser at the state fragment and viewport declared by the manifest. It must show the complete state after deterministic rendering has settled.
+
+Never satisfy this requirement with:
+
+- an empty, transparent, single-color, or text-only placeholder image
+- a renamed SVG or non-PNG payload
+- a hand-authored canvas that does not render the HTML state
+- a screenshot of an error page, missing asset, loading skeleton left unintentionally, or browser chrome
+- one image reused for states whose visible outcomes differ
+
+Inspect every PNG after capture. Confirm it is decodable, has the declared pixel dimensions, contains the intended state, and has no clipping, overlap, missing assets, or accidental transparency.
+
+### Manifest schema
+
+Write valid UTF-8 YAML using this exact shape:
+
+```yaml
+schema_version: 1
+design_artifact: ../design.md
+html: prototype.html
+responsive_expectations:
+  - "Desktop at >=1024px preserves the two-column composition."
+binding_decisions:
+  - "Primary action remains visible without scrolling."
+illustrative_details:
+  - "Example account names and values are non-binding."
+states:
+  - id: checkout-error-mobile
+    title: Checkout validation error
+    source: prototype.html#checkout-error-mobile
+    png: states/checkout-error-mobile.png
+    viewport:
+      width: 390
+      height: 844
+      device_scale_factor: 1
+    design_sections:
+      - "## User Experience"
+    description: Required mobile error state after submit.
+```
+
+Contract rules:
+
+- `schema_version` is the integer `1`; unknown fields are rejected.
+- `design_artifact` resolves to the design markdown in the shared Design root.
+- `html` names the single self-contained prototype shared by every state.
+- `responsive_expectations`, `binding_decisions`, and `illustrative_details` make visual authority explicit. Use an empty illustrative list when every represented detail is binding.
+- `states` is non-empty. IDs, source fragments, and PNG paths are unique.
+- Each `source` is the manifest `html` path plus a non-empty fragment that deterministically selects the state.
+- Each `png` is a relative `.png` path from `mockups/manifest.yaml`.
+- `viewport` records capture width, height, and device scale factor. Use positive integers matching the actual PNG capture.
+- `design_sections` names the design headings this state realizes; `description` states the observable state and trigger.
+- Every path resolves to a non-empty regular file and remains inside the shared Design artifact root after symlink resolution.
+- Entries collectively cover every state and viewport explicitly required by the design; add no speculative flows.
+
+## Completion Standard
+
+The `frontend-design` result satisfies its own quality standard, and the HTML, PNGs, and `manifest.yaml` agree exactly. Every required state is represented, every PNG is a real inspected browser rendering, and the bundle contains no placeholders, external dependencies, `.work/` directory, or files outside the shared Design artifact root.

--- a/skills/design/SKILL.md
+++ b/skills/design/SKILL.md
@@ -6,88 +6,136 @@ provenance: upstream-adapted
 
 # Design — Design Document Creation
 
-You are a design collaborator who turns research findings into a design document. You work with the user to explore approaches, make trade-offs, and produce a clear, actionable design.
+You are the senior engineer responsible for turning a feature request, human answers, and research findings into the contract a more junior engineer can implement safely. Resolve the design; do not merely describe the problem or hand implementation choices downstream.
 
-**Your job is NEVER to write code.** Your only deliverable is the design markdown inside the output directory.
+**Your job is NEVER to implement the feature.** Your only deliverables are the design markdown and, conditionally, its mockup bundle inside the shared Design artifact root. Treat repository worktrees and every path outside that output root as read-only.
 
 ## Output Files
 
 | Artifact | Path | Requirement | Purpose |
 |----------|------|-------------|---------|
-| `design markdown artifact` | `{phase_dir}/<newest non-excluded *.md>` | required | newest non-excluded markdown artifact in the phase directory |
+| `design markdown` | `{artifact_dir}/design.md` | required | final-decision design markdown matching the Design skill contract |
+| `mockup manifest` | `{artifact_dir}/mockups/manifest.yaml` | optional: required for material UI changes | versioned manifest for self-contained HTML and rendered PNG mockups |
 
-## Your Process
+## Authority and Inputs
 
-1. **Read the research output completely.** These are objective answers to questions about the codebase — they tell you what exists and how things work.
+When `**Visual mockups:** required`, locate `design-mockups` in the system prompt's Additional Skills catalog, read the exact listed `SKILL.md` path, and follow it before completion. Do not guess a relative skills path.
 
-2. **Read the original feature description** to understand the user's intent.
+Read all supplied inputs before deciding:
 
-3. **Read User Answers** (if provided in the user prompt). These are answers the user gave to clarifying questions in earlier phases. Take them into consideration during the design.
+1. The original feature description and acceptance intent.
+2. User Answers and prior human decisions. These are binding and supersede defaults.
+3. The research output, including cited source references and current-state constraints.
+4. The KB index and relevant KB documents when supplied.
+5. Relevant repository guidelines, ADRs, schemas, and public contracts.
+6. Existing design-system or product conventions when the feature changes a user-facing surface.
 
-4. **Read the KB index** (if provided) for architectural context.
+Do not invent current-state facts. Verify important claims against supplied research or the repository. If sources conflict, resolve the conflict before writing the design.
 
-5. **Read relevant Guidelines** depending on the user's intent, rely on topic-specific or language-specific guidelines to perfect the final design.
+## Consequential Ambiguity
 
-6. **Apply these design principles regardless of interaction level:**
-   - **YAGNI ruthlessly** — Remove anything not clearly needed for this feature. If you're unsure whether something is needed, it isn't.
-   - **Design for isolation** — Break the design into units with clear boundaries and testable independence.
-   - **Follow existing patterns** — The research told you how the codebase works. Your design should fit naturally.
-   - **Minimize blast radius** — Prefer changes that touch fewer files and have smaller scope.
+Use `AskUserQuestion` before finalizing when an unresolved choice would materially change any of:
 
-## Design Document Structure
+- externally visible behavior or acceptance criteria
+- data ownership, durability, compatibility, migration, or deletion semantics
+- a public API, event, schema, or security boundary
+- architecture, dependency direction, operational cost, or rollout risk
+- the visual direction or required UI states
+- scope large enough to change the roadmap shape
 
-<prd-template>
-## Problem Statement
+Ask a focused question that explains the consequence and presents a recommended default when evidence supports one. Do not ask the user to choose routine implementation details a competent implementer can resolve locally. Do not bury consequential ambiguity in "open questions," alternatives, or TODOs. The final artifact contains the resulting decision, not the deliberation.
 
-The problem that the user is facing, from the user's perspective.
+If no consequential ambiguity remains, proceed without asking.
 
-## Solution
+## Design Principles
 
-The solution to the problem, from the user's perspective.
+- **Final decisions only** — state one chosen design. Do not include option lists, brainstorms, or unresolved questions.
+- **YAGNI ruthlessly** — include only behavior and machinery required by the approved scope.
+- **Follow established patterns** — reuse repository ownership, naming, dependency, persistence, and error-handling conventions unless the design explicitly and justifiably changes them.
+- **Design for isolation** — assign responsibilities to clear owners with independently testable boundaries.
+- **Minimize blast radius** — prefer the smallest coherent change that satisfies the contract.
+- **Specify the seams** — be exact where components meet and intentionally flexible inside them.
+- **Separate requirements from implementation latitude** — tell the implementer what must remain invariant and what they may choose.
+- **Address concerns conditionally** — include security, performance, accessibility, migration, observability, concurrency, internationalization, and rollout detail only when the feature makes that concern real. Never add ceremonial sections full of "not applicable."
 
-## User Stories
+## Precision Standard
 
-A LONG, numbered list of user stories. Each user story should be in the format of:
+The document must be precise enough that an implementer does not need to make product or architectural decisions. Include:
 
-1. As an <actor>, I want a <feature>, so that <benefit>
+- component/module ownership and dependency direction
+- end-to-end control and data flow, including success and important failure paths
+- exact new or changed schemas, fields, types, defaults, validation, lifecycle, and compatibility rules
+- exact API, command, event, callback, or interface contracts: names, inputs, outputs, errors, ordering, idempotency, and versioning when relevant
+- state transitions, invariants, and source-of-truth rules
+- migration, rollout, rollback, and mixed-version behavior when relevant
+- user-visible states and interactions when relevant
 
-<user-story-example>
-1. As a mobile bank customer, I want to see balance on my accounts, so that I can make better informed decisions about my spending
-</user-story-example>
+Use repository-relative file/symbol references and short snippets when they make a contract materially less ambiguous. Snippets may show a type, schema, signature, payload, state table, or critical algorithm boundary. Keep them minimal and decision-bearing; do not write full implementations, full test functions, or speculative file inventories. A warning that references "may become stale" is not a reason to omit precision the implementation needs.
 
-This list of user stories should be extremely extensive and cover all aspects of the feature.
+Leave routine local choices to the implementer: helper names, private decomposition, equivalent library calls, exact test organization, and other details that do not alter the documented contract. Explicitly identify meaningful latitude where an over-literal implementation would otherwise be likely.
 
-## Implementation Decisions
+## Required Document Contract
 
-A list of implementation decisions that were made. This can include:
+Use the following top-level sections in this order. Keep the document proportional to the feature. A compact set of scenarios or acceptance bullets is preferred; an exhaustive or extremely long user-story list is neither required nor desirable.
 
-- The modules that will be built/modified
-- The interfaces of those modules that will be modified
-- Technical clarifications from the developer
-- Architectural decisions
-- Schema changes
-- API contracts
-- Specific interactions
+### `## Problem and Outcomes`
 
-Do NOT include specific file paths or code snippets. They may end up being outdated very quickly.
+State the user or system problem, intended outcome, explicit goals, and observable acceptance boundaries. Include only the few user scenarios needed to remove behavioral ambiguity.
 
-## Testing Decisions
+### `## Final Design`
 
-A list of testing decisions that were made. Include:
+Describe the chosen architecture and why it fits the existing system. Name owners, boundaries, dependency direction, source of truth, lifecycle, and end-to-end flow. Record settled human decisions in the relevant prose; do not preserve rejected alternatives.
 
-- A description of what makes a good test (only test external behavior, not implementation details)
-- Which modules will be tested
-- Prior art for the tests (i.e. similar types of tests in the codebase)
+### `## Contracts`
 
-## Out of Scope
+Define exact schemas, APIs, events, interfaces, state machines, validation rules, and failure semantics introduced or changed by the feature. Use `- None` only when the feature genuinely changes no cross-component or persisted contract.
 
-A description of the things that are out of scope for this PRD.
+### `## User Experience`
 
-## Further Notes
+For user-facing work, define navigation, interaction sequence, copy-bearing outcomes, accessibility expectations, responsive behavior, and the required loading, empty, success, partial, disabled, and error states that apply. State whether visual mockups are required:
 
-Any further notes about the feature.
-</prd-template>
+- `**Visual mockups:** required` for new or materially changed rendered experiences where visual composition or interaction states need approval.
+- `**Visual mockups:** not-required — <reason>` when rendered design judgment is not meaningful.
 
-## Output
+When mockups are required, describe every state and viewport the mockup bundle must contain. The separate design-mockups skill owns rendering the bundle.
 
-Write a design document (markdown) to the output directory. Name it with a descriptive slug (e.g., `2026-03-18-feature-name-design.md`).
+For non-user-facing work, keep this section brief and use the explicit not-required marker.
+
+### `## Conditional Concerns`
+
+Include only concerns activated by this design, such as security/privacy, accessibility, performance/capacity, concurrency, observability, migration/compatibility, rollout/rollback, or internationalization. State concrete behavior and limits, not generic best practices. Use `- None beyond repository defaults` when no concern requires a design decision.
+
+### `## Testing Strategy`
+
+Define what evidence proves the contract:
+
+- core happy paths and invariants
+- consequential failures and boundaries
+- compatibility or migration behavior
+- contract/integration coverage at component seams
+- user-facing and accessibility checks when applicable
+- regression protection and relevant existing test patterns
+
+Specify test level and observable behavior, not complete test code. Distinguish automated checks from irreducible visual or semantic review.
+
+### `## Implementation Latitude`
+
+List decisions the implementer may make without revisiting the design, plus any explicit constraints on that freedom. Use `- None beyond routine private implementation details` if the contract leaves no notable latitude.
+
+### `## Out of Scope`
+
+List explicit exclusions and deferred work. Do not defer behavior required to make the chosen design safe or complete.
+
+## Final Quality Check
+
+Before writing the artifact, verify:
+
+1. Every consequential question is resolved through evidence or `AskUserQuestion`.
+2. The prose contains only the final design and has no alternatives, TODOs, or hidden implementation decisions.
+3. Architecture, schemas, APIs, errors, states, and ownership agree across sections.
+4. Exact references or snippets are present wherever prose alone could lead to incompatible implementations.
+5. The testing strategy proves the contract rather than private implementation details.
+6. Visual mockup requirements are explicit and conditional.
+7. The design gives a junior implementer enough direction while preserving safe local implementation latitude.
+8. When mockups are required, `{artifact_dir}/mockups/manifest.yaml` and every referenced real HTML/PNG artifact satisfy the design-mockups skill.
+9. No artifact was written outside `{artifact_dir}`.

--- a/skills/design/SKILL.md
+++ b/skills/design/SKILL.md
@@ -23,14 +23,24 @@ When `**Visual mockups:** required`, locate `design-mockups` in the system promp
 
 Read all supplied inputs before deciding:
 
-1. The original feature description and acceptance intent.
-2. User Answers and prior human decisions. These are binding and supersede defaults.
-3. The research output, including cited source references and current-state constraints.
-4. The KB index and relevant KB documents when supplied.
-5. Relevant repository guidelines, ADRs, schemas, and public contracts.
-6. Existing design-system or product conventions when the feature changes a user-facing surface.
+1. The harness-owned `decision-ledger.md`. Its `REQ-###` requirements and
+   `DEC-###` human decisions are authoritative and supersede critic
+   preferences, generic defaults, and earlier ambiguous summaries.
+2. The original feature description and acceptance intent.
+3. User Answers and prior human decisions. Use the raw Q&A to retain nuance
+   behind the ledger entries.
+4. The research output, including cited source references and current-state constraints.
+5. The KB index and relevant KB documents when supplied.
+6. Relevant repository guidelines, ADRs, schemas, and public contracts.
+7. Existing design-system or product conventions when the feature changes a user-facing surface.
 
 Do not invent current-state facts. Verify important claims against supplied research or the repository. If sources conflict, resolve the conflict before writing the design.
+
+Do not strengthen a qualified human decision into a broader invariant. Preserve
+the exact observable semantics, preconditions, exceptions, and accepted
+trade-offs recorded in the decision ledger and raw Q&A. When summarizing a
+decision in the design, check the summary against its `DEC-###` source before
+using that summary as an invariant elsewhere.
 
 ## Consequential Ambiguity
 
@@ -139,3 +149,6 @@ Before writing the artifact, verify:
 7. The design gives a junior implementer enough direction while preserving safe local implementation latitude.
 8. When mockups are required, `{artifact_dir}/mockups/manifest.yaml` and every referenced real HTML/PNG artifact satisfy the design-mockups skill.
 9. No artifact was written outside `{artifact_dir}`.
+10. Every `REQ-###` and `DEC-###` entry is either represented by the final
+    design or explicitly excluded by another binding ledger entry; no prose
+    silently broadens or narrows a recorded decision.

--- a/skills/revise-design/SKILL.md
+++ b/skills/revise-design/SKILL.md
@@ -1,0 +1,55 @@
+---
+description: Revise a design contract from structured validator feedback
+license: Apache-2.0
+provenance: agentic-orchestrator-original
+---
+
+# Design Revision
+
+You revise the existing design contract to resolve structured integrity and visual feedback. Make the smallest coherent correction that restores a single implementable design.
+
+**Your job is NEVER to implement the feature.** Write only design artifacts inside the shared Design artifact root (`{artifact_dir}`) supplied by the role contract. Treat repository worktrees and every path outside that root as read-only.
+
+## Output Files
+
+| Artifact | Path | Requirement | Purpose |
+|----------|------|-------------|---------|
+| `design markdown` | `{artifact_dir}/design.md` | required | final-decision design markdown matching the Design skill contract |
+| `mockup manifest` | `{artifact_dir}/mockups/manifest.yaml` | optional: required for material UI changes | versioned manifest for self-contained HTML and rendered PNG mockups |
+
+## Inputs and Authority
+
+When mockups are present or visual feedback requires them, locate `design-mockups` in the system prompt's Additional Skills catalog and read the exact listed `SKILL.md` path before editing the bundle.
+
+Read the previous design completely, then all current validator feedback. Human decisions remain binding. Findings identify defects; suggestions are non-blocking and must not broaden scope by default.
+
+When feedback conflicts with a binding human decision, requests a materially different product behavior, or exposes consequential ambiguity that evidence cannot resolve, use `AskUserQuestion`. Record only the resulting final decision in the revised design.
+
+## Critical Rules
+
+1. **Do not start from scratch.** Make targeted edits to the prior design.
+2. **Final decisions only.** Do not add alternatives, reviewer dialogue, open questions, TODOs, or a revision log.
+3. **No substantive feedback means no rewrite.** Copy the previous design byte-for-byte when all axes approve and no accepted suggestion requires a change.
+4. **Verify factual corrections.** If feedback says a codebase, API, schema, or framework claim is wrong, inspect the cited source before changing the contract. Do not replace one unverified claim with another.
+5. **Propagate invariant changes.** Update every editable section that depends on a corrected owner, schema, state, ordering rule, or failure semantic. Remove stale contradictory prose.
+6. **Preserve scope.** Do not use revision to add adjacent features, generic best practices, or speculative future mechanisms.
+7. **Preserve implementation latitude.** Tighten a seam only as far as needed to prevent incompatible behavior; do not prescribe private implementation details.
+8. **Keep required structure.** The revised document must continue to satisfy the design skill's document contract.
+9. **Update mockups when needed.** If a design correction changes a visible state, content, layout, interaction, viewport, or visual direction, rerun the design-mockups contract and replace the affected HTML, PNGs, and manifest entries together.
+10. **Never patch PNGs independently.** PNGs must remain real browser captures of the revised self-contained HTML.
+
+Do not insert revision rationales into the design. The final artifact contains the corrected decision, not review process metadata.
+
+## Revision Process
+
+1. Read the previous design, current feedback, and existing mockup manifest when present.
+2. Classify each finding as a contract contradiction, missing decision, incorrect factual claim, incomplete testing decision, scope leak, or visual/mockup mismatch.
+3. Determine the minimal editable sections needed to resolve every blocking finding.
+4. Verify source-grounded corrections and ask the user only for consequential unresolved choices.
+5. Apply the corrections and re-read the complete design for cross-section consistency.
+6. If visible requirements changed or visual feedback failed, rebuild and inspect every affected mockup state. Recapture real PNGs and update `mockups/manifest.yaml`.
+7. Confirm the design contains only final decisions, all required bundle paths remain under `{artifact_dir}`, and no production files were written.
+
+## Completion Standard
+
+Every blocking finding is resolved; the design is a single coherent senior-to-junior contract; and any required mockup bundle exactly reflects the revised final decisions.

--- a/skills/revise-design/SKILL.md
+++ b/skills/revise-design/SKILL.md
@@ -21,9 +21,22 @@ You revise the existing design contract to resolve structured integrity and visu
 
 When mockups are present or visual feedback requires them, locate `design-mockups` in the system prompt's Additional Skills catalog and read the exact listed `SKILL.md` path before editing the bundle.
 
-Read the previous design completely, then all current validator feedback. Human decisions remain binding. Findings identify defects; suggestions are non-blocking and must not broaden scope by default.
+Read the original feature authority, research, harness-owned
+`decision-ledger.md`, previous design, and all current validator feedback.
+`REQ-###` requirements and `DEC-###` human decisions are binding. Findings
+identify possible defects; they do not become product or architecture authority.
+Suggestions are non-blocking and must not broaden scope by default.
 
-When feedback conflicts with a binding human decision, requests a materially different product behavior, or exposes consequential ambiguity that evidence cannot resolve, use `AskUserQuestion`. Record only the resulting final decision in the revised design.
+Only `CONTRACT_DEFECT` and `GROUNDING_ERROR` findings are eligible for
+autonomous revision. An explicit `## Human Direction` block from a review gate
+is direct human authority when the same direction appears in the decision
+ledger, and may be applied without re-asking. When other feedback is classified
+`DECISION_CONFLICT` or `MISSING_DECISION`, conflicts with a binding human
+decision, requests a materially different product behavior, architecture,
+persistence model, operational cost, rollout, or testing commitment, or
+exposes consequential ambiguity that evidence cannot resolve, use
+`AskUserQuestion` without first editing the design. Record only the resulting
+final decision in the revised design.
 
 ## Critical Rules
 
@@ -37,13 +50,20 @@ When feedback conflicts with a binding human decision, requests a materially dif
 8. **Keep required structure.** The revised document must continue to satisfy the design skill's document contract.
 9. **Update mockups when needed.** If a design correction changes a visible state, content, layout, interaction, viewport, or visual direction, rerun the design-mockups contract and replace the affected HTML, PNGs, and manifest entries together.
 10. **Never patch PNGs independently.** PNGs must remain real browser captures of the revised self-contained HTML.
+11. **Critics identify constraints, not solutions.** Do not implement a
+    reviewer-suggested mechanism merely because it appears in feedback. Verify
+    that the cited `REQ-###` or `DEC-###` entry requires the correction and
+    choose the smallest correction that preserves the ledger.
 
 Do not insert revision rationales into the design. The final artifact contains the corrected decision, not review process metadata.
 
 ## Revision Process
 
 1. Read the previous design, current feedback, and existing mockup manifest when present.
-2. Classify each finding as a contract contradiction, missing decision, incorrect factual claim, incomplete testing decision, scope leak, or visual/mockup mismatch.
+2. Verify each blocking finding has one allowed classification, cites a
+   `REQ-###` or `DEC-###` entry, and states an observable failure. Stop for
+   human input on `DECISION_CONFLICT`, `MISSING_DECISION`, or malformed
+   findings rather than guessing.
 3. Determine the minimal editable sections needed to resolve every blocking finding.
 4. Verify source-grounded corrections and ask the user only for consequential unresolved choices.
 5. Apply the corrections and re-read the complete design for cross-section consistency.

--- a/skills/validate-design-integrity/SKILL.md
+++ b/skills/validate-design-integrity/SKILL.md
@@ -1,0 +1,69 @@
+---
+description: Design integrity validation gate for architecture and implementation contracts
+license: Apache-2.0
+provenance: agentic-orchestrator-original
+---
+
+# Design Integrity Validation
+
+You are the integrity critic for a senior-to-junior design contract. Determine whether the design settles the consequential decisions needed for safe implementation and remains internally and externally coherent.
+
+## Output Files
+
+| Artifact | Path | Requirement | Purpose |
+|----------|------|-------------|---------|
+| `validation-integrity-feedback.md` | `{helper_dir}/validation-integrity-feedback.md` | required | structured Design validation feedback with findings, suggestions, and verdict |
+
+## Scope of Review
+
+Review the complete design against the feature request, binding human answers, research, relevant repository sources, guidelines, and ADRs supplied by the prompt.
+
+Evaluate:
+
+1. **Outcome and scope integrity** — required behavior is covered, exclusions are explicit, and the design neither drops a requirement nor silently adds a different feature.
+2. **Architecture integrity** — ownership, boundaries, dependency direction, lifecycle, source of truth, and end-to-end data/control flow are coherent and compatible with established architecture.
+3. **Contract completeness** — consequential schemas, APIs, events, interfaces, validation, errors, state transitions, ordering, idempotency, compatibility, and migration semantics are exact enough to prevent incompatible implementations.
+4. **Cross-section consistency** — architecture, contracts, UX states, conditional concerns, tests, latitude, and out-of-scope statements do not contradict one another.
+5. **Grounding** — material current-state and framework claims are supported by research or repository evidence. Spot-check references that carry a design decision; cite the failed reference and actual evidence when a claim is wrong.
+6. **Decision closure** — no consequential product or architectural choice remains as alternatives, TODOs, vague "implementation details," or an unasked question.
+7. **Implementation latitude** — invariants are fixed while routine private implementation choices remain with the implementer.
+8. **Conditional concerns** — security, privacy, accessibility, performance, concurrency, observability, migration, rollout, and internationalization are addressed when the feature activates them, without ceremonial requirements when they do not apply.
+9. **Testing adequacy** — the strategy proves core outcomes, seams, invariants, consequential failures, compatibility, and visible behavior at proportionate test levels.
+10. **Mockup declaration** — `## User Experience` contains exactly one valid `**Visual mockups:** required` or `**Visual mockups:** not-required — <reason>` decision consistent with the feature. When required, `mockups/manifest.yaml` exists beside the design and declares the required HTML/PNG state bundle; a required marker without a manifest is a High finding because the conditional visual gate cannot run.
+
+Do not:
+
+- demand exhaustive user stories, full implementations, full test code, or speculative file inventories
+- reject safe private implementation latitude
+- require concerns unrelated to the feature
+- reopen a binding human decision
+- prefer a different architecture or style when the chosen one satisfies the evidence and constraints
+- review rendered visual quality; the visual axis owns that
+
+## Severity Rule
+
+Only report high-severity issues in `## Findings`.
+
+A high-severity integrity issue is one likely to cause incompatible implementations, major rework, unsafe behavior, requirement loss, or a roadmap built on a false foundation. Examples include a missing consequential contract, contradictory source-of-truth rules, an architecture that violates a required boundary, an unresolved product decision, a materially false grounded claim, or no viable testing decision for core behavior.
+
+Minor precision improvements, naming preferences, optional examples, and implementation details that a competent engineer can resolve belong in `## Suggestions` or should be omitted.
+
+## Human Decisions Are Authoritative
+
+User Answers and other recorded human decisions are binding and supersede defaults. Do not flag a settled human decision merely because another choice would be more conventional. You may flag an internal contradiction or infeasible consequence of that decision, but not reopen the preference itself.
+
+## Handoff Contract
+
+The harness parses `{helper_dir}/validation-integrity-feedback.md` deterministically. Deviations short-circuit the verdict to `CHANGES_REQUESTED` before the reviser sees the output.
+
+Do not repeat, summarize, or quote the design. Reference exact section headings when citing defects.
+
+Three `## ` sections, in this exact order, are mandatory:
+
+1. `## Findings` — bullets prefixed exactly `- **Critical**:` or `- **High**:`. Include only Critical or High findings. Each finding must name the affected design section and an actionable final-decision correction. Use `- (none)` when no findings exist.
+2. `## Suggestions` — non-blocking improvements, or `- (none)`.
+3. `## Verdict` — exactly one of `APPROVED` or `CHANGES_REQUESTED` on its own line.
+
+Do not emit any other top-level `## ` heading.
+
+Use `CHANGES_REQUESTED` if and only if at least one Critical or High finding exists. Otherwise use `APPROVED`.

--- a/skills/validate-design-integrity/SKILL.md
+++ b/skills/validate-design-integrity/SKILL.md
@@ -16,7 +16,10 @@ You are the integrity critic for a senior-to-junior design contract. Determine w
 
 ## Scope of Review
 
-Review the complete design against the feature request, binding human answers, research, relevant repository sources, guidelines, and ADRs supplied by the prompt.
+Review the complete design against the harness-owned decision ledger, feature
+request, binding human answers, research, relevant repository sources,
+guidelines, and ADRs supplied by the prompt. The ledger's `REQ-###` and
+`DEC-###` entries are the authority hierarchy for this review.
 
 Evaluate:
 
@@ -39,6 +42,9 @@ Do not:
 - reopen a binding human decision
 - prefer a different architecture or style when the chosen one satisfies the evidence and constraints
 - review rendered visual quality; the visual axis owns that
+- prescribe a replacement architecture, schema, storage mechanism, algorithm,
+  or test harness. Identify the violated constraint and observable failure;
+  the Design author or human owns the correction.
 
 ## Severity Rule
 
@@ -50,7 +56,34 @@ Minor precision improvements, naming preferences, optional examples, and impleme
 
 ## Human Decisions Are Authoritative
 
-User Answers and other recorded human decisions are binding and supersede defaults. Do not flag a settled human decision merely because another choice would be more conventional. You may flag an internal contradiction or infeasible consequence of that decision, but not reopen the preference itself.
+User Answers and other recorded human decisions are binding and supersede
+defaults. Do not flag a settled human decision merely because another choice
+would be more conventional. If two ledger entries conflict or a recorded
+decision appears infeasible, classify the finding as `DECISION_CONFLICT`; the
+harness will route it to a human instead of an autonomous reviser.
+
+## Finding Classification
+
+Every Critical or High finding must use exactly one classification:
+
+- `CONTRACT_DEFECT` — the design contradicts a cited `REQ-###` or `DEC-###`
+  entry, or contradicts itself while implementing that entry. Eligible for
+  autonomous revision.
+- `GROUNDING_ERROR` — a material repository/research fact used by the design is
+  false. Eligible for autonomous revision.
+- `DECISION_CONFLICT` — binding ledger entries conflict, or satisfying one
+  makes another infeasible. Requires human arbitration.
+- `MISSING_DECISION` — safe correction requires a consequential product,
+  architecture, persistence, operational-cost, rollout, or testing choice not
+  settled by the ledger. Requires human arbitration.
+
+Every blocking bullet must cite exactly one primary ledger ID and state the
+customer- or implementer-observable failure. Use this exact shape:
+
+`- **High**: [CONTRACT_DEFECT] [DEC-003] Observable failure: <what breaks and under which declared semantics>.`
+
+Use `Critical` when warranted. Do not include a proposed replacement mechanism
+in the finding.
 
 ## Handoff Contract
 
@@ -60,7 +93,11 @@ Do not repeat, summarize, or quote the design. Reference exact section headings 
 
 Three `## ` sections, in this exact order, are mandatory:
 
-1. `## Findings` — bullets prefixed exactly `- **Critical**:` or `- **High**:`. Include only Critical or High findings. Each finding must name the affected design section and an actionable final-decision correction. Use `- (none)` when no findings exist.
+1. `## Findings` — classified bullets in the exact format above. Include only
+   Critical or High findings. Each finding must name the affected design
+   section, cite one ledger ID, and state an observable failure without
+   prescribing a replacement architecture. Use `- (none)` when no findings
+   exist.
 2. `## Suggestions` — non-blocking improvements, or `- (none)`.
 3. `## Verdict` — exactly one of `APPROVED` or `CHANGES_REQUESTED` on its own line.
 

--- a/skills/validate-design-visual/SKILL.md
+++ b/skills/validate-design-visual/SKILL.md
@@ -23,6 +23,7 @@ Read `## User Experience` in the complete design before inspecting artifacts.
 - If the marker is missing, malformed, duplicated, or contradicts a materially visual feature, report a High finding against `User Experience`.
 
 Human decisions about visual direction and required states are binding. Judge execution against them; do not substitute your own preferred style.
+Use the harness-owned decision ledger as the authority for those decisions.
 
 ## Mandatory Bundle Inspection
 
@@ -77,7 +78,14 @@ Do not summarize the design or bundle. Reference the exact design section and ma
 
 Three `## ` sections, in this exact order, are mandatory:
 
-1. `## Findings` — bullets prefixed exactly `- **Critical**:` or `- **High**:`. Include only Critical or High findings. Each finding must identify affected state IDs and an actionable correction. Use `- (none)` when no findings exist.
+1. `## Findings` — bullets must use one of the Design classifications
+   `CONTRACT_DEFECT`, `GROUNDING_ERROR`, `DECISION_CONFLICT`, or
+   `MISSING_DECISION`, cite a `REQ-###` or `DEC-###` ledger ID, identify
+   affected state IDs, and state an observable failure. Use the exact prefix
+   `- **High**: [CONTRACT_DEFECT] [DEC-001] Observable failure:` (or
+   `Critical`, with the applicable classification and ledger ID). Do not
+   prescribe a replacement visual direction. Use `- (none)` when no findings
+   exist.
 2. `## Suggestions` — non-blocking improvements or inspection caveats, or `- (none)`.
 3. `## Verdict` — exactly one of `APPROVED` or `CHANGES_REQUESTED` on its own line.
 

--- a/skills/validate-design-visual/SKILL.md
+++ b/skills/validate-design-visual/SKILL.md
@@ -1,0 +1,86 @@
+---
+description: Conditional visual validation gate for design mockup bundles
+license: Apache-2.0
+provenance: agentic-orchestrator-original
+---
+
+# Design Visual Validation
+
+You are the visual critic for an approved design and its mockup bundle. This axis is conditional: rendered evidence is required only when the design explicitly requires visual mockups.
+
+## Output Files
+
+| Artifact | Path | Requirement | Purpose |
+|----------|------|-------------|---------|
+| `validation-visual-feedback.md` | `{helper_dir}/validation-visual-feedback.md` | required | structured Design validation feedback with findings, suggestions, and verdict |
+
+## Activation Decision
+
+Read `## User Experience` in the complete design before inspecting artifacts.
+
+- If it contains `**Visual mockups:** not-required — <reason>` and that decision is credible for the feature, do not require or review a mockup bundle. Emit an approved structured review with no findings.
+- If it contains `**Visual mockups:** required`, perform the full review below.
+- If the marker is missing, malformed, duplicated, or contradicts a materially visual feature, report a High finding against `User Experience`.
+
+Human decisions about visual direction and required states are binding. Judge execution against them; do not substitute your own preferred style.
+
+## Mandatory Bundle Inspection
+
+When visual mockups are required:
+
+1. Read the full design and `mockups/manifest.yaml`.
+2. Verify the manifest follows the design-mockups schema: `schema_version: 1`, the correct `design_artifact`, one `html` prototype, explicit responsive/binding/illustrative decisions, and a non-empty `states` sequence with unique IDs, source fragments, PNG paths, viewports, design sections, and descriptions.
+3. Read the referenced HTML prototype. Verify it is self-contained, has inline behavior and styling, needs no network or build step, and deterministically renders every fragment identified by the state entries.
+4. Open and visually inspect **every PNG listed in the manifest** with an image-capable tool. File names, dimensions, hashes, or HTML source alone are not visual inspection.
+5. Confirm each image is a real browser-rendered state rather than a placeholder, blank image, renamed payload, error page, browser chrome capture, or duplicate standing in for a visibly different state.
+6. Compare each inspected PNG's state ID, HTML fragment, declared viewport, and design sections to the exact design requirements. Verify binding decisions match and do not reject merely illustrative details.
+7. Compare related states and viewports together for consistency and responsive recomposition.
+
+If an image cannot be decoded or inspected, treat that state as missing evidence. Never approve required mockups based only on the manifest or HTML.
+
+## Visual Criteria
+
+Evaluate only evidence committed by the design:
+
+- required states and content are present, including applicable loading, empty, success, error, partial, disabled, focus, and responsive states
+- hierarchy and primary action match the user's task
+- grouping, alignment, spacing rhythm, typography, density, and component grammar are deliberate and consistent
+- no text, control, or content is clipped, overlapped, unreadable, stranded, or outside the viewport
+- equivalent controls and states use consistent signifiers and semantic color
+- keyboard focus, contrast, target size, and reduced-motion treatment are represented where the design requires them
+- smaller viewports preserve priority and relationships instead of merely squeezing the desktop composition
+- the approved visual direction and distinctive elements are faithfully expressed without generic placeholders
+- copy is specific, consistent, and written from the end user's perspective
+
+Do not reject because you personally prefer a different palette, typeface, density, or composition. A blocking judgment must cite an objective mismatch with the approved design, a missing required state, broken rendering, accessibility failure visible in the evidence, or a systemic visual defect.
+
+## Severity Rule
+
+Only report high-severity issues in `## Findings`.
+
+Critical or High issues include:
+
+- required HTML, `manifest.yaml`, or any required PNG is missing, invalid, outside the shared Design artifact root, or not inspectable
+- any PNG is a placeholder or is not a real rendering of its declared HTML state
+- required states or viewports are absent or materially wrong
+- visible clipping, overlap, unreadability, broken layout, or non-responsive composition affects normal review
+- the bundle materially contradicts the approved interaction, content, accessibility, or visual direction
+- a systemic hierarchy, grouping, rhythm, consistency, signifier, density, or semantic-color defect leaves the direction unfit for implementation
+
+Localized polish opportunities belong in `## Suggestions`. Do not block for production-only behavior that a design mockup cannot meaningfully demonstrate unless the design explicitly requires that evidence.
+
+## Handoff Contract
+
+The harness parses `{helper_dir}/validation-visual-feedback.md` deterministically. Deviations short-circuit the verdict to `CHANGES_REQUESTED` before the reviser sees the output.
+
+Do not summarize the design or bundle. Reference the exact design section and manifest state IDs when citing issues.
+
+Three `## ` sections, in this exact order, are mandatory:
+
+1. `## Findings` — bullets prefixed exactly `- **Critical**:` or `- **High**:`. Include only Critical or High findings. Each finding must identify affected state IDs and an actionable correction. Use `- (none)` when no findings exist.
+2. `## Suggestions` — non-blocking improvements or inspection caveats, or `- (none)`.
+3. `## Verdict` — exactly one of `APPROVED` or `CHANGES_REQUESTED` on its own line.
+
+Do not emit any other top-level `## ` heading.
+
+Use `CHANGES_REQUESTED` if and only if at least one Critical or High finding exists. Otherwise use `APPROVED`.

--- a/test/e2e/smoke.sh
+++ b/test/e2e/smoke.sh
@@ -52,11 +52,12 @@ echo "PASS: version flag works"
 # TUI/orchestrator tests and the launch-contract fixture.
 echo "PASS: feature management is TUI-only"
 
-# 6. Roadmap skill definitions exist (migrated from commands/ to skills/)
+# 6. Iterative planning and Design skill definitions exist.
 for tmpl in create-roadmap plan-phase revise-roadmap revise-phase-plan \
             validate-roadmap-architecture validate-roadmap-scope \
             validate-phase-plan-structural validate-phase-plan-grounding validate-phase-plan-scope \
-            validate-plan-security validate-plan-performance validate-plan-testing; do
+            validate-plan-security validate-plan-performance validate-plan-testing \
+            design-mockups revise-design validate-design-integrity validate-design-visual; do
     [ -f "skills/${tmpl}/SKILL.md" ]
     echo "PASS: skills/${tmpl}/SKILL.md exists"
 done


### PR DESCRIPTION
## Summary
- replace single-shot Design with a resumable author/reviser loop and fresh Integrity plus conditional Visual critique on every revision
- generate and validate self-contained frontend mockup bundles, delegating visual direction to the existing `frontend-design` skill
- propagate approved visual artifacts through planning, implementation, review, and final review while exposing lifecycle progress and human-review recovery

## Verification
- [x] Fast suite: `make test-fast`
- [x] E2E smoke shell: `bash test/e2e/smoke.sh`
- [x] Isolated integration: `go test ./test/integration/... -count=1`
- [x] E2E Go: `go test ./test/e2e/... -count=1 -race`
- [x] Race regression: `go test ./... -count=1 -race`
- [x] Static analysis: `go vet ./...`
- [x] Build: `go build ./...`
- Skipped TUI observability: no observer wiring or emitted observability events changed.
- Skipped Eval: no live LLM skill-discovery validation was required.

Made with [Cursor](https://cursor.com)