### PR TITLE
Honor native macOS window close behavior

### DIFF
--- a/desktop/src/main/__tests__/quitCoordinator.test.ts
+++ b/desktop/src/main/__tests__/quitCoordinator.test.ts
@@ -3,6 +3,7 @@ import {
   QuitCoordinator,
   activeWorkDialog,
   quitAnywayDialog,
+  shouldRequestQuitOnMainWindowClose,
   stopFailureDialog,
   type ActiveWorkCheck,
   type QuitCoordinatorDeps,
@@ -42,6 +43,16 @@ function makeDeps(
     ...overrides,
   };
 }
+
+describe('shouldRequestQuitOnMainWindowClose', () => {
+  it.each([
+    ['darwin', false],
+    ['win32', true],
+    ['linux', true],
+  ] as const)('returns %s => %s', (platform, expected) => {
+    expect(shouldRequestQuitOnMainWindowClose(platform)).toBe(expected);
+  });
+});
 
 describe('QuitCoordinator', () => {
   it('quits immediately when authoritative activity is idle', async () => {

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -98,6 +98,7 @@ import {
   activeWorkDialog,
   hasActiveWork,
   quitAnywayDialog,
+  shouldRequestQuitOnMainWindowClose,
   stopFailureDialog,
   type ActiveWorkCheck,
   type ActiveWorkDecision,
@@ -807,7 +808,10 @@ if (!hasSingleInstanceLock) {
     }
 
     function handleWindowClose(event: ElectronEvent, window: BrowserWindow): void {
-      if (quitCoordinator.shouldAllowClose()) {
+      if (
+        quitCoordinator.shouldAllowClose() ||
+        !shouldRequestQuitOnMainWindowClose(process.platform)
+      ) {
         return;
       }
       event.preventDefault();

--- a/desktop/src/main/menuTemplate.ts
+++ b/desktop/src/main/menuTemplate.ts
@@ -118,8 +118,9 @@ export function buildApplicationMenuTemplate(deps: MenuTemplateDeps): MenuItemCo
     // is shell-level by design — it opens the creation sheet over whatever
     // pane is current — so it is enabled on readiness alone, regardless of
     // selection. `close` is the platform role, so ⌘W always closes whichever
-    // window is focused — the Settings window closes outright, the main window
-    // goes through its own close handler and the quit decision behind it.
+    // window is focused. Settings always closes outright; on macOS the main
+    // window closes while the application remains active, while other platforms
+    // send a main-window close through the coordinated quit decision.
     {
       label: 'File',
       submenu: [

--- a/desktop/src/main/quitCoordinator.ts
+++ b/desktop/src/main/quitCoordinator.ts
@@ -168,6 +168,10 @@ export function hasActiveWork(active: ActiveWorkCheck): boolean {
   return active.detectionFailed || active.featureIds.length > 0 || active.chatActive;
 }
 
+export function shouldRequestQuitOnMainWindowClose(platform: NodeJS.Platform): boolean {
+  return platform !== 'darwin';
+}
+
 export function activeWorkDialog(active: ActiveWorkCheck): QuitDialogOptions {
   const details = [
     active.detectionFailed

--- a/desktop/test/e2e/journeys/background-lifecycle-commands.spec.ts
+++ b/desktop/test/e2e/journeys/background-lifecycle-commands.spec.ts
@@ -97,22 +97,33 @@ test('packaged command palette, native menu routes, and active close policy stay
       timeout: 60_000,
     });
 
-    const closeResult = await triggerQuitDecision(handle, [0], 'window-close');
-    expect(closeResult.visible).toBe(false);
-    expect(JSON.stringify(closeResult.captured[0])).toContain('Keep Running');
-    expect(JSON.stringify(closeResult.captured[0])).toContain('Stop Work and Quit');
-    expect(JSON.stringify(closeResult.captured[0])).toContain('Cancel');
+    if (process.platform === 'darwin') {
+      await closeMainWindowAndReactivate(handle);
+      const restored = await handle.page.evaluate(
+        (id) => window.agentico.getFeature(id),
+        featureId,
+      );
+      expect(restored.actions).toContainEqual(
+        expect.objectContaining({ id: 'pause-stop', enabled: true }),
+      );
+    } else {
+      const closeResult = await triggerQuitDecision(handle, [0], 'window-close');
+      expect(closeResult.visible).toBe(false);
+      expect(JSON.stringify(closeResult.captured[0])).toContain('Keep Running');
+      expect(JSON.stringify(closeResult.captured[0])).toContain('Stop Work and Quit');
+      expect(JSON.stringify(closeResult.captured[0])).toContain('Cancel');
+      await handle.app.evaluate(({ BrowserWindow }) => {
+        const window = BrowserWindow.getAllWindows()[0];
+        window?.show();
+        window?.focus();
+      });
+    }
 
-    await handle.app.evaluate(({ BrowserWindow }) => {
-      const window = BrowserWindow.getAllWindows()[0];
-      window?.show();
-      window?.focus();
-    });
     const cancelResult = await triggerQuitDecision(handle, [2], 'native-quit');
     expect(cancelResult.visible).toBe(true);
     expect(JSON.stringify(cancelResult.captured[0])).toContain('Cancel');
 
-    const stopResult = await triggerQuitDecision(handle, [1], 'window-close');
+    const stopResult = await triggerQuitDecision(handle, [1], 'native-quit');
     expect(JSON.stringify(stopResult.captured[0])).toContain('Stop Work and Quit');
     await waitForAppExit(handle);
     handle.closed = true;
@@ -133,7 +144,35 @@ test('packaged command palette, native menu routes, and active close policy stay
   }
 });
 
-test('packaged idle close quits without prompting for active-work decisions', async ({}, testInfo) => {
+test('packaged macOS idle close keeps the app alive and activation recreates its window', async ({}, testInfo) => {
+  test.skip(process.platform !== 'darwin', 'macOS keeps the application active after window close');
+  const world = createWorld('background-lifecycle-idle-close', {
+    auth: { loggedIn: true, authMethod: 'oauth', email: 'e2e@example.invalid' },
+    presetWorkspaceRoot: true,
+    workflowProvider: true,
+  });
+  createRepo(world, 'idle-lab', { commit: true });
+  let handle: AppHandle | null = null;
+
+  try {
+    handle = await launchApp(world, testInfo, { traceName: 'background-lifecycle-idle-close' });
+    await expect(handle.page.getByRole('button', { name: 'New feature' })).toBeVisible({
+      timeout: 60_000,
+    });
+    await closeMainWindowAndReactivate(handle);
+    await clickNativeMenu(handle, 'global.quit');
+    await waitForAppExit(handle);
+    handle.closed = true;
+    persistAppLogs(handle, 'background-lifecycle-idle-close-app-server');
+  } finally {
+    if (handle !== null) await closeApp(handle).catch(() => {});
+    await assertNoLeakedProcesses(world);
+    destroyWorld(world);
+  }
+});
+
+test('packaged non-macOS idle close quits without prompting for active-work decisions', async ({}, testInfo) => {
+  test.skip(process.platform === 'darwin', 'macOS keeps the application active after window close');
   const world = createWorld('background-lifecycle-idle-close', {
     auth: { loggedIn: true, authMethod: 'oauth', email: 'e2e@example.invalid' },
     presetWorkspaceRoot: true,
@@ -171,7 +210,7 @@ test('packaged idle close quits without prompting for active-work decisions', as
   }
 });
 
-test('packaged close policy exposes partial-stop Retry controls', async ({}, testInfo) => {
+test('packaged explicit quit exposes partial-stop Retry controls', async ({}, testInfo) => {
   const world = createWorld('background-lifecycle-partial-retry', {
     auth: { loggedIn: true, authMethod: 'oauth', email: 'e2e@example.invalid' },
     presetWorkspaceRoot: true,
@@ -200,7 +239,7 @@ test('packaged close policy exposes partial-stop Retry controls', async ({}, tes
     });
     await forceNextStopFailure(handle, 1);
 
-    const result = await triggerQuitDecision(handle, [1, 1, 0], 'window-close');
+    const result = await triggerQuitDecision(handle, [1, 1, 0], 'native-quit');
     expect(JSON.stringify(result.captured[1])).toContain('Retry');
     expect(JSON.stringify(result.captured[1])).toContain('Quit Anyway');
     expect(JSON.stringify(result.captured[1])).toContain('Partial Stop Retry');
@@ -490,6 +529,55 @@ async function forceNextStopFailure(handle: AppHandle, count: number): Promise<v
     };
     global.__agenticoForceStopFailureCount = failureCount;
   }, count);
+}
+
+async function closeMainWindowAndReactivate(handle: AppHandle): Promise<void> {
+  const previousId = handle.mainWebContentsId;
+  const close = await handle.app.evaluate(async ({ BrowserWindow, dialog }, mainId) => {
+    const window = BrowserWindow.getAllWindows().find(
+      (candidate) => candidate.webContents.id === mainId,
+    );
+    if (window === undefined) throw new Error('main window missing');
+    const original = dialog.showMessageBox;
+    let promptCount = 0;
+    dialog.showMessageBox = (async () => {
+      promptCount += 1;
+      return { response: 2, checkboxChecked: false };
+    }) as typeof dialog.showMessageBox;
+    window.close();
+    const deadline = Date.now() + 2_000;
+    while (!window.isDestroyed() && Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+    dialog.showMessageBox = original;
+    return {
+      promptCount,
+      destroyed: window.isDestroyed(),
+      openWindows: BrowserWindow.getAllWindows().length,
+    };
+  }, previousId);
+  expect(close).toEqual({ promptCount: 0, destroyed: true, openWindows: 0 });
+  expect(handle.appProcess.exitCode).toBeNull();
+  expect(handle.appProcess.signalCode).toBeNull();
+  const discovery = readDiscovery(handle.world);
+  if (discovery === null) throw new Error('owned server discovery disappeared after window close');
+  expect(processAlive(discovery.pid)).toBe(true);
+
+  const appeared = handle.app.waitForEvent('window', { timeout: 30_000 });
+  await handle.app.evaluate(({ app }) => app.emit('activate'));
+  const page = await appeared;
+  page.setDefaultTimeout(Number(process.env['AGENTICO_E2E_ACTION_TIMEOUT'] ?? 60_000));
+  await expect(page.getByRole('status').filter({ hasText: 'Runtime ready' })).toBeVisible({
+    timeout: 60_000,
+  });
+  const mainWebContentsId = await handle.app.evaluate(({ BrowserWindow }) => {
+    const window = BrowserWindow.getAllWindows()[0];
+    if (window === undefined) throw new Error('reactivated main window missing');
+    return window.webContents.id;
+  });
+  expect(mainWebContentsId).not.toBe(previousId);
+  handle.page = page;
+  handle.mainWebContentsId = mainWebContentsId;
 }
 
 async function triggerQuitDecision(

--- a/docs/superpowers/plans/2026-08-10-macos-window-close.md
+++ b/docs/superpowers/plans/2026-08-10-macos-window-close.md
@@ -54,7 +54,7 @@ and the inverse regression where Windows or Linux silently remain running.
 Run:
 
 ```bash
-npm test --workspace desktop -- --project node desktop/src/main/__tests__/quitCoordinator.test.ts
+npm test --workspace desktop -- --project node src/main/__tests__/quitCoordinator.test.ts
 ```
 
 Expected: FAIL because `shouldRequestQuitOnMainWindowClose` is not exported.
@@ -225,7 +225,7 @@ shutdown as selected.
 - [ ] **Step 5: Run the focused unit test again**
 
 ```bash
-npm test --workspace desktop -- --project node desktop/src/main/__tests__/quitCoordinator.test.ts
+npm test --workspace desktop -- --project node src/main/__tests__/quitCoordinator.test.ts
 ```
 
 Expected: PASS, proving the entry point still consumes the tested policy.

--- a/docs/superpowers/plans/2026-08-10-macos-window-close.md
+++ b/docs/superpowers/plans/2026-08-10-macos-window-close.md
@@ -1,0 +1,298 @@
+# macOS Window Close Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the macOS red window button and Command-W close Agentico's main window without quitting the application or owned runtime, while preserving coordinated shutdown for explicit Quit.
+
+**Architecture:** Keep `QuitCoordinator` as the sole owner of explicit application shutdown and add a pure platform policy beside it for main-window close behavior. The Electron entry point consults that policy before preventing a close event; the existing `WindowRegistry`, `activate` listener, and `showMainWindow` path recreate a destroyed renderer without adding a second lifecycle owner.
+
+**Tech Stack:** Electron 43, TypeScript 5.9, Vitest 3, Playwright Electron packaged journeys, Go 1.24 verification gates.
+
+## Global Constraints
+
+- On macOS, a main-window close is a true `BrowserWindow` close, not hide and not application quit.
+- Command-Q, application-menu Quit, Dock-menu Quit, tray Quit, and Electron quit events continue through `QuitCoordinator`.
+- Windows and Linux keep their current close-to-quit behavior.
+- Do not change renderer copy, roles, accessible names, or IPC/preload surfaces.
+- Every modified test must name an observable regression and exercise real production behavior.
+- The targeted packaged journey must prove close, continued process/runtime life, activation, recreation, and explicit quit.
+
+---
+
+### Task 1: Encode the platform close policy
+
+**Files:**
+- Modify: `desktop/src/main/quitCoordinator.ts`
+- Test: `desktop/src/main/__tests__/quitCoordinator.test.ts`
+
+**Interfaces:**
+- Consumes: `NodeJS.Platform`, supplied explicitly by the Electron entry point or a unit test.
+- Produces: `shouldRequestQuitOnMainWindowClose(platform: NodeJS.Platform): boolean`; `false` only for `darwin`, `true` for `win32` and `linux`.
+
+- [ ] **Step 1: Write the failing platform-policy test**
+
+Add `shouldRequestQuitOnMainWindowClose` to the existing import from
+`../quitCoordinator`, then add this test before the `QuitCoordinator` describe:
+
+```ts
+describe('shouldRequestQuitOnMainWindowClose', () => {
+  it.each([
+    ['darwin', false],
+    ['win32', true],
+    ['linux', true],
+  ] as const)('returns %s => %s', (platform, expected) => {
+    expect(shouldRequestQuitOnMainWindowClose(platform)).toBe(expected);
+  });
+});
+```
+
+This catches the regression where macOS is routed back into quit coordination,
+and the inverse regression where Windows or Linux silently remain running.
+
+- [ ] **Step 2: Run the focused unit test and verify RED**
+
+Run:
+
+```bash
+npm test --workspace desktop -- --project node desktop/src/main/__tests__/quitCoordinator.test.ts
+```
+
+Expected: FAIL because `shouldRequestQuitOnMainWindowClose` is not exported.
+
+- [ ] **Step 3: Implement the minimal policy**
+
+Add this export beside `hasActiveWork` in `quitCoordinator.ts`:
+
+```ts
+export function shouldRequestQuitOnMainWindowClose(platform: NodeJS.Platform): boolean {
+  return platform !== 'darwin';
+}
+```
+
+- [ ] **Step 4: Run the focused unit test and verify GREEN**
+
+Run the command from Step 2.
+
+Expected: PASS for the new table and all existing quit-coordinator tests.
+
+- [ ] **Step 5: Commit the independently tested policy**
+
+```bash
+git add desktop/src/main/quitCoordinator.ts desktop/src/main/__tests__/quitCoordinator.test.ts
+git commit -m "Keep macOS window close distinct from application quit" -m "Co-authored-by: Codex <noreply@openai.com>"
+```
+
+---
+
+### Task 2: Route macOS close through the native window lifecycle
+
+**Files:**
+- Modify: `desktop/test/e2e/journeys/background-lifecycle-commands.spec.ts`
+- Modify: `desktop/src/main/index.ts`
+- Modify: `desktop/src/main/menuTemplate.ts`
+
+**Interfaces:**
+- Consumes: `shouldRequestQuitOnMainWindowClose(process.platform)` from Task 1, `WindowRegistry` eviction/recreation, Electron `app` activation, and the existing `global.quit` native command.
+- Produces: macOS close -> destroyed main window with live application/runtime; app activation -> fresh main window; explicit Quit -> unchanged `QuitCoordinator` flow.
+
+- [ ] **Step 1: Rewrite the packaged lifecycle expectation before wiring production**
+
+In the primary active-work journey:
+
+- replace the close-to-`Keep Running` assertion with a call to a new
+  `closeMainWindowAndReactivate(handle)` helper;
+- assert the same owned server PID is alive after close;
+- assert the recreated renderer can read the active feature and still sees an
+  enabled `pause-stop` action;
+- keep the explicit-quit cancellation and stop assertions, but trigger both
+  through `'native-quit'`, never `'window-close'`.
+
+Use these assertions after active work is observable:
+
+```ts
+await closeMainWindowAndReactivate(handle);
+const restored = await handle.page.evaluate((id) => window.agentico.getFeature(id), featureId);
+expect(restored.actions).toContainEqual(
+  expect.objectContaining({ id: 'pause-stop', enabled: true }),
+);
+
+const cancelResult = await triggerQuitDecision(handle, [2], 'native-quit');
+expect(cancelResult.visible).toBe(true);
+expect(JSON.stringify(cancelResult.captured[0])).toContain('Cancel');
+
+const stopResult = await triggerQuitDecision(handle, [1], 'native-quit');
+expect(JSON.stringify(stopResult.captured[0])).toContain('Stop Work and Quit');
+```
+
+Replace the idle-close journey's expectation that the app exits with the same
+close/reactivate contract, followed by a native explicit quit that does exit.
+
+```ts
+await closeMainWindowAndReactivate(handle);
+await clickNativeMenu(handle, 'global.quit');
+await waitForAppExit(handle);
+handle.closed = true;
+```
+
+Add this same-file helper near `triggerQuitDecision`:
+
+```ts
+async function closeMainWindowAndReactivate(handle: AppHandle): Promise<void> {
+  const previousId = handle.mainWebContentsId;
+  const close = await handle.app.evaluate(async ({ BrowserWindow, dialog }, mainId) => {
+    const window = BrowserWindow.getAllWindows().find(
+      (candidate) => candidate.webContents.id === mainId,
+    );
+    if (window === undefined) throw new Error('main window missing');
+    const original = dialog.showMessageBox;
+    let promptCount = 0;
+    dialog.showMessageBox = (async () => {
+      promptCount += 1;
+      return { response: 2, checkboxChecked: false };
+    }) as typeof dialog.showMessageBox;
+    window.close();
+    const deadline = Date.now() + 2_000;
+    while (!window.isDestroyed() && Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+    dialog.showMessageBox = original;
+    return { promptCount, destroyed: window.isDestroyed(), openWindows: BrowserWindow.getAllWindows().length };
+  }, previousId);
+  expect(close).toEqual({ promptCount: 0, destroyed: true, openWindows: 0 });
+  expect(handle.appProcess.exitCode).toBeNull();
+  expect(handle.appProcess.signalCode).toBeNull();
+  expect(processAlive(readDiscovery(handle.world)!.pid)).toBe(true);
+
+  const appeared = handle.app.waitForEvent('window', { timeout: 30_000 });
+  await handle.app.evaluate(({ app }) => app.emit('activate'));
+  const page = await appeared;
+  page.setDefaultTimeout(Number(process.env['AGENTICO_E2E_ACTION_TIMEOUT'] ?? 60_000));
+  await expect(page.getByRole('button', { name: 'New feature' })).toBeVisible({ timeout: 60_000 });
+  const mainWebContentsId = await handle.app.evaluate(({ BrowserWindow }) => {
+    const window = BrowserWindow.getAllWindows()[0];
+    if (window === undefined) throw new Error('reactivated main window missing');
+    return window.webContents.id;
+  });
+  expect(mainWebContentsId).not.toBe(previousId);
+  handle.page = page;
+  handle.mainWebContentsId = mainWebContentsId;
+}
+```
+
+- [ ] **Step 2: Build the unchanged application and verify the packaged test is RED**
+
+Run:
+
+```bash
+npm run package:verify
+npm run test:e2e:packaged -- test/e2e/journeys/background-lifecycle-commands.spec.ts
+```
+
+Expected: FAIL in `closeMainWindowAndReactivate` because the current main-window
+close handler initiates quit instead of destroying only the window and keeping
+the process alive.
+
+- [ ] **Step 3: Wire the policy into the main-window close handler**
+
+Import `shouldRequestQuitOnMainWindowClose` from `./quitCoordinator`, then change
+`handleWindowClose` to:
+
+```ts
+function handleWindowClose(event: ElectronEvent, window: BrowserWindow): void {
+  if (
+    quitCoordinator.shouldAllowClose() ||
+    !shouldRequestQuitOnMainWindowClose(process.platform)
+  ) {
+    return;
+  }
+  event.preventDefault();
+  void quitCoordinator.requestQuitDecision(window);
+}
+```
+
+Update the `File -> Close Window` comment in `menuTemplate.ts` so it states that
+Command-W closes the focused window, the macOS main window remains an active
+application, and non-macOS main windows still enter quit coordination.
+
+- [ ] **Step 4: Rebuild and verify the packaged lifecycle GREEN**
+
+Run the two commands from Step 2 again.
+
+Expected: both packaged tests cover close/recreate successfully; active work
+survives recreation; explicit native Quit still cancels or performs coordinated
+shutdown as selected.
+
+- [ ] **Step 5: Run the focused unit test again**
+
+```bash
+npm test --workspace desktop -- --project node desktop/src/main/__tests__/quitCoordinator.test.ts
+```
+
+Expected: PASS, proving the entry point still consumes the tested policy.
+
+- [ ] **Step 6: Commit the integrated behavior**
+
+```bash
+git add desktop/src/main/index.ts desktop/src/main/menuTemplate.ts desktop/test/e2e/journeys/background-lifecycle-commands.spec.ts
+git commit -m "Honor native macOS window close semantics" -m "Co-authored-by: Codex <noreply@openai.com>"
+```
+
+---
+
+### Task 3: Verify and publish the dedicated pull request
+
+**Files:**
+- Include: `docs/superpowers/specs/2026-08-10-macos-window-close-design.md`
+- Include: `docs/superpowers/plans/2026-08-10-macos-window-close.md`
+- Verify all production and test files committed in Tasks 1-2.
+
+**Interfaces:**
+- Consumes: the complete branch diff against `origin/main` and the canonical verification commands in `docs/testing-baseline.md`.
+- Produces: a pushed `fix/macos-window-close-behavior` branch and one GitHub pull request whose body names every verification tier run.
+
+- [ ] **Step 1: Run the required verification gates**
+
+```bash
+make test-fast
+npm run check
+npm test
+npm run test:security
+go vet ./...
+go build ./...
+```
+
+Expected: every command exits 0. The targeted Desktop packaged E2E was already
+run from a fresh package in Task 2 and is named separately in the PR.
+
+- [ ] **Step 2: Review the exact branch diff**
+
+```bash
+git status --short --branch
+git diff --check origin/main...HEAD
+git diff --stat origin/main...HEAD
+git log --oneline origin/main..HEAD
+```
+
+Expected: only the approved design/plan, quit policy, Electron close wiring,
+menu comment, and lifecycle tests appear; no dependency or generated-file drift.
+
+- [ ] **Step 3: Push the dedicated branch after confirming it is not main**
+
+```bash
+branch=$(git branch --show-current)
+test "$branch" != main
+test "$branch" != master
+git push -u origin "$branch"
+```
+
+- [ ] **Step 4: Open the separate PR**
+
+Check for an existing PR first with `gh pr view`, use the repository PR template
+if present, and create the PR with a body file. The final body must include a
+`Verification` section naming Fast suite, Desktop static checks, Desktop
+unit/component/security tests, Desktop packaged E2E (targeted lifecycle spec),
+Go static-analysis gate, and Go build gate. Its last line must be:
+
+```text
+Co-authored-by: Codex <noreply@openai.com>
+```

--- a/docs/superpowers/plans/2026-08-10-macos-window-close.md
+++ b/docs/superpowers/plans/2026-08-10-macos-window-close.md
@@ -22,10 +22,12 @@
 ### Task 1: Encode the platform close policy
 
 **Files:**
+
 - Modify: `desktop/src/main/quitCoordinator.ts`
 - Test: `desktop/src/main/__tests__/quitCoordinator.test.ts`
 
 **Interfaces:**
+
 - Consumes: `NodeJS.Platform`, supplied explicitly by the Electron entry point or a unit test.
 - Produces: `shouldRequestQuitOnMainWindowClose(platform: NodeJS.Platform): boolean`; `false` only for `darwin`, `true` for `win32` and `linux`.
 
@@ -35,12 +37,12 @@ Add `shouldRequestQuitOnMainWindowClose` to the existing import from
 `../quitCoordinator`, then add this test before the `QuitCoordinator` describe:
 
 ```ts
-describe('shouldRequestQuitOnMainWindowClose', () => {
+describe("shouldRequestQuitOnMainWindowClose", () => {
   it.each([
-    ['darwin', false],
-    ['win32', true],
-    ['linux', true],
-  ] as const)('returns %s => %s', (platform, expected) => {
+    ["darwin", false],
+    ["win32", true],
+    ["linux", true],
+  ] as const)("returns %s => %s", (platform, expected) => {
     expect(shouldRequestQuitOnMainWindowClose(platform)).toBe(expected);
   });
 });
@@ -64,8 +66,10 @@ Expected: FAIL because `shouldRequestQuitOnMainWindowClose` is not exported.
 Add this export beside `hasActiveWork` in `quitCoordinator.ts`:
 
 ```ts
-export function shouldRequestQuitOnMainWindowClose(platform: NodeJS.Platform): boolean {
-  return platform !== 'darwin';
+export function shouldRequestQuitOnMainWindowClose(
+  platform: NodeJS.Platform,
+): boolean {
+  return platform !== "darwin";
 }
 ```
 
@@ -87,11 +91,13 @@ git commit -m "Keep macOS window close distinct from application quit" -m "Co-au
 ### Task 2: Route macOS close through the native window lifecycle
 
 **Files:**
+
 - Modify: `desktop/test/e2e/journeys/background-lifecycle-commands.spec.ts`
 - Modify: `desktop/src/main/index.ts`
 - Modify: `desktop/src/main/menuTemplate.ts`
 
 **Interfaces:**
+
 - Consumes: `shouldRequestQuitOnMainWindowClose(process.platform)` from Task 1, `WindowRegistry` eviction/recreation, Electron `app` activation, and the existing `global.quit` native command.
 - Produces: macOS close -> destroyed main window with live application/runtime; app activation -> fresh main window; explicit Quit -> unchanged `QuitCoordinator` flow.
 
@@ -111,25 +117,29 @@ Use these assertions after active work is observable:
 
 ```ts
 await closeMainWindowAndReactivate(handle);
-const restored = await handle.page.evaluate((id) => window.agentico.getFeature(id), featureId);
+const restored = await handle.page.evaluate(
+  (id) => window.agentico.getFeature(id),
+  featureId,
+);
 expect(restored.actions).toContainEqual(
-  expect.objectContaining({ id: 'pause-stop', enabled: true }),
+  expect.objectContaining({ id: "pause-stop", enabled: true }),
 );
 
-const cancelResult = await triggerQuitDecision(handle, [2], 'native-quit');
+const cancelResult = await triggerQuitDecision(handle, [2], "native-quit");
 expect(cancelResult.visible).toBe(true);
-expect(JSON.stringify(cancelResult.captured[0])).toContain('Cancel');
+expect(JSON.stringify(cancelResult.captured[0])).toContain("Cancel");
 
-const stopResult = await triggerQuitDecision(handle, [1], 'native-quit');
-expect(JSON.stringify(stopResult.captured[0])).toContain('Stop Work and Quit');
+const stopResult = await triggerQuitDecision(handle, [1], "native-quit");
+expect(JSON.stringify(stopResult.captured[0])).toContain("Stop Work and Quit");
 ```
 
-Replace the idle-close journey's expectation that the app exits with the same
-close/reactivate contract, followed by a native explicit quit that does exit.
+Split the existing idle-close journey by platform: the macOS case uses the same
+close/reactivate contract followed by a native explicit quit that does exit,
+while the non-macOS case retains the existing close-to-quit assertion.
 
 ```ts
 await closeMainWindowAndReactivate(handle);
-await clickNativeMenu(handle, 'global.quit');
+await clickNativeMenu(handle, "global.quit");
 await waitForAppExit(handle);
 handle.closed = true;
 ```
@@ -139,38 +149,50 @@ Add this same-file helper near `triggerQuitDecision`:
 ```ts
 async function closeMainWindowAndReactivate(handle: AppHandle): Promise<void> {
   const previousId = handle.mainWebContentsId;
-  const close = await handle.app.evaluate(async ({ BrowserWindow, dialog }, mainId) => {
-    const window = BrowserWindow.getAllWindows().find(
-      (candidate) => candidate.webContents.id === mainId,
-    );
-    if (window === undefined) throw new Error('main window missing');
-    const original = dialog.showMessageBox;
-    let promptCount = 0;
-    dialog.showMessageBox = (async () => {
-      promptCount += 1;
-      return { response: 2, checkboxChecked: false };
-    }) as typeof dialog.showMessageBox;
-    window.close();
-    const deadline = Date.now() + 2_000;
-    while (!window.isDestroyed() && Date.now() < deadline) {
-      await new Promise((resolve) => setTimeout(resolve, 25));
-    }
-    dialog.showMessageBox = original;
-    return { promptCount, destroyed: window.isDestroyed(), openWindows: BrowserWindow.getAllWindows().length };
-  }, previousId);
+  const close = await handle.app.evaluate(
+    async ({ BrowserWindow, dialog }, mainId) => {
+      const window = BrowserWindow.getAllWindows().find(
+        (candidate) => candidate.webContents.id === mainId,
+      );
+      if (window === undefined) throw new Error("main window missing");
+      const original = dialog.showMessageBox;
+      let promptCount = 0;
+      dialog.showMessageBox = (async () => {
+        promptCount += 1;
+        return { response: 2, checkboxChecked: false };
+      }) as typeof dialog.showMessageBox;
+      window.close();
+      const deadline = Date.now() + 2_000;
+      while (!window.isDestroyed() && Date.now() < deadline) {
+        await new Promise((resolve) => setTimeout(resolve, 25));
+      }
+      dialog.showMessageBox = original;
+      return {
+        promptCount,
+        destroyed: window.isDestroyed(),
+        openWindows: BrowserWindow.getAllWindows().length,
+      };
+    },
+    previousId,
+  );
   expect(close).toEqual({ promptCount: 0, destroyed: true, openWindows: 0 });
   expect(handle.appProcess.exitCode).toBeNull();
   expect(handle.appProcess.signalCode).toBeNull();
   expect(processAlive(readDiscovery(handle.world)!.pid)).toBe(true);
 
-  const appeared = handle.app.waitForEvent('window', { timeout: 30_000 });
-  await handle.app.evaluate(({ app }) => app.emit('activate'));
+  const appeared = handle.app.waitForEvent("window", { timeout: 30_000 });
+  await handle.app.evaluate(({ app }) => app.emit("activate"));
   const page = await appeared;
-  page.setDefaultTimeout(Number(process.env['AGENTICO_E2E_ACTION_TIMEOUT'] ?? 60_000));
-  await expect(page.getByRole('button', { name: 'New feature' })).toBeVisible({ timeout: 60_000 });
+  page.setDefaultTimeout(
+    Number(process.env["AGENTICO_E2E_ACTION_TIMEOUT"] ?? 60_000),
+  );
+  await expect(
+    page.getByRole("status").filter({ hasText: "Runtime ready" }),
+  ).toBeVisible({ timeout: 60_000 });
   const mainWebContentsId = await handle.app.evaluate(({ BrowserWindow }) => {
     const window = BrowserWindow.getAllWindows()[0];
-    if (window === undefined) throw new Error('reactivated main window missing');
+    if (window === undefined)
+      throw new Error("reactivated main window missing");
     return window.webContents.id;
   });
   expect(mainWebContentsId).not.toBe(previousId);
@@ -242,11 +264,13 @@ git commit -m "Honor native macOS window close semantics" -m "Co-authored-by: Co
 ### Task 3: Verify and publish the dedicated pull request
 
 **Files:**
+
 - Include: `docs/superpowers/specs/2026-08-10-macos-window-close-design.md`
 - Include: `docs/superpowers/plans/2026-08-10-macos-window-close.md`
 - Verify all production and test files committed in Tasks 1-2.
 
 **Interfaces:**
+
 - Consumes: the complete branch diff against `origin/main` and the canonical verification commands in `docs/testing-baseline.md`.
 - Produces: a pushed `fix/macos-window-close-behavior` branch and one GitHub pull request whose body names every verification tier run.
 

--- a/docs/superpowers/specs/2026-08-10-macos-window-close-design.md
+++ b/docs/superpowers/specs/2026-08-10-macos-window-close-design.md
@@ -1,0 +1,94 @@
+# macOS Window Close Behavior
+
+## Context
+
+Agentico currently routes closing its main window through the same shutdown
+coordinator as an explicit application quit. When the runtime is idle, clicking
+the red window button or pressing Command-W terminates the application. With
+active work, the same action opens the quit-decision dialog.
+
+That behavior conflicts with the macOS window model. Apple's current user guide
+states that closing one or all windows does not quit an application, and
+distinguishes Command-W from Command-Q. Electron's current lifecycle guidance
+likewise recommends keeping the application active on macOS after
+`window-all-closed` and recreating a window on `activate`.
+
+References:
+
+- [Apple: Move and arrange app windows on Mac](https://support.apple.com/guide/mac-help/work-with-app-windows-mchlp2469/mac)
+- [Apple: Quit apps on Mac](https://support.apple.com/en-euro/guide/mac-help/mchl834d18c2/mac)
+- [Electron: Keyboard shortcuts](https://www.electronjs.org/docs/latest/tutorial/keyboard-shortcuts/)
+- [Electron: `app` lifecycle](https://www.electronjs.org/docs/latest/api/app)
+
+## Decision
+
+On macOS, closing the main window closes that `BrowserWindow` without initiating
+application shutdown. The Agentico process, owned runtime, event supervision,
+notifications, native menu, and tray integration remain active. No active-work
+dialog appears because a window close is no longer a request to stop work or
+quit.
+
+Agentico recreates the main window through its existing `WindowRegistry` when
+the user activates the application from the Dock, chooses Show Agentico, opens
+a notification or route, or launches Agentico again. This is a true window
+close, not a hide operation: the renderer is destroyed and rebuilt, while
+authoritative work continues in the main process and server.
+
+Explicit quit paths remain unchanged. Command-Q, the application-menu Quit
+command, the Dock-menu Quit command, tray Quit, and other Electron quit events
+continue through `QuitCoordinator`, including active-work detection, stop and
+retry controls, and orderly runtime shutdown.
+
+Windows and Linux retain their current behavior: closing the main window
+continues to request application quit through `QuitCoordinator`.
+
+## Implementation Shape
+
+Add a small, pure platform policy to the existing quit-coordination module. It
+will answer whether closing the main window should initiate quit for a supplied
+`NodeJS.Platform`. The main-window close handler will persist geometry as it
+does today, then:
+
+- allow the close event to proceed on macOS;
+- prevent the event and request a quit decision on other platforms; and
+- allow every platform's window close to proceed when `QuitCoordinator` has
+  already authorized shutdown.
+
+The existing `closed` listener will evict the destroyed window and revoke its
+renderer trust. The existing `activate` and `showMainWindow` paths will create a
+fresh trusted main window, so no new window-lifecycle owner is introduced.
+
+## Failure and State Handling
+
+Window geometry persistence remains best-effort and cannot block close.
+Recreating the renderer uses the existing crash recovery, runtime connection,
+and readiness paths. If no window is open, app-level streams and background
+state continue to run exactly as they do for an intentionally hidden window.
+
+An explicit quit that closes windows does not get mistaken for a red-button
+close: once the coordinator authorizes shutdown, its existing force-quit state
+allows window destruction while the main process shuts down.
+
+## Verification
+
+Unit coverage will prove the platform policy requests quit for Windows and
+Linux but not for macOS. The affected packaged lifecycle journey will prove the
+observable contract on macOS:
+
+1. close the main window with the native close action;
+2. observe no quit dialog and confirm both application and owned server remain
+   alive;
+3. activate the app and confirm a fresh main window becomes visible and usable;
+4. invoke explicit Quit and confirm the normal coordinated shutdown still
+   exits the application and owned server.
+
+Required handoff gates are the Fast suite, Desktop static checks, Desktop
+unit/component/security tests, the targeted Desktop packaged E2E lifecycle
+spec, `go vet ./...`, and `go build ./...`.
+
+## Non-Goals
+
+- Changing close behavior on Windows or Linux.
+- Preserving renderer-local UI state across a true window close.
+- Changing active-work prompts or shutdown semantics for explicit Quit.
+- Adding preferences for close-to-hide or close-to-quit behavior.


### PR DESCRIPTION
## Summary

- make the macOS red close button and Command-W destroy the main window without quitting Agentico or its managed runtime
- recreate the main window when the still-running application is activated, while preserving explicit Command-Q/native Quit coordination
- keep the existing coordinated close-to-quit behavior on Windows and Linux and add unit plus packaged lifecycle coverage

## Context

This follows the current macOS convention documented by Apple: closing an app window does not quit the app, while Command-Q explicitly quits it. Electron recommends the same macOS lifecycle, including recreating a window from the `activate` event.

- https://support.apple.com/guide/mac-help/work-with-app-windows-mchlp2469/mac
- https://www.electronjs.org/docs/latest/tutorial/keyboard-shortcuts/

## Verification

- Fast suite: `make test-fast`
- Desktop static checks: `npm run check`
- Desktop unit/component tests: `npm test`
- Desktop security tests: `npm run test:security`
- Desktop packaged E2E: `cd desktop && npm run test:e2e:packaged -- test/e2e/journeys/background-lifecycle-commands.spec.ts` (5 passed, 1 non-macOS-only test skipped on macOS; rebuilt and verified the package)
- Go static-analysis gate: `go vet ./...`
- Go build gate: `go build ./...`

Generated with Codex.

Co-authored-by: Codex <noreply@openai.com>