### PR TITLE
Fix options-only OpenCode question parsing

### DIFF
--- a/internal/llm/opencode/control.go
+++ b/internal/llm/opencode/control.go
@@ -458,6 +458,12 @@ func (p *Protocol) maybeSynthesizeQuestion(lastText string) (msg llm.SDKMessage,
 	// must not be forced through the question-reformat pipeline just because it
 	// enumerates items.
 	if stem, options, ok := parseNumberedOptions(lastText); ok && (stemLooksLikeQuestion(stem) || optionsCarryQuestionContract(options)) {
+		if strings.TrimSpace(stem) == "" {
+			if p.sendQuestionFormatReminder(lastText) {
+				return llm.SDKMessage{}, false, true
+			}
+			stem = "Which option should Agentico use?"
+		}
 		if !parsedOptionsHaveConfidence(options) {
 			if p.sendQuestionFormatReminder(lastText) {
 				return llm.SDKMessage{}, false, true
@@ -696,9 +702,6 @@ func parseNumberedOptions(text string) (string, []parsedOption, bool) {
 	cleaned := strings.TrimSpace(strings.Join(stem, "\n"))
 	if len(trailingStem) > 0 {
 		cleaned = strings.TrimSpace(strings.Join(trailingStem, "\n"))
-	}
-	if cleaned == "" {
-		cleaned = text
 	}
 	return cleaned, options, true
 }

--- a/internal/llm/opencode/control_test.go
+++ b/internal/llm/opencode/control_test.go
@@ -526,6 +526,50 @@ func TestPromptEndTurn_NumberedOptionsToleratesTrailingStemAndRecommendedAfterCo
 	}
 }
 
+// TestPromptEndTurn_NumberedOptionsWithoutStemRemindsBeforeSurfacing proves an
+// options-only response is not surfaced with the raw option list duplicated as
+// its question text.
+func TestPromptEndTurn_NumberedOptionsWithoutStemRemindsBeforeSurfacing(t *testing.T) {
+	p, buf, promptID := newPostHandshakeProtocol(t)
+	optionsOnly := strings.Join([]string{
+		"1. Both loops, all profiles (Recommended): Use the same mechanism everywhere. [confidence: 0.76]",
+		"2. Both loops, Moonshot only: Limit the additional context. [confidence: 0.52]",
+		"3. Final-review fixer only: Preserve the per-phase gate. [confidence: 0.48]",
+	}, "\n")
+	streamAssistantText(t, p, optionsOnly)
+	if msgs := endTurn(t, p, promptID); len(msgs) != 0 {
+		t.Fatalf("options-only question produced %+v, want no message while reminder is sent", msgs)
+	}
+	var reminder Request
+	if err := json.Unmarshal(buf.lastLine(t), &reminder); err != nil || reminder.Method != "session/prompt" {
+		t.Fatalf("expected question-format reminder session/prompt; got %q (err %v)", buf.String(), err)
+	}
+	var pp PromptParams
+	if err := json.Unmarshal(mustMarshal(t, reminder.Params), &pp); err != nil {
+		t.Fatalf("decode reminder params: %v", err)
+	}
+	if !strings.Contains(pp.Prompt[0].Text, "<question stem ending with '?'>") {
+		t.Fatalf("reminder = %q, want question-stem instruction", pp.Prompt[0].Text)
+	}
+
+	var msgs []llm.SDKMessage
+	for i := 0; i < maxQuestionFormatRetries+1 && len(msgs) == 0; i++ {
+		pID := p.promptIDForTest()
+		streamAssistantText(t, p, optionsOnly)
+		msgs = endTurn(t, p, pID)
+	}
+	if len(msgs) != 1 || msgs[0].ControlRequest == nil || msgs[0].Result != nil {
+		t.Fatalf("after retries, produced %+v, want a synthesized AskUserQuestion and no result", msgs)
+	}
+	qs := askUserQuestionsFrom(t, msgs[0].ControlRequest)
+	if len(qs) != 1 || qs[0].Question != "Which option should Agentico use?" {
+		t.Fatalf("fallback questions = %+v, want a neutral question stem", qs)
+	}
+	if len(qs[0].Options) != 3 {
+		t.Fatalf("fallback options = %+v, want all three parsed options", qs[0].Options)
+	}
+}
+
 func TestPromptEndTurn_NumberedOptionsMissingConfidenceRemindsBeforeSurfacing(t *testing.T) {
 	p, buf, promptID := newPostHandshakeProtocol(t)
 	streamAssistantText(t, p, strings.Join([]string{

--- a/internal/session/askuser_autopick.go
+++ b/internal/session/askuser_autopick.go
@@ -357,9 +357,6 @@ func inferAutoPickOptionsFromQuestionText(question string) (string, []autoPickOp
 	if len(trailingStem) > 0 {
 		cleaned = strings.TrimSpace(strings.Join(trailingStem, "\n"))
 	}
-	if cleaned == "" {
-		cleaned = question
-	}
 	return cleaned, options, true
 }
 

--- a/internal/session/askuser_autopick_test.go
+++ b/internal/session/askuser_autopick_test.go
@@ -201,6 +201,12 @@ func TestDecideAskUserAutoPick(t *testing.T) {
 			wantAnswer:  "Italian tech terms where established (Recommended)",
 			wantConf:    0.85,
 		},
+		{
+			name:        "numbered options without a question stem decline",
+			purpose:     ports.AskUserAutoPickPurposeInquire,
+			inquireness: feature.InquirenessNone,
+			input:       askInput(`{"question":"1. Both loops, all profiles (Recommended): Use the same mechanism everywhere. [confidence: 0.76]\n2. Both loops, Moonshot only: Limit the additional context. [confidence: 0.52]\n3. Final-review fixer only: Preserve the per-phase gate. [confidence: 0.48]","options":[]}`),
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

- treat OpenCode numbered choices without a question stem as malformed and request a correctly formatted retry
- after the bounded retry limit, retain the parsed choices under a neutral prompt instead of duplicating the raw list as the question
- prevent auto-pick normalization from treating an options-only response as a valid question

## Verification

- Targeted regression: `go test ./internal/llm/opencode -run '^TestPromptEndTurn_NumberedOptionsWithoutStemRemindsBeforeSurfacing$' -count=1`
- Targeted regression: `go test ./internal/session -run 'TestDecideAskUserAutoPick/numbered_options_without_a_question_stem_decline$' -count=1`
- Isolated integration: `go test ./test/integration/... -count=1`
- Go static-analysis gate: `go vet ./...`
- Go build gate: `go build ./...`
- Fast suite: attempted twice; both runs hit the pre-existing `TestPendingToolWatchdogAllowsPromptResultAfterCompletedTool` timing failure. The same package failure reproduces on clean `main`, while the isolated test passes 10/10 runs.
- Skipped Race regression: parsing-only change with no concurrency behavior modified.

Generated with Codex.

Co-authored-by: Codex <noreply@openai.com>
