### PR TITLE
Add durable fleet telemetry

### DIFF
--- a/cmd/agentico/main.go
+++ b/cmd/agentico/main.go
@@ -2792,7 +2792,8 @@ func runServer(configPath, stateDir string, dangerouslySkipPerms bool, enabledPr
 		PersistProviderModelCatalog: func(provider llm.LLMProvider, models []llm.ModelInfo) error {
 			return persistRefreshedProviderModelCatalog(boot.runtime.RuntimeDir, provider, models)
 		},
-		Worktrees: boot.worktrees,
+		Worktrees:   boot.worktrees,
+		HTTPMetrics: boot.observer,
 	})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: starting server: %v\n", err)

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,7 +1,132 @@
-# Observability Artifacts
+# Observability and Fleet Telemetry
 
 Agentic Orchestrator writes observability data under each feature directory in
 the configured state directory.
+
+`observability.events` and `observability.otel_enabled` are independent.
+`events` controls the local per-feature JSONL and summary artifacts described
+below. `otel_enabled` controls workflow traces, fleet metrics, and durable wide
+events. Setting an endpoint alone does not enable telemetry.
+
+## Outcome definitions
+
+- **Output ready** is the first transition to `CodeReady`.
+- **Delivered** is a transition to `Published` or `Done`.
+- **Agentico failure** is terminal `Failed`, classified by `failure_type`.
+- `Interrupted`, `NeedUserInput`, rewind, deletion/abandonment, and delivery are
+  distinct outcomes and are not counted as failures.
+- Quality evidence consists of plan validation, validator, verification item,
+  automatic review, and final review outcomes.
+
+Agentico does not observe GitHub merge state, external CI, deployment health,
+or production correctness.
+
+## OTel resource identity
+
+All three OTel signals carry `service.name`, `service.version`,
+`service.instance.id`, `agentico.build.revision`,
+`agentico.installation.id`, and `agentico.telemetry.schema.version=1`.
+`otel_service_name` overrides `service.name`; distribution resource attributes
+from standard OTel environment configuration are otherwise retained. The
+instance ID is random per process. The stable installation ID is stored at
+`<runtime-dir>/telemetry/installation-id` with mode `0600` (its parent is
+`0700`). Installation and instance identity are resource metadata, never
+metric labels.
+
+Personal identity, organizational ownership, username, hostname, machine ID, state/config/workspace
+paths, and repository names are never resource attributes. Repository names
+may appear in wide events only.
+
+## Fleet metrics
+
+Counters use `{event}` unless a more specific count unit is shown. Histograms
+use explicit bucket views; durations are seconds, token usage is `{token}`,
+cost is `USD`, sizes are bytes, and output quantities use `{file}`, `{line}` or
+`{commit}`. Gauges are sampled by the 60-second periodic reader. Set
+`OTEL_METRIC_EXPORT_INTERVAL` in milliseconds to override that interval.
+
+| Type | Instruments |
+| --- | --- |
+| Gauge | `agentico.feature.active`, `agentico.telemetry.outbox.pending`, `agentico.telemetry.outbox.bytes`, `agentico.telemetry.outbox.oldest.age` |
+| Counter | `agentico.runtime.startup.count`, `agentico.telemetry.export.failure.count`, `agentico.telemetry.dropped.count`, `agentico.feature.created.count`, `agentico.feature.transition.count`, `agentico.feature.milestone.count`, `agentico.feature.run.terminal.count`, `agentico.feature.rewind.count`, `agentico.feature.repository.count`, `agentico.phase.iteration.count`, `agentico.session.outcome.count`, `agentico.session.token.usage`, `agentico.session.turn.count`, `agentico.session.retry.count`, `agentico.session.truncation.count`, `agentico.session.context_handoff.count`, `agentico.review.outcome.count`, `agentico.validation.outcome.count`, `agentico.verification.item.count`, `agentico.publish.outcome.count`, `agentico.interaction.request.count`, `agentico.automatic_review.outcome.count`, `agentico.automatic_review.unavailable.count`, `agentico.recovery.action.count`, `agentico.session.critical_message_dropped.count`, `http.server.request.count` |
+| Histogram | `agentico.feature.run.duration`, `agentico.feature.run.time_to_code_ready`, `agentico.feature.run.time_to_delivery`, `agentico.feature.output.files_changed`, `agentico.feature.output.lines_added`, `agentico.feature.output.lines_deleted`, `agentico.feature.output.commit.count`, `agentico.phase.duration`, `agentico.session.duration`, `agentico.session.api.duration`, `agentico.session.cost`, `agentico.review.duration`, `agentico.validation.duration`, `agentico.validator.duration`, `agentico.interaction.wait.duration`, `agentico.automatic_review.duration`, `agentico.publish.duration`, `http.server.request.duration`, `http.server.request.body.size`, `http.server.response.body.size` |
+
+Allowed metric dimensions are bounded enums: pipeline, feature kind, risk,
+phase, status/outcome, failure type, provider, catalog-normalized model,
+effort, review/validator/verification type, interaction kind/decision,
+automatic/manual, publish mode, token type, HTTP method, normalized route, and
+HTTP status. Unknown or unbounded provider/model values become `other`.
+Feature/session IDs, repository names, paths, URLs, commands, questions,
+answers, and errors are forbidden metric dimensions. Provider CLI sessions are
+not reported as `gen_ai.client` calls because they aggregate multiple internal
+model requests.
+
+Health, CORS preflight, SSE, and session output-stream routes are excluded from
+HTTP metrics. Dynamic feature, session, review, repository, run, artifact, and
+log segments are normalized to their OpenAPI template names.
+
+## Durable wide events
+
+Every typed local event is also exported as a short span named
+`agentico.event.<event_type>`, including `phase.started`, `phase.completed`,
+`phase.failed`, `session.started`, `session.ended`, `iteration.started`,
+`iteration.ended`, `review.started`, `review.completed`, `validation.started`,
+`validation.completed`, `validator.started`, `validator.completed`,
+`permission.requested`, `permission.resolved`, `question.asked`,
+`question.answered`, `automatic_review.completed`,
+`automatic_review.unavailable`, `context.file_read`,
+`context.handoff_triggered`, `context.large_output`, `recovery.scanned`,
+`recovery.action`, `agent.task_started`, `agent.task_progress`,
+`agent.task_ended`, `feature.started`, `feature.completed`, `feature.failed`,
+`feature.interrupted`, `feature.config_changed`, and `feature.rewound`.
+
+Store-authoritative events add `runtime.started`, `runtime.stopped`,
+`feature.created`, `feature.state_changed`, `feature.deleted`,
+`feature.run_started`, `feature.run_sealed`, `feature.output_ready`,
+`feature.delivered`, `verification.item_completed`, and
+`feature.output_stats_collected`. Manual review gates add
+`review_gate.requested` and `review_gate.resolved`; authoritative persisted
+phase timing adds `phase.duration_recorded`. `publish.completed`,
+`publish.failed`, and `telemetry.data_loss` surface delivery and telemetry-loss
+outcomes.
+
+Every wide span has `agentico.analytics=true`, a UUID-like
+`agentico.event.id` deduplication key, the original timestamp, stable feature
+trace ID, unique span ID, run number, and typed `agentico.*` attributes.
+Common strings cover event type, feature/run/phase/status, pipeline/risk,
+parent/child kind, provider/model/effort, outcome and failure type. Numeric
+fields cover duration, cost, tokens, context, turns, repository count, review
+and validation evidence, wait time, and output counts. Repository names and
+bounded rich context can be present here; they never become metric labels.
+
+Rich strings are credential-redacted with the permission-audit vocabulary,
+absolute username-bearing paths are replaced with `<user-path>`, each rich
+field is limited to 4 KiB, and a record is limited to 32 KiB. Truncation is
+marked with the original byte count. Full prompts, system instructions,
+transcripts, raw model results, source files, diffs, environment variables,
+config contents, and authentication material are never captured.
+
+### Outbox guarantees
+
+Sanitized records are fsynced into 4 MiB append-only JSONL segments under
+`<runtime-dir>/telemetry/outbox/` (`0700` directory, `0600` files) before the
+emitting call returns. Batches are limited to 256 records and 1 MiB. An atomic
+cursor advances only after OTLP trace export succeeds; fully acknowledged
+segments are deleted. Delivery retries with jittered exponential backoff from
+one second to five minutes and is at least once. A crash after collector
+acceptance but before cursor advancement can duplicate a record; consumers
+must deduplicate by `agentico.event.id`.
+
+Unacknowledged data is retained for seven days or 256 MiB. Oldest sealed
+segments are evicted when either bound is exceeded and loss is surfaced in
+`agentico.telemetry.dropped.count`. Disabling OTel leaves the outbox untouched;
+re-enabling it resumes draining. Telemetry persistence/export failure never
+fails a feature workflow. Metrics are best effort; wide events are replayable.
+
+Collectors must retain `agentico.event.*` spans unsampled. Sampling them at
+the collector defeats the durable analytics guarantee. Existing `agentic.*`
+workflow-trace attributes remain compatibility aliases for one release;
+`agentico.*` is canonical.
 
 ## Event Log
 

