### PR TITLE
Refresh publish actions after rebase completion

### DIFF
--- a/desktop/src/renderer/src/features/FeatureCockpit.test.tsx
+++ b/desktop/src/renderer/src/features/FeatureCockpit.test.tsx
@@ -1224,7 +1224,7 @@ describe('FeatureCockpit convergence', () => {
             touched: true,
             status: 'unpublished_changes',
             pendingCommits: 1,
-            pushMode: 'rewrite',
+            pushMode: 'fast_forward',
           },
         ],
       });

--- a/desktop/src/renderer/src/features/FeatureCockpit.test.tsx
+++ b/desktop/src/renderer/src/features/FeatureCockpit.test.tsx
@@ -1197,6 +1197,58 @@ describe('FeatureCockpit convergence', () => {
     await waitFor(() => expect(mock.api.getFeature.mock.calls.length).toBe(base + 2));
   });
 
+  it('refreshes pending delivery when a rebase relationship settles', async () => {
+    const published = featureSnapshot({
+      status: 'Published',
+      actions: [
+        { id: 'rebase', enabled: true, disabledReasons: [] },
+        { id: 'cleanup', enabled: true, disabledReasons: [] },
+      ],
+    });
+    const mock = installAgenticoMock({ feature: published });
+    mock.api.preflightCompletion
+      .mockResolvedValueOnce({
+        featureId: FEATURE_ID,
+        sourceRevision: 'before-rebase',
+        canMarkDone: true,
+        repos: [{ repo: 'repo-a', publishable: true, touched: true, status: 'completed' }],
+      })
+      .mockResolvedValue({
+        featureId: FEATURE_ID,
+        sourceRevision: 'after-rebase',
+        canMarkDone: true,
+        repos: [
+          {
+            repo: 'repo-a',
+            publishable: true,
+            touched: true,
+            status: 'unpublished_changes',
+            pendingCommits: 1,
+            pushMode: 'rewrite',
+          },
+        ],
+      });
+    renderCockpit(mock);
+
+    const aftercare = await screen.findByRole('region', { name: 'Feature aftercare' });
+    await waitFor(() => expect(mock.api.preflightCompletion).toHaveBeenCalledTimes(1));
+    expect(within(aftercare).queryByRole('button', { name: /Publish new commits/ })).toBeNull();
+
+    mock.emitAppEvent({
+      type: 'invalidated',
+      kind: 'lifecycle.updated',
+      resourceType: 'relationship',
+      resourceId: `${FEATURE_ID}:rebase1234ef567890`,
+      parentId: FEATURE_ID,
+      childId: 'rebase1234ef567890',
+    });
+
+    expect(
+      await within(aftercare).findByRole('button', { name: /Publish new commits/ }),
+    ).toHaveTextContent('Publish updates');
+    expect(mock.api.preflightCompletion).toHaveBeenCalledTimes(2);
+  });
+
   it('delays and coalesces invalidations while inactive, then flushes on activation', async () => {
     const mock = installAgenticoMock();
     const view = renderCockpit(mock, false);

--- a/desktop/src/renderer/src/features/FeatureCockpit.tsx
+++ b/desktop/src/renderer/src/features/FeatureCockpit.tsx
@@ -952,6 +952,7 @@ export function FeatureCockpit({
   const actionInFlightRef = useRef(false);
   const loadRequestRef = useRef(0);
   const schedulerRef = useRef<FeatureRefreshScheduler | null>(null);
+  const completionRefreshRef = useRef<(() => Promise<void>) | null>(null);
   const completionSettleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const selectedRunNumberRef = useRef(selectedRunNumber);
   selectedRunNumberRef.current = selectedRunNumber;
@@ -1016,7 +1017,7 @@ export function FeatureCockpit({
         setRefreshFailed(false);
         setState({ phase: 'loading' });
       }
-      return window.agentico
+      const featureRefresh = window.agentico
         .getFeature(featureId)
         .then((snapshot) => {
           if (request !== loadRequestRef.current) return;
@@ -1036,6 +1037,8 @@ export function FeatureCockpit({
             setState({ phase: 'error', error: parsed });
           }
         });
+      const completionRefresh = completionRefreshRef.current?.() ?? Promise.resolve();
+      return Promise.all([featureRefresh, completionRefresh]).then(() => undefined);
     },
     [featureId],
   );
@@ -1086,6 +1089,7 @@ export function FeatureCockpit({
     [],
   );
   const completion = useCompletionPreflight(featureId, completionEnabled, preflightCompletion);
+  completionRefreshRef.current = completionEnabled ? completion.refresh : null;
   const pendingDelivery = useMemo(
     () => pendingDeliverySummary(completion.preflight),
     [completion.preflight],
@@ -1100,9 +1104,8 @@ export function FeatureCockpit({
     [],
   );
   const onCompletionDispatched = useCallback(() => {
-    void completion.refresh();
     void refreshFeature({ silent: true });
-  }, [completion, refreshFeature]);
+  }, [refreshFeature]);
 
   const onPassChanged = useCallback(() => {
     void refreshFeature({ silent: true });

--- a/desktop/test/e2e/journeys/rebase-pass.spec.ts
+++ b/desktop/test/e2e/journeys/rebase-pass.spec.ts
@@ -4,12 +4,14 @@
  * aftercare. A second branch covers the up-to-date case where the server
  * returns `rebase_already_up_to_date` and the cockpit stays in aftercare.
  *
- * The behind case seeds a Published feature whose repo is genuinely behind its
- * target by advancing the local `main` branch after feature creation (the same
- * seeding strategy the local-merge fixture uses). The rebase-provider stub
- * resolves the merge during the child's implement phase and approves the
- * review, so the full child lifecycle runs against the real bundled server
- * without network or real provider CLIs.
+ * The behind case seeds a Published feature whose publishable repo is genuinely
+ * behind its target by advancing `origin/main` after feature creation. Its
+ * existing pull-request branch stays at the pre-rebase parent tip, so child
+ * completion must refresh the aftercare preflight and reveal Publish updates
+ * without closing the tab. The rebase-provider stub resolves the merge during
+ * the child's implement phase and approves the review, so the full child
+ * lifecycle runs against the real bundled server without network or real
+ * provider CLIs.
  */
 import fs from 'node:fs';
 import path from 'node:path';
@@ -17,6 +19,7 @@ import { expect, test, type TestInfo } from '@playwright/test';
 import { closeApp, createFeatureViaForm, launchApp, type AppHandle } from '../helpers/app';
 import { Transcript } from '../helpers/transcript';
 import {
+  addBareRemote,
   createRepo,
   createWorld,
   destroyWorld,
@@ -27,7 +30,9 @@ import {
 } from '../helpers/world';
 import { setFeatureStatus } from '../helpers/seed';
 import {
+  activeRunYamlPath,
   featureYamlPath,
+  parseFeatureRepos,
   parseFeatureRepoSources,
   replaceTopLevelBlock,
   setRepoBaseBranch,
@@ -35,33 +40,52 @@ import {
 } from '../helpers/completionFixture';
 
 /**
- * Advances the local `main` branch on the source repo so the feature branch
- * is behind its target. Also sets `base_branch: main` and `publishable: false`
- * in the feature manifest so the server's rebase preflight resolves the target
- * to `main` and uses `IsBehindLocal` (not `IsBehindRemote`).
+ * Publishes the current feature tip as the existing pull-request branch, then
+ * advances `origin/main` so the feature branch is behind its remote target.
+ * Manual publish keeps the post-rebase parent work local until the user chooses
+ * Publish updates, and the seeded PR URL makes the preflight classify it as a
+ * rewrite of an existing pull request rather than a first publication.
  */
 function seedBehindFeature(world: ReturnType<typeof createWorld>, featureId: string): void {
   const featurePath = featureYamlPath(world, featureId);
   let featureYaml = fs.readFileSync(featurePath, 'utf8');
   const sources = parseFeatureRepoSources(featureYaml);
+  const worktrees = parseFeatureRepos(featureYaml);
   const alphaRepo = sources['alpha'];
+  const alphaWorktree = worktrees['alpha'];
   if (alphaRepo === undefined) {
     throw new Error('feature.yaml missing repo alpha');
   }
-  featureYaml = setRepoPublishable(featureYaml, 'alpha', false);
+  if (alphaWorktree === undefined) {
+    throw new Error('feature.yaml missing worktree alpha');
+  }
+  featureYaml = setRepoPublishable(featureYaml, 'alpha', true);
   featureYaml = setRepoBaseBranch(featureYaml, 'alpha', 'main');
   featureYaml = replaceTopLevelBlock(featureYaml, 'checkpoints', [
     'checkpoints:',
     '    inquiry_review: false',
     '    roadmap_review: false',
     '    phase_plan_review: false',
+    '    manual_publish: true',
   ]);
   fs.writeFileSync(featurePath, featureYaml);
+
+  let runYaml = fs.readFileSync(activeRunYamlPath(world, featureId), 'utf8');
+  runYaml = replaceTopLevelBlock(runYaml, 'repo_states', [
+    'repo_states:',
+    '    alpha:',
+    '        touched: true',
+    '        pr_url: https://github.example/agentico/alpha/pull/1',
+  ]);
+  fs.writeFileSync(activeRunYamlPath(world, featureId), runYaml);
+
+  git(alphaWorktree, 'push', '-u', 'origin', 'HEAD');
 
   git(alphaRepo, 'checkout', 'main');
   fs.writeFileSync(path.join(alphaRepo, 'README.md'), '# alpha\nRemote advance for rebase\n');
   git(alphaRepo, 'add', '.');
   git(alphaRepo, 'commit', '-m', 'Remote advance for rebase pass journey');
+  git(alphaRepo, 'push', 'origin', 'main');
   git(alphaRepo, 'checkout', '-');
 }
 
@@ -73,7 +97,9 @@ test('rebase pass: behind feature → card click → pass workspace → completi
     presetWorkspaceRoot: true,
     rebaseProvider: true,
   });
-  createRepo(world, 'alpha', { commit: true });
+  const alphaRepo = createRepo(world, 'alpha', { commit: true });
+  addBareRemote(world, alphaRepo);
+  git(alphaRepo, 'push', '-u', 'origin', 'main');
   transcript.section('World');
   transcript.step(`isolated world at \`${world.root}\``);
   transcript.step('committed repository: alpha');
@@ -173,8 +199,12 @@ test('rebase pass: behind feature → card click → pass workspace → completi
     expect(finalSnapshot.activeChild).toBeUndefined();
     const hasRebase = (finalSnapshot.childHistory ?? []).some((child) => child.kind === 'rebase');
     expect(hasRebase, 'rebase pass should appear in child history after completion').toBe(true);
+    await expect(aftercare).toBeVisible({ timeout: 30_000 });
+    const publishUpdates = aftercare.getByRole('button', { name: /Publish new commits/ });
+    await expect(publishUpdates).toBeVisible({ timeout: 30_000 });
+    await expect(publishUpdates).toContainText('Publish updates');
     transcript.step(
-      'rebase child completed; parent returned to aftercare with rebase pass in history',
+      'rebase child completed; parent returned to aftercare with Publish updates and pass history',
     );
     transcript.json('final feature status', finalSnapshot.status);
   } finally {

--- a/desktop/test/e2e/journeys/rebase-pass.spec.ts
+++ b/desktop/test/e2e/journeys/rebase-pass.spec.ts
@@ -44,7 +44,7 @@ import {
  * advances `origin/main` so the feature branch is behind its remote target.
  * Manual publish keeps the post-rebase parent work local until the user chooses
  * Publish updates, and the seeded PR URL makes the preflight classify it as a
- * rewrite of an existing pull request rather than a first publication.
+ * fast-forward update to an existing pull request rather than a first publication.
  */
 function seedBehindFeature(world: ReturnType<typeof createWorld>, featureId: string): void {
   const featurePath = featureYamlPath(world, featureId);
@@ -166,6 +166,7 @@ test('rebase pass: behind feature → card click → pass workspace → completi
 
     const startRebase = aftercare.getByRole('button', { name: /Start rebase pass/ });
     await expect(startRebase).toBeVisible();
+    await expect(aftercare.getByRole('button', { name: /Publish new commits/ })).toHaveCount(0);
     await startRebase.click();
     transcript.step('clicked "Start rebase pass" in aftercare');
 


### PR DESCRIPTION
## Summary

- refresh the completion preflight through the same single-flight coordinator as feature snapshots
- preserve SSE coalescing, inactive-tab delay, and visibility gating while keeping delivery actions current
- cover the reported rebase flow in both the renderer component suite and a packaged publishable-repository journey

## Root cause

Rebase completion invalidations refreshed the authoritative feature snapshot, but the separate completion preflight that drives aftercare delivery rows only fetched on mount. Closing and reopening the tab remounted that hook, which is why Publish updates appeared only after navigation.

## Verification

- Fast suite: `make test-fast`
- Desktop static checks: `npm run check`
- Desktop unit/component/security tests: `npm test && npm run test:security`
- Desktop packaged E2E: `npm run package:verify` and targeted `rebase-pass.spec.ts` packaged journey
- Go static-analysis gate: `go vet ./...`
- Go build gate: `go build ./...`
- Skipped Race regression: renderer-only change with no Go concurrency behavior modified.
- Skipped Isolated integration and E2E Go: no Go lifecycle, API, or process-launch boundary changed.

Generated with Codex.

Co-authored-by: Codex <noreply@openai.com>
