### PR TITLE
Avoid false rebase conflicts and duplicate diagnostics

### DIFF
--- a/desktop/src/renderer/src/features/refactor/refactorPassModel.test.ts
+++ b/desktop/src/renderer/src/features/refactor/refactorPassModel.test.ts
@@ -115,7 +115,7 @@ describe('passState post-review lifecycle', () => {
     expect(passActions(child)).toEqual([{ id: 'start', label: 'Start pass', kind: 'primary' }]);
   });
 
-  it('surfaces conflict files and diagnostics when the transaction parks', () => {
+  it('prefers repository diagnostics over redundant transaction details', () => {
     const state = passState(
       featureSnapshot({
         ...base,
@@ -134,11 +134,40 @@ describe('passState post-review lifecycle', () => {
       }),
     );
     expect(state).toMatchObject({ id: 'integration-attention', tone: 'attention' });
-    expect(state.problems).toEqual([
-      'merge conflict in repo-a',
-      'repo-a: conflicts in internal/api.go, cmd/main.go',
-      'repo-a: rebase stopped on internal/api.go',
-    ]);
+    expect(state.problems).toEqual(['repo-a: rebase stopped on internal/api.go']);
+  });
+
+  it('falls back to conflict files when a repository has no diagnostic', () => {
+    const state = passState(
+      featureSnapshot({
+        ...base,
+        status: 'ReviewPassed',
+        transaction: {
+          phase: 'attention',
+          entries: [
+            {
+              repo: 'repo-a',
+              conflictFiles: ['internal/api.go', 'cmd/main.go'],
+            },
+          ],
+        },
+      }),
+    );
+    expect(state.problems).toEqual(['repo-a: conflicts in internal/api.go, cmd/main.go']);
+  });
+
+  it('falls back to transaction attention when repositories provide no details', () => {
+    const state = passState(
+      featureSnapshot({
+        ...base,
+        status: 'ReviewPassed',
+        transaction: {
+          phase: 'attention',
+          attention: 'merge conflict in repo-a',
+        },
+      }),
+    );
+    expect(state.problems).toEqual(['merge conflict in repo-a']);
   });
 
   it('walks applied, merged, and discarded closures without reverting to ready', () => {

--- a/desktop/src/renderer/src/features/refactor/refactorPassModel.ts
+++ b/desktop/src/renderer/src/features/refactor/refactorPassModel.ts
@@ -44,20 +44,23 @@ const PARKED_TRANSACTION_PHASES = new Set(['attention', 'rolling_back', 'rolled_
 
 function transactionProblems(transaction: RelationshipTransactionView): string[] {
   const problems: string[] = [];
-  if (transaction.attention !== undefined && transaction.attention !== '') {
-    problems.push(transaction.attention);
-  }
   for (const entry of transaction.entries ?? []) {
     const repo = entry.repo === undefined ? '' : `${entry.repo}: `;
-    if (entry.conflictFiles !== undefined && entry.conflictFiles.length > 0) {
-      problems.push(`${repo}conflicts in ${entry.conflictFiles.join(', ')}`);
-    }
     if (entry.diagnostics !== undefined && entry.diagnostics !== '') {
       problems.push(`${repo}${entry.diagnostics}`);
+    } else if (entry.conflictFiles !== undefined && entry.conflictFiles.length > 0) {
+      problems.push(`${repo}conflicts in ${entry.conflictFiles.join(', ')}`);
     }
     if (entry.cleanupWarning !== undefined && entry.cleanupWarning !== '') {
       problems.push(`${repo}${entry.cleanupWarning}`);
     }
+  }
+  if (
+    problems.length === 0 &&
+    transaction.attention !== undefined &&
+    transaction.attention !== ''
+  ) {
+    problems.push(transaction.attention);
   }
   return problems;
 }

--- a/internal/git/merge_state.go
+++ b/internal/git/merge_state.go
@@ -40,10 +40,10 @@ func MergeInProgress(worktreePath string) bool {
 // worktreePath that contain literal git conflict marker lines. The scan
 // matches the `git grep`-based contract the generated rebase-child prompt and
 // exit criteria already impose: the three conflict markers (start, middle
-// separator, end) searched as fixed strings. It is a literal marker scan, not
-// an unmerged-index check — after the transaction commits child changes,
-// `git diff --name-only --diff-filter=U` is vacuous, so only a content scan
-// can prove a worktree is free of markers.
+// separator, end) searched as anchored line expressions. It is a literal
+// marker scan, not an unmerged-index check — after the transaction commits
+// child changes, `git diff --name-only --diff-filter=U` is vacuous, so only a
+// content scan can prove a worktree is free of markers.
 //
 // The marker patterns are constructed from split strings so this source file
 // does not itself contain the literal marker sequences and false-positive on
@@ -55,9 +55,9 @@ func MergeInProgress(worktreePath string) bool {
 func ConflictMarkerFiles(worktreePath string) ([]string, error) {
 	// Construct the marker patterns from split strings so this source file
 	// does not match its own scan.
-	start := "<" + "<<<<" + "<< "
-	mid := "=" + "=====" + "="
-	end := ">" + ">>>>" + ">> "
+	start := "^" + "<" + "<<<<" + "<< "
+	mid := "^" + "=" + "=====" + "=$"
+	end := "^" + ">" + ">>>>" + ">> "
 
 	cmd := exec.Command("git", "-C", worktreePath, "grep", "-l",
 		"-e", start, "-e", mid, "-e", end, "--", ".")

--- a/internal/git/merge_state.go
+++ b/internal/git/merge_state.go
@@ -40,10 +40,12 @@ func MergeInProgress(worktreePath string) bool {
 // worktreePath that contain literal git conflict marker lines. The scan
 // matches the `git grep`-based contract the generated rebase-child prompt and
 // exit criteria already impose: the three conflict markers (start, middle
-// separator, end) searched as anchored line expressions. It is a literal
-// marker scan, not an unmerged-index check — after the transaction commits
-// child changes, `git diff --name-only --diff-filter=U` is vacuous, so only a
-// content scan can prove a worktree is free of markers.
+// separator, end) searched as anchored line expressions. A file must contain
+// all three forms to be reported, so ordinary headings and dividers do not
+// trip the gate. It is a literal marker scan, not an unmerged-index check.
+// After the transaction commits child changes,
+// `git diff --name-only --diff-filter=U` is vacuous, so only a content scan can
+// prove a worktree is free of markers.
 //
 // The marker patterns are constructed from split strings so this source file
 // does not itself contain the literal marker sequences and false-positive on
@@ -59,20 +61,31 @@ func ConflictMarkerFiles(worktreePath string) ([]string, error) {
 	mid := "^" + "=" + "=====" + "=$"
 	end := "^" + ">" + ">>>>" + ">> "
 
-	cmd := exec.Command("git", "-C", worktreePath, "grep", "-l",
-		"-e", start, "-e", mid, "-e", end, "--", ".")
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		// git grep exits 1 when there are no matches: that is the clean-tree
-		// case, not an error. Distinguish it from a real failure by checking
-		// the exit code via the typed *exec.ExitError.
-		if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 1 {
-			return nil, nil
+	patterns := []string{start, mid, end}
+	matches := make(map[string]int)
+	for _, pattern := range patterns {
+		cmd := exec.Command("git", "-C", worktreePath, "grep", "-l",
+			"-e", pattern, "--", ".")
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			// git grep exits 1 when there are no matches: that is a clean result
+			// for this marker form, not a scan failure.
+			if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 1 {
+				continue
+			}
+			return nil, &ConflictMarkerScanError{WorktreePath: worktreePath, Err: err, Output: string(out)}
 		}
-		return nil, &ConflictMarkerScanError{WorktreePath: worktreePath, Err: err, Output: string(out)}
+		for _, file := range parseGrepFiles(string(out)) {
+			matches[file]++
+		}
 	}
 
-	files := parseGrepFiles(string(out))
+	files := make([]string, 0, len(matches))
+	for file, count := range matches {
+		if count == len(patterns) {
+			files = append(files, file)
+		}
+	}
 	sort.Strings(files)
 	return files, nil
 }

--- a/internal/git/merge_state_test.go
+++ b/internal/git/merge_state_test.go
@@ -158,6 +158,7 @@ func TestConflictMarkerFiles_IgnoresDecorativeSeparators(t *testing.T) {
 	content := strings.Join([]string{
 		`log.Printf("==============================")`,
 		"// =============================================================================",
+		"=======",
 		"embedded ======= separator",
 		"prefixed <<<<<<< example",
 		"prefixed >>>>>>> example",

--- a/internal/git/merge_state_test.go
+++ b/internal/git/merge_state_test.go
@@ -148,6 +148,31 @@ func TestConflictMarkerFiles_CleanTree(t *testing.T) {
 	}
 }
 
+func TestConflictMarkerFiles_IgnoresDecorativeSeparators(t *testing.T) {
+	if testing.Short() {
+		t.Skip("real-git conflict marker scan")
+	}
+	t.Parallel()
+	repo := testutil.InitGitRepo(t)
+
+	content := strings.Join([]string{
+		`log.Printf("==============================")`,
+		"// =============================================================================",
+		"embedded ======= separator",
+		"prefixed <<<<<<< example",
+		"prefixed >>>>>>> example",
+	}, "\n") + "\n"
+	testutil.CommitFile(t, repo, "decorative.txt", content, "add decorative separators")
+
+	files, err := ConflictMarkerFiles(repo)
+	if err != nil {
+		t.Fatalf("ConflictMarkerFiles() error = %v", err)
+	}
+	if len(files) != 0 {
+		t.Errorf("ConflictMarkerFiles() = %v; want empty for decorative separators", files)
+	}
+}
+
 func TestConflictMarkerFiles_DetectsMarkers(t *testing.T) {
 	if testing.Short() {
 		t.Skip("real-git conflict marker scan")


### PR DESCRIPTION
## Summary

- require all three anchored Git conflict-marker forms in the same tracked file before blocking rebase integration
- ignore decorative separators, generated dividers, embedded marker-like text, and standalone Markdown Setext underlines
- collapse redundant transaction summary, conflict-file, and repository-diagnostic rows while preserving structured fallbacks and cleanup warnings

## Root cause

The rebase gate used one `git grep` invocation with OR-ed marker fragments. The unanchored seven-equals fragment matched ordinary repository content, so valid rebase children parked at integration attention. The renderer then displayed three representations of the same durable transaction failure.

## Verification

- Fast suite: `make test-fast`
- Desktop static checks: `npm run check`
- Desktop unit/component/security tests: `npm test && npm run test:security` (1,508 unit/component tests and 84 explicit security tests)
- Go static-analysis gate: `go vet ./...`
- Go build gate: `go build ./...`
- Original Taulu reproduction: zero files contain a complete anchored start/middle/end marker set
- Independent code review: no findings after the standalone `=======` regression fix
- Skipped Desktop packaged E2E: no renderer copy, roles, accessible names, IPC, preload, or main-process behavior changed, and no packaged journey asserts on the affected fixture text
- Skipped Race regression: the change does not touch concurrency or shared mutable state

Generated with Codex.

Co-authored-by: Codex <noreply@openai.com>