--- a/go.mod
+++ b/go.mod
@@ -10,8 +10,9 @@ require (
 	go.opentelemetry.io/otel v1.43.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.42.0
 	go.opentelemetry.io/otel/sdk v1.43.0
+	go.opentelemetry.io/otel/sdk/metric v1.43.0
 	go.opentelemetry.io/otel/trace v1.43.0
-	go.opentelemetry.io/proto/otlp v1.9.0
+	go.opentelemetry.io/proto/otlp v1.10.0
 	go.uber.org/fx v1.24.0
 	golang.org/x/sys v0.45.0
 	golang.org/x/term v0.43.0
@@ -30,7 +31,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-openapi/jsonpointer v0.22.5 // indirect
 	github.com/go-openapi/swag/jsonname v0.25.5 // indirect
-	github.com/google/uuid v1.6.0 // indirect
+	github.com/google/uuid v1.6.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect
 	github.com/henvic/httpretty v0.0.6 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
@@ -46,8 +47,9 @@ require (
 	github.com/thlib/go-timezone-local v0.0.0-20210907160436-ef149e42d28e // indirect
 	github.com/vmware-labs/yaml-jsonpath v0.3.2 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
+	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.43.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.42.0 // indirect
-	go.opentelemetry.io/otel/metric v1.43.0 // indirect
+	go.opentelemetry.io/otel/metric v1.43.0
 	go.uber.org/dig v1.19.0 // indirect
 	go.uber.org/multierr v1.10.0 // indirect
 	go.uber.org/zap v1.26.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -130,6 +130,8 @@ go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
 go.opentelemetry.io/otel v1.43.0 h1:mYIM03dnh5zfN7HautFE4ieIig9amkNANT+xcVxAj9I=
 go.opentelemetry.io/otel v1.43.0/go.mod h1:JuG+u74mvjvcm8vj8pI5XiHy1zDeoCS2LB1spIq7Ay0=
+go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.43.0 h1:8UQVDcZxOJLtX6gxtDt3vY2WTgvZqMQRzjsqiIHQdkc=
+go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.43.0/go.mod h1:2lmweYCiHYpEjQ/lSJBYhj9jP1zvCvQW4BqL9dnT7FQ=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.42.0 h1:THuZiwpQZuHPul65w4WcwEnkX2QIuMT+UFoOrygtoJw=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.42.0/go.mod h1:J2pvYM5NGHofZ2/Ru6zw/TNWnEQp5crgyDeSrYpXkAw=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.42.0 h1:zWWrB1U6nqhS/k6zYB74CjRpuiitRtLLi68VcgmOEto=
@@ -142,8 +144,8 @@ go.opentelemetry.io/otel/sdk/metric v1.43.0 h1:S88dyqXjJkuBNLeMcVPRFXpRw2fuwdvfC
 go.opentelemetry.io/otel/sdk/metric v1.43.0/go.mod h1:C/RJtwSEJ5hzTiUz5pXF1kILHStzb9zFlIEe85bhj6A=
 go.opentelemetry.io/otel/trace v1.43.0 h1:BkNrHpup+4k4w+ZZ86CZoHHEkohws8AY+WTX09nk+3A=
 go.opentelemetry.io/otel/trace v1.43.0/go.mod h1:/QJhyVBUUswCphDVxq+8mld+AvhXZLhe+8WVFxiFff0=
-go.opentelemetry.io/proto/otlp v1.9.0 h1:l706jCMITVouPOqEnii2fIAuO3IVGBRPV5ICjceRb/A=
-go.opentelemetry.io/proto/otlp v1.9.0/go.mod h1:xE+Cx5E/eEHw+ISFkwPLwCZefwVjY+pqKg1qcK03+/4=
+go.opentelemetry.io/proto/otlp v1.10.0 h1:IQRWgT5srOCYfiWnpqUYz9CVmbO8bFmKcwYxpuCSL2g=
+go.opentelemetry.io/proto/otlp v1.10.0/go.mod h1:/CV4QoCR/S9yaPj8utp3lvQPoqMtxXdzn7ozvvozVqk=
 go.uber.org/dig v1.19.0 h1:BACLhebsYdpQ7IROQ1AGPjrXcP5dF80U3gKoFzbaq/4=
 go.uber.org/dig v1.19.0/go.mod h1:Us0rSJiThwCv2GteUN0Q7OKvU7n5J4dxZ9JKUXozFdE=
 go.uber.org/fx v1.24.0 h1:wE8mruvpg2kiiL1Vqd0CC+tr0/24XIB10Iwp2lLWzkg=

--- a/internal/agent/bounded_helper.go
+++ b/internal/agent/bounded_helper.go
@@ -174,23 +174,25 @@ func (pr *PhaseRunner) RunBoundedHelper(ctx context.Context, cfg BoundedHelperCo
 }
 
 type boundedHelperRunConfig struct {
-	sessionID     string
-	featureID     string
-	phase         feature.Phase
-	label         string
-	observerPhase string
-	model         string
-	responsePath  string
-	repoName      string
-	workDir       string
-	command       []string
-	env           []string
-	sessOpts      *ports.SessionOpts
-	requireOutput bool
-	completionDir string
-	contractPhase feature.Phase
-	contractRole  Role
-	parentSpanCtx observe.SpanContext
+	sessionID        string
+	featureID        string
+	phase            feature.Phase
+	label            string
+	observerPhase    string
+	model            string
+	responsePath     string
+	repoName         string
+	workDir          string
+	command          []string
+	env              []string
+	sessOpts         *ports.SessionOpts
+	requireOutput    bool
+	completionDir    string
+	contractPhase    feature.Phase
+	contractRole     Role
+	parentSpanCtx    observe.SpanContext
+	taskPollInterval time.Duration
+	taskQuietGrace   time.Duration
 }
 
 func (pr *PhaseRunner) runBoundedHelperSession(ctx context.Context, cfg boundedHelperRunConfig) (*BoundedHelperResult, error) {
@@ -271,7 +273,7 @@ func (pr *PhaseRunner) runBoundedHelperSessionOnce(ctx context.Context, cfg boun
 			RepoName:      cfg.repoName,
 		})
 		if pr.Observer != nil {
-			pr.Observer.SessionEnded(sessionCtx, observerPhase, cfg.sessionID, cfg.repoName, toSessionUsage(cost), time.Since(sessionStart), sessionErrFromStatus(sess))
+			pr.Observer.SessionEnded(sessionCtx, observerPhase, cfg.sessionID, cfg.repoName, toSessionUsage(cost, sess), time.Since(sessionStart), sessionErrFromStatus(sess))
 		}
 		_ = sess.Stop()
 		sess.Wait()
@@ -312,7 +314,7 @@ func (pr *PhaseRunner) runBoundedHelperSessionOnce(ctx context.Context, cfg boun
 	// budget is consumed. The bgTicker below provides the fallback paths.
 	awaitingBackgroundTasks := false
 	autoResumeAttempts := 0
-	bgTicker := time.NewTicker(backgroundTaskPollInterval)
+	bgTicker := time.NewTicker(durationOrDefault(cfg.taskPollInterval, backgroundTaskPollInterval))
 	defer bgTicker.Stop()
 
 	for {
@@ -332,7 +334,7 @@ func (pr *PhaseRunner) runBoundedHelperSessionOnce(ctx context.Context, cfg boun
 			// All tasks finished but no new result arrived: the CLI did not
 			// re-invoke the agent on its own. Resume it explicitly, bounded so
 			// a session that keeps yielding without finishing still converges.
-			if quiet < backgroundTaskQuietGrace {
+			if quiet < durationOrDefault(cfg.taskQuietGrace, backgroundTaskQuietGrace) {
 				continue
 			}
 			awaitingBackgroundTasks = false

--- a/internal/agent/bounded_helper_test.go
+++ b/internal/agent/bounded_helper_test.go
@@ -642,8 +642,6 @@ func (s *boundedBgTaskSession) LastStdoutAt() time.Time      { return time.Unix(
 // re-invokes the agent when they complete. Nudge capability is unarmed,
 // matching providers where the yield-for-tasks pattern showed up.
 func TestRunBoundedHelper_DefersOnLiveBackgroundTasks(t *testing.T) {
-	withBackgroundTaskPollInterval(t, 5*time.Millisecond)
-
 	phaseDir := t.TempDir()
 	sess := newBoundedBgTaskSession(&llm.ResultMessage{Type: testResultMessageType, Subtype: testResultSuccessValue, StopReason: testStopReasonEndTurn})
 	sess.liveTasks.Store(3)
@@ -657,11 +655,12 @@ func TestRunBoundedHelper_DefersOnLiveBackgroundTasks(t *testing.T) {
 	resultCh := make(chan *BoundedHelperResult, 1)
 	go func() {
 		result, _ := pr.runBoundedHelperSession(context.Background(), boundedHelperRunConfig{
-			sessionID:     "helper-bg-defer",
-			workDir:       t.TempDir(),
-			completionDir: phaseDir,
-			contractPhase: feature.PhaseReview,
-			contractRole:  RoleImplementationReviewCraft,
+			taskPollInterval: 5 * time.Millisecond,
+			sessionID:        "helper-bg-defer",
+			workDir:          t.TempDir(),
+			completionDir:    phaseDir,
+			contractPhase:    feature.PhaseReview,
+			contractRole:     RoleImplementationReviewCraft,
 		})
 		resultCh <- result
 	}()
@@ -706,8 +705,6 @@ func TestRunBoundedHelper_DefersOnLiveBackgroundTasks(t *testing.T) {
 // agent, the waiter sends the auto-resume continuation instead of hanging or
 // violating.
 func TestRunBoundedHelper_BackgroundTasksFinishQuietlyAutoResumes(t *testing.T) {
-	withBackgroundTaskPollInterval(t, 5*time.Millisecond)
-
 	phaseDir := t.TempDir()
 	sess := newBoundedBgTaskSession(&llm.ResultMessage{Type: testResultMessageType, Subtype: testResultSuccessValue, StopReason: testStopReasonEndTurn})
 	sess.liveTasks.Store(1)
@@ -721,11 +718,12 @@ func TestRunBoundedHelper_BackgroundTasksFinishQuietlyAutoResumes(t *testing.T) 
 	resultCh := make(chan *BoundedHelperResult, 1)
 	go func() {
 		result, _ := pr.runBoundedHelperSession(context.Background(), boundedHelperRunConfig{
-			sessionID:     "helper-bg-resume",
-			workDir:       t.TempDir(),
-			completionDir: phaseDir,
-			contractPhase: feature.PhaseReview,
-			contractRole:  RoleImplementationReviewCraft,
+			taskPollInterval: 5 * time.Millisecond,
+			sessionID:        "helper-bg-resume",
+			workDir:          t.TempDir(),
+			completionDir:    phaseDir,
+			contractPhase:    feature.PhaseReview,
+			contractRole:     RoleImplementationReviewCraft,
 		})
 		resultCh <- result
 	}()
@@ -1022,8 +1020,6 @@ func TestRunBoundedHelper_TruncatedTurnResumeCapThenFails(t *testing.T) {
 // TestRunBoundedHelper_SilentLiveTaskWaitsUntilTerminal proves provider task
 // lifecycle is authoritative even when the parent stream remains silent.
 func TestRunBoundedHelper_SilentLiveTaskWaitsUntilTerminal(t *testing.T) {
-	withBackgroundTaskPollInterval(t, 5*time.Millisecond)
-
 	phaseDir := t.TempDir()
 	sess := newBoundedBgTaskSession(&llm.ResultMessage{Type: testResultMessageType, Subtype: testResultSuccessValue, StopReason: testStopReasonEndTurn})
 	sess.liveTasks.Store(1)
@@ -1038,11 +1034,12 @@ func TestRunBoundedHelper_SilentLiveTaskWaitsUntilTerminal(t *testing.T) {
 	resultCh := make(chan *BoundedHelperResult, 1)
 	go func() {
 		result, _ := pr.runBoundedHelperSession(context.Background(), boundedHelperRunConfig{
-			sessionID:     "helper-bg-stall",
-			workDir:       t.TempDir(),
-			completionDir: phaseDir,
-			contractPhase: feature.PhaseReview,
-			contractRole:  RoleImplementationReviewCraft,
+			taskPollInterval: 5 * time.Millisecond,
+			sessionID:        "helper-bg-stall",
+			workDir:          t.TempDir(),
+			completionDir:    phaseDir,
+			contractPhase:    feature.PhaseReview,
+			contractRole:     RoleImplementationReviewCraft,
 		})
 		resultCh <- result
 	}()

--- a/internal/agent/cost.go
+++ b/internal/agent/cost.go
@@ -84,14 +84,41 @@ func applySessionCostAdjustment(cost *SessionCost, adjustment llm.SessionCostAdj
 }
 
 // toSessionUsage converts a SessionCost to an observe.SessionUsage.
-func toSessionUsage(cost SessionCost) observe.SessionUsage {
-	return observe.SessionUsage{
+func toSessionUsage(cost SessionCost, sessions ...ports.SessionView) observe.SessionUsage {
+	usage := observe.SessionUsage{
 		TotalCostUSD:             cost.TotalCostUSD,
 		InputTokens:              cost.Usage.InputTokens,
 		OutputTokens:             cost.Usage.OutputTokens,
 		CacheReadInputTokens:     cost.Usage.CacheReadInputTokens,
 		CacheCreationInputTokens: cost.Usage.CacheCreationInputTokens,
+		ContextWindow:            cost.Usage.ContextWindow,
+		ContextTotalTokens:       cost.Usage.ContextTotalTokens,
 	}
+	if len(sessions) == 0 || sessions[0] == nil {
+		return usage
+	}
+	sess := sessions[0]
+	usage.Provider = sess.ProviderName()
+	usage.Model = sess.Model()
+	usage.Effort = string(sess.EffectiveEffort())
+	if result := sess.Cost(); result != nil {
+		usage.ResultSubtype = result.Subtype
+		usage.StopReason = result.StopReason
+		usage.Truncated = result.IsTurnTruncated()
+		usage.APIDurationMS = result.DurationAPI
+		usage.Turns = result.NumTurns
+		usage.Outcome = "success"
+		if result.IsError || result.Subtype != "success" {
+			usage.Outcome = "error"
+		}
+		if len(result.ModelUsage) > 0 {
+			usage.PerModelContextWindows = make(map[string]int, len(result.ModelUsage))
+			for model, entry := range result.ModelUsage {
+				usage.PerModelContextWindows[model] = entry.ContextWindow
+			}
+		}
+	}
+	return usage
 }
 
 // accumulateSessionCostToFeature adds a session's cost to the latest active

--- a/internal/agent/final_review_loop.go
+++ b/internal/agent/final_review_loop.go
@@ -733,7 +733,7 @@ func (s *featureFinalReviewLoopState) runFix(iteration int, iterDir, feedback st
 			ObserverPhase: feature.PhaseFinalReview.String(),
 		})
 		if observed {
-			cfg.Observer.SessionEnded(sessionCtx, feature.PhaseFinalReview.String(), sessionID, "", toSessionUsage(cost), time.Since(sessionStart), sessionErrFromStatus(sess))
+			cfg.Observer.SessionEnded(sessionCtx, feature.PhaseFinalReview.String(), sessionID, "", toSessionUsage(cost, sess), time.Since(sessionStart), sessionErrFromStatus(sess))
 		}
 	}()
 

--- a/internal/agent/implement.go
+++ b/internal/agent/implement.go
@@ -625,7 +625,7 @@ func RunImplementationLoop(cfg ImplementConfig, sm ports.SessionManager) (result
 				if resumeID := providerSessionID(sess); resumeID != "" {
 					// Account the dead session before replacing it.
 					deadCost := ExtractSessionCost(sess)
-					cfg.Observer.SessionEnded(implSessionCtx, "implement", sessionID, cfg.RepoName, toSessionUsage(deadCost), time.Since(iterStart), sessionErrFromLogicalAgentStatus(agentStatus, sess))
+					cfg.Observer.SessionEnded(implSessionCtx, "implement", sessionID, cfg.RepoName, toSessionUsage(deadCost, sess), time.Since(iterStart), sessionErrFromLogicalAgentStatus(agentStatus, sess))
 					_ = accumulateSessionCostToFeature(cfg.FeatureStore, cfg.Feature.ID, "implement", deadCost, SessionCostMetadata{
 						SessionID:     sessionID,
 						ObserverPhase: "implement",
@@ -658,7 +658,7 @@ func RunImplementationLoop(cfg ImplementConfig, sm ports.SessionManager) (result
 
 			// Read cost from session's ResultMessage
 			cost = ExtractSessionCost(sess)
-			cfg.Observer.SessionEnded(implSessionCtx, "implement", sessionID, cfg.RepoName, toSessionUsage(cost), time.Since(iterStart), sessionErrFromLogicalAgentStatus(agentStatus, sess))
+			cfg.Observer.SessionEnded(implSessionCtx, "implement", sessionID, cfg.RepoName, toSessionUsage(cost, sess), time.Since(iterStart), sessionErrFromLogicalAgentStatus(agentStatus, sess))
 			emitLargeCodexCommandOutputEvents(cfg.Observer, implSessionCtx, "implement", sessionID, cfg.RepoName, sess.ProviderName(), i, logPath)
 
 			// Read output from message log
@@ -1561,33 +1561,32 @@ const maxAutoResumeAttempts = 3
 const autoResumeMessage = `Continue where you left off. If the task is complete, validate the required artifacts and finish with exactly one <agentico-outcome>{"status":"success"}</agentico-outcome> or <agentico-outcome>{"status":"retry"}</agentico-outcome> tag.`
 
 // backgroundTaskPollInterval is how often the waiter re-checks a session that
-// ended its turn while background subagents were still running. Declared as
-// var (not const) so tests can override it.
-var backgroundTaskPollInterval = 2 * time.Second
+// ended its turn while background subagents were still running.
+const backgroundTaskPollInterval = 2 * time.Second
 
 // backgroundTaskQuietGrace is how long a session whose background tasks have
 // all finished may stay quiet (no stdout) before the waiter concludes the CLI
 // did not re-invoke the agent on its own and sends the auto-resume
 // continuation.
-var backgroundTaskQuietGrace = 15 * time.Second
+const backgroundTaskQuietGrace = 15 * time.Second
 
 // backgroundTaskStallGrace is how long live background tasks may stay silent
 // (no stdout, which carries all task activity) after the root outcome is
 // already present before the waiter stops the session — killing runaway
 // monitors with the process group — and commits the outcome. Var for tests.
-var backgroundTaskStallGrace = 10 * time.Minute
+const backgroundTaskStallGrace = 10 * time.Minute
 
 // backgroundTaskDeferralCeiling bounds how long a turn may be deferred for live
 // background tasks, however chatty they are. Past it the tasks are killed with
 // the session and any present outcome is committed, so a never-true poll loop
 // cannot hold a finished phase open indefinitely. Var for tests.
-var backgroundTaskDeferralCeiling = 25 * time.Minute
+const backgroundTaskDeferralCeiling = 25 * time.Minute
 
 // phaseOutcomeReclassifyInterval paces the fallback re-classification tick:
 // a session whose terminal Result status was coalesced away or mis-delivered
 // would otherwise wait forever, since Done never fires for multi-turn
 // keep-alive sessions. Var for tests.
-var phaseOutcomeReclassifyInterval = 45 * time.Second
+const phaseOutcomeReclassifyInterval = 45 * time.Second
 
 // liveBackgroundTaskCounter is the optional session capability that reports
 // running background subagents. Provider sessions that do not track them
@@ -1897,6 +1896,12 @@ type PhaseOutcomeWaitOptions struct {
 	// committed and anything else fails the turn instead of waiting forever.
 	// Nil leaves the wait unbounded.
 	Ctx context.Context
+	// Per-call timing overrides keep tests isolated from package-level state.
+	backgroundTaskPollInterval     time.Duration
+	backgroundTaskQuietGrace       time.Duration
+	backgroundTaskStallGrace       time.Duration
+	backgroundTaskDeferralCeiling  time.Duration
+	phaseOutcomeReclassifyInterval time.Duration
 }
 
 // PhaseOutcomeWaitResult reports the semantic result of an autonomous root
@@ -1965,6 +1970,13 @@ func iterationContextMeta(sess ports.SessionView, handoff contextSnapshot) *Cont
 	return meta
 }
 
+func durationOrDefault(value, fallback time.Duration) time.Duration {
+	if value > 0 {
+		return value
+	}
+	return fallback
+}
+
 func enableTurnContinuation(sessOpts *ports.SessionOpts) *ports.SessionOpts {
 	if sessOpts == nil {
 		sessOpts = &ports.SessionOpts{}
@@ -1978,6 +1990,11 @@ func enableTurnContinuation(sessOpts *ports.SessionOpts) *ports.SessionOpts {
 // completion, AskUserQuestion, delegated-task liveness, and phase completion are
 // deliberately independent signals.
 func WaitForPhaseOutcome(sess ports.SessionView, opts PhaseOutcomeWaitOptions) PhaseOutcomeWaitResult {
+	taskPollInterval := durationOrDefault(opts.backgroundTaskPollInterval, backgroundTaskPollInterval)
+	taskQuietGrace := durationOrDefault(opts.backgroundTaskQuietGrace, backgroundTaskQuietGrace)
+	taskStallGrace := durationOrDefault(opts.backgroundTaskStallGrace, backgroundTaskStallGrace)
+	taskDeferralCeiling := durationOrDefault(opts.backgroundTaskDeferralCeiling, backgroundTaskDeferralCeiling)
+	reclassifyInterval := durationOrDefault(opts.phaseOutcomeReclassifyInterval, phaseOutcomeReclassifyInterval)
 	// Counts consecutive auto-resumes triggered by CLI truncation. Resets
 	// whenever we observe a non-truncated result, so each fresh stall has
 	// its own retry budget.
@@ -2013,10 +2030,11 @@ func WaitForPhaseOutcome(sess ports.SessionView, opts PhaseOutcomeWaitOptions) P
 	// re-invokes the agent when the tasks complete, so no nudge is sent and no
 	// budget is consumed. The bgTicker below provides the fallback paths.
 	awaitingBackgroundTasks := false
+	var deferredTaskIntent llm.CompletionIntent
 	// awaitingSince stamps when the deferral started so the absolute ceiling is
 	// measured from the yield, not from the last (possibly repeated) output.
 	var awaitingSince time.Time
-	bgTicker := time.NewTicker(backgroundTaskPollInterval)
+	bgTicker := time.NewTicker(taskPollInterval)
 	defer bgTicker.Stop()
 
 	// Novel-output tracking: LastStdoutAt is refreshed by any line, so a task
@@ -2037,8 +2055,9 @@ func WaitForPhaseOutcome(sess ports.SessionView, opts PhaseOutcomeWaitOptions) P
 	// terminal Result. classifiedSeq keeps the tick idempotent with the
 	// normal paths — a result handleStatus already saw is never re-classified,
 	// so no commit or nudge is ever duplicated.
-	reclassifyTicker := time.NewTicker(phaseOutcomeReclassifyInterval)
+	reclassifyTicker := time.NewTicker(reclassifyInterval)
 	defer reclassifyTicker.Stop()
+	outcomeC := rootOutcomeSignal(sess)
 	var classifiedResult *llm.ResultMessage
 	var classifiedSeq uint64
 
@@ -2162,10 +2181,20 @@ func WaitForPhaseOutcome(sess ports.SessionView, opts PhaseOutcomeWaitOptions) P
 				awaitingSince = time.Now()
 			}
 			awaitingBackgroundTasks = true
+			deferredTaskIntent = intent
+			clearRootCompletionIntent(sess)
+			// The root outcome observed alongside live delegated work is stale
+			// by construction. Consume its signal now so it cannot commit merely
+			// because the scheduler delivers it after the tasks finish.
+			select {
+			case <-outcomeC:
+			default:
+			}
 			return PhaseOutcomeWaitResult{}, false
 
 		case llm.TurnTruncated:
 			awaitingBackgroundTasks = false
+			deferredTaskIntent = llm.CompletionIntent{}
 			if autoResumeAttempts < maxAutoResumeAttempts {
 				autoResumeAttempts++
 				if err := sess.SendUserMessage(autoResumeMessage); err == nil {
@@ -2185,11 +2214,13 @@ func WaitForPhaseOutcome(sess ports.SessionView, opts PhaseOutcomeWaitOptions) P
 
 		case llm.TurnCommitSuccess, llm.TurnCommitRetry:
 			awaitingBackgroundTasks = false
+			deferredTaskIntent = llm.CompletionIntent{}
 			autoResumeAttempts = 0
 			return commitIntent(intent, sessionDone)
 
 		case llm.TurnProtocolViolation:
 			awaitingBackgroundTasks = false
+			deferredTaskIntent = llm.CompletionIntent{}
 			autoResumeAttempts = 0
 			violations := completionIntentViolations(intent, opts.MissingArtifacts)
 			if !sessionDone && decideFinishOrViolate(sess, disposition, &finishOrViolateNudges, protocolViolationArtifacts(violations)) {
@@ -2230,7 +2261,6 @@ func WaitForPhaseOutcome(sess ports.SessionView, opts PhaseOutcomeWaitOptions) P
 	}
 
 	doneCh := sess.Done()
-	outcomeC := rootOutcomeSignal(sess)
 	var ctxDone <-chan struct{}
 	if opts.Ctx != nil {
 		ctxDone = opts.Ctx.Done()
@@ -2282,10 +2312,14 @@ func WaitForPhaseOutcome(sess ports.SessionView, opts PhaseOutcomeWaitOptions) P
 				// new. Stop kills the process group, taking the monitors
 				// with it; the outcome is committed as normal.
 				ceilingExpired := !awaitingSince.IsZero() &&
-					time.Since(awaitingSince) >= backgroundTaskDeferralCeiling
+					time.Since(awaitingSince) >= taskDeferralCeiling
 				intent := rootCompletionIntent(sess)
+				if !intent.Valid() {
+					intent = deferredTaskIntent
+				}
 				if intent.Found && !hasPendingRootQuestion(sess) &&
-					(ceilingExpired || silence() >= backgroundTaskStallGrace) {
+					(ceilingExpired || silence() >= taskStallGrace) &&
+					liveBackgroundTasks(sess) > 0 {
 					_ = sess.Stop()
 					if result, done := commitIntent(intent, true); done {
 						return result
@@ -2310,10 +2344,11 @@ func WaitForPhaseOutcome(sess ports.SessionView, opts PhaseOutcomeWaitOptions) P
 			// re-invoke the agent on its own. Resume it explicitly, reusing
 			// the truncation budget so a session that keeps yielding without
 			// finishing still converges to a violation.
-			if quiet < backgroundTaskQuietGrace {
+			if quiet < taskQuietGrace {
 				continue
 			}
 			awaitingBackgroundTasks = false
+			deferredTaskIntent = llm.CompletionIntent{}
 			if autoResumeAttempts < maxAutoResumeAttempts {
 				autoResumeAttempts++
 				if err := sess.SendUserMessage(autoResumeMessage); err == nil {
@@ -2336,6 +2371,9 @@ func WaitForPhaseOutcome(sess ports.SessionView, opts PhaseOutcomeWaitOptions) P
 			// the outcome itself, but leave any unclassified Result to the
 			// Result-driven paths so truncation and error dispositions keep
 			// precedence.
+			if awaitingBackgroundTasks {
+				continue
+			}
 			if cost := sess.Cost(); cost != nil && cost != classifiedResult {
 				continue
 			}

--- a/internal/agent/implement_test.go
+++ b/internal/agent/implement_test.go
@@ -3080,39 +3080,40 @@ type bgTaskSession struct {
 	lastStdoutNs atomic.Int64
 	userMessages chan string
 	stopped      atomic.Bool
+	liveObserved chan struct{}
+	observeOnce  sync.Once
 }
 
 func newBgTaskSession() *bgTaskSession {
 	s := &bgTaskSession{
 		utilityTestSession: newUtilityTestSession(),
 		userMessages:       make(chan string, 4),
+		liveObserved:       make(chan struct{}),
 	}
 	s.lastStdoutNs.Store(time.Now().UnixNano())
 	return s
 }
 
-func (s *bgTaskSession) LiveBackgroundTaskCount() int { return int(s.liveTasks.Load()) }
-func (s *bgTaskSession) LastStdoutAt() time.Time      { return time.Unix(0, s.lastStdoutNs.Load()) }
+func (s *bgTaskSession) LiveBackgroundTaskCount() int {
+	count := int(s.liveTasks.Load())
+	if count > 0 {
+		s.observeOnce.Do(func() { close(s.liveObserved) })
+	}
+	return count
+}
+func (s *bgTaskSession) LastStdoutAt() time.Time { return time.Unix(0, s.lastStdoutNs.Load()) }
 func (s *bgTaskSession) SendUserMessage(text string) error {
 	s.setRootIntent(llm.CompletionIntent{})
 	s.userMessages <- text
 	return nil
 }
+func (s *bgTaskSession) ClearRootCompletionIntent() { s.setRootIntent(llm.CompletionIntent{}) }
 func (s *bgTaskSession) Stop() error {
 	s.stopped.Store(true)
 	return nil
 }
 
-func withBackgroundTaskPollInterval(t *testing.T, d time.Duration) {
-	t.Helper()
-	prev := backgroundTaskPollInterval
-	backgroundTaskPollInterval = d
-	t.Cleanup(func() { backgroundTaskPollInterval = prev })
-}
-
 func TestWaitForPhaseOutcome_DefersCommitUntilDelegatedTasksFinish(t *testing.T) {
-	withBackgroundTaskPollInterval(t, 5*time.Millisecond)
-
 	sess := newBgTaskSession()
 	sess.liveTasks.Store(1)
 	sess.result = newEndedAfterTextResult()
@@ -3123,12 +3124,18 @@ func TestWaitForPhaseOutcome_DefersCommitUntilDelegatedTasksFinish(t *testing.T)
 	resultCh := make(chan PhaseOutcomeWaitResult, 1)
 	go func() {
 		resultCh <- WaitForPhaseOutcome(sess, PhaseOutcomeWaitOptions{
+			backgroundTaskPollInterval: 5 * time.Millisecond,
 			CommitOutcome: func(llm.CompletionIntent) ([]ProtocolViolation, error) {
 				commits.Add(1)
 				return nil, nil
 			},
 		})
 	}()
+	select {
+	case <-sess.liveObserved:
+	case <-time.After(time.Second):
+		t.Fatal("waiter did not observe the live delegated task")
+	}
 
 	select {
 	case result := <-resultCh:
@@ -3143,7 +3150,9 @@ func TestWaitForPhaseOutcome_DefersCommitUntilDelegatedTasksFinish(t *testing.T)
 	sess.lastStdoutNs.Store(time.Now().Add(-time.Hour).UnixNano())
 	select {
 	case <-sess.userMessages:
-	case <-time.After(time.Second):
+	case result := <-resultCh:
+		t.Fatalf("WaitForPhaseOutcome() returned before resuming the root session: %+v", result)
+	case <-time.After(5 * time.Second):
 		t.Fatal("root session was not resumed after delegated tasks finished")
 	}
 	sess.setRootIntent(validSuccessCompletionIntent())
@@ -3154,7 +3163,7 @@ func TestWaitForPhaseOutcome_DefersCommitUntilDelegatedTasksFinish(t *testing.T)
 		if result.Status != agentStatusSuccess || result.Err != nil || len(result.ProtocolViolations) != 0 {
 			t.Fatalf("WaitForPhaseOutcome() = %+v, want success", result)
 		}
-	case <-time.After(time.Second):
+	case <-time.After(5 * time.Second):
 		t.Fatal("WaitForPhaseOutcome() did not finish after root outcome")
 	}
 	if got := commits.Load(); got != 1 {
@@ -3187,27 +3196,11 @@ func TestWaitForPhaseOutcome_RejectsProviderExitWithLiveDelegatedTasks(t *testin
 	}
 }
 
-func withPhaseOutcomeReclassifyInterval(t *testing.T, d time.Duration) {
-	t.Helper()
-	prev := phaseOutcomeReclassifyInterval
-	phaseOutcomeReclassifyInterval = d
-	t.Cleanup(func() { phaseOutcomeReclassifyInterval = prev })
-}
-
-func withBackgroundTaskStallGrace(t *testing.T, d time.Duration) {
-	t.Helper()
-	prev := backgroundTaskStallGrace
-	backgroundTaskStallGrace = d
-	t.Cleanup(func() { backgroundTaskStallGrace = prev })
-}
-
 // TestWaitForPhaseOutcome_ReclassifyTickRecoversDroppedSuccessStatus proves the
 // fallback tick classifies a terminal success Result whose SUCCESS status was
 // never delivered on StatusCh (and whose Done never fires), instead of parking
 // the phase in WaitingHelp forever.
 func TestWaitForPhaseOutcome_ReclassifyTickRecoversDroppedSuccessStatus(t *testing.T) {
-	withPhaseOutcomeReclassifyInterval(t, 5*time.Millisecond)
-
 	sess := newBgTaskSession()
 	sess.result = newEndedAfterTextResult()
 	sess.setRootIntent(validSuccessCompletionIntent())
@@ -3217,6 +3210,7 @@ func TestWaitForPhaseOutcome_ReclassifyTickRecoversDroppedSuccessStatus(t *testi
 	resultCh := make(chan PhaseOutcomeWaitResult, 1)
 	go func() {
 		resultCh <- WaitForPhaseOutcome(sess, PhaseOutcomeWaitOptions{
+			phaseOutcomeReclassifyInterval: 5 * time.Millisecond,
 			CommitOutcome: func(llm.CompletionIntent) ([]ProtocolViolation, error) {
 				commits.Add(1)
 				return nil, nil
@@ -3242,9 +3236,6 @@ func TestWaitForPhaseOutcome_ReclassifyTickRecoversDroppedSuccessStatus(t *testi
 // tasks keep the waiter alive past the stall grace, the waiter stops the
 // session and commits the outcome instead of deferring forever.
 func TestWaitForPhaseOutcome_StopsRunawayTasksAndCommitsPresentOutcome(t *testing.T) {
-	withBackgroundTaskPollInterval(t, 5*time.Millisecond)
-	withBackgroundTaskStallGrace(t, 20*time.Millisecond)
-
 	sess := newBgTaskSession()
 	sess.liveTasks.Store(1)
 	sess.result = newEndedAfterTextResult()
@@ -3256,6 +3247,8 @@ func TestWaitForPhaseOutcome_StopsRunawayTasksAndCommitsPresentOutcome(t *testin
 	resultCh := make(chan PhaseOutcomeWaitResult, 1)
 	go func() {
 		resultCh <- WaitForPhaseOutcome(sess, PhaseOutcomeWaitOptions{
+			backgroundTaskPollInterval: 5 * time.Millisecond,
+			backgroundTaskStallGrace:   20 * time.Millisecond,
 			CommitOutcome: func(llm.CompletionIntent) ([]ProtocolViolation, error) {
 				commits.Add(1)
 				return nil, nil
@@ -3380,13 +3373,6 @@ func (s *outcomeSignalSession) emitOutcome(intent llm.CompletionIntent) {
 func (s *outcomeSignalSession) emitResult(result *llm.ResultMessage) {
 	s.costPtr.Store(result)
 	s.seq.Add(1)
-}
-
-func withBackgroundTaskDeferralCeiling(t *testing.T, d time.Duration) {
-	t.Helper()
-	prev := backgroundTaskDeferralCeiling
-	backgroundTaskDeferralCeiling = d
-	t.Cleanup(func() { backgroundTaskDeferralCeiling = prev })
 }
 
 // chatterUntil keeps the session's stdout timestamp fresh, appending either
@@ -3518,10 +3504,6 @@ func TestWaitForPhaseOutcome_LaterResultDoesNotReadjudicateOutcome(t *testing.T)
 // that keeps printing the same line does not hold the stall grace open: only
 // novel output counts as activity.
 func TestWaitForPhaseOutcome_RepeatedTaskOutputCountsAsSilent(t *testing.T) {
-	withBackgroundTaskPollInterval(t, 5*time.Millisecond)
-	withBackgroundTaskStallGrace(t, 30*time.Millisecond)
-	withBackgroundTaskDeferralCeiling(t, time.Hour)
-
 	sess := newOutcomeSignalSession()
 	sess.liveTasks.Store(1)
 	sess.emitResult(newEndedAfterTextResult())
@@ -3534,6 +3516,9 @@ func TestWaitForPhaseOutcome_RepeatedTaskOutputCountsAsSilent(t *testing.T) {
 	resultCh := make(chan PhaseOutcomeWaitResult, 1)
 	go func() {
 		resultCh <- WaitForPhaseOutcome(sess, PhaseOutcomeWaitOptions{
+			backgroundTaskPollInterval:    5 * time.Millisecond,
+			backgroundTaskStallGrace:      30 * time.Millisecond,
+			backgroundTaskDeferralCeiling: time.Hour,
 			CommitOutcome: func(llm.CompletionIntent) ([]ProtocolViolation, error) {
 				commits.Add(1)
 				return nil, nil
@@ -3561,10 +3546,6 @@ func TestWaitForPhaseOutcome_RepeatedTaskOutputCountsAsSilent(t *testing.T) {
 // absolute ceiling ends the deferral even when the tasks keep producing novel
 // output forever.
 func TestWaitForPhaseOutcome_DeferralCeilingCommitsChattyPollLoop(t *testing.T) {
-	withBackgroundTaskPollInterval(t, 5*time.Millisecond)
-	withBackgroundTaskStallGrace(t, time.Hour)
-	withBackgroundTaskDeferralCeiling(t, 40*time.Millisecond)
-
 	sess := newOutcomeSignalSession()
 	sess.liveTasks.Store(1)
 	sess.emitResult(newEndedAfterTextResult())
@@ -3577,6 +3558,9 @@ func TestWaitForPhaseOutcome_DeferralCeilingCommitsChattyPollLoop(t *testing.T) 
 	resultCh := make(chan PhaseOutcomeWaitResult, 1)
 	go func() {
 		resultCh <- WaitForPhaseOutcome(sess, PhaseOutcomeWaitOptions{
+			backgroundTaskPollInterval:    5 * time.Millisecond,
+			backgroundTaskStallGrace:      time.Hour,
+			backgroundTaskDeferralCeiling: 40 * time.Millisecond,
 			CommitOutcome: func(llm.CompletionIntent) ([]ProtocolViolation, error) {
 				commits.Add(1)
 				return nil, nil
@@ -3603,10 +3587,6 @@ func TestWaitForPhaseOutcome_DeferralCeilingCommitsChattyPollLoop(t *testing.T) 
 // TestWaitForPhaseOutcome_DeferralCeilingViolatesWithoutOutcome proves an
 // expired ceiling with no outcome to commit records a protocol violation.
 func TestWaitForPhaseOutcome_DeferralCeilingViolatesWithoutOutcome(t *testing.T) {
-	withBackgroundTaskPollInterval(t, 5*time.Millisecond)
-	withBackgroundTaskStallGrace(t, time.Hour)
-	withBackgroundTaskDeferralCeiling(t, 40*time.Millisecond)
-
 	sess := newOutcomeSignalSession()
 	sess.liveTasks.Store(1)
 	sess.emitResult(newEndedAfterTextResult())
@@ -3617,6 +3597,9 @@ func TestWaitForPhaseOutcome_DeferralCeilingViolatesWithoutOutcome(t *testing.T)
 	resultCh := make(chan PhaseOutcomeWaitResult, 1)
 	go func() {
 		resultCh <- WaitForPhaseOutcome(sess, PhaseOutcomeWaitOptions{
+			backgroundTaskPollInterval:    5 * time.Millisecond,
+			backgroundTaskStallGrace:      time.Hour,
+			backgroundTaskDeferralCeiling: 40 * time.Millisecond,
 			CommitOutcome: func(llm.CompletionIntent) ([]ProtocolViolation, error) {
 				return nil, nil
 			},

--- a/internal/agent/phase.go
+++ b/internal/agent/phase.go
@@ -336,7 +336,7 @@ func (pr *PhaseRunner) runInteractivePhase(f *feature.Feature, cfg interactivePh
 	sessionStart := time.Now()
 	sess.AddCleanupFunc(func() {
 		cost := ExtractSessionCost(sess)
-		usage := toSessionUsage(cost)
+		usage := toSessionUsage(cost, sess)
 		duration := time.Since(sessionStart)
 		_ = accumulateSessionCostToFeatureKey(pr.FeatureStore, f.ID, cfg.Phase.DirName(), cost, SessionCostMetadata{
 			SessionID:     sessionID,
@@ -672,7 +672,7 @@ func (pr *PhaseRunner) runKBSession(f *feature.Feature, repo feature.FeatureRepo
 			ObserverPhase: feature.PhaseKnowledgeBase.String(),
 			RepoName:      repo.Name,
 		})
-		pr.Observer.SessionEnded(sessionCtx, feature.PhaseKnowledgeBase.String(), sessionID, repo.Name, toSessionUsage(cost), time.Since(sessionStart), sessionErrFromStatus(sess))
+		pr.Observer.SessionEnded(sessionCtx, feature.PhaseKnowledgeBase.String(), sessionID, repo.Name, toSessionUsage(cost, sess), time.Since(sessionStart), sessionErrFromStatus(sess))
 	})
 
 	// Register cleanup to release lock when session ends.

--- a/internal/agent/plan_validation.go
+++ b/internal/agent/plan_validation.go
@@ -2311,7 +2311,7 @@ func handleCompletedPlanSession(
 ) (outcome planSessionOutcome, result *PlanLoopResult, newCriticFeedback string, newSessionAttempt int) {
 	agentStatus := waitResult.Status
 	cfg.Observer.SessionEnded(planSessionCtx, "plan", sessionID, cfg.RepoName,
-		toSessionUsage(cost), time.Since(sessionStart), sessionErrFromAgentStatus(agentStatus))
+		toSessionUsage(cost, sess), time.Since(sessionStart), sessionErrFromAgentStatus(agentStatus))
 
 	output := sess.MessageLog().Text()
 	_ = os.WriteFile(logPath, []byte(output), 0o644)

--- a/internal/feature/mutation_observer.go
+++ b/internal/feature/mutation_observer.go
@@ -1,0 +1,115 @@
+// Copyright 2026 DoorDash, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package feature
+
+import (
+	"reflect"
+	"time"
+)
+
+type MutationKind string
+
+const (
+	MutationSaved   MutationKind = "saved"
+	MutationDeleted MutationKind = "deleted"
+	MutationRewound MutationKind = "rewound"
+)
+
+// MutationSnapshot is an immutable, telemetry-safe view captured at the
+// persistence boundary. It intentionally excludes paths, descriptions,
+// prompts, answers, and other rich content.
+type MutationSnapshot struct {
+	ID                string
+	Name              string
+	Created           time.Time
+	Status            Status
+	Phase             Phase
+	ActiveRun         int
+	RunCount          int
+	Pipeline          PipelineProfile
+	Risk              RiskLevel
+	FeatureKind       string
+	RepositoryNames   []string
+	TraceID           string
+	FeatureSpanID     string
+	FailureType       string
+	VerificationItems []VerificationItemStatus
+	OutputRepos       []MutationOutputRepo
+	StartedAt         *time.Time
+	PhaseTimings      map[string]time.Duration
+}
+
+type MutationOutputRepo struct{ Name, Path, WorktreePath, BaseBranch string }
+
+type Mutation struct {
+	Kind   MutationKind
+	Before *MutationSnapshot
+	After  *MutationSnapshot
+	At     time.Time
+}
+
+type MutationObserver interface{ FeatureMutated(Mutation) }
+
+func mutationSnapshot(f *Feature) *MutationSnapshot {
+	if f == nil {
+		return nil
+	}
+	repos := make([]string, 0, len(f.Repos))
+	outputRepos := make([]MutationOutputRepo, 0, len(f.Repos))
+	for _, repo := range f.Repos {
+		repos = append(repos, repo.Name)
+		outputRepos = append(outputRepos, MutationOutputRepo{Name: repo.Name, Path: repo.Path, WorktreePath: repo.WorktreePath, BaseBranch: repo.BaseBranch})
+	}
+	kind := "parent"
+	if f.IsChild() {
+		kind = "child"
+	}
+	return &MutationSnapshot{ID: f.ID, Name: f.Name, Created: f.Created, Status: f.Status, Phase: f.CurrentPhase,
+		ActiveRun: f.ActiveRun, RunCount: f.RunCount, Pipeline: f.Pipeline, Risk: f.RiskLevel, FeatureKind: kind,
+		RepositoryNames: repos, TraceID: f.TraceID, FeatureSpanID: f.FeatureSpanID, FailureType: f.FailureType,
+		VerificationItems: append([]VerificationItemStatus(nil), f.VerificationItems...), OutputRepos: outputRepos, StartedAt: cloneTime(f.StartedAt), PhaseTimings: cloneDurations(f.PhaseTimings)}
+}
+
+func cloneTime(value *time.Time) *time.Time {
+	if value == nil {
+		return nil
+	}
+	copy := *value
+	return &copy
+}
+func cloneDurations(in map[string]time.Duration) map[string]time.Duration {
+	out := make(map[string]time.Duration, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}
+
+func mutationSnapshotsEqual(a, b *MutationSnapshot) bool { return reflect.DeepEqual(a, b) }
+
+func (s *Store) SetMutationObserver(observer MutationObserver) {
+	s.mu.Lock()
+	s.mutationObserver = observer
+	s.mu.Unlock()
+}
+
+func (s *Store) notifyMutation(m Mutation) {
+	s.mu.RLock()
+	observer := s.mutationObserver
+	s.mu.RUnlock()
+	if observer != nil {
+		observer.FeatureMutated(m)
+	}
+}

--- a/internal/feature/mutation_observer_test.go
+++ b/internal/feature/mutation_observer_test.go
@@ -1,0 +1,104 @@
+// Copyright 2026 DoorDash, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package feature
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+type mutationCapture struct {
+	store           *Store
+	mu              sync.Mutex
+	events          []Mutation
+	callbackLoadErr error
+}
+
+func (c *mutationCapture) FeatureMutated(m Mutation) {
+	_, c.callbackLoadErr = c.store.Load(func() string {
+		if m.After != nil {
+			return m.After.ID
+		}
+		return m.Before.ID
+	}())
+	c.mu.Lock()
+	c.events = append(c.events, m)
+	c.mu.Unlock()
+}
+
+func TestStoreMutationObserverNotifiesOnceAfterPersistenceAndOutsideLock(t *testing.T) {
+	store := NewStore(t.TempDir())
+	capture := &mutationCapture{store: store}
+	store.SetMutationObserver(capture)
+	f := &Feature{ID: "f1", Name: "one", Created: time.Now(), Status: StatusCreated, ActiveRun: 1, RunCount: 1, SchemaVersion: SchemaVersionCurrent}
+	f.SetRun(&Run{RunNumber: 1})
+	if err := store.Save(f); err != nil {
+		t.Fatal(err)
+	}
+	if capture.callbackLoadErr != nil {
+		t.Fatalf("callback could not load persisted feature: %v", capture.callbackLoadErr)
+	}
+	if len(capture.events) != 1 || capture.events[0].Before != nil || capture.events[0].After.Status != StatusCreated {
+		t.Fatalf("create notifications=%+v", capture.events)
+	}
+	if err := store.Modify("f1", func(*Feature) error { return nil }); err != nil {
+		t.Fatal(err)
+	}
+	if len(capture.events) != 1 {
+		t.Fatalf("no-op emitted notification: %d", len(capture.events))
+	}
+	if err := store.Modify("f1", func(f *Feature) error { f.Status = StatusCodeReady; return nil }); err != nil {
+		t.Fatal(err)
+	}
+	if len(capture.events) != 2 || capture.events[1].Before.Status != StatusCreated || capture.events[1].After.Status != StatusCodeReady {
+		t.Fatalf("modify notifications=%+v", capture.events)
+	}
+	if err := store.Delete("f1"); err != nil {
+		t.Fatal(err)
+	}
+	if len(capture.events) != 3 || capture.events[2].Kind != MutationDeleted {
+		t.Fatalf("delete notifications=%+v", capture.events)
+	}
+}
+
+func TestCreateChildLockedNotifiesForDurableChildCreation(t *testing.T) {
+	store := NewStore(t.TempDir())
+	parent := &Feature{ID: "parent", Name: "parent", Created: time.Now(), Status: StatusCreated, ActiveRun: 1, RunCount: 1, SchemaVersion: SchemaVersionCurrent}
+	parent.SetRun(&Run{RunNumber: 1})
+	if err := store.Save(parent); err != nil {
+		t.Fatal(err)
+	}
+	capture := &mutationCapture{store: store}
+	store.SetMutationObserver(capture)
+	child, err := store.CreateChildLocked(parent.ID, func(parent, activeChild *Feature) (*Feature, *ChildCreationIntent, error) {
+		if activeChild != nil {
+			t.Fatalf("unexpected active child %s", activeChild.ID)
+		}
+		child := &Feature{ID: "child", Name: "child", Created: time.Now(), Status: StatusCreated, ActiveRun: 1, RunCount: 1, SchemaVersion: SchemaVersionCurrent,
+			Parent: &ChildRelationship{ParentID: parent.ID, Kind: ChildKindRefactor}}
+		child.SetRun(&Run{RunNumber: 1})
+		return child, &ChildCreationIntent{ChildID: child.ID, Kind: ChildKindRefactor, CreatedAt: child.Created, Child: *child}, nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if child.ID != "child" || capture.callbackLoadErr != nil {
+		t.Fatalf("child=%+v callback error=%v", child, capture.callbackLoadErr)
+	}
+	if len(capture.events) != 1 || capture.events[0].Before != nil || capture.events[0].After.ID != child.ID {
+		t.Fatalf("notifications=%+v", capture.events)
+	}
+}

--- a/internal/feature/store.go
+++ b/internal/feature/store.go
@@ -76,6 +76,7 @@ type Store struct {
 	// testSaveInterceptor is a test-only hook consulted by saveUnlocked to
 	// inject failures. The concrete wiring lives in export_test.go.
 	testSaveInterceptor func(f *Feature) error
+	mutationObserver    MutationObserver
 }
 
 // RelationshipChildren is the complete child-owned relationship view for a
@@ -112,9 +113,17 @@ func NewStore(baseDir string) *Store {
 
 func (s *Store) Save(f *Feature) error {
 	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	return s.saveUnlocked(f)
+	var before *MutationSnapshot
+	if existing, err := s.loadUnlocked(f.ID); err == nil {
+		before = mutationSnapshot(existing)
+	}
+	err := s.saveUnlocked(f)
+	after := mutationSnapshot(f)
+	s.mu.Unlock()
+	if err == nil && (before == nil || !mutationSnapshotsEqual(before, after)) {
+		s.notifyMutation(Mutation{Kind: MutationSaved, Before: before, After: after, At: time.Now()})
+	}
+	return err
 }
 
 func (s *Store) Load(id string) (*Feature, error) {
@@ -126,16 +135,23 @@ func (s *Store) Load(id string) (*Feature, error) {
 // concurrent writes from corrupting the YAML file.
 func (s *Store) Modify(id string, fn func(f *Feature) error) error {
 	s.mu.Lock()
-	defer s.mu.Unlock()
-
 	f, err := s.loadUnlocked(id)
 	if err != nil {
+		s.mu.Unlock()
 		return err
 	}
+	before := mutationSnapshot(f)
 	if err := fn(f); err != nil {
+		s.mu.Unlock()
 		return err
 	}
-	return s.saveUnlocked(f)
+	err = s.saveUnlocked(f)
+	after := mutationSnapshot(f)
+	s.mu.Unlock()
+	if err == nil && !mutationSnapshotsEqual(before, after) {
+		s.notifyMutation(Mutation{Kind: MutationSaved, Before: before, After: after, At: time.Now()})
+	}
+	return err
 }
 
 // RelationshipGuardFunc evaluates whether a mutation is allowed given the
@@ -158,13 +174,15 @@ func (s *Store) ModifyGuarded(
 	fn func(f *Feature) error,
 ) error {
 	s.mu.Lock()
-	defer s.mu.Unlock()
 
 	f, err := s.loadUnlocked(id)
 	if err != nil {
+		s.mu.Unlock()
 		return err
 	}
+	before := mutationSnapshot(f)
 	if f.IsChild() && !f.IsActiveChild() {
+		s.mu.Unlock()
 		return ErrChildRelationshipClosed
 	}
 
@@ -172,20 +190,29 @@ func (s *Store) ModifyGuarded(
 	if !f.IsChild() {
 		activeChild, err = s.activeChildOfUnlocked(id)
 		if err != nil {
+			s.mu.Unlock()
 			return fmt.Errorf("checking active child during guarded modify: %w", err)
 		}
 	}
 
 	if guard != nil {
 		if err := guard(f, activeChild); err != nil {
+			s.mu.Unlock()
 			return err
 		}
 	}
 
 	if err := fn(f); err != nil {
+		s.mu.Unlock()
 		return err
 	}
-	return s.saveUnlocked(f)
+	err = s.saveUnlocked(f)
+	after := mutationSnapshot(f)
+	s.mu.Unlock()
+	if err == nil && !mutationSnapshotsEqual(before, after) {
+		s.notifyMutation(Mutation{Kind: MutationSaved, Before: before, After: after, At: time.Now()})
+	}
+	return err
 }
 
 // RelationshipChildren returns the unique active child and complete closed
@@ -611,11 +638,18 @@ func (s *Store) List() ([]*Feature, error) {
 
 func (s *Store) Delete(id string) error {
 	s.mu.Lock()
-	defer s.mu.Unlock()
-
+	var before *MutationSnapshot
+	if f, err := s.loadUnlocked(id); err == nil {
+		before = mutationSnapshot(f)
+	}
 	dir := filepath.Join(s.BaseDir, id)
 	if err := os.RemoveAll(dir); err != nil {
+		s.mu.Unlock()
 		return fmt.Errorf("deleting feature directory: %w", err)
+	}
+	s.mu.Unlock()
+	if before != nil {
+		s.notifyMutation(Mutation{Kind: MutationDeleted, Before: before, At: time.Now()})
 	}
 	return nil
 }
@@ -725,14 +759,21 @@ func (s *Store) SealAndForkRun(
 	seal func(oldRun *Run) error,
 	fork func(oldRun *Run) (*Run, error),
 	populate func(oldRun, newRun *Run) error,
-) (*Feature, error) {
+) (result *Feature, retErr error) {
 	s.mu.Lock()
-	defer s.mu.Unlock()
+	var before, after *MutationSnapshot
+	defer func() {
+		s.mu.Unlock()
+		if retErr == nil && after != nil {
+			s.notifyMutation(Mutation{Kind: MutationRewound, Before: before, After: after, At: time.Now()})
+		}
+	}()
 
 	f, err := s.loadUnlocked(featureID)
 	if err != nil {
 		return nil, fmt.Errorf("loading feature for seal+fork: %w", err)
 	}
+	before = mutationSnapshot(f)
 	oldRun := f.run
 	if oldRun == nil {
 		return nil, fmt.Errorf("feature %s has no active run loaded", featureID)
@@ -807,6 +848,7 @@ func (s *Store) SealAndForkRun(
 	if err := s.saveUnlocked(f); err != nil {
 		return nil, fmt.Errorf("saving feature after seal+fork: %w", err)
 	}
+	after = mutationSnapshot(f)
 	return f, nil
 }
 
@@ -956,12 +998,19 @@ func (s *Store) CreateChildLocked(
 	fn func(parent *Feature, activeChild *Feature) (child *Feature, intent *ChildCreationIntent, err error),
 ) (*Feature, error) {
 	s.mu.Lock()
-	defer s.mu.Unlock()
+	var notifications []Mutation
+	defer func() {
+		s.mu.Unlock()
+		for _, notification := range notifications {
+			s.notifyMutation(notification)
+		}
+	}()
 
 	parent, err := s.loadUnlocked(parentID)
 	if err != nil {
 		return nil, err
 	}
+	parentBefore := mutationSnapshot(parent)
 	activeChild, err := s.activeChildOfUnlocked(parentID)
 	if err != nil {
 		return nil, err
@@ -987,6 +1036,10 @@ func (s *Store) CreateChildLocked(
 	parent.PendingChild = nil
 	if err := s.saveUnlocked(parent); err != nil {
 		return nil, fmt.Errorf("clearing child intent on parent: %w", err)
+	}
+	notifications = append(notifications, Mutation{Kind: MutationSaved, After: mutationSnapshot(child), At: time.Now()})
+	if parentAfter := mutationSnapshot(parent); !mutationSnapshotsEqual(parentBefore, parentAfter) {
+		notifications = append(notifications, Mutation{Kind: MutationSaved, Before: parentBefore, After: parentAfter, At: time.Now()})
 	}
 	return child, nil
 }
@@ -1023,7 +1076,13 @@ func (s *Store) activeChildOfUnlocked(parentID string) (*Feature, error) {
 // correct order.
 func (s *Store) ReconcilePendingChildCreations() ([]string, error) {
 	s.mu.Lock()
-	defer s.mu.Unlock()
+	var notifications []Mutation
+	defer func() {
+		s.mu.Unlock()
+		for _, notification := range notifications {
+			s.notifyMutation(notification)
+		}
+	}()
 
 	entries, err := os.ReadDir(s.BaseDir)
 	if err != nil {
@@ -1055,7 +1114,10 @@ func (s *Store) ReconcilePendingChildCreations() ([]string, error) {
 			continue
 		}
 		intent := parent.PendingChild
-		if _, err := s.loadUnlocked(intent.ChildID); err != nil {
+		var childSnapshot *MutationSnapshot
+		if existingChild, err := s.loadUnlocked(intent.ChildID); err == nil {
+			childSnapshot = mutationSnapshot(existingChild)
+		} else {
 			child := intent.Child
 			if child.ID == "" || child.ID != intent.ChildID {
 				errs = append(errs, fmt.Errorf("parent %s: child intent %q is incomplete; cannot roll forward", parent.ID, intent.ChildID))
@@ -1075,11 +1137,15 @@ func (s *Store) ReconcilePendingChildCreations() ([]string, error) {
 				errs = append(errs, fmt.Errorf("parent %s: rebuilding child %s: %w", parent.ID, intent.ChildID, err))
 				continue
 			}
+			childSnapshot = mutationSnapshot(&child)
 		}
 		parent.PendingChild = nil
 		if err := s.writeFeatureYAMLUnlocked(parent.ID, &parent); err != nil {
 			errs = append(errs, fmt.Errorf("clearing child intent on parent %s: %w", parent.ID, err))
 			continue
+		}
+		if childSnapshot != nil {
+			notifications = append(notifications, Mutation{Kind: MutationSaved, After: childSnapshot, At: time.Now()})
 		}
 		reconciled = append(reconciled, parent.ID)
 	}

--- a/internal/observe/fleet_telemetry_test.go
+++ b/internal/observe/fleet_telemetry_test.go
@@ -1,0 +1,325 @@
+// Copyright 2026 DoorDash, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package observe
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	collectorMetric "go.opentelemetry.io/proto/otlp/collector/metrics/v1"
+	collectorTrace "go.opentelemetry.io/proto/otlp/collector/trace/v1"
+	metricpb "go.opentelemetry.io/proto/otlp/metrics/v1"
+	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
+	"google.golang.org/grpc"
+)
+
+type fleetCollector struct {
+	collectorTrace.UnimplementedTraceServiceServer
+	collectorMetric.UnimplementedMetricsServiceServer
+	mu      sync.Mutex
+	spans   []*tracepb.ResourceSpans
+	metrics []*metricpb.ResourceMetrics
+}
+
+func (c *fleetCollector) Export(ctx context.Context, req *collectorTrace.ExportTraceServiceRequest) (*collectorTrace.ExportTraceServiceResponse, error) {
+	c.mu.Lock()
+	c.spans = append(c.spans, req.ResourceSpans...)
+	c.mu.Unlock()
+	return &collectorTrace.ExportTraceServiceResponse{}, nil
+}
+func (c *fleetCollector) ExportMetrics(ctx context.Context, req *collectorMetric.ExportMetricsServiceRequest) (*collectorMetric.ExportMetricsServiceResponse, error) {
+	c.mu.Lock()
+	c.metrics = append(c.metrics, req.ResourceMetrics...)
+	c.mu.Unlock()
+	return &collectorMetric.ExportMetricsServiceResponse{}, nil
+}
+
+// Export cannot be overloaded in Go, so the metric service is implemented by
+// a narrow adapter while both signals still share one capture.
+type metricCollectorAdapter struct {
+	collectorMetric.UnimplementedMetricsServiceServer
+	target *fleetCollector
+}
+
+func (a metricCollectorAdapter) Export(ctx context.Context, req *collectorMetric.ExportMetricsServiceRequest) (*collectorMetric.ExportMetricsServiceResponse, error) {
+	return a.target.ExportMetrics(ctx, req)
+}
+
+func TestOTelOnlyExportsWideEventsAndMetricsWithoutLocalJSONL(t *testing.T) {
+	collector := &fleetCollector{}
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := grpc.NewServer()
+	collectorTrace.RegisterTraceServiceServer(server, collector)
+	collectorMetric.RegisterMetricsServiceServer(server, metricCollectorAdapter{target: collector})
+	go server.Serve(lis)
+	defer server.Stop()
+	runtimeDir := t.TempDir()
+	stateDir := filepath.Join(runtimeDir, "features")
+	if err := os.MkdirAll(filepath.Join(stateDir, "f1"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	obs := New(false, stateDir, true, lis.Addr().String(), true, "fleet-test")
+	if err := obs.Emit(Event{Timestamp: time.Unix(1700000000, 0), TraceID: "00000000000000000000000000000001", EventType: "validation.completed", FeatureID: "f1", Status: "passed", DurationMs: 125}); err != nil {
+		t.Fatal(err)
+	}
+	if err := obs.Shutdown(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(stateDir, "f1", "events.jsonl")); !os.IsNotExist(err) {
+		t.Fatalf("OTel-only observer wrote local events.jsonl: %v", err)
+	}
+	collector.mu.Lock()
+	defer collector.mu.Unlock()
+	if len(collector.spans) == 0 {
+		t.Fatal("no trace exports")
+	}
+	if len(collector.metrics) == 0 {
+		t.Fatal("no metric exports")
+	}
+	found := false
+	for _, rs := range collector.spans {
+		for _, ss := range rs.ScopeSpans {
+			for _, span := range ss.Spans {
+				if span.Name == "agentico.event.validation.completed" {
+					found = true
+					if span.StartTimeUnixNano != uint64(time.Unix(1700000000, 0).UnixNano()) {
+						t.Fatalf("timestamp=%d", span.StartTimeUnixNano)
+					}
+				}
+			}
+		}
+	}
+	if !found {
+		t.Fatal("wide-event span not exported")
+	}
+	info, err := os.Stat(filepath.Join(runtimeDir, "telemetry", "installation-id"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("installation id mode=%o", info.Mode().Perm())
+	}
+}
+
+type captureWideExporter struct {
+	mu      sync.Mutex
+	fail    bool
+	records []wideRecord
+}
+
+func (e *captureWideExporter) ExportEventBatch(_ context.Context, records []wideRecord) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.fail {
+		return context.DeadlineExceeded
+	}
+	e.records = append(e.records, records...)
+	return nil
+}
+
+func TestOutboxSanitizesReplaysAndPreservesEventID(t *testing.T) {
+	runtimeDir := t.TempDir()
+	stateDir := filepath.Join(runtimeDir, "features")
+	exporter := &captureWideExporter{fail: true}
+	o := newEventOutbox(stateDir, exporter, nil, nil)
+	o.Enqueue(Event{Timestamp: time.Now(), TraceID: "00000000000000000000000000000001", EventType: "question.answered", FeatureID: "f1", Error: "token=top-secret", Data: map[string]any{"answer": "see /Users/alice/private and api_key=abc123"}})
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		segments, _ := filepath.Glob(filepath.Join(runtimeDir, "telemetry", "outbox", "segment-*.jsonl"))
+		if len(segments) > 0 {
+			data, err := os.ReadFile(segments[0])
+			if err == nil {
+				got := string(data)
+				if strings.Contains(got, "top-secret") || strings.Contains(got, "/Users/alice") || strings.Contains(got, "abc123") {
+					t.Fatalf("unsanitized outbox: %s", got)
+				}
+				if !strings.Contains(got, "[redacted]") || (!strings.Contains(got, "<user-path>") && !strings.Contains(got, `\u003cuser-path\u003e`)) {
+					t.Fatalf("missing sanitization markers: %s", got)
+				}
+				break
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("outbox segment not written")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	exporter.mu.Lock()
+	exporter.fail = false
+	exporter.mu.Unlock()
+	o.wake <- struct{}{}
+	deadline = time.Now().Add(2 * time.Second)
+	for {
+		exporter.mu.Lock()
+		count := len(exporter.records)
+		var id string
+		if count > 0 {
+			id = exporter.records[0].EventID
+		}
+		exporter.mu.Unlock()
+		if count > 0 {
+			if id == "" {
+				t.Fatal("empty event id")
+			}
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("outbox did not replay")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := o.Shutdown(ctx); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestOutboxRepairsPartialTrailingRecordBeforeAppend(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "telemetry", "outbox")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	segment := filepath.Join(dir, "segment-00000000000000000001-deadbeef.jsonl")
+	first, err := json.Marshal(sanitizeWideEvent(Event{Timestamp: time.Now(), EventType: "feature.created"}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(segment, append(append(first, '\n'), []byte(`{"event_id":"partial`)...), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	o := &eventOutbox{dir: dir, segment: segment, exporter: &captureWideExporter{}, wake: make(chan struct{}, 1)}
+	o.Enqueue(Event{Timestamp: time.Now(), EventType: "feature.state_changed"})
+	data, err := os.ReadFile(segment)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("record count=%d data=%q", len(lines), data)
+	}
+	for i, line := range lines {
+		if !json.Valid([]byte(line)) {
+			t.Fatalf("line %d is corrupt: %q", i+1, line)
+		}
+	}
+}
+
+func TestOutboxAdvancesPastCorruptSealedTailWithoutRepeatingLoss(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "telemetry", "outbox")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	segment := filepath.Join(dir, "segment-00000000000000000001-deadbeef.jsonl")
+	if err := os.WriteFile(segment, []byte(`{"event_id":"partial`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	o := &eventOutbox{dir: dir, exporter: &captureWideExporter{}}
+	if err := o.drainOnce(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(segment); !os.IsNotExist(err) {
+		t.Fatalf("corrupt sealed segment was not acknowledged and removed: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(dir, "loss.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), `"dropped":1`) {
+		t.Fatalf("loss metadata=%s", data)
+	}
+}
+
+func TestTelemetryResourceFiltersPersonalAndMachineIdentity(t *testing.T) {
+	t.Setenv("OTEL_RESOURCE_ATTRIBUTES", "deployment.environment.name=test,host.name=private-host,workspace.path=/Users/alice/project,team.name=private-team")
+	res, _ := telemetryResource(filepath.Join(t.TempDir(), "features"), "public-service")
+	got := resourceStrings(res)
+	if got["service.name"] != "public-service" || got["deployment.environment.name"] != "test" {
+		t.Fatalf("resource=%v", got)
+	}
+	for _, key := range []string{"host.name", "workspace.path", "team.name"} {
+		if _, exists := got[key]; exists {
+			t.Fatalf("forbidden resource attribute %q survived: %v", key, got)
+		}
+	}
+}
+
+func TestInstallationIDRecoversCorruptFile(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "telemetry")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "installation-id")
+	if err := os.WriteFile(path, []byte("not-a-uuid\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	first, err := loadInstallationID(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := loadInstallationID(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first == "" || first != second {
+		t.Fatalf("installation ID was not persisted: %q %q", first, second)
+	}
+}
+
+func TestMetricModelAttributeIsBounded(t *testing.T) {
+	if got := metricEnum("model", "gpt-"+strings.Repeat("x", 200)); got != "other" {
+		t.Fatalf("unbounded model normalized to %q", got)
+	}
+	if got := metricEnum("model", "gpt-5.4[272K]"); got != "gpt-5.4" {
+		t.Fatalf("catalog alias normalized to %q", got)
+	}
+	if got := metricEnum("model", "anthropic/claude-sonnet-4-5"); got != "sonnet" {
+		t.Fatalf("provider-qualified model normalized to %q", got)
+	}
+}
+
+func TestWideEventTraceIDFallbackIsStableAndForbiddenContentIsRemoved(t *testing.T) {
+	event := Event{Timestamp: time.Now(), TraceID: "legacy-trace", FeatureID: "feature-a", EventType: "session.ended", Data: map[string]any{
+		"prompt": "do not export", "summary": "safe", "nested": map[string]any{"transcript": "private", "status": "ok"},
+	}}
+	first := sanitizeWideEvent(event)
+	second := sanitizeWideEvent(event)
+	if event.Data["prompt"] != "do not export" {
+		t.Fatalf("sanitization mutated caller data: %v", event.Data)
+	}
+	if first.Event.TraceID != second.Event.TraceID || len(first.Event.TraceID) != 32 {
+		t.Fatalf("trace IDs are not stable: %q %q", first.Event.TraceID, second.Event.TraceID)
+	}
+	data, err := json.Marshal(first)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(data), "do not export") || strings.Contains(string(data), "private") {
+		t.Fatalf("forbidden content survived: %s", data)
+	}
+	if !strings.Contains(string(data), "safe") {
+		t.Fatalf("safe summary missing: %s", data)
+	}
+}

--- a/internal/observe/metrics.go
+++ b/internal/observe/metrics.go
@@ -1,0 +1,406 @@
+// Copyright 2026 DoorDash, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package observe
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
+	"go.opentelemetry.io/otel/metric"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/resource"
+)
+
+var metricCounterNames = []string{
+	"agentico.runtime.startup.count", "agentico.feature.created.count", "agentico.feature.transition.count",
+	"agentico.feature.milestone.count", "agentico.feature.run.terminal.count", "agentico.feature.rewind.count",
+	"agentico.feature.repository.count", "agentico.phase.iteration.count", "agentico.session.outcome.count",
+	"agentico.session.token.usage", "agentico.session.turn.count", "agentico.session.retry.count",
+	"agentico.session.truncation.count", "agentico.session.context_handoff.count", "agentico.review.outcome.count",
+	"agentico.validation.outcome.count", "agentico.verification.item.count", "agentico.publish.outcome.count",
+	"agentico.interaction.request.count", "agentico.automatic_review.outcome.count", "agentico.automatic_review.unavailable.count",
+	"agentico.recovery.action.count", "agentico.session.critical_message_dropped.count",
+}
+
+var metricHistogramNames = map[string]string{
+	"agentico.feature.run.duration": "s", "agentico.feature.run.time_to_code_ready": "s", "agentico.feature.run.time_to_delivery": "s",
+	"agentico.feature.output.files_changed": "{file}", "agentico.feature.output.lines_added": "{line}", "agentico.feature.output.lines_deleted": "{line}",
+	"agentico.feature.output.commit.count": "{commit}", "agentico.phase.duration": "s", "agentico.session.duration": "s",
+	"agentico.session.api.duration": "s", "agentico.session.cost": "USD", "agentico.review.duration": "s",
+	"agentico.validation.duration": "s", "agentico.validator.duration": "s", "agentico.interaction.wait.duration": "s",
+	"agentico.automatic_review.duration": "s", "agentico.publish.duration": "s",
+}
+
+type telemetryMetrics struct {
+	mp               *sdkmetric.MeterProvider
+	counters         map[string]metric.Int64Counter
+	histograms       map[string]metric.Float64Histogram
+	exportFailures   metric.Int64Counter
+	dropped          metric.Int64Counter
+	active           atomic.Int64
+	httpRequests     metric.Int64Counter
+	httpDuration     metric.Float64Histogram
+	httpRequestSize  metric.Int64Histogram
+	httpResponseSize metric.Int64Histogram
+}
+
+func newTelemetryMetrics(enabled bool, endpoint string, insecure bool, res *resource.Resource, stateDir string) *telemetryMetrics {
+	if !enabled {
+		return nil
+	}
+	opts := []otlpmetricgrpc.Option{}
+	if endpoint != "" {
+		opts = append(opts, otlpmetricgrpc.WithEndpoint(endpoint))
+	}
+	if insecure {
+		opts = append(opts, otlpmetricgrpc.WithInsecure())
+	}
+	exporter, err := otlpmetricgrpc.New(context.Background(), opts...)
+	if err != nil {
+		return nil
+	}
+	interval := 60 * time.Second
+	if raw := strings.TrimSpace(os.Getenv("OTEL_METRIC_EXPORT_INTERVAL")); raw != "" {
+		if ms, err := strconv.ParseInt(raw, 10, 64); err == nil && ms > 0 {
+			interval = time.Duration(ms) * time.Millisecond
+		}
+	}
+	reader := sdkmetric.NewPeriodicReader(exporter, sdkmetric.WithInterval(interval))
+	views := []sdkmetric.Option{sdkmetric.WithReader(reader), sdkmetric.WithResource(res)}
+	for name := range metricHistogramNames {
+		views = append(views, sdkmetric.WithView(sdkmetric.NewView(
+			sdkmetric.Instrument{Name: name, Kind: sdkmetric.InstrumentKindHistogram},
+			sdkmetric.Stream{Aggregation: sdkmetric.AggregationExplicitBucketHistogram{Boundaries: histogramBounds(name)}},
+		)))
+	}
+	for _, name := range []string{"http.server.request.duration", "http.server.request.body.size", "http.server.response.body.size"} {
+		views = append(views, sdkmetric.WithView(sdkmetric.NewView(sdkmetric.Instrument{Name: name, Kind: sdkmetric.InstrumentKindHistogram}, sdkmetric.Stream{Aggregation: sdkmetric.AggregationExplicitBucketHistogram{Boundaries: histogramBounds(name)}})))
+	}
+	mp := sdkmetric.NewMeterProvider(views...)
+	meter := mp.Meter("agentico")
+	m := &telemetryMetrics{mp: mp, counters: map[string]metric.Int64Counter{}, histograms: map[string]metric.Float64Histogram{}}
+	for _, name := range metricCounterNames {
+		c, _ := meter.Int64Counter(name, metric.WithUnit(counterUnit(name)))
+		m.counters[name] = c
+	}
+	for name, unit := range metricHistogramNames {
+		h, _ := meter.Float64Histogram(name, metric.WithUnit(unit))
+		m.histograms[name] = h
+	}
+	m.exportFailures, _ = meter.Int64Counter("agentico.telemetry.export.failure.count", metric.WithUnit("{failure}"))
+	m.dropped, _ = meter.Int64Counter("agentico.telemetry.dropped.count", metric.WithUnit("{event}"))
+	m.httpRequests, _ = meter.Int64Counter("http.server.request.count", metric.WithUnit("{request}"))
+	m.httpDuration, _ = meter.Float64Histogram("http.server.request.duration", metric.WithUnit("s"))
+	m.httpRequestSize, _ = meter.Int64Histogram("http.server.request.body.size", metric.WithUnit("By"))
+	m.httpResponseSize, _ = meter.Int64Histogram("http.server.response.body.size", metric.WithUnit("By"))
+	activeGauge, _ := meter.Int64ObservableGauge("agentico.feature.active", metric.WithUnit("{feature}"))
+	pendingGauge, _ := meter.Int64ObservableGauge("agentico.telemetry.outbox.pending", metric.WithUnit("{event}"))
+	bytesGauge, _ := meter.Int64ObservableGauge("agentico.telemetry.outbox.bytes", metric.WithUnit("By"))
+	oldestGauge, _ := meter.Float64ObservableGauge("agentico.telemetry.outbox.oldest.age", metric.WithUnit("s"))
+	outboxDir := filepath.Join(filepath.Dir(stateDir), "telemetry", "outbox")
+	_, _ = meter.RegisterCallback(func(_ context.Context, observer metric.Observer) error {
+		observer.ObserveInt64(activeGauge, m.active.Load())
+		var pending, bytes int64
+		var oldest time.Time
+		var cursor outboxCursor
+		if data, err := os.ReadFile(filepath.Join(outboxDir, "cursor.json")); err == nil {
+			_ = json.Unmarshal(data, &cursor)
+		}
+		entries, _ := os.ReadDir(outboxDir)
+		for _, entry := range entries {
+			if entry.IsDir() || !strings.HasPrefix(entry.Name(), "segment-") {
+				continue
+			}
+			if info, err := entry.Info(); err == nil {
+				f, err := os.Open(filepath.Join(outboxDir, entry.Name()))
+				if err == nil {
+					scanner := bufio.NewScanner(f)
+					line := 0
+					segmentPending := false
+					for scanner.Scan() {
+						line++
+						if entry.Name() < cursor.Segment || (entry.Name() == cursor.Segment && line <= cursor.Line) {
+							continue
+						}
+						pending++
+						bytes += int64(len(scanner.Bytes()) + 1)
+						segmentPending = true
+					}
+					_ = f.Close()
+					if segmentPending && (oldest.IsZero() || info.ModTime().Before(oldest)) {
+						oldest = info.ModTime()
+					}
+				}
+			}
+		}
+		observer.ObserveInt64(pendingGauge, pending)
+		observer.ObserveInt64(bytesGauge, bytes)
+		if !oldest.IsZero() {
+			observer.ObserveFloat64(oldestGauge, time.Since(oldest).Seconds())
+		}
+		return nil
+	}, activeGauge, pendingGauge, bytesGauge, oldestGauge)
+	m.counters["agentico.runtime.startup.count"].Add(context.Background(), 1)
+	return m
+}
+
+func counterUnit(name string) string {
+	switch name {
+	case "agentico.session.token.usage":
+		return "{token}"
+	case "agentico.session.turn.count":
+		return "{turn}"
+	case "agentico.feature.repository.count":
+		return "{repository}"
+	case "agentico.phase.iteration.count":
+		return "{iteration}"
+	}
+	return "{event}"
+}
+
+func (m *telemetryMetrics) setActive(n int64) {
+	if m != nil {
+		m.active.Store(n)
+	}
+}
+func (m *telemetryMetrics) addActive(delta int64) {
+	if m != nil {
+		m.active.Add(delta)
+	}
+}
+
+func (m *telemetryMetrics) recordHTTP(route, method string, status int, duration time.Duration, requestBytes, responseBytes int64) {
+	if m == nil {
+		return
+	}
+	attrs := metric.WithAttributes(attribute.String("http.request.method", method), attribute.String("http.route", route), attribute.Int("http.response.status_code", status))
+	m.httpRequests.Add(context.Background(), 1, attrs)
+	m.httpDuration.Record(context.Background(), duration.Seconds(), attrs)
+	if requestBytes >= 0 {
+		m.httpRequestSize.Record(context.Background(), requestBytes, attrs)
+	}
+	m.httpResponseSize.Record(context.Background(), responseBytes, attrs)
+}
+
+func histogramBounds(name string) []float64 {
+	switch {
+	case strings.Contains(name, "duration") || strings.Contains(name, "time_to") || strings.Contains(name, "wait"):
+		return []float64{0.01, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60, 300, 900, 3600, 14400, 86400}
+	case strings.Contains(name, "cost"):
+		return []float64{0.001, 0.01, 0.05, 0.1, 0.5, 1, 5, 10, 50, 100}
+	default:
+		return []float64{0, 1, 2, 5, 10, 25, 50, 100, 250, 500, 1000, 5000, 10000, 50000}
+	}
+}
+
+func (m *telemetryMetrics) record(evt Event) {
+	if m == nil {
+		return
+	}
+	ctx := context.Background()
+	opts := metric.WithAttributes(metricAttrs(evt)...)
+	add := func(name string, n int64) {
+		if c := m.counters[name]; c != nil {
+			c.Add(ctx, n, opts)
+		}
+	}
+	recordSeconds := func(name string) {
+		if h := m.histograms[name]; h != nil && evt.DurationMs >= 0 {
+			h.Record(ctx, float64(evt.DurationMs)/1000, opts)
+		}
+	}
+	switch evt.EventType {
+	case "feature.created":
+		add("agentico.feature.created.count", 1)
+		if n, ok := number(evt.Data["repository_count"]); ok {
+			m.counters["agentico.feature.repository.count"].Add(ctx, int64(n), opts)
+		}
+	case "feature.state_changed":
+		add("agentico.feature.transition.count", 1)
+	case "feature.output_ready", "feature.delivered":
+		add("agentico.feature.milestone.count", 1)
+		if evt.EventType == "feature.output_ready" {
+			recordSeconds("agentico.feature.run.time_to_code_ready")
+		} else {
+			recordSeconds("agentico.feature.run.time_to_delivery")
+		}
+	case "feature.run_sealed":
+		add("agentico.feature.run.terminal.count", 1)
+		recordSeconds("agentico.feature.run.duration")
+	case "feature.rewound":
+		add("agentico.feature.rewind.count", 1)
+	case "feature.output_stats_collected":
+		for key, name := range map[string]string{"files_changed": "agentico.feature.output.files_changed", "lines_added": "agentico.feature.output.lines_added", "lines_deleted": "agentico.feature.output.lines_deleted", "commit_count": "agentico.feature.output.commit.count"} {
+			if n, ok := number(evt.Data[key]); ok {
+				m.histograms[name].Record(ctx, n, opts)
+			}
+		}
+	case "phase.duration_recorded":
+		recordSeconds("agentico.phase.duration")
+	case "iteration.ended":
+		add("agentico.phase.iteration.count", 1)
+	case "session.ended":
+		add("agentico.session.outcome.count", 1)
+		recordSeconds("agentico.session.duration")
+		if cost, ok := number(evt.Data["total_cost_usd"]); ok {
+			m.histograms["agentico.session.cost"].Record(ctx, cost, opts)
+		}
+		for _, key := range []string{"input_tokens", "output_tokens", "cache_read_input_tokens", "cache_creation_input_tokens"} {
+			if n, ok := number(evt.Data[key]); ok {
+				m.counters["agentico.session.token.usage"].Add(ctx, int64(n), metric.WithAttributes(append(metricAttrs(evt), attribute.String("token.type", key))...))
+			}
+		}
+		if n, ok := number(evt.Data["api_duration_ms"]); ok {
+			m.histograms["agentico.session.api.duration"].Record(ctx, n/1000, opts)
+		}
+		if n, ok := number(evt.Data["turns"]); ok {
+			m.counters["agentico.session.turn.count"].Add(ctx, int64(n), opts)
+		}
+		if n, ok := number(evt.Data["retry_count"]); ok && n > 0 {
+			m.counters["agentico.session.retry.count"].Add(ctx, int64(n), opts)
+		}
+		if truncated, _ := evt.Data["truncated"].(bool); truncated {
+			m.counters["agentico.session.truncation.count"].Add(ctx, 1, opts)
+		}
+	case "review.completed":
+		add("agentico.review.outcome.count", 1)
+		recordSeconds("agentico.review.duration")
+	case "validation.completed":
+		add("agentico.validation.outcome.count", 1)
+		recordSeconds("agentico.validation.duration")
+	case "validator.completed":
+		recordSeconds("agentico.validator.duration")
+	case "automatic_review.completed":
+		add("agentico.automatic_review.outcome.count", 1)
+		recordSeconds("agentico.automatic_review.duration")
+	case "automatic_review.unavailable":
+		add("agentico.automatic_review.unavailable.count", 1)
+	case "session.critical_message_dropped":
+		add("agentico.session.critical_message_dropped.count", 1)
+	case "verification.item_completed":
+		add("agentico.verification.item.count", 1)
+	case "permission.requested", "question.asked", "review_gate.requested":
+		add("agentico.interaction.request.count", 1)
+	case "permission.resolved", "question.answered", "review_gate.resolved":
+		recordSeconds("agentico.interaction.wait.duration")
+	case "context.handoff_triggered":
+		add("agentico.session.context_handoff.count", 1)
+	case "recovery.action":
+		add("agentico.recovery.action.count", 1)
+	case "publish.completed", "publish.failed":
+		add("agentico.publish.outcome.count", 1)
+		recordSeconds("agentico.publish.duration")
+	}
+}
+
+func metricAttrs(evt Event) []attribute.KeyValue {
+	attrs := make([]attribute.KeyValue, 0, 5)
+	if evt.Phase != "" {
+		attrs = append(attrs, attribute.String("phase", metricEnum("phase", evt.Phase)))
+	}
+	if evt.Status != "" {
+		attrs = append(attrs, attribute.String("outcome", metricEnum("outcome", evt.Status)))
+	}
+	for _, key := range []string{"pipeline", "feature_kind", "risk", "provider", "model", "effort", "failure_type", "publish_mode", "verification_type", "review_type", "validator_type", "interaction_kind", "decision", "automatic"} {
+		if v, ok := evt.Data[key].(string); ok && v != "" {
+			attrs = append(attrs, attribute.String(key, metricEnum(key, v)))
+		}
+	}
+	return attrs
+}
+
+var safeModelPattern = regexp.MustCompile(`^gpt-[0-9](?:\.[0-9]{1,2})?(?:-mini|-codex)?$`)
+
+func metricEnum(key, s string) string {
+	v := strings.ToLower(strings.TrimSpace(s))
+	allowed := map[string]map[string]bool{
+		"pipeline":          {"medium": true, "large": true, "moonshot": true},
+		"feature_kind":      {"parent": true, "child": true},
+		"risk":              {"low": true, "medium": true, "high": true},
+		"provider":          {"claude": true, "codex": true, "opencode": true},
+		"effort":            {"low": true, "medium": true, "high": true, "xhigh": true, "max": true, "ultra": true, "none": true},
+		"failure_type":      {"safety_rail": true, "max_iterations": true, "session_crash": true, "missing_artifact": true, "protocol_violation": true, "infrastructure": true, "worktree_setup": true},
+		"publish_mode":      {"published": true, "done": true, "manual": true, "automatic": true, "draft": true},
+		"verification_type": {"testing_contract": true, "validator": true, "plan": true},
+		"review_type":       {"automatic": true, "final": true, "manual": true},
+		"validator_type":    {"plan": true, "roadmap": true, "testing_contract": true},
+		"interaction_kind":  {"permission": true, "question": true, "review_gate": true},
+		"decision":          {"allow": true, "deny": true, "approved": true, "rejected": true, "answered": true, "waived": true},
+		"automatic":         {"true": true, "false": true},
+		"phase":             {"setup": true, "knowledgebase": true, "inquire": true, "research": true, "design": true, "plan": true, "implement": true, "review": true, "final_review": true, "publish": true},
+		"outcome":           {"created": true, "started": true, "completed": true, "passed": true, "failed": true, "error": true, "ok": true, "success": true, "interrupted": true, "needuserinput": true, "codeready": true, "published": true, "done": true, "delivered": true, "ready": true, "resolved": true, "requested": true, "recorded": true, "unavailable": true, "blocked": true, "waived": true, "regression": true, "inherited_failure": true, "unclassified_failure": true, "missing_capability": true, "contract_error": true, "environment_limited": true, "flaky_failure": true},
+	}
+	if key == "model" {
+		return normalizeMetricModel(v)
+	}
+	if values := allowed[key]; values != nil && values[v] {
+		return v
+	}
+	return "other"
+}
+
+func normalizeMetricModel(value string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	if idx := strings.IndexByte(value, '['); idx >= 0 {
+		value = value[:idx]
+	}
+	if idx := strings.LastIndexByte(value, '/'); idx >= 0 {
+		value = value[idx+1:]
+	}
+	switch {
+	case value == "opus" || strings.Contains(value, "claude-opus"):
+		return "opus"
+	case value == "sonnet" || strings.Contains(value, "claude-sonnet"):
+		return "sonnet"
+	case value == "haiku" || strings.Contains(value, "claude-haiku"):
+		return "haiku"
+	case value == "codex":
+		return "codex"
+	case len(value) <= 32 && safeModelPattern.MatchString(value):
+		return value
+	default:
+		return "other"
+	}
+}
+func number(v any) (float64, bool) {
+	switch n := v.(type) {
+	case int:
+		return float64(n), true
+	case int64:
+		return float64(n), true
+	case float64:
+		return n, true
+	case float32:
+		return float64(n), true
+	}
+	return 0, false
+}
+
+func (m *telemetryMetrics) Shutdown(ctx context.Context) error {
+	if m == nil || m.mp == nil {
+		return nil
+	}
+	return m.mp.Shutdown(ctx)
+}

--- a/internal/observe/module.go
+++ b/internal/observe/module.go
@@ -15,21 +15,34 @@
 package observe
 
 import (
+	"context"
+
 	"github.com/doordash-oss/agentic-orchestrator/internal/config"
+	"github.com/doordash-oss/agentic-orchestrator/internal/feature"
 	"go.uber.org/fx"
 )
 
 // Params holds fx-injected parameters for the observe module.
 type Params struct {
 	fx.In
-	Config   *config.Config
-	StateDir string `name:"stateDir"`
+	Config    *config.Config
+	StateDir  string `name:"stateDir"`
+	Lifecycle fx.Lifecycle
+	Store     *feature.Store `optional:"true"`
 }
 
 // Module provides the Observer via fx.
 var Module = fx.Module("observe",
 	fx.Provide(func(p Params) *Observer {
 		obs := p.Config.Observability
-		return New(obs.Events, p.StateDir, obs.OTelEnabled, obs.OTelEndpoint, obs.OTelInsecure, obs.OTelServiceName)
+		o := New(obs.Events, p.StateDir, obs.OTelEnabled, obs.OTelEndpoint, obs.OTelInsecure, obs.OTelServiceName)
+		if p.Store != nil {
+			p.Store.SetMutationObserver(o)
+			if features, err := p.Store.List(); err == nil || feature.IsPartialLoadError(err) {
+				o.initializeActive(features)
+			}
+		}
+		p.Lifecycle.Append(fx.Hook{OnStop: func(context.Context) error { return o.Shutdown() }})
+		return o
 	}),
 )

--- a/internal/observe/observer.go
+++ b/internal/observe/observer.go
@@ -15,14 +15,19 @@
 package observe
 
 import (
+	"bufio"
+	"context"
 	"fmt"
+	"os/exec"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/doordash-oss/agentic-orchestrator/internal/autoreview"
 	"github.com/doordash-oss/agentic-orchestrator/internal/feature"
 	"github.com/doordash-oss/agentic-orchestrator/internal/permission"
+	"go.opentelemetry.io/otel/sdk/resource"
 )
 
 // Observer is the central observability facade. It coordinates JSONL event
@@ -31,8 +36,20 @@ import (
 type Observer struct {
 	emitter          *Emitter
 	otel             *otelBridge
+	metrics          *telemetryMetrics
+	outbox           *eventOutbox
 	enabled          bool
+	localEnabled     bool
 	activePhaseSpans sync.Map
+	interactions     sync.Map
+	producerWG       sync.WaitGroup
+	shutdownOnce     sync.Once
+	shutdownErr      error
+}
+
+type pendingInteraction struct {
+	id      string
+	started time.Time
 }
 
 // RewindEventInput carries the durable context for a successful rewind audit
@@ -88,16 +105,266 @@ type AutomaticReviewUnavailableEventInput struct {
 	Reason    string
 }
 
+// FeatureMutated receives authoritative post-persistence notifications from
+// the feature store. The store invokes this callback after releasing its lock.
+func (o *Observer) FeatureMutated(m feature.Mutation) {
+	if o == nil || !o.enabled {
+		return
+	}
+	current := m.After
+	if current == nil {
+		current = m.Before
+	}
+	if current == nil {
+		return
+	}
+	sc := SpanContextForFeature(current.ID, current.TraceID, current.Name, current.FeatureSpanID).WithRun(current.ActiveRun)
+	base := map[string]any{
+		"pipeline":         string(current.Pipeline),
+		"risk":             string(current.Risk),
+		"feature_kind":     current.FeatureKind,
+		"repository_count": len(current.RepositoryNames),
+		"repository_names": append([]string(nil), current.RepositoryNames...),
+	}
+	if current.FailureType != "" {
+		base["failure_type"] = current.FailureType
+	}
+	emit := func(kind, status string, extra map[string]any) {
+		data := copyAnyMap(base)
+		var durationMs int64
+		eventPhase := current.Phase.DirName()
+		for key, value := range extra {
+			if key == "_duration_ms" {
+				if n, ok := value.(int64); ok {
+					durationMs = n
+				}
+				continue
+			}
+			if key == "phase" {
+				if phase, ok := value.(string); ok && phase != "" {
+					eventPhase = phase
+				}
+			}
+			data[key] = value
+		}
+		_ = o.emit(sc, Event{Timestamp: m.At, TraceID: sc.TraceID, SpanID: NewSpanID(), EventType: kind,
+			Status: status, FeatureID: current.ID, Phase: eventPhase, DurationMs: durationMs, Data: data})
+	}
+	if m.Before == nil && m.After != nil {
+		if !telemetryTerminal(m.After.Status) {
+			o.metrics.addActive(1)
+		}
+		emit("feature.created", current.Status.String(), map[string]any{"created_at": current.Created.UTC().Format(time.RFC3339Nano)})
+		emit("feature.run_started", "started", map[string]any{"run_number": current.ActiveRun})
+		return
+	}
+	if m.Kind == feature.MutationDeleted {
+		if !telemetryTerminal(m.Before.Status) {
+			o.metrics.addActive(-1)
+		}
+		emit("feature.deleted", "deleted", nil)
+		return
+	}
+	if m.Before == nil || m.After == nil {
+		return
+	}
+	if m.Before.ActiveRun != m.After.ActiveRun {
+		emit("feature.run_sealed", m.Before.Status.String(), map[string]any{"run_number": m.Before.ActiveRun, "_duration_ms": sinceMillis(m.Before.StartedAt, m.At)})
+		emit("feature.run_started", "started", map[string]any{"run_number": m.After.ActiveRun})
+	}
+	if m.Before.Status != m.After.Status {
+		if telemetryTerminal(m.Before.Status) != telemetryTerminal(m.After.Status) {
+			if telemetryTerminal(m.After.Status) {
+				o.metrics.addActive(-1)
+			} else {
+				o.metrics.addActive(1)
+			}
+		}
+		emit("feature.state_changed", m.After.Status.String(), map[string]any{"previous_status": m.Before.Status.String()})
+		gateKey := current.ID + "\x00review_gate"
+		if !reviewGateStatus(m.Before.Status) && reviewGateStatus(m.After.Status) {
+			pending := pendingInteraction{id: randomHex(16), started: m.At}
+			o.interactions.Store(gateKey, pending)
+			emit("review_gate.requested", "requested", map[string]any{"correlation_id": pending.id, "interaction_kind": "review_gate"})
+		} else if reviewGateStatus(m.Before.Status) && !reviewGateStatus(m.After.Status) {
+			extra := map[string]any{"interaction_kind": "review_gate", "decision": m.After.Status.String()}
+			if value, ok := o.interactions.LoadAndDelete(gateKey); ok {
+				pending := value.(pendingInteraction)
+				extra["correlation_id"] = pending.id
+				extra["wait_duration_ms"] = m.At.Sub(pending.started).Milliseconds()
+				extra["_duration_ms"] = m.At.Sub(pending.started).Milliseconds()
+			}
+			emit("review_gate.resolved", "resolved", extra)
+		}
+		if !telemetryTerminal(m.Before.Status) && telemetryTerminal(m.After.Status) {
+			emit("feature.run_sealed", m.After.Status.String(), map[string]any{"run_number": m.After.ActiveRun, "_duration_ms": sinceMillis(m.After.StartedAt, m.At)})
+		}
+		switch m.After.Status {
+		case feature.StatusCodeReady:
+			emit("feature.output_ready", "ready", map[string]any{"_duration_ms": m.At.Sub(m.After.Created).Milliseconds()})
+			o.collectOutputStatsAsync(sc, m.After.OutputRepos, "output_ready")
+		case feature.StatusPublished, feature.StatusDone:
+			if !telemetryDelivered(m.Before.Status) {
+				emit("feature.delivered", "delivered", map[string]any{"_duration_ms": m.At.Sub(m.After.Created).Milliseconds()})
+				o.collectOutputStatsAsync(sc, m.After.OutputRepos, "delivered")
+			}
+			if m.After.Status == feature.StatusPublished {
+				emit("publish.completed", "published", map[string]any{"publish_mode": "published"})
+			}
+		case feature.StatusFailed:
+			if m.After.Phase == feature.PhasePublish {
+				emit("publish.failed", "failed", map[string]any{"failure_type": m.After.FailureType})
+			}
+		}
+	}
+	beforeItems := make(map[string]string, len(m.Before.VerificationItems))
+	for _, item := range m.Before.VerificationItems {
+		beforeItems[item.Name] = item.State
+	}
+	for _, item := range m.After.VerificationItems {
+		if beforeItems[item.Name] == item.State || item.State == "" || item.State == "pending" || item.State == "running" {
+			continue
+		}
+		emit("verification.item_completed", item.State, map[string]any{"verification_type": "testing_contract", "item_name": item.Name})
+	}
+	for phase, total := range m.After.PhaseTimings {
+		if delta := total - m.Before.PhaseTimings[phase]; delta > 0 {
+			emit("phase.duration_recorded", "recorded", map[string]any{"phase": phase, "_duration_ms": delta.Milliseconds()})
+		}
+	}
+}
+
+func sinceMillis(start *time.Time, end time.Time) int64 {
+	if start == nil || end.Before(*start) {
+		return 0
+	}
+	return end.Sub(*start).Milliseconds()
+}
+
+func (o *Observer) collectOutputStatsAsync(sc SpanContext, repos []feature.MutationOutputRepo, milestone string) {
+	if len(repos) == 0 {
+		return
+	}
+	o.producerWG.Add(1)
+	go func() {
+		defer o.producerWG.Done()
+		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		defer cancel()
+		files, added, deleted, commits := 0, 0, 0, 0
+		failures := 0
+		for _, repo := range repos {
+			dir := repo.WorktreePath
+			if dir == "" {
+				dir = repo.Path
+			}
+			if dir == "" {
+				failures++
+				continue
+			}
+			base := repo.BaseBranch
+			if base == "" {
+				base = "HEAD~1"
+			}
+			output, err := exec.CommandContext(ctx, "git", "-C", dir, "diff", "--numstat", base+"...HEAD").Output()
+			if err != nil {
+				failures++
+				continue
+			}
+			scanner := bufio.NewScanner(strings.NewReader(string(output)))
+			for scanner.Scan() {
+				parts := strings.Fields(scanner.Text())
+				if len(parts) < 3 {
+					continue
+				}
+				files++
+				if n, e := strconv.Atoi(parts[0]); e == nil {
+					added += n
+				}
+				if n, e := strconv.Atoi(parts[1]); e == nil {
+					deleted += n
+				}
+			}
+			if output, err := exec.CommandContext(ctx, "git", "-C", dir, "rev-list", "--count", base+"..HEAD").Output(); err == nil {
+				if n, e := strconv.Atoi(strings.TrimSpace(string(output))); e == nil {
+					commits += n
+				}
+			}
+		}
+		status := "collected"
+		if failures == len(repos) {
+			status = "unavailable"
+		}
+		_ = o.emit(sc, Event{Timestamp: time.Now(), TraceID: sc.TraceID, SpanID: NewSpanID(), EventType: "feature.output_stats_collected", FeatureID: sc.FeatureID, Status: status, Data: map[string]any{"milestone": milestone, "files_changed": files, "lines_added": added, "lines_deleted": deleted, "commit_count": commits, "repository_failures": failures}})
+	}()
+}
+
+func telemetryTerminal(status feature.Status) bool {
+	switch status {
+	case feature.StatusPublished, feature.StatusDone, feature.StatusFailed, feature.StatusInterrupted:
+		return true
+	}
+	return false
+}
+
+func telemetryDelivered(status feature.Status) bool {
+	return status == feature.StatusPublished || status == feature.StatusDone
+}
+
+func reviewGateStatus(status feature.Status) bool {
+	switch status {
+	case feature.StatusPlanNeedsReview, feature.StatusPromptNeedsReview, feature.StatusInquiryNeedsReview, feature.StatusResearchNeedsReview, feature.StatusDesignNeedsReview:
+		return true
+	}
+	return false
+}
+
+func (o *Observer) initializeActive(features []*feature.Feature) {
+	var count int64
+	for _, f := range features {
+		if f != nil && !telemetryTerminal(f.Status) {
+			count++
+		}
+	}
+	o.metrics.setActive(count)
+}
+
+func (o *Observer) ObserveHTTPRequest(route, method string, status int, duration time.Duration, requestBytes, responseBytes int64) {
+	if o != nil {
+		o.metrics.recordHTTP(route, method, status, duration, requestBytes, responseBytes)
+	}
+}
+
+func copyAnyMap(in map[string]any) map[string]any {
+	out := make(map[string]any, len(in))
+	for key, value := range in {
+		out[key] = value
+	}
+	return out
+}
+
 // New creates an Observer. When enabled is false, all methods return immediately.
 func New(enabled bool, stateDir string, otelEnabled bool, otelEndpoint string, otelInsecure bool, otelServiceName string) *Observer {
-	if !enabled {
+	if !enabled && !otelEnabled {
 		return &Observer{enabled: false}
 	}
-	return &Observer{
-		emitter: NewEmitter(stateDir),
-		otel:    newOtelBridge(otelEnabled, otelEndpoint, otelInsecure, otelServiceName),
-		enabled: true,
+	var res *resource.Resource
+	if otelEnabled {
+		res, _ = telemetryResource(stateDir, otelServiceName)
 	}
+	bridge := newOtelBridgeWithResource(otelEnabled, otelEndpoint, otelInsecure, otelServiceName, res)
+	metrics := newTelemetryMetrics(otelEnabled, otelEndpoint, otelInsecure, res, stateDir)
+	o := &Observer{
+		otel: bridge, metrics: metrics,
+		enabled: true, localEnabled: enabled,
+	}
+	if enabled {
+		o.emitter = NewEmitter(stateDir)
+	}
+	if otelEnabled {
+		o.outbox = newEventOutbox(stateDir, bridge, metrics, res)
+		o.outbox.Enqueue(Event{Timestamp: time.Now(), EventType: "runtime.started", Status: "started"})
+	}
+	return o
 }
 
 // ensureFeatureSpan re-materializes the feature-level OTel span in the bridge
@@ -129,7 +396,16 @@ func (o *Observer) ensureFeatureSpan(sc SpanContext) {
 // when o == nil || !o.enabled before reaching this helper).
 func (o *Observer) emit(sc SpanContext, evt Event) error {
 	evt.RunNumber = sc.RunNumber
-	return o.emitter.Emit(evt)
+	if o.metrics != nil {
+		o.metrics.record(evt)
+	}
+	if o.outbox != nil {
+		o.outbox.Enqueue(evt)
+	}
+	if o.localEnabled && o.emitter != nil {
+		return o.emitter.Emit(evt)
+	}
+	return nil
 }
 
 // addRunNumber inserts the current run number into an attrs map when nonzero.
@@ -247,6 +523,19 @@ type SessionUsage struct {
 	OutputTokens             int
 	CacheReadInputTokens     int
 	CacheCreationInputTokens int
+	ContextWindow            int
+	ContextTotalTokens       int
+	Provider                 string
+	Model                    string
+	Effort                   string
+	ResultSubtype            string
+	Outcome                  string
+	StopReason               string
+	APIDurationMS            float64
+	Turns                    int
+	PerModelContextWindows   map[string]int
+	RetryCount               int
+	Truncated                bool
 }
 
 // SessionEnded emits a session.ended event.
@@ -272,11 +561,41 @@ func (o *Observer) SessionEnded(sc SpanContext, phase, sessionID, repoName strin
 			"output_tokens":               usage.OutputTokens,
 			"cache_read_input_tokens":     usage.CacheReadInputTokens,
 			"cache_creation_input_tokens": usage.CacheCreationInputTokens,
+			"context_window":              usage.ContextWindow,
+			"context_total_tokens":        usage.ContextTotalTokens,
 		},
 	}
 	if err != nil {
 		evt.Status = "error"
 		evt.Error = err.Error()
+	}
+	for key, value := range map[string]any{"provider": usage.Provider, "model": usage.Model, "effort": usage.Effort,
+		"result_subtype": usage.ResultSubtype, "outcome": usage.Outcome, "stop_reason": usage.StopReason,
+		"api_duration_ms": usage.APIDurationMS, "turns": usage.Turns, "per_model_context_windows": usage.PerModelContextWindows} {
+		switch v := value.(type) {
+		case string:
+			if v != "" {
+				evt.Data[key] = v
+			}
+		case int:
+			if v != 0 {
+				evt.Data[key] = v
+			}
+		case float64:
+			if v != 0 {
+				evt.Data[key] = v
+			}
+		case map[string]int:
+			if len(v) > 0 {
+				evt.Data[key] = v
+			}
+		}
+	}
+	if usage.RetryCount > 0 {
+		evt.Data["retry_count"] = usage.RetryCount
+	}
+	if usage.Truncated {
+		evt.Data["truncated"] = true
 	}
 	o.emit(sc, evt)
 	o.otel.EndSpan(sc.SpanID, evt.Status, map[string]string{
@@ -606,8 +925,11 @@ func (o *Observer) PermissionRequested(sc SpanContext, sessionID string, repoNam
 	if len(toolInput) > 200 {
 		toolInput = toolInput[:200]
 	}
+	now := time.Now()
+	pending := pendingInteraction{id: randomHex(16), started: now}
+	o.interactions.Store(sessionID+"\x00permission\x00"+toolName, pending)
 	o.emit(sc, Event{
-		Timestamp:    time.Now(),
+		Timestamp:    now,
 		TraceID:      sc.TraceID,
 		SpanID:       sc.SpanID,
 		ParentSpanID: sc.ParentSpanID,
@@ -617,8 +939,10 @@ func (o *Observer) PermissionRequested(sc SpanContext, sessionID string, repoNam
 		RepoName:     repoName,
 		Iteration:    iteration,
 		Data: map[string]any{
-			"tool_name":  toolName,
-			"tool_input": toolInput,
+			"tool_name":        toolName,
+			"tool_input":       toolInput,
+			"correlation_id":   pending.id,
+			"interaction_kind": "permission",
 		},
 	})
 	o.otel.AddSpanEvent(sc.ParentSpanID, "permission.requested", addRunNumber(sc, map[string]string{
@@ -631,8 +955,17 @@ func (o *Observer) PermissionResolved(sc SpanContext, sessionID string, repoName
 	if o == nil || !o.enabled {
 		return
 	}
+	now := time.Now()
+	data := map[string]any{"tool_name": toolName, "decision": decision, "interaction_kind": "permission"}
+	duration := int64(0)
+	if value, ok := o.interactions.LoadAndDelete(sessionID + "\x00permission\x00" + toolName); ok {
+		pending := value.(pendingInteraction)
+		data["correlation_id"] = pending.id
+		duration = now.Sub(pending.started).Milliseconds()
+		data["wait_duration_ms"] = duration
+	}
 	o.emit(sc, Event{
-		Timestamp:    time.Now(),
+		Timestamp:    now,
 		TraceID:      sc.TraceID,
 		SpanID:       sc.SpanID,
 		ParentSpanID: sc.ParentSpanID,
@@ -641,10 +974,8 @@ func (o *Observer) PermissionResolved(sc SpanContext, sessionID string, repoName
 		SessionID:    sessionID,
 		RepoName:     repoName,
 		Iteration:    iteration,
-		Data: map[string]any{
-			"tool_name": toolName,
-			"decision":  decision,
-		},
+		DurationMs:   duration,
+		Data:         data,
 	})
 	o.otel.AddSpanEvent(sc.ParentSpanID, "permission.resolved", addRunNumber(sc, map[string]string{
 		"tool_name": toolName,
@@ -752,8 +1083,11 @@ func (o *Observer) QuestionAsked(sc SpanContext, sessionID string, repoName stri
 	if o == nil || !o.enabled {
 		return
 	}
+	now := time.Now()
+	pending := pendingInteraction{id: randomHex(16), started: now}
+	o.interactions.Store(sessionID+"\x00question\x00"+question, pending)
 	o.emit(sc, Event{
-		Timestamp:    time.Now(),
+		Timestamp:    now,
 		TraceID:      sc.TraceID,
 		SpanID:       sc.SpanID,
 		ParentSpanID: sc.ParentSpanID,
@@ -763,7 +1097,9 @@ func (o *Observer) QuestionAsked(sc SpanContext, sessionID string, repoName stri
 		RepoName:     repoName,
 		Iteration:    iteration,
 		Data: map[string]any{
-			"question": question,
+			"question":         question,
+			"correlation_id":   pending.id,
+			"interaction_kind": "question",
 		},
 	})
 	o.otel.AddSpanEvent(sc.ParentSpanID, "question.asked", addRunNumber(sc, map[string]string{
@@ -785,8 +1121,9 @@ func (o *Observer) QuestionAnswered(sc SpanContext, sessionID string, repoName s
 		return
 	}
 	data := map[string]any{
-		"question": question,
-		"answer":   answer,
+		"question":         question,
+		"answer":           answer,
+		"interaction_kind": "question",
 	}
 	attrs := map[string]string{
 		"question": question,
@@ -798,8 +1135,16 @@ func (o *Observer) QuestionAnswered(sc SpanContext, sessionID string, repoName s
 		attrs["auto_picked"] = "true"
 		attrs["confidence"] = fmt.Sprintf("%.2f", metadata[0].Confidence)
 	}
+	now := time.Now()
+	duration := int64(0)
+	if value, ok := o.interactions.LoadAndDelete(sessionID + "\x00question\x00" + question); ok {
+		pending := value.(pendingInteraction)
+		data["correlation_id"] = pending.id
+		duration = now.Sub(pending.started).Milliseconds()
+		data["wait_duration_ms"] = duration
+	}
 	o.emit(sc, Event{
-		Timestamp:    time.Now(),
+		Timestamp:    now,
 		TraceID:      sc.TraceID,
 		SpanID:       sc.SpanID,
 		ParentSpanID: sc.ParentSpanID,
@@ -808,6 +1153,7 @@ func (o *Observer) QuestionAnswered(sc SpanContext, sessionID string, repoName s
 		SessionID:    sessionID,
 		RepoName:     repoName,
 		Iteration:    iteration,
+		DurationMs:   duration,
 		Data:         data,
 	})
 	o.otel.AddSpanEvent(sc.ParentSpanID, "question.answered", addRunNumber(sc, attrs))
@@ -1100,7 +1446,7 @@ func (o *Observer) AgentTaskEnded(sc SpanContext, phase, sessionID, taskID, tool
 
 // WriteFeatureSummary produces observe-summary.yaml from feature metadata and events.
 func (o *Observer) WriteFeatureSummary(input FeatureSummaryInput) error {
-	if o == nil || !o.enabled {
+	if o == nil || !o.localEnabled {
 		return nil
 	}
 	return writeFeatureSummaryImpl(input)
@@ -1171,7 +1517,35 @@ func (o *Observer) Shutdown() error {
 	if o == nil || !o.enabled {
 		return nil
 	}
-	return o.otel.Shutdown()
+	o.shutdownOnce.Do(func() {
+		if o.outbox != nil {
+			waitDone := make(chan struct{})
+			go func() { o.producerWG.Wait(); close(waitDone) }()
+			select {
+			case <-waitDone:
+			case <-time.After(4 * time.Second):
+			}
+			o.outbox.Enqueue(Event{Timestamp: time.Now(), EventType: "runtime.stopped", Status: "stopped"})
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if o.outbox != nil {
+			if err := o.outbox.Shutdown(ctx); err != nil {
+				o.shutdownErr = err
+			}
+		}
+		if o.metrics != nil {
+			if err := o.metrics.Shutdown(ctx); err != nil && o.shutdownErr == nil {
+				o.shutdownErr = err
+			}
+		}
+		if o.otel != nil {
+			if err := o.otel.Shutdown(); err != nil && o.shutdownErr == nil {
+				o.shutdownErr = err
+			}
+		}
+	})
+	return o.shutdownErr
 }
 
 // Emit is the generic escape hatch for ad-hoc events that do not have a
@@ -1195,7 +1569,16 @@ func (o *Observer) Emit(evt Event) error {
 	if evt.Timestamp.IsZero() {
 		evt.Timestamp = time.Now()
 	}
-	return o.emitter.Emit(evt)
+	if o.metrics != nil {
+		o.metrics.record(evt)
+	}
+	if o.outbox != nil {
+		o.outbox.Enqueue(evt)
+	}
+	if o.localEnabled && o.emitter != nil {
+		return o.emitter.Emit(evt)
+	}
+	return nil
 }
 
 // ActivePhaseSpanContext returns the SpanContext stored when PhaseStarted was

--- a/internal/observe/observer_integration_test.go
+++ b/internal/observe/observer_integration_test.go
@@ -17,7 +17,6 @@ package observe
 import (
 	"bufio"
 	"context"
-	"encoding/hex"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -26,7 +25,6 @@ import (
 
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
-	"go.opentelemetry.io/otel/trace"
 )
 
 func TestObserverWritesJSONLAndOTelConsistently(t *testing.T) {
@@ -43,9 +41,10 @@ func TestObserverWritesJSONLAndOTelConsistently(t *testing.T) {
 		spans:   make(map[string]activeSpan),
 	}
 	obs := &Observer{
-		emitter: NewEmitter(tmpDir),
-		otel:    bridge,
-		enabled: true,
+		emitter:      NewEmitter(tmpDir),
+		otel:         bridge,
+		enabled:      true,
+		localEnabled: true,
 	}
 
 	featureID := "test-feat-1"
@@ -115,16 +114,8 @@ func TestObserverWritesJSONLAndOTelConsistently(t *testing.T) {
 		t.Errorf("OTel agentic.span_id=%q != JSONL SpanID=%q", foundSpanID, events[0].SpanID)
 	}
 
-	// Verify the actual OTel SpanID matches the roadmap SpanID (not just the attribute).
-	spanBytes, err := hex.DecodeString(events[0].SpanID)
-	if err != nil || len(spanBytes) != 8 {
-		t.Fatalf("invalid roadmap SpanID in JSONL: %q", events[0].SpanID)
-	}
-	var expectedSID trace.SpanID
-	copy(expectedSID[:], spanBytes)
-	if otelSpan.SpanContext().SpanID() != expectedSID {
-		t.Errorf("OTel SpanID %s != JSONL roadmap SpanID %s",
-			otelSpan.SpanContext().SpanID(), expectedSID)
+	if !otelSpan.SpanContext().SpanID().IsValid() {
+		t.Error("runtime OTel SpanID is invalid")
 	}
 }
 

--- a/internal/observe/otel.go
+++ b/internal/observe/otel.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"encoding/json"
+	"errors"
 	"log"
 	"strings"
 	"sync"
@@ -28,8 +30,10 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
+	"go.opentelemetry.io/otel/sdk/instrumentation"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
 	"go.opentelemetry.io/otel/trace"
 )
@@ -130,9 +134,13 @@ func (h *otelErrorHandler) Handle(err error) {
 // real OTel spans using an in-memory store, without requiring context.Context
 // propagation through the application.
 type otelBridge struct {
-	enabled bool
-	tracer  trace.Tracer
-	tp      *sdktrace.TracerProvider
+	enabled      bool
+	tracer       trace.Tracer
+	tp           *sdktrace.TracerProvider
+	wideExporter sdktrace.SpanExporter
+	serviceName  string
+	wideMu       sync.Mutex
+	wideOptions  []otlptracegrpc.Option
 
 	mu    sync.Mutex
 	spans map[string]activeSpan // keyed by roadmap SpanID
@@ -144,33 +152,20 @@ type activeSpan struct {
 	ctx  context.Context
 }
 
-// wantSpanIDKey is a context key for passing a desired OTel SpanID to the
-// custom IDGenerator. Each call to StartSpan injects the roadmap SpanID into
-// the context so that the generator returns it instead of a random value.
-type otelCtxKey int
-
-const wantSpanIDKey otelCtxKey = iota
-
-// roadmapIDGen implements sdktrace.IDGenerator. When the start context carries
-// a desired SpanID (set by StartSpan), it returns that value; otherwise it
-// falls back to cryptographically random generation.
+// roadmapIDGen implements sdktrace.IDGenerator with fresh runtime IDs. The
+// persisted logical IDs remain attributes, so a restart cannot reuse a real
+// OTel span ID.
 type roadmapIDGen struct{}
 
-func (roadmapIDGen) NewIDs(ctx context.Context) (trace.TraceID, trace.SpanID) {
+func (roadmapIDGen) NewIDs(context.Context) (trace.TraceID, trace.SpanID) {
 	var tid trace.TraceID
 	_, _ = rand.Read(tid[:])
-	if sid, ok := ctx.Value(wantSpanIDKey).(trace.SpanID); ok && sid.IsValid() {
-		return tid, sid
-	}
 	var sid trace.SpanID
 	_, _ = rand.Read(sid[:])
 	return tid, sid
 }
 
-func (roadmapIDGen) NewSpanID(ctx context.Context, _ trace.TraceID) trace.SpanID {
-	if sid, ok := ctx.Value(wantSpanIDKey).(trace.SpanID); ok && sid.IsValid() {
-		return sid
-	}
+func (roadmapIDGen) NewSpanID(context.Context, trace.TraceID) trace.SpanID {
 	var sid trace.SpanID
 	_, _ = rand.Read(sid[:])
 	return sid
@@ -183,6 +178,14 @@ func (roadmapIDGen) NewSpanID(ctx context.Context, _ trace.TraceID) trace.SpanID
 // callers to override endpoint/TLS settings. If exporter creation fails, it degrades
 // gracefully to a bare provider.
 func newOtelBridge(enabled bool, endpoint string, insecure bool, serviceName string, grpcOpts ...otlptracegrpc.Option) *otelBridge {
+	if serviceName == "" {
+		serviceName = "agentico"
+	}
+	res := resource.NewSchemaless(semconv.ServiceNameKey.String(serviceName))
+	return newOtelBridgeWithResource(enabled, endpoint, insecure, serviceName, res, grpcOpts...)
+}
+
+func newOtelBridgeWithResource(enabled bool, endpoint string, insecure bool, serviceName string, res *resource.Resource, grpcOpts ...otlptracegrpc.Option) *otelBridge {
 	if !enabled {
 		return &otelBridge{
 			enabled: false,
@@ -205,22 +208,25 @@ func newOtelBridge(enabled bool, endpoint string, insecure bool, serviceName str
 	exporter, err := otlptracegrpc.New(ctx, grpcOpts...)
 	if err != nil {
 		// Graceful degradation: create bridge with bare provider.
-		tp := sdktrace.NewTracerProvider(sdktrace.WithIDGenerator(roadmapIDGen{}))
+		tp := sdktrace.NewTracerProvider(sdktrace.WithResource(res), sdktrace.WithIDGenerator(roadmapIDGen{}))
 		return &otelBridge{
-			enabled: true,
-			tracer:  tp.Tracer(serviceName),
-			tp:      tp,
-			spans:   make(map[string]activeSpan),
+			enabled:     true,
+			tracer:      tp.Tracer(serviceName),
+			tp:          tp,
+			spans:       make(map[string]activeSpan),
+			serviceName: serviceName,
+			wideOptions: append([]otlptracegrpc.Option(nil), grpcOpts...),
 		}
 	}
 
-	res, err := resource.New(ctx,
-		resource.WithAttributes(semconv.ServiceNameKey.String(serviceName)),
-		resource.WithFromEnv(),
-		resource.WithTelemetrySDK(),
-	)
-	if err != nil {
-		res = resource.NewSchemaless(semconv.ServiceNameKey.String(serviceName))
+	if res == nil {
+		res, err = resource.New(ctx,
+			resource.WithFromEnv(), resource.WithTelemetrySDK(),
+			resource.WithAttributes(semconv.ServiceNameKey.String(serviceName)),
+		)
+		if err != nil {
+			res = resource.NewSchemaless(semconv.ServiceNameKey.String(serviceName))
+		}
 	}
 
 	// Wrap the exporter so we can track whether a first successful export
@@ -236,11 +242,15 @@ func newOtelBridge(enabled bool, endpoint string, insecure bool, serviceName str
 		sdktrace.WithResource(res),
 		sdktrace.WithIDGenerator(roadmapIDGen{}),
 	)
+	wideExporter, _ := otlptracegrpc.New(ctx, grpcOpts...)
 	return &otelBridge{
-		enabled: true,
-		tracer:  tp.Tracer(serviceName),
-		tp:      tp,
-		spans:   make(map[string]activeSpan),
+		enabled:      true,
+		tracer:       tp.Tracer(serviceName),
+		tp:           tp,
+		spans:        make(map[string]activeSpan),
+		wideExporter: wideExporter,
+		serviceName:  serviceName,
+		wideOptions:  append([]otlptracegrpc.Option(nil), grpcOpts...),
 	}
 }
 
@@ -283,6 +293,9 @@ func (b *otelBridge) StartSpan(sc SpanContext, operationName string, attrs map[s
 
 	// Build span options with standard attributes.
 	spanAttrs := []attribute.KeyValue{
+		attribute.String("agentico.feature.id", sc.FeatureID),
+		attribute.String("agentico.logical.span.id", sc.SpanID),
+		attribute.String("agentico.feature.trace.id", sc.TraceID),
 		attribute.String("agentic.feature_id", sc.FeatureID),
 		attribute.String("agentic.span_id", sc.SpanID),
 		attribute.String("agentic.trace_id", sc.TraceID),
@@ -306,16 +319,102 @@ func (b *otelBridge) StartSpan(sc SpanContext, operationName string, attrs map[s
 	}
 	remoteCtx := seedTraceContext(sc, parentCtx)
 
-	// Inject roadmap SpanID so the custom IDGenerator returns it
-	// instead of a random value.
-	if spanBytes, err := hex.DecodeString(sc.SpanID); err == nil && len(spanBytes) == 8 {
-		var otelSID trace.SpanID
-		copy(otelSID[:], spanBytes)
-		remoteCtx = context.WithValue(remoteCtx, wantSpanIDKey, otelSID)
-	}
-
 	ctx, span := b.tracer.Start(remoteCtx, operationName, opts...)
 	b.spans[sc.SpanID] = activeSpan{span: span, ctx: ctx}
+}
+
+// ExportEventBatch materializes durable records as short, analytics-marked
+// spans. Its successful collector response is the acknowledgement boundary
+// used by the outbox.
+func (b *otelBridge) ExportEventBatch(ctx context.Context, records []wideRecord) error {
+	if !b.enabled || len(records) == 0 {
+		return nil
+	}
+	b.wideMu.Lock()
+	if b.wideExporter == nil {
+		if exporter, err := otlptracegrpc.New(ctx, b.wideOptions...); err == nil {
+			b.wideExporter = exporter
+		}
+	}
+	exporter := b.wideExporter
+	b.wideMu.Unlock()
+	if exporter == nil {
+		return errors.New("OTLP wide-event exporter unavailable")
+	}
+	spans := make([]sdktrace.ReadOnlySpan, 0, len(records))
+	for _, record := range records {
+		evt := record.Event
+		traceID, _ := trace.TraceIDFromHex(evt.TraceID)
+		var spanID trace.SpanID
+		if spanBytes, err := hex.DecodeString(record.SpanID); err == nil && len(spanBytes) == 8 {
+			copy(spanID[:], spanBytes)
+		}
+		attrs := []attribute.KeyValue{
+			attribute.Bool("agentico.analytics", true),
+			attribute.String("agentico.event.id", record.EventID),
+			attribute.Int("agentico.telemetry.schema.version", telemetrySchemaVersion),
+			attribute.String("agentico.event.type", evt.EventType),
+			attribute.String("agentico.feature.id", evt.FeatureID),
+			attribute.String("agentico.logical.span.id", evt.SpanID),
+			attribute.String("agentico.logical.parent_span.id", evt.ParentSpanID),
+			attribute.Int("agentico.run.number", evt.RunNumber),
+		}
+		if evt.Phase != "" {
+			attrs = append(attrs, attribute.String("agentico.phase", evt.Phase))
+		}
+		if evt.Status != "" {
+			attrs = append(attrs, attribute.String("agentico.status", evt.Status))
+		}
+		if evt.SessionID != "" {
+			attrs = append(attrs, attribute.String("agentico.session.id", evt.SessionID))
+		}
+		if evt.RepoName != "" {
+			attrs = append(attrs, attribute.String("agentico.repository.name", evt.RepoName))
+		}
+		if evt.DurationMs != 0 {
+			attrs = append(attrs, attribute.Int64("agentico.duration.ms", evt.DurationMs))
+		}
+		if evt.Error != "" {
+			attrs = append(attrs, attribute.String("agentico.error", evt.Error))
+		}
+		for key, value := range evt.Data {
+			attrs = append(attrs, wideAttribute("agentico."+strings.ReplaceAll(key, "_", "."), value))
+		}
+		started := evt.Timestamp
+		if started.IsZero() {
+			started = time.Now()
+		}
+		resourceAttrs := make([]attribute.KeyValue, 0, len(record.Resource))
+		for key, value := range record.Resource {
+			resourceAttrs = append(resourceAttrs, attribute.String(key, value))
+		}
+		stub := tracetest.SpanStub{Name: "agentico.event." + evt.EventType,
+			SpanContext: trace.NewSpanContext(trace.SpanContextConfig{TraceID: traceID, SpanID: spanID, TraceFlags: trace.FlagsSampled}),
+			StartTime:   started, EndTime: started.Add(time.Nanosecond), Attributes: attrs, Resource: resource.NewSchemaless(resourceAttrs...),
+			InstrumentationScope: instrumentation.Scope{Name: b.serviceName}}
+		spans = append(spans, stub.Snapshot())
+	}
+	return exporter.ExportSpans(ctx, spans)
+}
+
+func wideAttribute(key string, value any) attribute.KeyValue {
+	switch v := value.(type) {
+	case string:
+		return attribute.String(key, v)
+	case bool:
+		return attribute.Bool(key, v)
+	case int:
+		return attribute.Int(key, v)
+	case int64:
+		return attribute.Int64(key, v)
+	case float64:
+		return attribute.Float64(key, v)
+	case []string:
+		return attribute.StringSlice(key, v)
+	default:
+		data, _ := json.Marshal(v)
+		return attribute.String(key, string(data))
+	}
 }
 
 // EndSpan ends the span matching the given roadmap SpanID, applying final
@@ -383,7 +482,17 @@ func (b *otelBridge) Shutdown() error {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	return b.tp.Shutdown(ctx)
+	err := b.tp.Shutdown(ctx)
+	b.wideMu.Lock()
+	wideExporter := b.wideExporter
+	b.wideExporter = nil
+	b.wideMu.Unlock()
+	if wideExporter != nil {
+		if wideErr := wideExporter.Shutdown(ctx); err == nil {
+			err = wideErr
+		}
+	}
+	return err
 }
 
 // seedTraceContext creates a span context seeded with the roadmap TraceID

--- a/internal/observe/otel_bridge_test.go
+++ b/internal/observe/otel_bridge_test.go
@@ -16,7 +16,6 @@ package observe
 
 import (
 	"context"
-	"encoding/hex"
 	"net"
 	"sync/atomic"
 	"testing"
@@ -25,7 +24,6 @@ import (
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
-	"go.opentelemetry.io/otel/trace"
 	collectortracepb "go.opentelemetry.io/proto/otlp/collector/trace/v1"
 	"google.golang.org/grpc"
 )
@@ -97,9 +95,10 @@ func TestOTelBridgeStartEndCreatesHierarchy(t *testing.T) {
 			childSpan.SpanContext().TraceID(), rootSpan.SpanContext().TraceID())
 	}
 
-	// Verify OTel SpanIDs match roadmap SpanIDs (deterministic mapping).
-	assertSpanID(t, rootSpan, root.SpanID)
-	assertSpanID(t, childSpan, child.SpanID)
+	// Runtime span IDs are unique per process segment; persisted logical IDs
+	// remain available as compatibility attributes.
+	assertAttr(t, rootSpan, "agentico.logical.span.id", root.SpanID)
+	assertAttr(t, childSpan, "agentico.logical.span.id", child.SpanID)
 
 	// Verify standard attributes are present.
 	assertAttr(t, rootSpan, "agentic.feature_id", "feat-1")
@@ -213,8 +212,7 @@ func TestOTelBridgeMissingParentFallsBackToRoot(t *testing.T) {
 		t.Errorf("expected root span (no valid parent), got parent=%s", s.Parent().SpanID())
 	}
 
-	// Verify OTel SpanID matches roadmap SpanID even for orphaned spans.
-	assertSpanID(t, s, sc.SpanID)
+	assertAttr(t, s, "agentico.logical.span.id", sc.SpanID)
 
 	// Should record that parent was missing.
 	assertAttr(t, s, "agentic.parent_missing", "true")
@@ -403,22 +401,6 @@ func TestDisabledBridgeProducesNoExporterActivity(t *testing.T) {
 	}
 }
 
-// assertSpanID verifies that the OTel span's SpanID matches the hex-encoded
-// roadmap SpanID (deterministic mapping via roadmapIDGen).
-func assertSpanID(t *testing.T, s sdktrace.ReadOnlySpan, roadmapID string) {
-	t.Helper()
-	b, err := hex.DecodeString(roadmapID)
-	if err != nil || len(b) != 8 {
-		t.Fatalf("invalid roadmap SpanID %q", roadmapID)
-	}
-	var want trace.SpanID
-	copy(want[:], b)
-	got := s.SpanContext().SpanID()
-	if got != want {
-		t.Errorf("OTel SpanID %s != roadmap SpanID %s", got, want)
-	}
-}
-
 // assertAttr checks that the span has the given key-value attribute.
 func assertAttr(t *testing.T, s sdktrace.ReadOnlySpan, key, wantVal string) {
 	t.Helper()
@@ -435,5 +417,4 @@ func assertAttr(t *testing.T, s sdktrace.ReadOnlySpan, key, wantVal string) {
 }
 
 // Ensure trace and attribute packages are used (prevent unused import).
-var _ trace.Tracer
 var _ = attribute.Key("test")

--- a/internal/observe/outbox.go
+++ b/internal/observe/outbox.go
@@ -1,0 +1,728 @@
+// Copyright 2026 DoorDash, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package observe
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"math/rand/v2"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+	"unicode/utf8"
+
+	"github.com/doordash-oss/agentic-orchestrator/internal/permission"
+	"github.com/google/uuid"
+	"go.opentelemetry.io/otel/sdk/resource"
+)
+
+const (
+	outboxSegmentLimit = 4 << 20
+	outboxBatchRecords = 256
+	outboxBatchBytes   = 1 << 20
+	outboxRetention    = 7 * 24 * time.Hour
+	outboxCapacity     = 256 << 20
+	maxWideFieldBytes  = 4 << 10
+	maxWideEventBytes  = 32 << 10
+)
+
+var absolutePathPattern = regexp.MustCompile(`(?:/Users/[^/\s]+|/home/[^/\s]+|[A-Za-z]:\\Users\\[^\\\s]+)(?:[/\\][^\s"']*)?`)
+
+type wideRecord struct {
+	EventID   string            `json:"event_id"`
+	SpanID    string            `json:"span_id"`
+	Event     Event             `json:"event"`
+	Bytes     int               `json:"original_bytes,omitempty"`
+	Truncated bool              `json:"truncated,omitempty"`
+	Resource  map[string]string `json:"resource,omitempty"`
+}
+
+type outboxCursor struct {
+	Segment string `json:"segment,omitempty"`
+	Line    int    `json:"line,omitempty"`
+}
+
+type wideEventExporter interface {
+	ExportEventBatch(context.Context, []wideRecord) error
+}
+
+type eventOutbox struct {
+	dir      string
+	exporter wideEventExporter
+	metrics  *telemetryMetrics
+	resource map[string]string
+
+	mu      sync.Mutex
+	lossMu  sync.Mutex
+	segment string
+	stop    chan struct{}
+	wake    chan struct{}
+	done    chan struct{}
+	once    sync.Once
+	lossLog sync.Once
+}
+
+func newEventOutbox(stateDir string, exporter wideEventExporter, metrics *telemetryMetrics, res *resource.Resource) *eventOutbox {
+	o := &eventOutbox{
+		dir:      filepath.Join(filepath.Dir(stateDir), "telemetry", "outbox"),
+		exporter: exporter,
+		metrics:  metrics,
+		resource: resourceStrings(res),
+		stop:     make(chan struct{}), wake: make(chan struct{}, 1), done: make(chan struct{}),
+	}
+	if err := os.MkdirAll(o.dir, 0o700); err != nil {
+		log.Printf("telemetry outbox unavailable: %v", err)
+		o.exporter = nil
+		close(o.done)
+		return o
+	}
+	_ = os.Chmod(o.dir, 0o700)
+	go o.run()
+	return o
+}
+
+func (o *eventOutbox) Enqueue(evt Event) bool {
+	if o == nil || o.exporter == nil {
+		return false
+	}
+	record := sanitizeWideEvent(evt)
+	record.Resource = o.resource
+	data, err := json.Marshal(record)
+	if err != nil {
+		o.recordDrop(1)
+		return false
+	}
+	if len(data) > maxWideEventBytes {
+		record.Event.Data = map[string]any{"truncated": true, "original_bytes": len(data)}
+		record.Event.Error = boundWideText(record.Event.Error)
+		record.Truncated = true
+		record.Bytes = len(data)
+		data, _ = json.Marshal(record)
+		if len(data) > maxWideEventBytes {
+			record.Resource = essentialResource(record.Resource)
+			data, _ = json.Marshal(record)
+		}
+	}
+
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	segment, err := o.appendTarget(len(data) + 1)
+	if err == nil {
+		f, openErr := os.OpenFile(segment, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
+		if openErr != nil {
+			err = openErr
+		} else {
+			_ = f.Chmod(0o600)
+			_, err = f.Write(append(data, '\n'))
+			if err == nil {
+				err = f.Sync()
+			}
+			_ = f.Close()
+		}
+	}
+	if err != nil {
+		log.Printf("telemetry outbox append failed: %v", err)
+		o.recordDrop(1)
+		return false
+	}
+	o.enforceLimitsLocked()
+	select {
+	case o.wake <- struct{}{}:
+	default:
+	}
+	return true
+}
+
+func essentialResource(in map[string]string) map[string]string {
+	out := make(map[string]string)
+	for _, key := range []string{"service.name", "service.version", "service.instance.id", "agentico.build.revision", "agentico.installation.id", "agentico.telemetry.schema.version"} {
+		if value := in[key]; value != "" {
+			out[key] = value
+		}
+	}
+	return out
+}
+
+func resourceStrings(res *resource.Resource) map[string]string {
+	out := map[string]string{}
+	if res == nil {
+		return out
+	}
+	iter := res.Iter()
+	for iter.Next() {
+		kv := iter.Attribute()
+		out[string(kv.Key)] = kv.Value.Emit()
+	}
+	return out
+}
+
+func (o *eventOutbox) appendTarget(next int) (string, error) {
+	if o.segment != "" {
+		if err := repairSegmentTail(o.segment); err != nil {
+			return "", err
+		}
+		if info, err := os.Stat(o.segment); err == nil && info.Size()+int64(next) <= outboxSegmentLimit {
+			return o.segment, nil
+		}
+	}
+	o.segment = filepath.Join(o.dir, fmt.Sprintf("segment-%020d-%s.jsonl", time.Now().UnixNano(), randomHex(4)))
+	return o.segment, nil
+}
+
+// repairSegmentTail removes an incomplete or corrupt suffix before appending.
+// A process crash can interrupt the final write even though normal writes are
+// fsynced; appending after that partial line would otherwise make every later
+// record in the segment unreadable.
+func repairSegmentTail(path string) error {
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	validEnd := 0
+	for offset := 0; offset < len(data); {
+		relativeEnd := bytes.IndexByte(data[offset:], '\n')
+		if relativeEnd < 0 {
+			break
+		}
+		lineEnd := offset + relativeEnd
+		if !json.Valid(data[offset:lineEnd]) {
+			break
+		}
+		validEnd = lineEnd + 1
+		offset = validEnd
+	}
+	if validEnd == len(data) {
+		return nil
+	}
+	f, err := os.OpenFile(path, os.O_WRONLY, 0o600)
+	if err != nil {
+		return err
+	}
+	if err = f.Truncate(int64(validEnd)); err == nil {
+		err = f.Sync()
+	}
+	if closeErr := f.Close(); err == nil {
+		err = closeErr
+	}
+	return err
+}
+
+func (o *eventOutbox) run() {
+	defer close(o.done)
+	backoff := time.Second
+	for {
+		if err := o.drainOnce(context.Background()); err != nil {
+			if o.metrics != nil {
+				o.metrics.exportFailures.Add(context.Background(), 1)
+			}
+			jitter := time.Duration(rand.Int64N(int64(backoff/2 + 1)))
+			t := time.NewTimer(backoff + jitter)
+			select {
+			case <-o.stop:
+				t.Stop()
+				return
+			case <-t.C:
+			}
+			backoff = min(backoff*2, 5*time.Minute)
+			continue
+		}
+		backoff = time.Second
+		select {
+		case <-o.stop:
+			return
+		case <-o.wake:
+		case <-time.After(time.Minute):
+		}
+	}
+}
+
+func (o *eventOutbox) drainOnce(parent context.Context) error {
+	for {
+		records, cursor, next, err := o.readBatch()
+		if err != nil {
+			return err
+		}
+		if len(records) == 0 {
+			if next != cursor {
+				if err := o.saveCursor(next); err != nil {
+					return err
+				}
+				o.cleanupAcknowledged(next)
+			}
+			return nil
+		}
+		ctx, cancel := context.WithTimeout(parent, 15*time.Second)
+		err = o.exporter.ExportEventBatch(ctx, records)
+		cancel()
+		if err != nil {
+			return err
+		}
+		o.emitLossSummary()
+		if err := o.saveCursor(next); err != nil {
+			return err
+		}
+		o.cleanupAcknowledged(next)
+	}
+}
+
+func (o *eventOutbox) cleanupAcknowledged(cursor outboxCursor) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	names, _ := o.segments()
+	for _, name := range names {
+		if name < cursor.Segment {
+			_ = os.Remove(filepath.Join(o.dir, name))
+		}
+	}
+	if cursor.Segment == "" || cursor.Segment == o.currentSegmentName() {
+		return
+	}
+	f, err := os.Open(filepath.Join(o.dir, cursor.Segment))
+	if err != nil {
+		return
+	}
+	scanner := bufio.NewScanner(f)
+	lines := 0
+	for scanner.Scan() {
+		lines++
+	}
+	_ = f.Close()
+	if lines <= cursor.Line {
+		_ = os.Remove(filepath.Join(o.dir, cursor.Segment))
+		_ = o.saveCursor(outboxCursor{})
+	}
+}
+
+func (o *eventOutbox) readBatch() ([]wideRecord, outboxCursor, outboxCursor, error) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	cursor := o.loadCursor()
+	segments, err := o.segments()
+	if err != nil {
+		return nil, cursor, cursor, err
+	}
+	if len(segments) == 0 {
+		return nil, cursor, cursor, nil
+	}
+	start := 0
+	if cursor.Segment != "" {
+		start = sort.SearchStrings(segments, cursor.Segment)
+		if start == len(segments) {
+			return nil, cursor, cursor, nil
+		}
+	}
+	var records []wideRecord
+	total := 0
+	next := cursor
+	for si := start; si < len(segments) && len(records) < outboxBatchRecords; si++ {
+		name := segments[si]
+		f, err := os.Open(filepath.Join(o.dir, name))
+		if err != nil {
+			return nil, cursor, cursor, err
+		}
+		s := bufio.NewScanner(f)
+		s.Buffer(make([]byte, 64<<10), maxWideEventBytes+1024)
+		line := 0
+		for s.Scan() {
+			line++
+			if name == cursor.Segment && line <= cursor.Line {
+				continue
+			}
+			if total+len(s.Bytes()) > outboxBatchBytes && len(records) > 0 {
+				break
+			}
+			var record wideRecord
+			if err := json.Unmarshal(s.Bytes(), &record); err != nil {
+				// A partial/corrupt trailing record is ignored until a later append
+				// completes it; corruption in a sealed segment is explicitly lost.
+				if name != o.currentSegmentName() {
+					o.recordDrop(1)
+					next = outboxCursor{Segment: name, Line: line}
+					continue
+				}
+				break
+			}
+			records = append(records, record)
+			total += len(s.Bytes())
+			next = outboxCursor{Segment: name, Line: line}
+			if len(records) == outboxBatchRecords {
+				break
+			}
+		}
+		scanErr := s.Err()
+		_ = f.Close()
+		if scanErr != nil && !errors.Is(scanErr, io.EOF) {
+			return nil, cursor, cursor, scanErr
+		}
+		if len(records) >= outboxBatchRecords || total >= outboxBatchBytes {
+			break
+		}
+	}
+	return records, cursor, next, nil
+}
+
+func (o *eventOutbox) currentSegmentName() string { return filepath.Base(o.segment) }
+
+func (o *eventOutbox) segments() ([]string, error) {
+	entries, err := os.ReadDir(o.dir)
+	if err != nil {
+		return nil, err
+	}
+	var names []string
+	for _, e := range entries {
+		if !e.IsDir() && strings.HasPrefix(e.Name(), "segment-") && strings.HasSuffix(e.Name(), ".jsonl") {
+			names = append(names, e.Name())
+		}
+	}
+	sort.Strings(names)
+	return names, nil
+}
+
+func (o *eventOutbox) loadCursor() outboxCursor {
+	data, err := os.ReadFile(filepath.Join(o.dir, "cursor.json"))
+	if err != nil {
+		return outboxCursor{}
+	}
+	var c outboxCursor
+	_ = json.Unmarshal(data, &c)
+	return c
+}
+
+func (o *eventOutbox) saveCursor(c outboxCursor) error {
+	data, _ := json.Marshal(c)
+	tmp, err := os.CreateTemp(o.dir, ".cursor-*")
+	if err != nil {
+		return err
+	}
+	name := tmp.Name()
+	defer os.Remove(name)
+	_ = tmp.Chmod(0o600)
+	if _, err = tmp.Write(data); err == nil {
+		err = tmp.Sync()
+	}
+	if closeErr := tmp.Close(); err == nil {
+		err = closeErr
+	}
+	if err == nil {
+		err = os.Rename(name, filepath.Join(o.dir, "cursor.json"))
+	}
+	return err
+}
+
+func (o *eventOutbox) enforceLimitsLocked() {
+	names, _ := o.segments()
+	cursor := o.loadCursor()
+	var total int64
+	type item struct {
+		name string
+		size int64
+		mod  time.Time
+	}
+	items := make([]item, 0, len(names))
+	for _, name := range names {
+		if info, err := os.Stat(filepath.Join(o.dir, name)); err == nil {
+			total += info.Size()
+			items = append(items, item{name, info.Size(), info.ModTime()})
+		}
+	}
+	now := time.Now()
+	dropped := int64(0)
+	for _, item := range items {
+		if now.Sub(item.mod) <= outboxRetention && total <= outboxCapacity {
+			continue
+		}
+		if item.name == o.currentSegmentName() {
+			continue
+		}
+		skip := 0
+		if item.name < cursor.Segment {
+			skip = -1
+		} else if item.name == cursor.Segment {
+			skip = cursor.Line
+		}
+		count := countSegmentRecords(filepath.Join(o.dir, item.name), skip)
+		if os.Remove(filepath.Join(o.dir, item.name)) == nil {
+			total -= item.size
+			dropped += count
+		}
+	}
+	if dropped > 0 {
+		o.recordDrop(dropped)
+		o.lossLog.Do(func() {
+			log.Printf("telemetry outbox evicted unacknowledged events due to retention/capacity limits")
+		})
+	}
+}
+
+// countSegmentRecords returns the number of non-empty records after skip.
+// A negative skip means the whole segment was already acknowledged.
+func countSegmentRecords(path string, skip int) int64 {
+	if skip < 0 {
+		return 0
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return 0
+	}
+	defer f.Close()
+	var count int64
+	line := 0
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 64<<10), maxWideEventBytes+1024)
+	for scanner.Scan() {
+		line++
+		if line > skip && len(strings.TrimSpace(scanner.Text())) > 0 {
+			count++
+		}
+	}
+	return count
+}
+
+func (o *eventOutbox) recordDrop(n int64) {
+	if o.metrics != nil {
+		o.metrics.dropped.Add(context.Background(), n)
+	}
+	o.lossMu.Lock()
+	defer o.lossMu.Unlock()
+	path := filepath.Join(o.dir, "loss.json")
+	var state outboxLoss
+	if data, err := os.ReadFile(path); err == nil {
+		_ = json.Unmarshal(data, &state)
+	}
+	if state.Since.IsZero() {
+		state.Since = time.Now().UTC()
+	}
+	state.Dropped += n
+	o.writeLossLocked(path, state)
+}
+
+type outboxLoss struct {
+	Dropped int64     `json:"dropped"`
+	Since   time.Time `json:"since"`
+}
+
+func (o *eventOutbox) writeLossLocked(path string, state outboxLoss) {
+	data, _ := json.Marshal(state)
+	tmp, err := os.CreateTemp(o.dir, ".loss-*")
+	if err != nil {
+		return
+	}
+	name := tmp.Name()
+	defer os.Remove(name)
+	_ = tmp.Chmod(0o600)
+	_, err = tmp.Write(data)
+	if err == nil {
+		err = tmp.Sync()
+	}
+	_ = tmp.Close()
+	if err == nil {
+		_ = os.Rename(name, path)
+	}
+}
+
+func (o *eventOutbox) emitLossSummary() {
+	o.lossMu.Lock()
+	path := filepath.Join(o.dir, "loss.json")
+	data, err := os.ReadFile(path)
+	o.lossMu.Unlock()
+	if err != nil {
+		return
+	}
+	var state outboxLoss
+	if json.Unmarshal(data, &state) != nil || state.Dropped <= 0 {
+		return
+	}
+	if !o.Enqueue(Event{Timestamp: time.Now(), EventType: "telemetry.data_loss", Status: "dropped", Data: map[string]any{"dropped_count": state.Dropped, "since": state.Since.Format(time.RFC3339Nano)}}) {
+		return
+	}
+	o.lossMu.Lock()
+	var current outboxLoss
+	if latest, readErr := os.ReadFile(path); readErr == nil && json.Unmarshal(latest, &current) == nil {
+		current.Dropped -= state.Dropped
+		if current.Dropped <= 0 {
+			_ = os.Remove(path)
+		} else {
+			o.writeLossLocked(path, current)
+		}
+	}
+	o.lossMu.Unlock()
+}
+
+func (o *eventOutbox) Shutdown(ctx context.Context) error {
+	if o == nil || o.exporter == nil {
+		return nil
+	}
+	o.once.Do(func() { close(o.stop) })
+	select {
+	case <-o.done:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	return o.drainOnce(ctx)
+}
+
+func sanitizeWideEvent(evt Event) wideRecord {
+	// Sanitization must not alter the local JSONL event or the caller's map.
+	// Nested maps and slices are rebuilt by sanitizeWideValue below.
+	evt.Data = copyAnyMap(evt.Data)
+	if decoded, err := hex.DecodeString(evt.TraceID); err != nil || len(decoded) != 16 {
+		seed := evt.TraceID
+		if evt.FeatureID != "" {
+			seed = evt.FeatureID
+		}
+		if seed == "" {
+			evt.TraceID = randomHex(16)
+		} else {
+			digest := sha256.Sum256([]byte(seed))
+			evt.TraceID = hex.EncodeToString(digest[:16])
+		}
+	}
+	raw, _ := json.Marshal(evt)
+	original := len(raw)
+	truncated := map[string]int{}
+	if value, n, cut := sanitizeWideString(evt.Error); true {
+		evt.Error = value
+		if cut {
+			truncated["error"] = n
+		}
+	}
+	for key, value := range evt.Data {
+		if forbiddenWideField(key) {
+			data, _ := json.Marshal(value)
+			truncated[key] = len(data)
+			delete(evt.Data, key)
+			continue
+		}
+		sanitized, n, cut := sanitizeWideValue(value)
+		evt.Data[key] = sanitized
+		if cut {
+			truncated[key] = n
+		}
+	}
+	if len(truncated) > 0 {
+		if evt.Data == nil {
+			evt.Data = map[string]any{}
+		}
+		evt.Data["telemetry_truncated_fields"] = truncated
+	}
+	return wideRecord{EventID: uuid.NewString(), SpanID: randomHex(8), Event: evt, Bytes: original}
+}
+
+func forbiddenWideField(key string) bool {
+	key = strings.ToLower(strings.TrimSpace(key))
+	switch key {
+	case "prompt", "full_prompt", "system_prompt", "system_instructions", "transcript", "raw_result", "raw_model_result", "source_file", "source_files", "diff", "environment_variables", "config_contents", "authentication_material":
+		return true
+	default:
+		return false
+	}
+}
+
+func sanitizeWideString(s string) (string, int, bool) {
+	original := len(s)
+	s = permission.RedactTelemetryText(s)
+	s = absolutePathPattern.ReplaceAllString(s, "<user-path>")
+	bounded := boundWideText(s)
+	return bounded, original, len(s) > len(bounded)
+}
+
+func sanitizeWideValue(value any) (any, int, bool) {
+	switch v := value.(type) {
+	case string:
+		s, n, cut := sanitizeWideString(v)
+		return s, n, cut
+	case []string:
+		cut := false
+		original := 0
+		out := make([]string, len(v))
+		for i, item := range v {
+			var c bool
+			out[i], _, c = sanitizeWideString(item)
+			original += len(item)
+			cut = cut || c
+		}
+		return out, original, cut
+	case []any:
+		cut := false
+		original := 0
+		out := make([]any, len(v))
+		for i, item := range v {
+			var n int
+			var c bool
+			out[i], n, c = sanitizeWideValue(item)
+			original += n
+			cut = cut || c
+		}
+		return out, original, cut
+	case map[string]any:
+		cut := false
+		original := 0
+		out := make(map[string]any, len(v))
+		for key, item := range v {
+			if forbiddenWideField(key) {
+				data, _ := json.Marshal(item)
+				original += len(data)
+				cut = true
+				continue
+			}
+			var n int
+			var c bool
+			out[key], n, c = sanitizeWideValue(item)
+			original += n
+			cut = cut || c
+		}
+		return out, original, cut
+	case map[string]string:
+		cut := false
+		original := 0
+		out := make(map[string]string, len(v))
+		for key, item := range v {
+			var c bool
+			out[key], _, c = sanitizeWideString(item)
+			original += len(item)
+			cut = cut || c
+		}
+		return out, original, cut
+	default:
+		data, _ := json.Marshal(value)
+		return value, len(data), false
+	}
+}
+
+func boundWideText(s string) string {
+	if len(s) <= maxWideFieldBytes {
+		return s
+	}
+	n := maxWideFieldBytes
+	for n > 0 && !utf8.ValidString(s[:n]) {
+		n--
+	}
+	return s[:n]
+}

--- a/internal/observe/resource.go
+++ b/internal/observe/resource.go
@@ -1,0 +1,141 @@
+// Copyright 2026 DoorDash, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package observe
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/doordash-oss/agentic-orchestrator/internal/buildinfo"
+	"github.com/google/uuid"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/resource"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+)
+
+const telemetrySchemaVersion = 1
+
+func telemetryResource(stateDir, serviceName string) (*resource.Resource, string) {
+	if serviceName == "" {
+		serviceName = "agentico"
+	}
+	installationID, _ := loadInstallationID(filepath.Join(filepath.Dir(stateDir), "telemetry"))
+	instanceID := uuid.NewString()
+	attrs := filteredEnvironmentResourceAttributes()
+	attrs = append(attrs,
+		semconv.ServiceNameKey.String(serviceName),
+		semconv.ServiceVersionKey.String(buildinfo.Version()),
+		semconv.ServiceInstanceIDKey.String(instanceID),
+		attribute.String("agentico.build.revision", buildinfo.Revision()),
+		attribute.String("agentico.installation.id", installationID),
+		attribute.Int("agentico.telemetry.schema.version", telemetrySchemaVersion),
+	)
+	res := resource.NewSchemaless(attrs...)
+	return res, installationID
+}
+
+func filteredEnvironmentResourceAttributes() []attribute.KeyValue {
+	res, err := resource.New(context.Background(), resource.WithFromEnv(), resource.WithTelemetrySDK())
+	if err != nil {
+		return nil
+	}
+	attrs := make([]attribute.KeyValue, 0, res.Len())
+	iter := res.Iter()
+	for iter.Next() {
+		kv := iter.Attribute()
+		key := strings.ToLower(string(kv.Key))
+		value := kv.Value.Emit()
+		if forbiddenResourceAttribute(key, value) {
+			continue
+		}
+		attrs = append(attrs, kv)
+	}
+	return attrs
+}
+
+func forbiddenResourceAttribute(key, value string) bool {
+	for _, token := range []string{"user", "employee", "team", "host", "machine", "repository", "repo", "workspace", "config", "path", "directory"} {
+		if strings.Contains(key, token) {
+			return true
+		}
+	}
+	return absolutePathPattern.MatchString(value)
+}
+
+func loadInstallationID(telemetryDir string) (string, error) {
+	if err := os.MkdirAll(telemetryDir, 0o700); err != nil {
+		return "", err
+	}
+	if err := os.Chmod(telemetryDir, 0o700); err != nil {
+		return "", err
+	}
+	path := filepath.Join(telemetryDir, "installation-id")
+	replaceInvalid := false
+	if data, err := os.ReadFile(path); err == nil {
+		id := strings.TrimSpace(string(data))
+		if _, parseErr := uuid.Parse(id); parseErr == nil {
+			_ = os.Chmod(path, 0o600)
+			return id, nil
+		}
+		replaceInvalid = true
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return "", err
+	}
+	id := uuid.NewString()
+	tmp, err := os.CreateTemp(telemetryDir, ".installation-id-*")
+	if err != nil {
+		return "", err
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName)
+	if err := tmp.Chmod(0o600); err == nil {
+		_, err = tmp.WriteString(id + "\n")
+	}
+	if err == nil {
+		err = tmp.Sync()
+	}
+	if closeErr := tmp.Close(); err == nil {
+		err = closeErr
+	}
+	if err == nil {
+		if replaceInvalid {
+			err = os.Rename(tmpName, path)
+		} else {
+			err = os.Link(tmpName, path)
+		}
+		if errors.Is(err, os.ErrExist) {
+			if data, readErr := os.ReadFile(path); readErr == nil {
+				candidate := strings.TrimSpace(string(data))
+				if _, parseErr := uuid.Parse(candidate); parseErr == nil {
+					id, err = candidate, nil
+				}
+			}
+		}
+	}
+	return id, err
+}
+
+func randomHex(n int) string {
+	b := make([]byte, n)
+	if _, err := rand.Read(b); err != nil {
+		return strings.Repeat("0", n*2)
+	}
+	return hex.EncodeToString(b)
+}

--- a/internal/permission/audit.go
+++ b/internal/permission/audit.go
@@ -132,6 +132,13 @@ func sanitizeAuditField(s string) string {
 	return s
 }
 
+// RedactTelemetryText applies the same credential vocabulary used by the
+// permission audit log. Telemetry callers add their own path scrubbing and
+// size bounds after this shared secret-redaction step.
+func RedactTelemetryText(s string) string {
+	return sanitizeAuditField(s)
+}
+
 func boundAuditText(s string, limit int) string {
 	if limit <= 0 || len(s) <= limit {
 		return s

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -53,12 +53,13 @@ type apiHandler struct {
 	// deduplicated background cache. worktrees stays the uncached authority
 	// for mutations and launch preflights, which must see the worktree as it
 	// is at the instant they act.
-	cleanliness           git.CleanlinessInspector
-	cfg                   *config.Config
-	registry              *llm.Registry
-	sessions              ports.SessionManager
-	broker                *eventBroker
-	mutations             MutationTarget
+	cleanliness git.CleanlinessInspector
+	cfg         *config.Config
+	registry    *llm.Registry
+	sessions    ports.SessionManager
+	httpMetrics HTTPMetrics
+	broker      *eventBroker
+	mutations   MutationTarget
 	// uploads owns the octet-stream upload staging area under the runtime
 	// state dir; nil when the runtime identity has no state dir (tests that
 	// never stage uploads).
@@ -121,6 +122,7 @@ func newAPIHandler(opts HandlerOptions) *apiHandler {
 		cfg:                   opts.Config,
 		registry:              opts.Registry,
 		sessions:              opts.Sessions,
+		httpMetrics:           opts.HTTPMetrics,
 		broker:                newEventBroker(opts.Events, opts.DomainEvents),
 		mutations:             opts.Mutations,
 		uploads:               newUploadStore(opts.Runtime.StateDir),

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -84,10 +84,11 @@ func Start(ctx context.Context, opts Options) (*RuntimeServer, error) {
 		PersistProviderModelCatalog: opts.PersistProviderModelCatalog,
 		InitGitRepository:           opts.InitGitRepository,
 		Worktrees:                   opts.Worktrees,
+		HTTPMetrics:                 opts.HTTPMetrics,
 		RuntimePolicy:               policy,
 	})
 	httpServer := &http.Server{
-		Handler: handler.routes(),
+		Handler: withHTTPMetrics(handler.routes(), opts.HTTPMetrics),
 		// ReadHeaderTimeout (not ReadTimeout) is intentional: ReadTimeout
 		// would cap the whole connection lifetime, killing long-lived SSE
 		// streams (/api/v1/events, /sessions/{id}/output/stream). Mutation

--- a/internal/server/telemetry.go
+++ b/internal/server/telemetry.go
@@ -1,0 +1,178 @@
+// Copyright 2026 DoorDash, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"net/http"
+	"strings"
+	"time"
+)
+
+type HTTPMetrics interface {
+	ObserveHTTPRequest(route, method string, status int, duration time.Duration, requestBytes, responseBytes int64)
+}
+
+type metricResponseWriter struct {
+	http.ResponseWriter
+	status int
+	bytes  int64
+}
+
+func (w *metricResponseWriter) WriteHeader(status int) {
+	if w.status == 0 {
+		w.status = status
+	}
+	w.ResponseWriter.WriteHeader(status)
+}
+func (w *metricResponseWriter) Write(p []byte) (int, error) {
+	if w.status == 0 {
+		w.status = http.StatusOK
+	}
+	n, err := w.ResponseWriter.Write(p)
+	w.bytes += int64(n)
+	return n, err
+}
+func (w *metricResponseWriter) Unwrap() http.ResponseWriter { return w.ResponseWriter }
+
+func withHTTPMetrics(next http.Handler, metrics HTTPMetrics) http.Handler {
+	if metrics == nil {
+		return next
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		route, ok := telemetryRoute(r)
+		if !ok {
+			next.ServeHTTP(w, r)
+			return
+		}
+		started := time.Now()
+		mw := &metricResponseWriter{ResponseWriter: w}
+		next.ServeHTTP(mw, r)
+		status := mw.status
+		if status == 0 {
+			status = http.StatusOK
+		}
+		metrics.ObserveHTTPRequest(route, r.Method, status, time.Since(started), r.ContentLength, mw.bytes)
+	})
+}
+
+func telemetryRoute(r *http.Request) (string, bool) {
+	if r.Method == http.MethodOptions {
+		return "", false
+	}
+	path := r.URL.EscapedPath()
+	if path == apiPathHealth || path == apiPathEvents || strings.HasSuffix(path, "/output/stream") {
+		return "", false
+	}
+	parts := strings.Split(path, "/")
+	if len(parts) < 4 || parts[1] != "api" || parts[2] != "v1" {
+		return "/{other}", true
+	}
+	switch parts[3] {
+	case "features":
+		if len(parts) > 4 {
+			parts[4] = "{feature_id}"
+			if len(parts) > 6 {
+				switch parts[5] {
+				case "actions":
+					parts[6] = "{action}"
+					if len(parts) > 7 {
+						parts[7] = "{subaction}"
+						parts = parts[:8]
+					}
+				case "reviews":
+					parts[6] = "{review_id}"
+					if len(parts) > 7 {
+						if parts[7] != "draft" && parts[7] != "validate" && parts[7] != "decision" {
+							parts[7] = "{other}"
+						}
+						parts = parts[:8]
+					}
+				case "repositories":
+					parts[6] = "{repo_name}"
+					if len(parts) > 7 {
+						if parts[7] != "diff" && parts[7] != "path" {
+							parts[7] = "{other}"
+						}
+						parts = parts[:8]
+					}
+				case "runs":
+					parts[6] = "{run_number}"
+					if len(parts) > 8 && parts[7] == "artifacts" {
+						parts[8] = "{artifact_id}"
+						parts = parts[:9]
+					} else if len(parts) > 8 && parts[7] == "logs" {
+						parts[8] = "{log_id}"
+						parts = parts[:9]
+					} else if len(parts) > 7 && parts[7] != "artifacts" && parts[7] != "logs" && parts[7] != "sessions" {
+						parts[7] = "{other}"
+						parts = parts[:8]
+					}
+				}
+			}
+			if len(parts) > 5 && !knownFeatureRouteSegment(parts[5]) {
+				parts[5] = "{other}"
+				parts = parts[:6]
+			}
+			if len(parts) > 6 && parts[5] != "actions" && parts[5] != "reviews" && parts[5] != "repositories" && parts[5] != "runs" {
+				valid := (parts[5] == "completion" && parts[6] == "preflight") || (parts[5] == "rewind" && parts[6] == "preview")
+				if !valid {
+					parts[6] = "{other}"
+				}
+				parts = parts[:7]
+			}
+		}
+	case "sessions":
+		if len(parts) > 4 {
+			parts[4] = "{session_id}"
+			if len(parts) > 5 && parts[5] != "transcript" && parts[5] != "output" {
+				parts[5] = "{other}"
+				parts = parts[:6]
+			} else if len(parts) > 6 {
+				parts[6] = "{other}"
+				parts = parts[:7]
+			}
+		}
+	case "prompts", "permissions":
+		if len(parts) > 4 {
+			parts[4] = "{action}"
+			parts = parts[:5]
+		}
+	default:
+		if !knownStaticTelemetryRoute(path) {
+			return "/api/v1/{other}", true
+		}
+	}
+	return strings.Join(parts, "/"), true
+}
+
+func knownFeatureRouteSegment(segment string) bool {
+	switch segment {
+	case "actions", "completion", "config", "live-preview", "repositories", "reviews", "rewind", "runs":
+		return true
+	default:
+		return false
+	}
+}
+
+func knownStaticTelemetryRoute(path string) bool {
+	switch path {
+	case apiPathConfigRuntime, apiPathCatalogModels, apiPathCatalogRefresh,
+		apiPathReadiness, apiPathReadinessRefresh, apiPathWorkspaceRepositoriesInit,
+		apiPathRecovery, apiPathRecoveryActions, apiPathRecoveryLogs, apiPathUploads:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/server/telemetry_test.go
+++ b/internal/server/telemetry_test.go
@@ -1,0 +1,67 @@
+// Copyright 2026 DoorDash, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+type httpMetricCapture struct {
+	routes   []string
+	statuses []int
+}
+
+func (c *httpMetricCapture) ObserveHTTPRequest(route, method string, status int, duration time.Duration, requestBytes, responseBytes int64) {
+	c.routes = append(c.routes, method+" "+route)
+	c.statuses = append(c.statuses, status)
+}
+
+func TestHTTPMetricsNormalizesIDsAndExcludesStreamingRoutes(t *testing.T) {
+	capture := &httpMetricCapture{}
+	handler := withHTTPMetrics(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte("ok"))
+	}), capture)
+	for _, target := range []string{
+		"/api/v1/features/secret-id/actions/publish",
+		"/api/v1/features/secret-id/repositories/private-repo/diff",
+		"/api/v1/features/secret-id/runs/42/artifacts/private-artifact",
+		"/api/v1/features/secret-id/not-a-route/private-value",
+		"/private/request/path",
+		"/api/v1/health",
+		"/api/v1/events",
+		"/api/v1/sessions/session-secret/output/stream",
+	} {
+		handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, target, nil))
+	}
+	want := []string{
+		"POST /api/v1/features/{feature_id}/actions/{action}",
+		"POST /api/v1/features/{feature_id}/repositories/{repo_name}/diff",
+		"POST /api/v1/features/{feature_id}/runs/{run_number}/artifacts/{artifact_id}",
+		"POST /api/v1/features/{feature_id}/{other}",
+		"POST /{other}",
+	}
+	if len(capture.routes) != len(want) {
+		t.Fatalf("routes=%v", capture.routes)
+	}
+	for i := range want {
+		if capture.routes[i] != want[i] || capture.statuses[i] != http.StatusCreated {
+			t.Fatalf("routes=%v statuses=%v", capture.routes, capture.statuses)
+		}
+	}
+}

--- a/internal/server/types.go
+++ b/internal/server/types.go
@@ -73,7 +73,8 @@ type Options struct {
 	// attach the same structured diagnostics the launch-time error carries.
 	// Nil is tolerated: the dirty_parent disabled reason then ships without
 	// a diagnostics target.
-	Worktrees feature.WorktreeOps
+	Worktrees   feature.WorktreeOps
+	HTTPMetrics HTTPMetrics
 }
 
 type HandlerOptions struct {
@@ -98,6 +99,7 @@ type HandlerOptions struct {
 	Config                      *config.Config
 	Registry                    *llm.Registry
 	Sessions                    ports.SessionManager
+	HTTPMetrics                 HTTPMetrics
 	Events                      <-chan interface{}
 	DomainEvents                <-chan ports.Event
 	Mutations                   MutationTarget

--- a/skills/chat/user-guide/configuration.md
+++ b/skills/chat/user-guide/configuration.md
@@ -335,10 +335,16 @@ observability:
 | Field               | Default      | Description                              |
 | ------------------- | ------------ | ---------------------------------------- |
 | `events`            | `true`       | Enable JSONL event recording per feature |
-| `otel_enabled`      | `false`      | Enable OpenTelemetry trace export        |
-| `otel_endpoint`     | `""`         | OTLP endpoint URL                        |
+| `otel_enabled`      | `false`      | Enable OTel traces, durable wide events, and fleet metrics |
+| `otel_endpoint`     | `""`         | OTLP endpoint for traces and metrics; does not enable telemetry |
 | `otel_insecure`     | `false`      | Allow insecure OTLP connections          |
-| `otel_service_name` | `"agentico"` | Service name for OTel traces             |
+| `otel_service_name` | `"agentico"` | Service name for every OTel signal       |
+
+When `otel_endpoint` is empty, standard common and per-signal OTel environment
+settings are honored. `OTEL_METRIC_EXPORT_INTERVAL` controls the metric export
+interval in milliseconds. Local JSONL and OTel may be enabled independently.
+See `docs/observability.md` for metric schemas, privacy constraints, and the
+durable outbox contract.
 
 ## Server (`server`)
 


### PR DESCRIPTION
## Summary

- Enables independent low-cardinality OTLP metrics, replayable wide-event spans, and existing workflow traces under `otel_enabled`.
- Adds a durable, privacy-sanitized, at-least-once telemetry outbox with bounded retention and explicit loss reporting.
- Captures store-authoritative feature and run milestones, enriched session, quality, interaction, and output telemetry, plus normalized HTTP server metrics.
- Documents signal contracts, privacy and cardinality limits, resource identity, and collector and outbox requirements.
- Keeps the implementation OSS-generic: no organization-specific identity, services, dimensions, or assumptions.

## Verification

- Fast suite: `make test-fast`
- Isolated integration: `go test ./test/integration/... -count=1`
- E2E Go (process-launch / API-driven): `go test ./test/e2e/... -count=1 -race`
- Race regression: `go test ./... -count=1 -race`
- Go static-analysis gate: `go vet ./...`
- Go build gate: `go build ./...`

Generated with [Codex](https://openai.com/codex/).

Co-authored-by: Codex <noreply@openai.com>
