### PR TITLE
Keep pending questions visible across protocol boundaries

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -4465,8 +4465,10 @@ components:
       properties:
         label:
           type: string
+          maxLength: 1000
         description:
           type: string
+          maxLength: 4000
         confidence:
           type: number
           format: double

--- a/desktop/src/main/__tests__/attention.test.ts
+++ b/desktop/src/main/__tests__/attention.test.ts
@@ -445,6 +445,8 @@ describe('AttentionService review items', () => {
   });
 
   it("routes a refactor pass's prompts to the parent instead of dropping them", async () => {
+    const longOptionLabel =
+      '**Service-level row and byte caps — Recommended (High confidence).** Configure global maximum rows and decoded bytes, stop scanning as soon as either limit is exceeded, and expose classified overflow telemetry. This protects memory predictably without expanding table metadata or cross-repo configuration contracts.';
     const service = new AttentionService({
       apiRequest: (path) => {
         const body =
@@ -458,7 +460,12 @@ describe('AttentionService review items', () => {
                     session_id: 'child-1-fix-01',
                     tool_name: 'ask-user',
                     status: 'pending',
-                    questions: [{ question: 'Which language should the body keep?' }],
+                    questions: [
+                      {
+                        question: 'What scope should control the maximum snapshot size?',
+                        options: [{ label: longOptionLabel }],
+                      },
+                    ],
                   },
                 ],
                 help_queue: [
@@ -521,6 +528,10 @@ describe('AttentionService review items', () => {
     for (const item of snapshot.items) {
       expect(item).toMatchObject({ featureId: 'child-1', parentFeatureId: 'parent-1' });
     }
+    expect(snapshot.items.find((item) => item.id === 'ask-pass')).toMatchObject({
+      kind: 'questions',
+      questions: [{ options: [{ label: longOptionLabel }] }],
+    });
   });
 
   it('returns the stale-resolution response for a missing pending request', async () => {

--- a/desktop/src/shared/api/parse.ts
+++ b/desktop/src/shared/api/parse.ts
@@ -192,7 +192,8 @@ const AttentionTextSchema = z.string().max(64 * 1024);
 const AttentionIDSchema = z.string().min(1).max(200);
 
 export const ServerAskUserOptionSchema = z.object({
-  label: z.string().max(200).optional(),
+  // Matches the server's SafeDisplayText budget for AskUser option labels.
+  label: z.string().max(1000).optional(),
   description: AttentionTextSchema.optional(),
   confidence: z.number().min(0).max(1).optional(),
 });

--- a/desktop/src/shared/ipc.ts
+++ b/desktop/src/shared/ipc.ts
@@ -1767,7 +1767,8 @@ export type RewindExecuteRequest = z.output<typeof RewindExecuteRequestSchema>;
 const AttentionIDSchema = z.string().min(1).max(200);
 const AttentionTextSchema = z.string().max(64 * 1024);
 export const AttentionOptionSchema = z.strictObject({
-  label: z.string().max(200),
+  // The server preserves provider-visible option labels up to 1,000 chars.
+  label: z.string().max(1000),
   description: AttentionTextSchema.optional(),
   confidence: z.number().min(0).max(1).optional(),
 });

--- a/internal/llm/codex/protocol.go
+++ b/internal/llm/codex/protocol.go
@@ -2268,6 +2268,18 @@ func splitOptionLabelDesc(raw string) (string, string) {
 	if raw == "" {
 		return "", ""
 	}
+	if strings.HasPrefix(raw, "**") {
+		if closing := strings.Index(raw[2:], "**"); closing >= 0 {
+			closing += 2
+			label := strings.TrimSpace(raw[2:closing])
+			desc := strings.TrimSpace(raw[closing+2:])
+			if desc != "" {
+				label = strings.TrimSpace(strings.TrimRight(label, ".:"))
+				desc = strings.TrimSpace(strings.TrimLeft(desc, "—–-: "))
+			}
+			return label, desc
+		}
+	}
 	label := raw
 	desc := ""
 	if idx := strings.Index(raw, ":"); idx >= 0 {

--- a/internal/llm/codex/protocol_test.go
+++ b/internal/llm/codex/protocol_test.go
@@ -1623,6 +1623,44 @@ func TestTurnCompleted_MultiSentenceStemQuestionSurfacesOptions(t *testing.T) {
 	}
 }
 
+func TestTurnCompleted_MarkdownOptionsSeparateLabelsFromDescriptions(t *testing.T) {
+	p := NewProtocol(llm.ProtocolOpts{WorkDir: "/tmp/test", Model: "codex"})
+	p.SetThreadIDForTest("thread-1")
+
+	p.mu.Lock()
+	p.lastAssistantText = "What scope should control the maximum linearized snapshot size?\n" +
+		"1. **Service-level row and byte caps — Recommended (High confidence).** Configure global maximum rows and decoded bytes, stop scanning as soon as either limit is exceeded.\n" +
+		"2. **Per-table metadata cap (Medium confidence).** Add a table-specific limit to the control plane.\n" +
+		"3. **Fixed code constant (Low confidence).** Enforce one compiled limit with no runtime configuration."
+	p.mu.Unlock()
+
+	msg, ok := p.parseNotification("turn/completed", completedTurnParams(t, "thread-1"))
+	if !ok || msg.ControlRequest == nil {
+		t.Fatalf("got ok=%v message=%+v, want AskUserQuestion control request", ok, msg)
+	}
+	var parsed struct {
+		Questions []struct {
+			Options []struct {
+				Label       string `json:"label"`
+				Description string `json:"description"`
+			} `json:"options"`
+		} `json:"questions"`
+	}
+	if err := json.Unmarshal(msg.ControlRequest.Request.Input, &parsed); err != nil {
+		t.Fatalf("unmarshal control request input: %v", err)
+	}
+	if len(parsed.Questions) != 1 || len(parsed.Questions[0].Options) != 3 {
+		t.Fatalf("questions = %+v, want one question with three options", parsed.Questions)
+	}
+	first := parsed.Questions[0].Options[0]
+	if first.Label != "Service-level row and byte caps — Recommended (High confidence)" {
+		t.Errorf("first label = %q, want concise Markdown label", first.Label)
+	}
+	if first.Description != "Configure global maximum rows and decoded bytes, stop scanning as soon as either limit is exceeded." {
+		t.Errorf("first description = %q, want trailing option explanation", first.Description)
+	}
+}
+
 func TestTurnCompleted_NonQuestionStemWithContractMarkersSurfacesOptions(t *testing.T) {
 	p := NewProtocol(llm.ProtocolOpts{WorkDir: "/tmp/test", Model: "codex"})
 	p.SetThreadIDForTest("thread-1")


### PR DESCRIPTION
## Summary

- align desktop AskUser option-label bounds with the server's existing 1,000-character contract so a long option cannot invalidate the whole attention snapshot
- split Codex Markdown options such as `**Label.** explanation` into bounded labels and separate descriptions
- cover the live refactor-pass payload shape at the main-process service boundary and the synthesized Codex control-request boundary

## Root cause

Codex's text fallback treated the full Markdown option plus tradeoff prose as its label. The server preserved that valid bounded label, but Electron rejected labels over 200 characters while parsing `/api/v1/prompts`; the renderer then cleared attention after the failed refresh.

## Verification

- Targeted desktop regression: `npm test -- --run src/main/__tests__/attention.test.ts`
- Targeted Codex regression: `go test ./internal/llm/codex -run '^TestTurnCompleted_MarkdownOptionsSeparateLabelsFromDescriptions$' -count=1`
- Fast suite: `make test-fast` (green rerun; the initial run hit the known unrelated `TestPendingToolWatchdogAllowsPromptResultAfterCompletedTool` timing flake, which passed 10/10 in isolation)
- Go static-analysis gate: `go vet ./...`
- Go build gate: `go build ./...`
- Desktop static checks: `npm run check`
- Desktop unit/component/security tests: `npm test && npm run test:security`
- Desktop packaged E2E: `npm run package:verify` and targeted `attention-resolution.spec.ts` journey `packaged inbox and cockpit resolve real attention classes from the bundled server`
- Skipped Race regression: bounded parsing and schema-contract change with no concurrency behavior modified.

Generated with Codex.

Co-authored-by: Codex <noreply@openai.com>
