### PR TITLE
Prevent deleted feature residue from blocking recovery

### DIFF
--- a/internal/feature/store.go
+++ b/internal/feature/store.go
@@ -300,7 +300,7 @@ func (s *Store) AllRelationshipChildren() (map[string]*RelationshipChildren, err
 		if !entry.IsDir() || isLegacyProviderBookkeepingDir(entry.Name()) {
 			continue
 		}
-		child, err := s.loadUnlocked(entry.Name())
+		child, exists, err := s.loadFeatureForScan(entry.Name())
 		if err != nil {
 			if errors.Is(err, ErrLegacySchemaVersion) {
 				// Legacy records predate child relationships; one stale
@@ -309,6 +309,9 @@ func (s *Store) AllRelationshipChildren() (map[string]*RelationshipChildren, err
 				continue
 			}
 			return nil, fmt.Errorf("classifying feature record %q during relationship scan: %w", entry.Name(), err)
+		}
+		if !exists {
+			continue
 		}
 		if child.Parent == nil || child.Parent.ParentID == child.ID {
 			continue
@@ -356,7 +359,7 @@ func (s *Store) validatedRelationshipChildrenUnlocked(parentID string) (*Relatio
 		if !entry.IsDir() || entry.Name() == parentID || isLegacyProviderBookkeepingDir(entry.Name()) {
 			continue
 		}
-		child, err := s.loadUnlocked(entry.Name())
+		child, exists, err := s.loadFeatureForScan(entry.Name())
 		if err != nil {
 			if errors.Is(err, ErrLegacySchemaVersion) {
 				// Legacy records predate child relationships; one stale
@@ -365,6 +368,9 @@ func (s *Store) validatedRelationshipChildrenUnlocked(parentID string) (*Relatio
 				continue
 			}
 			return nil, fmt.Errorf("classifying feature record %q during relationship scan: %w", entry.Name(), err)
+		}
+		if !exists {
+			continue
 		}
 		if child.Parent == nil || child.Parent.ParentID != parentID {
 			continue
@@ -567,6 +573,28 @@ func (s *Store) loadUnlocked(id string) (*Feature, error) {
 	return &f, nil
 }
 
+// loadFeatureForScan loads one directory entry while treating a missing
+// feature.yaml as an absent record. Delete removes the complete feature
+// directory, but a concurrent scan or a late artifact from an older runtime
+// can still expose a directory after the authoritative record is gone.
+//
+// The second existence check deliberately distinguishes that case from a
+// present feature.yaml whose active run is missing: the latter is a corrupt
+// record and must continue to fail closed.
+func (s *Store) loadFeatureForScan(id string) (*Feature, bool, error) {
+	f, err := s.loadUnlocked(id)
+	if err == nil {
+		return f, true, nil
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		return nil, false, err
+	}
+	if _, statErr := os.Stat(filepath.Join(s.BaseDir, id, "feature.yaml")); errors.Is(statErr, os.ErrNotExist) {
+		return nil, false, nil
+	}
+	return nil, false, err
+}
+
 // loadRunUnlocked reads the run.yaml for a specific run number. It does not
 // acquire s.mu; run writes are committed by atomic rename.
 func (s *Store) loadRunUnlocked(featureID string, runNumber int) (*Run, error) {
@@ -596,9 +624,12 @@ func (s *Store) List() ([]*Feature, error) {
 		if !e.IsDir() || isLegacyProviderBookkeepingDir(e.Name()) {
 			continue
 		}
-		f, err := s.loadUnlocked(e.Name())
+		f, exists, err := s.loadFeatureForScan(e.Name())
 		if err != nil {
 			warnings = append(warnings, LoadWarning{ID: e.Name(), Err: err})
+			continue
+		}
+		if !exists {
 			continue
 		}
 		features = append(features, f)
@@ -614,10 +645,31 @@ func (s *Store) Delete(id string) error {
 	defer s.mu.Unlock()
 
 	dir := filepath.Join(s.BaseDir, id)
-	if err := os.RemoveAll(dir); err != nil {
+	if err := removeAllResilient(dir); err != nil {
 		return fmt.Errorf("deleting feature directory: %w", err)
 	}
 	return nil
+}
+
+// removeAllResilient removes dir even when it contains read-only directories
+// such as module caches captured in run artifacts. os.RemoveAll can delete
+// feature.yaml before encountering one of those directories, leaving a path
+// that looks like a corrupt feature on the next scan. Restore owner access to
+// directories after the first failure, then retry the complete removal.
+func removeAllResilient(dir string) error {
+	if err := os.RemoveAll(dir); err == nil {
+		return nil
+	}
+	_ = filepath.WalkDir(dir, func(path string, entry os.DirEntry, err error) error {
+		if err != nil || !entry.IsDir() {
+			return nil
+		}
+		if info, infoErr := entry.Info(); infoErr == nil && info.Mode().Perm()&0o700 != 0o700 {
+			_ = os.Chmod(path, info.Mode().Perm()|0o700)
+		}
+		return nil
+	})
+	return os.RemoveAll(dir)
 }
 
 // CreateRun writes a fresh run.yaml for a new run. RunNumber must be set.
@@ -900,7 +952,7 @@ func (s *Store) CleanupOrphanRuns(id string) ([]int, error) {
 			continue
 		}
 		runPath := filepath.Join(runsDir, e.Name())
-		if err := os.RemoveAll(runPath); err != nil {
+		if err := removeAllResilient(runPath); err != nil {
 			// Preserve in max-on-disk — the directory is still on disk.
 			if n > maxOnDisk {
 				maxOnDisk = n

--- a/internal/feature/store_test.go
+++ b/internal/feature/store_test.go
@@ -324,6 +324,98 @@ func TestStoreScansSkipRuntimeBookkeepingDirs(t *testing.T) {
 	}
 }
 
+// TestStoreScansSkipDirectoriesWithoutFeatureRecord pins that directories
+// left behind after a feature is deleted do not poison feature listing or
+// relationship reads. A directory is a feature record only while its
+// feature.yaml exists; malformed records that do exist must still fail closed.
+func TestStoreScansSkipDirectoriesWithoutFeatureRecord(t *testing.T) {
+	t.Parallel()
+	// parallel-candidate: per-test temp dirs and mocks isolate filesystem and collaborator state.
+	dir := t.TempDir()
+	store := NewStore(dir)
+
+	parent := &Feature{ID: "parent-001", Name: "Parent", Slug: "parent", Status: StatusCreated, SchemaVersion: SchemaVersionCurrent}
+	if err := store.Save(parent); err != nil {
+		t.Fatalf("save parent: %v", err)
+	}
+	deletedDir := filepath.Join(dir, "deleted-002")
+	if err := os.MkdirAll(deletedDir, 0o755); err != nil {
+		t.Fatalf("mkdir deleted feature residue: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(deletedDir, "events.jsonl"), []byte("{}\n"), 0o644); err != nil {
+		t.Fatalf("write deleted feature residue: %v", err)
+	}
+
+	features, err := store.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(features) != 1 || features[0].ID != parent.ID {
+		t.Fatalf("features = %+v, want only %s", features, parent.ID)
+	}
+	if _, err := store.AllRelationshipChildren(); err != nil {
+		t.Fatalf("AllRelationshipChildren: %v", err)
+	}
+	if _, err := store.RelationshipChildren(parent.ID); err != nil {
+		t.Fatalf("RelationshipChildren: %v", err)
+	}
+}
+
+func TestStoreScansDoNotIgnoreFeatureWithMissingActiveRun(t *testing.T) {
+	t.Parallel()
+	// parallel-candidate: per-test temp dirs and mocks isolate filesystem and collaborator state.
+	dir := t.TempDir()
+	store := NewStore(dir)
+
+	broken := &Feature{ID: "broken-001", Name: "Broken", Slug: "broken", Status: StatusCreated, SchemaVersion: SchemaVersionCurrent}
+	if err := store.Save(broken); err != nil {
+		t.Fatalf("save broken feature: %v", err)
+	}
+	if err := os.Remove(filepath.Join(store.RunDir(broken.ID, broken.ActiveRun), "run.yaml")); err != nil {
+		t.Fatalf("remove active run: %v", err)
+	}
+
+	if _, err := store.List(); err == nil || !IsPartialLoadError(err) {
+		t.Fatalf("List error = %v, want partial load error", err)
+	}
+	if _, err := store.AllRelationshipChildren(); err == nil {
+		t.Fatal("AllRelationshipChildren error = nil, want missing active run failure")
+	}
+}
+
+// TestStoreDeleteRemovesReadOnlyArtifacts locks in that Delete succeeds even
+// when run artifacts include read-only directories, which can otherwise leave
+// feature debris after feature.yaml has already been removed.
+func TestStoreDeleteRemovesReadOnlyArtifacts(t *testing.T) {
+	t.Parallel()
+	// parallel-candidate: per-test temp dirs and mocks isolate filesystem and collaborator state.
+	dir := t.TempDir()
+	store := NewStore(dir)
+
+	f := &Feature{ID: "to-delete", Name: "Delete Me", Slug: "delete-me", SchemaVersion: SchemaVersionCurrent}
+	if err := store.Save(f); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	cache := filepath.Join(dir, f.ID, "runs", "run-001", "build-cache", "mod")
+	if err := os.MkdirAll(cache, 0o755); err != nil {
+		t.Fatalf("mkdir cache: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cache, "cached.go"), []byte("x"), 0o444); err != nil {
+		t.Fatalf("write cached artifact: %v", err)
+	}
+	if err := os.Chmod(cache, 0o555); err != nil {
+		t.Fatalf("chmod cache: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(cache, 0o755) })
+
+	if err := store.Delete(f.ID); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, f.ID)); !os.IsNotExist(err) {
+		t.Fatalf("Stat after delete = %v, want not-exist", err)
+	}
+}
+
 func TestStoreReadPathsDoNotWaitForInFlightModify(t *testing.T) {
 	const featureNameOriginal = "Original"
 

--- a/internal/orchestrator/cascade_delete_internal_test.go
+++ b/internal/orchestrator/cascade_delete_internal_test.go
@@ -181,6 +181,21 @@ func TestReconcileCascadeDeletesEmitsChangedNonTerminalRelationshipState(t *test
 	}
 }
 
+func TestReconcileCascadeDeletesIgnoresDeletedFeatureResidue(t *testing.T) {
+	t.Parallel()
+
+	store, _, _ := saveCascadeTestRelationship(t)
+	residue := filepath.Join(store.BaseDir, "deleted-feature", "runs", "run-001")
+	if err := os.MkdirAll(residue, 0o755); err != nil {
+		t.Fatalf("mkdir deleted feature residue: %v", err)
+	}
+	o := New(Deps{Store: store, Worktrees: &cascadeTestWorktrees{store: store}}, Hooks{})
+
+	if err := o.ReconcileCascadeDeletes(); err != nil {
+		t.Fatalf("ReconcileCascadeDeletes() error = %v, want deleted residue ignored", err)
+	}
+}
+
 func TestDeleteCascadeCleansChildrenThenParentAndConverges(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Retry feature and orphan-run deletion after restoring owner access to read-only artifact directories.
- Ignore directories without an authoritative `feature.yaml` during feature and relationship scans.
- Preserve fail-closed behavior for records whose `feature.yaml` exists but whose YAML or active run is corrupt.

## Root cause

`os.RemoveAll` could remove `feature.yaml` and then fail on a read-only nested run artifact. The half-deleted directory was subsequently treated as a corrupt feature by startup cascade recovery and relationship history reads.

## Verification

- Fast suite: `make test-fast`
- Isolated integration: `go test ./test/integration/... -count=1`
- E2E Go (process-launch / API-driven): `go test ./test/e2e/... -count=1 -race`
- Go static-analysis gate: `go vet ./...`
- Go build gate: `go build ./...`

Generated with [Codex](https://openai.com/codex/).

Co-authored-by: Codex <noreply@openai.com>
