### PR TITLE
Fix KB inspection for repository names with special characters

### DIFF
--- a/internal/agent/kb_integration_test.go
+++ b/internal/agent/kb_integration_test.go
@@ -316,7 +316,7 @@ func TestRunKnowledgeBaseForRepo_SessionID(t *testing.T) {
 	f := &feature.Feature{
 		ID: "abc123",
 		Repos: []feature.FeatureRepo{
-			{Name: "my-service", Path: repoPath},
+			{Name: "my service", Path: repoPath},
 		},
 		Models: config.ModelConfig{Research: "test"},
 	}
@@ -327,10 +327,15 @@ func TestRunKnowledgeBaseForRepo_SessionID(t *testing.T) {
 		t.Fatalf("RunKnowledgeBaseForRepo error: %v", err)
 	}
 
-	// Verify session ID format: "<featureID>-kb-<repoName>"
-	expectedID := "abc123-kb-my-service"
+	// Repository display names may contain characters that are not valid in an
+	// IPC path segment. The session ID must remain safe for the desktop IPC and
+	// HTTP boundaries while session metadata retains the canonical name.
+	expectedID := BuildKBSessionID("abc123", repo.Name)
 	if sessionID != expectedID {
 		t.Errorf("session ID = %q, want %q", sessionID, expectedID)
+	}
+	if !validKBSessionIDPattern.MatchString(sessionID) {
+		t.Errorf("session ID = %q, want an IPC-safe path segment", sessionID)
 	}
 
 	// Wait for session to complete

--- a/internal/agent/knowledgebase.go
+++ b/internal/agent/knowledgebase.go
@@ -16,11 +16,13 @@ package agent
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -43,16 +45,35 @@ func KBStateDir(stateDir, repoName string) string {
 	return filepath.Join(filepath.Dir(stateDir), "knowledge-base", repoName)
 }
 
-// BuildKBSessionID returns the canonical session ID for a per-repo KB build.
-// Format: "<featureID>-kb-<repoName>". Mirrors the literal in
-// PhaseRunner.RunKnowledgeBaseForRepo.
+var validKBSessionIDPattern = regexp.MustCompile(`^[A-Za-z0-9._-]{1,200}$`)
+
+// BuildKBSessionID returns a desktop- and URL-safe session ID for a per-repo
+// KB build. It preserves the legacy "<featureID>-kb-<repoName>" form when the
+// repository name is already safe. Qualified discovery keys and other names
+// containing unsafe characters use a readable slug plus a collision-resistant
+// hash; callers must use the session's RepoName metadata as canonical identity.
 func BuildKBSessionID(featureID, repoName string) string {
-	return fmt.Sprintf("%s-kb-%s", featureID, repoName)
+	legacyID := fmt.Sprintf("%s-kb-%s", featureID, repoName)
+	if validKBSessionIDPattern.MatchString(legacyID) {
+		return legacyID
+	}
+
+	safeFeatureID := feature.Slugify(featureID)
+	if safeFeatureID == "" {
+		safeFeatureID = "feature"
+	}
+	safeRepoName := feature.Slugify(repoName)
+	if safeRepoName == "" {
+		safeRepoName = "repo"
+	}
+	digest := sha256.Sum256([]byte(repoName))
+	return fmt.Sprintf("%s-kbv2-%s-%x", safeFeatureID, safeRepoName, digest[:6])
 }
 
 // RepoNameFromKBSession extracts the repo name from a per-repo KB session ID.
 // Format: "<featureID>-kb-<repoName>" → "<repoName>". Returns "" when the
-// session ID does not contain the "-kb-" separator (legacy "<featureID>-kb").
+// session ID does not use that legacy, reversible format. New encoded IDs keep
+// the canonical repository name in session metadata instead.
 func RepoNameFromKBSession(sessionID string) string {
 	idx := strings.Index(sessionID, "-kb-")
 	if idx < 0 {

--- a/internal/agent/knowledgebase_test.go
+++ b/internal/agent/knowledgebase_test.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -33,6 +34,29 @@ func TestKBStateDir(t *testing.T) {
 	want := "/home/user/.agentic-workflow/knowledge-base/myrepo"
 	if got != want {
 		t.Errorf("KBStateDir = %q, want %q", got, want)
+	}
+}
+
+func TestBuildKBSessionIDKeepsQualifiedRepoNamesURLSafeAndDistinct(t *testing.T) {
+	t.Parallel()
+
+	validSessionID := regexp.MustCompile(`^[A-Za-z0-9._-]{1,200}$`)
+	first := BuildKBSessionID("abc123", "root-a/service")
+	second := BuildKBSessionID("abc123", "root-b/service")
+
+	for _, id := range []string{first, second} {
+		if !validSessionID.MatchString(id) {
+			t.Errorf("BuildKBSessionID returned desktop-incompatible ID %q", id)
+		}
+	}
+	if first == second {
+		t.Fatalf("qualified repository names produced the same session ID %q", first)
+	}
+	if got := RepoNameFromKBSession(first); got != "" {
+		t.Errorf("RepoNameFromKBSession(encoded ID) = %q, want empty metadata fallback", got)
+	}
+	if got, want := BuildKBSessionID("abc123", "my-service"), "abc123-kb-my-service"; got != want {
+		t.Errorf("BuildKBSessionID preserved format = %q, want %q", got, want)
 	}
 }
 

--- a/internal/agent/phase.go
+++ b/internal/agent/phase.go
@@ -472,7 +472,6 @@ func (pr *PhaseRunner) RunKnowledgeBase(f *feature.Feature) (string, error) {
 }
 
 // RunKnowledgeBaseForRepo starts a KB build for a single repo within a feature.
-// Session ID format: "<featureID>-kb-<repoName>"
 // Returns (sessionID, error). Returns ("", nil) if KB is already fresh.
 func (pr *PhaseRunner) RunKnowledgeBaseForRepo(f *feature.Feature, repo feature.FeatureRepo) (string, error) {
 	kbDir := KBStateDir(pr.StateDir, repo.Name)
@@ -604,7 +603,7 @@ func (pr *PhaseRunner) runKBSession(f *feature.Feature, repo feature.FeatureRepo
 		GuidelinesDir: pr.GuidelinesDir,
 		AskingClause:  pr.askingQuestionsClauseForModel(kbModel),
 	})
-	sessionID := fmt.Sprintf("%s-kb-%s", f.ID, repo.Name)
+	sessionID := BuildKBSessionID(f.ID, repo.Name)
 
 	featureCtx := observe.SpanContextForFeature(f.ID, f.TraceID, f.Name, f.FeatureSpanID).WithRun(f.ActiveRun)
 	phaseCtx := featureCtx.Child()

--- a/internal/orchestrator/completion.go
+++ b/internal/orchestrator/completion.go
@@ -89,6 +89,13 @@ func formatSingleShotProtocolViolationError(role agent.Role, dir string, violati
 	return agent.FormatSingleShotProtocolViolationError(role, dir, violations)
 }
 
+func singleShotFailureType(input PhaseCompletionInput) string {
+	if input.FailureType != "" {
+		return input.FailureType
+	}
+	return feature.FailureSessionCrash
+}
+
 // markFailedWithEvent transitions the feature to StatusFailed via lifecycle
 // and emits FeatureFailed. External observer concerns remain upstream of the
 // orchestrator port.
@@ -147,9 +154,9 @@ func (o *Orchestrator) MarkFailed(featureID, failureType, errMsg string) error {
 //  1. MarkRepoKBFailed(featureID, repoName, errMsg).
 //  2. Stop sibling KB sessions for this feature.
 //  3. emit PhaseCompleted with err.
-//  4. markFailedWithEvent(FailureSessionCrash).
+//  4. markFailedWithEvent(reported failure type, defaulting to session crash).
 func (o *Orchestrator) onKBCompleted(featureID string, input PhaseCompletionInput) error {
-	repoName := agent.RepoNameFromKBSession(input.SessionID)
+	repoName := o.repoNameForKBSession(input.SessionID)
 
 	if !input.Success {
 		errMsg := input.ErrorDetail
@@ -180,7 +187,7 @@ func (o *Orchestrator) onKBCompleted(featureID string, input PhaseCompletionInpu
 			}
 		}
 		o.emitPhaseCompleted(featureID, feature.PhaseKnowledgeBase, errors.New(errMsg))
-		err := o.markFailedWithEvent(featureID, feature.FailureSessionCrash, errMsg)
+		err := o.markFailedWithEvent(featureID, singleShotFailureType(input), errMsg)
 		// The session-cleanup func released this feature's kb.lock before
 		// onKBCompleted was dispatched. Wake any waiters parked on that lock
 		// regardless of whether the failure-mark itself succeeded.
@@ -362,7 +369,7 @@ func (o *Orchestrator) onArtifactPhaseCompletedWithKey(
 			errMsg = fmt.Sprintf("%s phase failed: %s", input.Phase, input.ErrorDetail)
 		}
 		o.emitPhaseCompleted(featureID, input.Phase, errors.New(errMsg))
-		return o.markFailedWithEvent(featureID, feature.FailureSessionCrash, errMsg)
+		return o.markFailedWithEvent(featureID, singleShotFailureType(input), errMsg)
 	}
 
 	f, err := o.deps.Lifecycle.Get(featureID)

--- a/internal/orchestrator/completion_commit.go
+++ b/internal/orchestrator/completion_commit.go
@@ -81,7 +81,7 @@ func (o *Orchestrator) singleShotCompletionContract(
 	}
 	switch phase {
 	case feature.PhaseKnowledgeBase:
-		repoName := agent.RepoNameFromKBSession(sessionID)
+		repoName := o.repoNameForKBSession(sessionID)
 		if repoName == "" {
 			return "", "", nil, fmt.Errorf("resolving knowledge base completion contract: repo name is missing from session %q", sessionID)
 		}
@@ -99,4 +99,13 @@ func (o *Orchestrator) singleShotCompletionContract(
 	default:
 		return "", "", nil, fmt.Errorf("resolving completion contract: phase %s is not single-shot", phase)
 	}
+}
+
+func (o *Orchestrator) repoNameForKBSession(sessionID string) string {
+	if o != nil && o.deps.Sessions != nil {
+		if sess := o.deps.Sessions.GetSession(sessionID); sess != nil && sess.RepoName() != "" {
+			return sess.RepoName()
+		}
+	}
+	return agent.RepoNameFromKBSession(sessionID)
 }

--- a/internal/orchestrator/completion_preflight_test.go
+++ b/internal/orchestrator/completion_preflight_test.go
@@ -21,9 +21,12 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/doordash-oss/agentic-orchestrator/internal/agent"
 	"github.com/doordash-oss/agentic-orchestrator/internal/config"
 	"github.com/doordash-oss/agentic-orchestrator/internal/feature"
 	"github.com/doordash-oss/agentic-orchestrator/internal/git"
+	"github.com/doordash-oss/agentic-orchestrator/internal/ports"
+	"github.com/doordash-oss/agentic-orchestrator/test/testutil/mocks"
 )
 
 type completionFixture struct {
@@ -101,6 +104,44 @@ func runCompletionGit(t *testing.T, dir string, args ...string) {
 }
 
 func boolPtr(b bool) *bool { return &b }
+
+func TestKnowledgeBaseCompletionContractUsesSessionRepoMetadata(t *testing.T) {
+	t.Parallel()
+
+	store := feature.NewStore(t.TempDir())
+	sessions := mocks.NewMockSessionManager()
+	const (
+		sessionID = "abc123-kbv2-root-a-service-0123456789ab"
+		repoName  = "root-a/service"
+	)
+	sess := mocks.NewMockSessionView(sessionID, "abc123")
+	sess.RepoNameVal = repoName
+	sessions.GetSessionFn = func(id string) ports.SessionView {
+		if id != sessionID {
+			t.Fatalf("GetSession(%q), want %q", id, sessionID)
+		}
+		return sess
+	}
+	o := New(Deps{Store: store, Sessions: sessions}, Hooks{})
+
+	role, artifactDir, repoNames, err := o.singleShotCompletionContract(
+		&feature.Feature{ID: "abc123"},
+		sessionID,
+		feature.PhaseKnowledgeBase,
+	)
+	if err != nil {
+		t.Fatalf("singleShotCompletionContract: %v", err)
+	}
+	if role != agent.RoleKnowledgeBaseBuilder {
+		t.Errorf("role = %q, want %q", role, agent.RoleKnowledgeBaseBuilder)
+	}
+	if want := agent.KBStateDir(store.BaseDir, repoName); artifactDir != want {
+		t.Errorf("artifactDir = %q, want %q", artifactDir, want)
+	}
+	if len(repoNames) != 1 || repoNames[0] != repoName {
+		t.Errorf("repoNames = %v, want [%q]", repoNames, repoName)
+	}
+}
 
 func TestCompletionPreflightEnumeratesRepoStatus(t *testing.T) {
 	t.Parallel()

--- a/internal/orchestrator/completion_test.go
+++ b/internal/orchestrator/completion_test.go
@@ -658,6 +658,36 @@ func TestOrchestrator_HandlePhaseCompletion_Inquire_Failure(t *testing.T) {
 	}
 }
 
+func TestOrchestrator_HandlePhaseCompletion_Inquire_ProtocolFailure(t *testing.T) {
+	f := &feature.Feature{
+		ID:           "feat-inq-protocol",
+		Status:       feature.StatusInquiring,
+		CurrentPhase: feature.PhaseInquire,
+		Pipeline:     feature.PipelineLarge,
+	}
+	lc := lifecycleForFeature(f)
+	lc.MarkFailedFn = func(id, ft, msg string) error { return nil }
+	fs := newFeatureStore(f)
+
+	var failureType string
+	o := orchestrator.New(orchestrator.Deps{Lifecycle: lc, Store: fs}, orchestrator.Hooks{
+		OnFeatureFailed: func(id string, ft, em string) { failureType = ft },
+	})
+
+	if err := o.HandlePhaseCompletion("feat-inq-protocol", orchestrator.PhaseCompletionInput{
+		Phase:       feature.PhaseInquire,
+		Success:     false,
+		ErrorDetail: "protocol violation: inquirer @ /tmp/inquire: agentico-outcome is missing",
+		FailureType: feature.FailureProtocolViolation,
+	}); err != nil {
+		t.Fatalf("HandlePhaseCompletion: %v", err)
+	}
+
+	if failureType != feature.FailureProtocolViolation {
+		t.Errorf("failure type = %q, want %q", failureType, feature.FailureProtocolViolation)
+	}
+}
+
 func TestOrchestrator_HandlePhaseCompletion_ArtifactPhaseFailureOnInterruptedFeature_DoesNotMarkFailed(t *testing.T) {
 	for _, tc := range artifactPhaseCases() {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -82,12 +82,14 @@ type Hooks struct {
 // PhaseCompletionInput is a sum-type describing a phase completion. Exactly
 // one of the pointer result fields is non-nil for loop-driven phases; for
 // session-parser-driven phases (KB/Inquire/Research/Design) all pointer
-// fields are nil and the handler uses Success + ErrorDetail + SessionID.
+// fields are nil and the handler uses Success + ErrorDetail + FailureType +
+// SessionID. FailureType is optional and defaults to a session crash.
 type PhaseCompletionInput struct {
 	Phase       feature.Phase
 	SessionID   string
 	Success     bool
 	ErrorDetail string
+	FailureType string
 
 	PlanResult      *agent.PlanLoopResult
 	ImplementResult *agent.LoopResult

--- a/internal/orchestrator/phase_supervisor.go
+++ b/internal/orchestrator/phase_supervisor.go
@@ -16,6 +16,7 @@ package orchestrator
 
 import (
 	"fmt"
+	"path/filepath"
 	"sync"
 
 	"github.com/doordash-oss/agentic-orchestrator/internal/agent"
@@ -106,17 +107,32 @@ func (s *phaseSupervisor) runSingleShotSession(featureID, sessionID string, phas
 	}
 
 	detail := singleShotErrorDetail(phase, sess)
+	failureType := ""
 	if result.Err != nil {
 		detail = result.Err.Error()
 	} else if len(result.ProtocolViolations) > 0 {
-		detail = formatSingleShotProtocolViolationError("", "", result.ProtocolViolations)
+		artifactDir := ""
+		if logPath := sess.LogFilePath(); logPath != "" {
+			artifactDir = filepath.Dir(logPath)
+		}
+		detail = formatSingleShotProtocolViolationError(singleShotPhaseRole(phase), artifactDir, result.ProtocolViolations)
+		failureType = feature.FailureProtocolViolation
 	}
 	s.complete(featureID, PhaseCompletionInput{
 		Phase:       phase,
 		SessionID:   sessionID,
 		Success:     false,
 		ErrorDetail: detail,
+		FailureType: failureType,
 	})
+}
+
+func singleShotPhaseRole(phase feature.Phase) agent.Role {
+	if phase == feature.PhaseKnowledgeBase {
+		return agent.RoleKnowledgeBaseBuilder
+	}
+	role, _ := artifactPhaseRole(phase)
+	return role
 }
 
 func (s *phaseSupervisor) claimSingleShotSession(sessionID string) bool {

--- a/internal/orchestrator/phase_supervisor_test.go
+++ b/internal/orchestrator/phase_supervisor_test.go
@@ -16,6 +16,8 @@ package orchestrator
 
 import (
 	"errors"
+	"path/filepath"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -169,6 +171,45 @@ func TestPhaseSupervisorSingleShotFailsWhenSessionExitsWithoutResult(t *testing.
 	}
 	if call.input.ErrorDetail != "process exited unexpectedly" {
 		t.Fatalf("ErrorDetail = %q, want session detail", call.input.ErrorDetail)
+	}
+}
+
+func TestPhaseSupervisorSingleShotReportsTerminalOutcomeViolation(t *testing.T) {
+	sink := newRecordingPhaseCompletionSink()
+	sm := mocks.NewMockSessionManager()
+	sess := mocks.NewMockSessionView("feat-kbv2-my-service-0123456789ab", "feat")
+	sess.PhaseVal = feature.PhaseKnowledgeBase
+	sess.LogFilePathVal = filepath.Join(t.TempDir(), "output.txt")
+	sess.CostVal = &llm.ResultMessage{Subtype: "success", StopReason: "end_turn"}
+	sm.GetSessionFn = func(string) ports.SessionView { return sess }
+
+	supervisor := newPhaseSupervisor(phaseSupervisorConfig{
+		Completion: sink,
+		Sessions:   sm,
+	})
+	supervisor.superviseSingleShotSession("feat", sess.ID(), feature.PhaseKnowledgeBase)
+
+	// The first two clean turns receive bounded correction nudges. The third
+	// missing outcome is terminal and must be reported as a protocol failure.
+	for range 3 {
+		sess.StatusChVal <- phaseSupervisorStatusSuccess
+	}
+
+	call := sink.wait(t)
+	if call.input.FailureType != feature.FailureProtocolViolation {
+		t.Errorf("FailureType = %q, want %q", call.input.FailureType, feature.FailureProtocolViolation)
+	}
+	if !strings.Contains(call.input.ErrorDetail, string(agent.RoleKnowledgeBaseBuilder)) {
+		t.Errorf("ErrorDetail = %q, want knowledge base role", call.input.ErrorDetail)
+	}
+	if want := filepath.Dir(sess.LogFilePathVal); !strings.Contains(call.input.ErrorDetail, want) {
+		t.Errorf("ErrorDetail = %q, want artifact dir %q", call.input.ErrorDetail, want)
+	}
+	if strings.Contains(call.input.ErrorDetail, "<unresolved>") {
+		t.Errorf("ErrorDetail = %q, want resolved artifact dir", call.input.ErrorDetail)
+	}
+	if got := len(sess.SentMessages); got != 2 {
+		t.Errorf("completion correction nudges = %d, want 2", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

- generate deterministic, URL-safe Knowledge Base session IDs when repository names contain spaces, slashes, or other path-unsafe characters
- retain the canonical repository name in session metadata so completion validation targets the correct Knowledge Base directory
- report terminal structured-outcome failures as protocol violations with the agent role and resolved artifact directory instead of a generic session crash

## Why

Knowledge Base session IDs previously embedded repository names verbatim. The server accepted those IDs, but the desktop rejected them at the `id` field, leaving current-run inspection stuck behind a misleading release-mismatch error. Separately, a terminal missing-outcome violation was labeled as a session crash and formatted without the role or artifact location.

## Verification

- **Fast suite:** `make test-fast`
- **Isolated integration:** `go test ./test/integration/... -count=1`
- **Focused/full package regression:** `go test ./internal/agent ./internal/orchestrator -count=1`
- **Static analysis:** `go vet ./...`
- **Build:** `go build ./...`
- Skipped **Race regression**: the change does not alter shared synchronization or session goroutine ownership.

Generated with Codex.

Co-authored-by: Codex <noreply@openai.com>
