### PR TITLE
Harden git lock recovery after child integration

### DIFF
--- a/internal/git/ancestor.go
+++ b/internal/git/ancestor.go
@@ -14,10 +14,6 @@
 
 package git
 
-import (
-	"os/exec"
-)
-
 // IsAncestor reports whether ancestor is an ancestor of descendant in the
 // repository at repoPath. It shells out to
 // `git merge-base --is-ancestor <ancestor> <descendant>`, which exits 0 when
@@ -32,7 +28,7 @@ func IsAncestor(repoPath, ancestor, descendant string) bool {
 	if ancestor == "" || descendant == "" {
 		return false
 	}
-	cmd := exec.Command("git", "-C", repoPath, "merge-base", "--is-ancestor", ancestor, descendant)
+	cmd := readGitCmd(repoPath, "merge-base", "--is-ancestor", ancestor, descendant)
 	if err := cmd.Run(); err != nil {
 		return false
 	}

--- a/internal/git/branch.go
+++ b/internal/git/branch.go
@@ -29,7 +29,7 @@ func BranchName(featureSlug string) string {
 // BranchExistsOnRemote checks whether a branch exists on the origin remote.
 // Returns false if the remote is unreachable or not configured.
 func BranchExistsOnRemote(repoPath, branch string) bool {
-	cmd := exec.Command("git", "-C", repoPath, "ls-remote", "--heads", "origin", "refs/heads/"+branch)
+	cmd := readGitCmd(repoPath, "ls-remote", "--heads", "origin", "refs/heads/"+branch)
 	out, err := cmd.Output()
 	if err != nil {
 		return false
@@ -39,7 +39,7 @@ func BranchExistsOnRemote(repoPath, branch string) bool {
 
 // HasOriginRemote returns true if the repo at repoPath has an "origin" remote configured.
 func HasOriginRemote(repoPath string) bool {
-	cmd := exec.Command("git", "-C", repoPath, "remote")
+	cmd := readGitCmd(repoPath, "remote")
 	out, err := cmd.Output()
 	if err != nil {
 		return false

--- a/internal/git/cleanliness.go
+++ b/internal/git/cleanliness.go
@@ -113,6 +113,10 @@ func (w *WorktreeManager) InspectCleanliness(worktreePath string, maxPerCategory
 // never as a clean worktree.
 var ErrCleanlinessUnknown = errors.New("git worktree cleanliness is unknown")
 
+// ErrWorktreeBusy reports that a cached read probe yielded to an in-flight
+// worktree mutation. It provides no evidence about repository cleanliness.
+var ErrWorktreeBusy = errors.New("git worktree mutation is in progress")
+
 // CleanlinessInspector is the InspectCleanliness surface CleanlinessCache
 // decorates.
 type CleanlinessInspector interface {
@@ -141,6 +145,9 @@ func NewCleanlinessCache(inspector CleanlinessInspector) *CleanlinessCache {
 	c := &CleanlinessCache{}
 	c.cache = NewProbeCache(0, 0, func(key string) cleanlinessResult {
 		path, maxPerCategory := splitCleanlinessKey(key)
+		if worktreeMutationInProgress(path) {
+			return cleanlinessResult{err: ErrWorktreeBusy}
+		}
 		report, err := inspector.InspectCleanliness(path, maxPerCategory)
 		if err == nil && report == nil {
 			err = ErrCleanlinessUnknown

--- a/internal/git/delivery.go
+++ b/internal/git/delivery.go
@@ -15,7 +15,6 @@
 package git
 
 import (
-	"os/exec"
 	"strconv"
 	"strings"
 )
@@ -39,11 +38,11 @@ func PendingAgainst(worktreePath, dest string) (PendingWork, bool) {
 	if worktreePath == "" || dest == "" {
 		return PendingWork{}, false
 	}
-	verify := exec.Command("git", "-C", worktreePath, "rev-parse", "--verify", "--quiet", dest+"^{commit}")
+	verify := readGitCmd(worktreePath, "rev-parse", "--verify", "--quiet", dest+"^{commit}")
 	if err := verify.Run(); err != nil {
 		return PendingWork{}, false
 	}
-	out, err := exec.Command("git", "--no-optional-locks", "-C", worktreePath,
+	out, err := readGitCmd(worktreePath,
 		"rev-list", "--left-right", "--count", "HEAD..."+dest).Output()
 	if err != nil {
 		return PendingWork{}, false

--- a/internal/git/diff_preview.go
+++ b/internal/git/diff_preview.go
@@ -18,7 +18,6 @@ import (
 	"crypto/sha1"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -92,7 +91,7 @@ func BranchDiffPreviews(worktreePath, baseBranch string) ([]DiffPreview, error) 
 // base branch (committed + uncommitted tracked changes), plus untracked
 // files which git diff does not see.
 func branchDiffEntries(worktreePath, base string) ([]statusEntry, error) {
-	out, err := exec.Command("git", "-C", worktreePath, "diff", "--find-renames", "--no-ext-diff", "--name-status", base).CombinedOutput()
+	out, err := readGitCmd(worktreePath, "diff", "--find-renames", "--no-ext-diff", "--name-status", base).CombinedOutput()
 	if err != nil {
 		return nil, fmt.Errorf("git diff --name-status %s: %s: %w", base, strings.TrimSpace(string(out)), err)
 	}
@@ -138,7 +137,7 @@ func parseNameStatus(out string) []statusEntry {
 }
 
 func untrackedEntries(worktreePath string) ([]statusEntry, error) {
-	out, err := exec.Command("git", "-C", worktreePath, "status", "--porcelain").CombinedOutput()
+	out, err := readGitCmd(worktreePath, "status", "--porcelain").CombinedOutput()
 	if err != nil {
 		return nil, fmt.Errorf("git status --porcelain: %s: %w", strings.TrimSpace(string(out)), err)
 	}
@@ -167,12 +166,12 @@ func branchEntryPatch(worktreePath, base string, entry statusEntry) (string, err
 			return untracked, nil
 		}
 	}
-	args := []string{"-C", worktreePath, "diff", "--find-renames", "--no-ext-diff", "--unified=3", base, "--"}
+	args := []string{"diff", "--find-renames", "--no-ext-diff", "--unified=3", base, "--"}
 	if entry.oldPath != "" {
 		args = append(args, entry.oldPath)
 	}
 	args = append(args, entry.path)
-	cmd := exec.Command("git", args...)
+	cmd := readGitCmd(worktreePath, args...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return "", fmt.Errorf("git diff preview %s: %s: %w", entry.path, strings.TrimSpace(string(out)), err)
@@ -253,7 +252,7 @@ func SingleFileDiffPreview(worktreePath, baseBranch, relPath string) (*DiffPrevi
 // singleFileBranchStatus checks whether a specific file differs from the base
 // branch (tracked) or is untracked. Returns nil if the file has no changes.
 func singleFileBranchStatus(worktreePath, base, relPath string) (*statusEntry, error) {
-	out, err := exec.Command("git", "-C", worktreePath, "diff", "--find-renames", "--no-ext-diff", "--name-status", base, "--", relPath).CombinedOutput()
+	out, err := readGitCmd(worktreePath, "diff", "--find-renames", "--no-ext-diff", "--name-status", base, "--", relPath).CombinedOutput()
 	if err != nil {
 		return nil, fmt.Errorf("git diff --name-status %s -- %s: %s: %w", base, relPath, strings.TrimSpace(string(out)), err)
 	}
@@ -261,7 +260,7 @@ func singleFileBranchStatus(worktreePath, base, relPath string) (*statusEntry, e
 	if len(entries) > 0 {
 		return &entries[0], nil
 	}
-	statusOut, err := exec.Command("git", "-C", worktreePath, "status", "--porcelain", "--", relPath).CombinedOutput()
+	statusOut, err := readGitCmd(worktreePath, "status", "--porcelain", "--", relPath).CombinedOutput()
 	if err != nil {
 		return nil, fmt.Errorf("git status %s: %s: %w", relPath, strings.TrimSpace(string(statusOut)), err)
 	}

--- a/internal/git/freshness.go
+++ b/internal/git/freshness.go
@@ -30,7 +30,10 @@ func RepoFreshness(worktreePath string) string {
 	if worktreePath == "" {
 		return FreshnessUnknown
 	}
-	if out, _, err := runProbe("--no-optional-locks", "-C", worktreePath, "status", "--porcelain"); err != nil {
+	if worktreeMutationInProgress(worktreePath) {
+		return FreshnessUnknown
+	}
+	if out, _, err := runProbe("-C", worktreePath, "status", "--porcelain"); err != nil {
 		return FreshnessUnknown
 	} else if strings.TrimSpace(string(out)) != "" {
 		return FreshnessLocalChanges

--- a/internal/git/merge_candidate.go
+++ b/internal/git/merge_candidate.go
@@ -84,7 +84,7 @@ func CreateMergeCandidate(mainRepo, parentTip, childHead, message string) (*Merg
 	}
 
 	// Capture the resulting merge commit SHA.
-	headCmd := exec.Command("git", "-C", tmpWorktree, "rev-parse", "HEAD")
+	headCmd := readGitCmd(tmpWorktree, "rev-parse", "HEAD")
 	headOut, err := headCmd.Output()
 	if err != nil {
 		return nil, fmt.Errorf("capturing merge candidate HEAD: %w", err)
@@ -95,7 +95,7 @@ func CreateMergeCandidate(mainRepo, parentTip, childHead, message string) (*Merg
 	}
 
 	// Verify the merge commit has exactly two parents.
-	parentsCmd := exec.Command("git", "-C", tmpWorktree, "rev-list", "--parents", "-n", "1", "HEAD")
+	parentsCmd := readGitCmd(tmpWorktree, "rev-list", "--parents", "-n", "1", "HEAD")
 	parentsOut, err := parentsCmd.Output()
 	if err != nil {
 		return nil, fmt.Errorf("verifying merge parents: %w", err)
@@ -123,7 +123,7 @@ func (e *MergeCandidateConflictError) Error() string {
 // extractConflictFiles reads the conflict file list from a worktree with an
 // in-progress merge.
 func extractConflictFiles(worktreePath string) []string {
-	cmd := exec.Command("git", "-C", worktreePath, "diff", "--name-only", "--diff-filter=U")
+	cmd := readGitCmd(worktreePath, "diff", "--name-only", "--diff-filter=U")
 	out, err := cmd.Output()
 	if err != nil {
 		return nil

--- a/internal/git/merge_state.go
+++ b/internal/git/merge_state.go
@@ -64,7 +64,7 @@ func ConflictMarkerFiles(worktreePath string) ([]string, error) {
 	patterns := []string{start, mid, end}
 	matches := make(map[string]int)
 	for _, pattern := range patterns {
-		cmd := exec.Command("git", "-C", worktreePath, "grep", "-l",
+		cmd := readGitCmd(worktreePath, "grep", "-l",
 			"-e", pattern, "--", ".")
 		out, err := cmd.CombinedOutput()
 		if err != nil {

--- a/internal/git/probe.go
+++ b/internal/git/probe.go
@@ -51,7 +51,7 @@ func runProbe(args ...string) (out []byte, timedOut bool, err error) {
 func runProbeBounded(timeout time.Duration, args ...string) (out []byte, timedOut bool, err error) {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
-	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd := probeGitCmd(ctx, args...)
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	cmd.Cancel = func() error {
 		if killErr := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL); !errors.Is(killErr, syscall.ESRCH) {
@@ -63,4 +63,18 @@ func runProbeBounded(timeout time.Duration, args ...string) (out []byte, timedOu
 	cmd.WaitDelay = time.Second
 	out, err = cmd.Output()
 	return out, errors.Is(ctx.Err(), context.DeadlineExceeded), err
+}
+
+func probeGitCmd(ctx context.Context, args ...string) *exec.Cmd {
+	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd.Env = append(cmd.Environ(), "GIT_OPTIONAL_LOCKS=0")
+	return cmd
+}
+
+// readGitCmd constructs a read-only Git command that cannot take optional
+// locks, including the index refresh lock used by commands such as status.
+func readGitCmd(dir string, args ...string) *exec.Cmd {
+	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	cmd.Env = append(cmd.Environ(), "GIT_OPTIONAL_LOCKS=0")
+	return cmd
 }

--- a/internal/git/probe_cache_test.go
+++ b/internal/git/probe_cache_test.go
@@ -258,6 +258,34 @@ func TestFreshnessCacheServesEntryWithoutProbing(t *testing.T) {
 	}
 }
 
+func TestCachedProbesYieldToWorktreeMutation(t *testing.T) {
+	path := t.TempDir()
+	mu := worktreeMutationLock(path)
+	mu.Lock()
+
+	inspector := &stubCleanlinessInspector{report: &CleanlinessReport{}}
+	cache := NewCleanlinessCache(inspector)
+	report, err := cache.InspectCleanliness(path, 0)
+	if report != nil || !errors.Is(err, ErrWorktreeBusy) {
+		t.Fatalf("busy cleanliness = (%+v, %v), want nil ErrWorktreeBusy", report, err)
+	}
+	if got := inspector.calls.Load(); got != 0 {
+		t.Fatalf("inspector ran %d times while mutation lock held, want 0", got)
+	}
+	if got := RepoFreshness(path); got != FreshnessUnknown {
+		t.Fatalf("busy RepoFreshness() = %q, want unknown", got)
+	}
+
+	mu.Unlock()
+	cache = NewCleanlinessCache(inspector)
+	if _, err := cache.InspectCleanliness(path, 0); err != nil {
+		t.Fatalf("InspectCleanliness() after release error = %v", err)
+	}
+	if got := inspector.calls.Load(); got != 1 {
+		t.Fatalf("inspector ran %d times after release, want 1", got)
+	}
+}
+
 type stubCleanlinessInspector struct {
 	report  *CleanlinessReport
 	err     error

--- a/internal/git/probe_test.go
+++ b/internal/git/probe_test.go
@@ -15,6 +15,7 @@
 package git
 
 import (
+	"context"
 	"errors"
 	"os"
 	"os/exec"
@@ -75,6 +76,24 @@ func TestRepoFreshnessStatusTimeoutIsUnknown(t *testing.T) {
 	}
 	if elapsed > 5*time.Second {
 		t.Errorf("RepoFreshness() took %v; want bounded by ProbeTimeout", elapsed)
+	}
+}
+
+func TestReadOnlyGitCommandsDisableOptionalLocks(t *testing.T) {
+	for name, cmd := range map[string]*exec.Cmd{
+		"bounded probe": probeGitCmd(context.Background(), "status"),
+		"read command":  readGitCmd(t.TempDir(), "status"),
+	} {
+		found := false
+		for _, env := range cmd.Env {
+			if env == "GIT_OPTIONAL_LOCKS=0" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("%s environment does not disable optional locks", name)
+		}
 	}
 }
 

--- a/internal/git/publish.go
+++ b/internal/git/publish.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -30,11 +31,29 @@ import (
 // git-push operations (e.g. when corporate hooks block pushes to local repos).
 var PushFunc = defaultPush
 
-const (
+var (
 	indexLockRetryWindow       = 5 * time.Second
 	indexLockRetryInitialDelay = 25 * time.Millisecond
 	indexLockRetryMaxDelay     = 250 * time.Millisecond
+	gitLockStaleAfter          = 10 * time.Minute
 )
+
+var gitLockPathPattern = regexp.MustCompile(`(?i)'([^']+\.lock)'`)
+
+// GitLockContentionError reports a Git mutation that exhausted its retry
+// window while a known lock remained in place.
+type GitLockContentionError struct {
+	LockPath string
+	Age      time.Duration
+}
+
+func (e *GitLockContentionError) Error() string {
+	age := e.Age.Round(time.Second)
+	if e.Age > gitLockStaleAfter {
+		return fmt.Sprintf("stale git lock (%s old) at %s", age, e.LockPath)
+	}
+	return fmt.Sprintf("git lock contention (%s old) at %s", age, e.LockPath)
+}
 
 var worktreeMutationLocks sync.Map
 
@@ -95,7 +114,7 @@ func DiffSummary(worktreePath string, baseBranch ...string) (string, error) {
 	}
 
 	// Uncommitted diff: working tree changes not yet committed (tracked files)
-	cmd := exec.Command("git", "-C", worktreePath, "diff", "HEAD")
+	cmd := readGitCmd(worktreePath, "diff", "HEAD")
 	out, err := cmd.CombinedOutput()
 	if err == nil && len(strings.TrimSpace(string(out))) > 0 {
 		parts = append(parts, string(out))
@@ -116,7 +135,7 @@ func DiffSummary(worktreePath string, baseBranch ...string) (string, error) {
 }
 
 func diffRange(worktreePath, rangeSpec string) (string, error) {
-	cmd := exec.Command("git", "-C", worktreePath, "diff", rangeSpec)
+	cmd := readGitCmd(worktreePath, "diff", rangeSpec)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return "", err
@@ -129,7 +148,7 @@ func diffRange(worktreePath, rangeSpec string) (string, error) {
 
 // untrackedFilesDiff generates a unified diff representation for untracked files.
 func untrackedFilesDiff(worktreePath string) (string, error) {
-	cmd := exec.Command("git", "-C", worktreePath, "ls-files", "--others", "--exclude-standard")
+	cmd := readGitCmd(worktreePath, "ls-files", "--others", "--exclude-standard")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return "", err
@@ -168,7 +187,7 @@ func untrackedFilesDiff(worktreePath string) (string, error) {
 // HasUncommittedChanges returns true if the worktree has staged, unstaged,
 // or untracked changes.
 func HasUncommittedChanges(worktreePath string) bool {
-	cmd := exec.Command("git", "-C", worktreePath, "status", "--porcelain")
+	cmd := readGitCmd(worktreePath, "status", "--porcelain")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return false
@@ -183,12 +202,12 @@ func CommitAll(worktreePath, message string) error {
 	mu.Lock()
 	defer mu.Unlock()
 
-	if out, err := runGitMutationWithIndexLockRetry(worktreePath, "add", "-A"); err != nil {
+	if out, err := runGitMutationWithLockRetry(worktreePath, "add", "-A"); err != nil {
 		return fmt.Errorf("staging changes: %s: %w", strings.TrimSpace(string(out)), err)
 	}
 	// Append Agentic signature trailer
 	message = message + "\n\n" + CommitSignatureTrailer
-	if out, err := runGitMutationWithIndexLockRetry(worktreePath, "commit", "-m", message); err != nil {
+	if out, err := runGitMutationWithLockRetry(worktreePath, "commit", "-m", message); err != nil {
 		return fmt.Errorf("creating commit: %s: %w", strings.TrimSpace(string(out)), err)
 	}
 	return nil
@@ -202,10 +221,10 @@ func CommitAllAndGetHead(worktreePath, message string) (string, error) {
 	mu.Lock()
 	defer mu.Unlock()
 
-	if out, err := runGitMutationWithIndexLockRetry(worktreePath, "add", "-A"); err != nil {
+	if out, err := runGitMutationWithLockRetry(worktreePath, "add", "-A"); err != nil {
 		return "", fmt.Errorf("staging changes: %s: %w", strings.TrimSpace(string(out)), err)
 	}
-	status := exec.Command("git", "-C", worktreePath, "status", "--porcelain")
+	status := readGitCmd(worktreePath, "status", "--porcelain")
 	out, err := status.CombinedOutput()
 	if err != nil {
 		return "", fmt.Errorf("checking staged changes: %s: %w", strings.TrimSpace(string(out)), err)
@@ -214,7 +233,7 @@ func CommitAllAndGetHead(worktreePath, message string) (string, error) {
 		return CurrentHeadSHA(worktreePath)
 	}
 	message = message + "\n\n" + CommitSignatureTrailer
-	if out, err := runGitMutationWithIndexLockRetry(worktreePath, "commit", "-m", message); err != nil {
+	if out, err := runGitMutationWithLockRetry(worktreePath, "commit", "-m", message); err != nil {
 		return "", fmt.Errorf("creating commit: %s: %w", strings.TrimSpace(string(out)), err)
 	}
 	return CurrentHeadSHA(worktreePath)
@@ -226,16 +245,53 @@ func worktreeMutationLock(worktreePath string) *sync.Mutex {
 	return actual.(*sync.Mutex)
 }
 
-// runGitMutationWithIndexLockRetry tolerates a short-lived lock held by
-// another Git process. It never removes the lock: a lock that remains beyond
-// the retry window is reported with Git's original diagnostic.
-func runGitMutationWithIndexLockRetry(worktreePath string, args ...string) ([]byte, error) {
+func worktreeMutationInProgress(worktreePath string) bool {
+	mu := worktreeMutationLock(worktreePath)
+	if mu.TryLock() {
+		mu.Unlock()
+		return false
+	}
+	return true
+}
+
+// runGitMutationWithLockRetry tolerates short-lived Git locks and removes one
+// stale lock per invocation when Git reports its concrete path. Fresh locks
+// remain untouched and are retried only within the bounded window.
+func runGitMutationWithLockRetry(worktreePath string, args ...string) ([]byte, error) {
+	return runGitMutationWithLockRetryStdin(worktreePath, "", args...)
+}
+
+func runGitMutationWithLockRetryStdin(worktreePath, stdin string, args ...string) ([]byte, error) {
 	deadline := time.Now().Add(indexLockRetryWindow)
 	delay := indexLockRetryInitialDelay
+	removedStaleLock := false
 	for {
 		cmdArgs := append([]string{"-C", worktreePath}, args...)
-		out, err := exec.Command("git", cmdArgs...).CombinedOutput()
-		if err == nil || !isIndexLockContention(out) || !time.Now().Before(deadline) {
+		cmd := exec.Command("git", cmdArgs...)
+		if stdin != "" {
+			cmd.Stdin = strings.NewReader(stdin)
+		}
+		out, err := cmd.CombinedOutput()
+		lockPath, contention := lockContention(out)
+		if err == nil || !contention {
+			return out, err
+		}
+		lockAge := time.Duration(0)
+		if lockPath != "" && strings.HasSuffix(filepath.Base(lockPath), ".lock") {
+			if info, statErr := os.Stat(lockPath); statErr == nil {
+				lockAge = time.Since(info.ModTime())
+				if !removedStaleLock && lockAge > gitLockStaleAfter {
+					removedStaleLock = true
+					if removeErr := os.Remove(lockPath); removeErr == nil || os.IsNotExist(removeErr) {
+						continue
+					}
+				}
+			}
+		}
+		if !time.Now().Before(deadline) {
+			if lockPath != "" {
+				return out, &GitLockContentionError{LockPath: lockPath, Age: lockAge}
+			}
 			return out, err
 		}
 
@@ -253,15 +309,23 @@ func runGitMutationWithIndexLockRetry(worktreePath string, args ...string) ([]by
 	}
 }
 
-func isIndexLockContention(out []byte) bool {
+func lockContention(out []byte) (string, bool) {
 	msg := strings.ToLower(string(out))
-	return strings.Contains(msg, "index.lock") &&
-		(strings.Contains(msg, "file exists") || strings.Contains(msg, "unable to create"))
+	if !strings.Contains(msg, ".lock") ||
+		!(strings.Contains(msg, "file exists") || strings.Contains(msg, "unable to create") ||
+			strings.Contains(msg, "cannot lock") || strings.Contains(msg, "could not lock")) {
+		return "", false
+	}
+	match := gitLockPathPattern.FindSubmatch(out)
+	if len(match) == 2 {
+		return string(match[1]), true
+	}
+	return "", true
 }
 
 // CurrentHeadSHA returns the full SHA of HEAD in the given worktree.
 func CurrentHeadSHA(worktreePath string) (string, error) {
-	cmd := exec.Command("git", "-C", worktreePath, "rev-parse", "HEAD")
+	cmd := readGitCmd(worktreePath, "rev-parse", "HEAD")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return "", fmt.Errorf("getting HEAD SHA: %s: %w", strings.TrimSpace(string(out)), err)
@@ -291,7 +355,7 @@ func ClosePR(prURL string) error {
 // description generation where the short oneline log is not descriptive enough.
 func CommitBodies(worktreePath string, baseBranch ...string) (string, error) {
 	base := resolveBase(worktreePath, baseBranch...)
-	cmd := exec.Command("git", "-C", worktreePath, "log", "--format=%B%n---commit---", base+"..HEAD")
+	cmd := readGitCmd(worktreePath, "log", "--format=%B%n---commit---", base+"..HEAD")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return "", fmt.Errorf("getting commit bodies: %s: %w", strings.TrimSpace(string(out)), err)
@@ -304,7 +368,7 @@ func CommitBodies(worktreePath string, baseBranch ...string) (string, error) {
 // when the full diff is too large to prompt with.
 func DiffStat(worktreePath string, baseBranch ...string) (string, error) {
 	base := resolveBase(worktreePath, baseBranch...)
-	cmd := exec.Command("git", "-C", worktreePath, "diff", "--stat", base+"...HEAD")
+	cmd := readGitCmd(worktreePath, "diff", "--stat", base+"...HEAD")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return "", fmt.Errorf("getting diff stat: %s: %w", strings.TrimSpace(string(out)), err)
@@ -324,7 +388,7 @@ func resolveBase(worktreePath string, baseBranch ...string) string {
 		base = DefaultBranch(worktreePath)
 	}
 	remoteRef := "refs/remotes/origin/" + base
-	if exec.Command("git", "-C", worktreePath, "show-ref", "--verify", "--quiet", remoteRef).Run() == nil {
+	if readGitCmd(worktreePath, "show-ref", "--verify", "--quiet", remoteRef).Run() == nil {
 		return "origin/" + base
 	}
 	return base

--- a/internal/git/publish_test.go
+++ b/internal/git/publish_test.go
@@ -16,6 +16,7 @@ package git
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -28,6 +29,104 @@ import (
 
 	"github.com/doordash-oss/agentic-orchestrator/test/testutil"
 )
+
+func TestLockContentionRecognizesGitLockDiagnostics(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		msg  string
+		path string
+		ok   bool
+	}{
+		{name: "index file exists", msg: "fatal: Unable to create '/repo/.git/index.lock': File exists.", path: "/repo/.git/index.lock", ok: true},
+		{name: "ref cannot lock", msg: "fatal: cannot lock ref 'refs/heads/main': Unable to create '/repo/.git/refs/heads/main.lock': File exists.", path: "/repo/.git/refs/heads/main.lock", ok: true},
+		{name: "packed refs could not lock", msg: "error: could not lock config file '/repo/.git/packed-refs.lock': File exists", path: "/repo/.git/packed-refs.lock", ok: true},
+		{name: "case insensitive", msg: "FATAL: UNABLE TO CREATE '/repo/.git/HEAD.LOCK': FILE EXISTS", path: "/repo/.git/HEAD.LOCK", ok: true},
+		{name: "unquoted retry only", msg: "cannot lock shallow.lock: file exists", ok: true},
+		{name: "unrelated failure", msg: "fatal: not a git repository", ok: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			path, ok := lockContention([]byte(tt.msg))
+			if ok != tt.ok || path != tt.path {
+				t.Fatalf("lockContention(%q) = (%q, %v), want (%q, %v)", tt.msg, path, ok, tt.path, tt.ok)
+			}
+		})
+	}
+}
+
+func TestResetToCommitClearsStaleIndexLock(t *testing.T) {
+	repo := testutil.InitGitRepo(t)
+	anchor := testutil.CommitFile(t, repo, "anchor.txt", "anchor\n", "anchor")
+	testutil.CommitFile(t, repo, "later.txt", "later\n", "later")
+	lockPath := strings.TrimSpace(string(mustGitOutput(t, repo, "rev-parse", "--git-path", "index.lock")))
+	if !filepath.IsAbs(lockPath) {
+		lockPath = filepath.Join(repo, lockPath)
+	}
+	if err := os.WriteFile(lockPath, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	old := time.Now().Add(-time.Hour)
+	if err := os.Chtimes(lockPath, old, old); err != nil {
+		t.Fatal(err)
+	}
+
+	mgr := NewWorktreeManager(t.TempDir())
+	if err := mgr.ResetToCommit(repo, anchor); err != nil {
+		t.Fatalf("ResetToCommit() error = %v, want stale lock recovered", err)
+	}
+	if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
+		t.Fatalf("stale lock still exists, stat error = %v", err)
+	}
+}
+
+func TestResetToCommitPreservesFreshIndexLockAndReturnsTypedError(t *testing.T) {
+	repo := testutil.InitGitRepo(t)
+	anchor := testutil.CommitFile(t, repo, "anchor.txt", "anchor\n", "anchor")
+	testutil.CommitFile(t, repo, "later.txt", "later\n", "later")
+	lockPath := strings.TrimSpace(string(mustGitOutput(t, repo, "rev-parse", "--git-path", "index.lock")))
+	if !filepath.IsAbs(lockPath) {
+		lockPath = filepath.Join(repo, lockPath)
+	}
+	if err := os.WriteFile(lockPath, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	previousWindow, previousInitial, previousMax := indexLockRetryWindow, indexLockRetryInitialDelay, indexLockRetryMaxDelay
+	indexLockRetryWindow = 30 * time.Millisecond
+	indexLockRetryInitialDelay = time.Millisecond
+	indexLockRetryMaxDelay = 5 * time.Millisecond
+	t.Cleanup(func() {
+		indexLockRetryWindow = previousWindow
+		indexLockRetryInitialDelay = previousInitial
+		indexLockRetryMaxDelay = previousMax
+	})
+
+	err := NewWorktreeManager(t.TempDir()).ResetToCommit(repo, anchor)
+	var lockErr *GitLockContentionError
+	if !errors.As(err, &lockErr) {
+		t.Fatalf("ResetToCommit() error = %v, want *GitLockContentionError", err)
+	}
+	wantInfo, wantErr := os.Stat(lockPath)
+	gotInfo, gotErr := os.Stat(lockErr.LockPath)
+	if wantErr != nil || gotErr != nil || !os.SameFile(wantInfo, gotInfo) {
+		t.Fatalf("lock path = %q, want same file as %q (stat errors %v, %v)", lockErr.LockPath, lockPath, gotErr, wantErr)
+	}
+	if _, err := os.Stat(lockPath); err != nil {
+		t.Fatalf("fresh lock was removed: %v", err)
+	}
+}
+
+func mustGitOutput(t *testing.T, dir string, args ...string) []byte {
+	t.Helper()
+	out, err := exec.Command("git", append([]string{"-C", dir}, args...)...).CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, out)
+	}
+	return out
+}
 
 func TestDiffSummary_MixedChanges(t *testing.T) {
 	t.Parallel()

--- a/internal/git/rebase.go
+++ b/internal/git/rebase.go
@@ -61,7 +61,7 @@ func PullRebase(worktreePath, branch string) PullRebaseResult {
 	}
 
 	// 2. Check if origin/<branch> exists
-	verifyCmd := exec.Command("git", "-C", worktreePath, "rev-parse", "--verify", "origin/"+branch)
+	verifyCmd := readGitCmd(worktreePath, "rev-parse", "--verify", "origin/"+branch)
 	if err := verifyCmd.Run(); err != nil {
 		// Remote branch doesn't exist (first publish) — no-op
 		return PullRebaseResult{Outcome: PullRebaseSuccess}
@@ -103,7 +103,7 @@ func PullRebase(worktreePath, branch string) PullRebaseResult {
 // resolveGitDir returns the .git directory for a worktree path.
 // For worktrees, .git is a file pointing to the actual git dir.
 func resolveGitDir(worktreePath string) string {
-	cmd := exec.Command("git", "-C", worktreePath, "rev-parse", "--git-dir")
+	cmd := readGitCmd(worktreePath, "rev-parse", "--git-dir")
 	out, err := cmd.Output()
 	if err != nil {
 		return filepath.Join(worktreePath, ".git")
@@ -186,7 +186,7 @@ func RebaseOnto(worktreePath, target string) RebaseResult {
 
 // listConflictFiles returns the list of files with unmerged conflicts.
 func listConflictFiles(worktreePath string) []string {
-	cmd := exec.Command("git", "-C", worktreePath, "diff", "--name-only", "--diff-filter=U")
+	cmd := readGitCmd(worktreePath, "diff", "--name-only", "--diff-filter=U")
 	out, err := cmd.Output()
 	if err != nil {
 		return nil
@@ -264,7 +264,7 @@ func PRBaseBranch(_ string, prURL string) string {
 // Returns true if there are commits on origin/<baseBranch> not in the local branch.
 func IsBehindRemote(worktreePath, baseBranch string) bool {
 	target := "origin/" + baseBranch
-	cmd := exec.Command("git", "-C", worktreePath, "rev-list", "--count", "HEAD.."+target)
+	cmd := readGitCmd(worktreePath, "rev-list", "--count", "HEAD.."+target)
 	out, err := cmd.Output()
 	if err != nil {
 		return false
@@ -276,7 +276,7 @@ func IsBehindRemote(worktreePath, baseBranch string) bool {
 // identityFallbackArgs returns -c committer-identity fallbacks when neither
 // the repo nor the environment configures one; an explicit identity wins.
 func identityFallbackArgs(repoPath string) []string {
-	out, err := exec.Command("git", "-C", repoPath, "config", "user.email").Output()
+	out, err := readGitCmd(repoPath, "config", "user.email").Output()
 	if err == nil && strings.TrimSpace(string(out)) != "" {
 		return nil
 	}
@@ -347,7 +347,7 @@ func RebaseInProgress(worktreePath string) bool {
 // IsBehindLocal checks if the current branch is behind a local base branch.
 // Returns true if there are commits on baseBranch not in the current branch.
 func IsBehindLocal(worktreePath, baseBranch string) bool {
-	cmd := exec.Command("git", "-C", worktreePath, "rev-list", "--count", "HEAD.."+baseBranch)
+	cmd := readGitCmd(worktreePath, "rev-list", "--count", "HEAD.."+baseBranch)
 	out, err := cmd.Output()
 	if err != nil {
 		return false

--- a/internal/git/ref_cas.go
+++ b/internal/git/ref_cas.go
@@ -16,7 +16,6 @@ package git
 
 import (
 	"fmt"
-	"os/exec"
 	"strings"
 )
 
@@ -35,7 +34,7 @@ func (e *RefCASMismatchError) Error() string {
 // ReadRefSHA returns the full SHA of the named ref (e.g. "refs/heads/main"
 // or "main") in the given repo path, or an error if the ref does not resolve.
 func ReadRefSHA(repoPath, ref string) (string, error) {
-	cmd := exec.Command("git", "-C", repoPath, "rev-parse", "--verify", "--quiet", ref)
+	cmd := readGitCmd(repoPath, "rev-parse", "--verify", "--quiet", ref)
 	out, err := cmd.Output()
 	if err != nil {
 		return "", fmt.Errorf("rev-parse %s in %s: %w", ref, repoPath, err)
@@ -69,9 +68,7 @@ func UpdateRefCAS(repoPath, ref, oldSHA, newSHA string) error {
 	// process moves the ref between our read and the update, git itself
 	// will reject the update.
 	stdin := fmt.Sprintf("update %s %s %s\n", ref, newSHA, oldSHA)
-	cmd := exec.Command("git", "-C", repoPath, "update-ref", "--stdin")
-	cmd.Stdin = strings.NewReader(stdin)
-	out, err := cmd.CombinedOutput()
+	out, err := runGitMutationWithLockRetryStdin(repoPath, stdin, "update-ref", "--stdin")
 	if err != nil {
 		// Re-read to capture the observed SHA for diagnostics.
 		observed, _ := ReadRefSHA(repoPath, ref)

--- a/internal/git/ref_cas_test.go
+++ b/internal/git/ref_cas_test.go
@@ -20,10 +20,43 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	gitpkg "github.com/doordash-oss/agentic-orchestrator/internal/git"
 	"github.com/doordash-oss/agentic-orchestrator/test/testutil"
 )
+
+func TestUpdateRefCASRetriesTransientRefLock(t *testing.T) {
+	repo := testutil.InitGitRepo(t)
+	oldSHA := runGitRefTest(t, repo, "rev-parse", "refs/heads/main")
+	newSHA := testutil.CommitFile(t, repo, "next.txt", "next\n", "next")
+	runGitRefTest(t, repo, "reset", "--hard", oldSHA)
+
+	gitDir := runGitRefTest(t, repo, "rev-parse", "--git-dir")
+	if !filepath.IsAbs(gitDir) {
+		gitDir = filepath.Join(repo, gitDir)
+	}
+	lockPath := filepath.Join(gitDir, "refs", "heads", "main.lock")
+	if err := os.WriteFile(lockPath, nil, 0o644); err != nil {
+		t.Fatalf("create ref lock: %v", err)
+	}
+	released := make(chan struct{})
+	go func() {
+		defer close(released)
+		timer := time.NewTimer(75 * time.Millisecond)
+		defer timer.Stop()
+		<-timer.C
+		_ = os.Remove(lockPath)
+	}()
+	t.Cleanup(func() { <-released })
+
+	if err := gitpkg.UpdateRefCAS(repo, "refs/heads/main", oldSHA, newSHA); err != nil {
+		t.Fatalf("UpdateRefCAS() error = %v, want transient ref lock retried", err)
+	}
+	if got := runGitRefTest(t, repo, "rev-parse", "refs/heads/main"); got != newSHA {
+		t.Fatalf("main = %s, want %s", got, newSHA)
+	}
+}
 
 func runGitRefTest(t *testing.T, dir string, args ...string) string {
 	t.Helper()

--- a/internal/git/remote_url.go
+++ b/internal/git/remote_url.go
@@ -17,7 +17,6 @@ package git
 import (
 	"fmt"
 	"net/url"
-	"os/exec"
 	"strings"
 )
 
@@ -51,7 +50,7 @@ func ParseRemoteURL(remote string) (host, owner, repo string, err error) {
 // originRepo resolves the origin remote of the repo at repoPath into
 // host, owner, and repository name.
 func originRepo(repoPath string) (host, owner, repo string, err error) {
-	cmd := exec.Command("git", "-C", repoPath, "remote", "get-url", "origin")
+	cmd := readGitCmd(repoPath, "remote", "get-url", "origin")
 	out, err := cmd.Output()
 	if err != nil {
 		return "", "", "", fmt.Errorf("reading origin remote: %w", err)

--- a/internal/git/review.go
+++ b/internal/git/review.go
@@ -17,7 +17,6 @@ package git
 import (
 	"fmt"
 	"net/url"
-	"os/exec"
 	"sort"
 	"strconv"
 	"strings"
@@ -230,7 +229,7 @@ func ResolveReviewThread(_ string, threadNodeID string) error {
 
 // LatestCommitSHA returns the short SHA of HEAD in the given directory.
 func LatestCommitSHA(worktreePath string) (string, error) {
-	cmd := exec.Command("git", "-C", worktreePath, "rev-parse", "--short", "HEAD")
+	cmd := readGitCmd(worktreePath, "rev-parse", "--short", "HEAD")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return "", fmt.Errorf("getting HEAD SHA: %s: %w", strings.TrimSpace(string(out)), err)

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -89,7 +89,7 @@ func (w *WorktreeManager) Create(repoPath, featureSlug, repoName, startPoint str
 // hasCommits reports whether the repository has at least one commit (a born
 // HEAD). A freshly initialized repo returns false.
 func hasCommits(repoPath string) bool {
-	cmd := exec.Command("git", "-C", repoPath, "rev-parse", "--verify", "--quiet", "HEAD")
+	cmd := readGitCmd(repoPath, "rev-parse", "--verify", "--quiet", "HEAD")
 	return cmd.Run() == nil
 }
 
@@ -98,7 +98,7 @@ func hasCommits(repoPath string) bool {
 // (main, master).
 func DefaultBranch(repoPath string) string {
 	// Try remote HEAD symref (most reliable for repos with a remote)
-	cmd := exec.Command("git", "-C", repoPath, "symbolic-ref", "refs/remotes/origin/HEAD")
+	cmd := readGitCmd(repoPath, "symbolic-ref", "refs/remotes/origin/HEAD")
 	if out, err := cmd.Output(); err == nil {
 		ref := strings.TrimSpace(string(out))
 		// refs/remotes/origin/main → main
@@ -108,7 +108,7 @@ func DefaultBranch(repoPath string) string {
 	}
 
 	// Check local HEAD symref — works for any repo regardless of remote
-	cmd = exec.Command("git", "-C", repoPath, "symbolic-ref", "HEAD")
+	cmd = readGitCmd(repoPath, "symbolic-ref", "HEAD")
 	if out, err := cmd.Output(); err == nil {
 		ref := strings.TrimSpace(string(out))
 		// refs/heads/trunk → trunk
@@ -119,7 +119,7 @@ func DefaultBranch(repoPath string) string {
 
 	// Fallback: check if main or master branches exist locally
 	for _, name := range []string{"main", "master"} {
-		cmd = exec.Command("git", "-C", repoPath, "rev-parse", "--verify", name)
+		cmd = readGitCmd(repoPath, "rev-parse", "--verify", name)
 		if err := cmd.Run(); err == nil {
 			return name
 		}
@@ -130,7 +130,7 @@ func DefaultBranch(repoPath string) string {
 
 // CurrentBranch returns the branch currently checked out in the given repo.
 func CurrentBranch(repoPath string) string {
-	cmd := exec.Command("git", "-C", repoPath, "rev-parse", "--abbrev-ref", "HEAD")
+	cmd := readGitCmd(repoPath, "rev-parse", "--abbrev-ref", "HEAD")
 	out, err := cmd.Output()
 	if err != nil {
 		return ""
@@ -151,7 +151,7 @@ func CurrentBranch(repoPath string) string {
 // recorded identity instead.
 func (w *WorktreeManager) Remove(worktreePath string, deleteBranch bool) error {
 	// Find the main repo for this worktree
-	cmd := exec.Command("git", "-C", worktreePath, "rev-parse", "--git-common-dir")
+	cmd := readGitCmd(worktreePath, "rev-parse", "--git-common-dir")
 	out, err := cmd.Output()
 	if err != nil {
 		// Worktree may already be gone; just remove the directory. Removing
@@ -167,7 +167,7 @@ func (w *WorktreeManager) Remove(worktreePath string, deleteBranch bool) error {
 	// Get branch name before removing
 	var branch string
 	if deleteBranch {
-		branchCmd := exec.Command("git", "-C", worktreePath, "rev-parse", "--abbrev-ref", "HEAD")
+		branchCmd := readGitCmd(worktreePath, "rev-parse", "--abbrev-ref", "HEAD")
 		branchOut, err := branchCmd.Output()
 		if err == nil {
 			branch = strings.TrimSpace(string(branchOut))
@@ -205,7 +205,7 @@ func (w *WorktreeManager) RemoveRef(worktreePath, mainRepo, branch string) error
 
 	// Delete branch if requested; an already-absent branch is success.
 	if branch != "" && branch != "main" && branch != "master" {
-		verify := exec.Command("git", "-C", mainRepo, "rev-parse", "--verify", "--quiet", "refs/heads/"+branch)
+		verify := readGitCmd(mainRepo, "rev-parse", "--verify", "--quiet", "refs/heads/"+branch)
 		if verify.Run() == nil {
 			delCmd := exec.Command("git", "-C", mainRepo, "branch", "-D", branch)
 			if out, err := delCmd.CombinedOutput(); err != nil {
@@ -229,10 +229,10 @@ func (w *WorktreeManager) ResetToBase(worktreePath, baseBranch string) error {
 	if out, err := fetchCmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("fetching origin/%s: %s: %w", baseBranch, strings.TrimSpace(string(out)), err)
 	}
-	if out, err := runGitMutationWithIndexLockRetry(worktreePath, "reset", "--hard", "origin/"+baseBranch); err != nil {
+	if out, err := runGitMutationWithLockRetry(worktreePath, "reset", "--hard", "origin/"+baseBranch); err != nil {
 		return fmt.Errorf("resetting worktree to %s: %s: %w", baseBranch, strings.TrimSpace(string(out)), err)
 	}
-	if out, err := runGitMutationWithIndexLockRetry(worktreePath, "clean", "-fd"); err != nil {
+	if out, err := runGitMutationWithLockRetry(worktreePath, "clean", "-fd"); err != nil {
 		return fmt.Errorf("cleaning worktree after reset to %s: %s: %w", baseBranch, strings.TrimSpace(string(out)), err)
 	}
 	return nil
@@ -245,10 +245,10 @@ func (w *WorktreeManager) ResetToBaseLocal(worktreePath, baseBranch string) erro
 	mu.Lock()
 	defer mu.Unlock()
 
-	if out, err := runGitMutationWithIndexLockRetry(worktreePath, "reset", "--hard", baseBranch); err != nil {
+	if out, err := runGitMutationWithLockRetry(worktreePath, "reset", "--hard", baseBranch); err != nil {
 		return fmt.Errorf("resetting to local %s: %s: %w", baseBranch, strings.TrimSpace(string(out)), err)
 	}
-	if out, err := runGitMutationWithIndexLockRetry(worktreePath, "clean", "-fd"); err != nil {
+	if out, err := runGitMutationWithLockRetry(worktreePath, "clean", "-fd"); err != nil {
 		return fmt.Errorf("cleaning worktree after reset to local %s: %s: %w", baseBranch, strings.TrimSpace(string(out)), err)
 	}
 	return nil
@@ -261,10 +261,10 @@ func (w *WorktreeManager) ResetToCommit(worktreePath, commitSHA string) error {
 	mu.Lock()
 	defer mu.Unlock()
 
-	if out, err := runGitMutationWithIndexLockRetry(worktreePath, "reset", "--hard", commitSHA); err != nil {
+	if out, err := runGitMutationWithLockRetry(worktreePath, "reset", "--hard", commitSHA); err != nil {
 		return fmt.Errorf("resetting to commit %s: %s: %w", commitSHA, strings.TrimSpace(string(out)), err)
 	}
-	if out, err := runGitMutationWithIndexLockRetry(worktreePath, "clean", "-fd"); err != nil {
+	if out, err := runGitMutationWithLockRetry(worktreePath, "clean", "-fd"); err != nil {
 		return fmt.Errorf("cleaning worktree after reset to commit %s: %s: %w", commitSHA, strings.TrimSpace(string(out)), err)
 	}
 	return nil

--- a/internal/orchestrator/child_integration.go
+++ b/internal/orchestrator/child_integration.go
@@ -167,7 +167,9 @@ func (o *Orchestrator) runTransactionIntegration(childID string, child, parent *
 	// vector, check whether the parent tips have moved. If they moved
 	// cleanly and child code did not change, rebuild the candidate vector.
 	// If child code changed, invalidate final review.
-	if journal != nil && journal.AllCandidatesPrepared() && !journal.AllApplied() {
+	if journal != nil &&
+		(journal.Phase == feature.TransactionPhasePrepared || journal.Phase == feature.TransactionPhaseAttention) &&
+		journal.AllCandidatesPrepared() && !journal.AllApplied() {
 		currentTips, err := o.transactionParentTipVector(parent, journal)
 		if err != nil {
 			return err
@@ -378,7 +380,27 @@ func (o *Orchestrator) closeTransactionAfterApply(childID, parentID string) erro
 			parentWorktree = parentRepo.Path
 		}
 		if err := o.deps.Worktrees.ResetToCommit(parentWorktree, entry.CandidateSHA); err != nil {
-			return fmt.Errorf("syncing parent worktree for repo %s during closure: %w", entry.Repo, err)
+			syncErr := fmt.Errorf("syncing parent worktree for repo %s: %w", entry.Repo, err)
+			if modifyErr := o.deps.Store.Modify(childID, func(f *feature.Feature) error {
+				f.LastError = syncErr.Error()
+				return nil
+			}); modifyErr != nil {
+				return fmt.Errorf("persisting parent worktree sync error: %v (original error: %w)", modifyErr, syncErr)
+			}
+			o.emitEvent(ports.Event{
+				Type:      ports.RelationshipIntegrationChanged,
+				FeatureID: childID,
+				ParentID:  parentID,
+				ChildID:   childID,
+				Message:   "child integration needs attention: " + syncErr.Error(),
+			})
+			return syncErr
+		}
+		if strings.HasPrefix(entry.Diagnostics, "worktree sync pending after apply for repo ") {
+			entry.Diagnostics = ""
+			if err := o.persistTransaction(childID, journal); err != nil {
+				return fmt.Errorf("clearing pending worktree sync for repo %s: %w", entry.Repo, err)
+			}
 		}
 	}
 

--- a/internal/orchestrator/child_transaction.go
+++ b/internal/orchestrator/child_transaction.go
@@ -239,6 +239,8 @@ func (o *Orchestrator) applyTransactionCandidates(child, parent *feature.Feature
 		return fmt.Errorf("recording applying phase: %w", err)
 	}
 
+	pendingWorktreeSync := false
+
 	// Apply each candidate in order. Compare-and-swap: update the parent
 	// branch ref to the candidate SHA only if it still equals the expected
 	// old SHA.
@@ -335,9 +337,9 @@ func (o *Orchestrator) applyTransactionCandidates(child, parent *feature.Feature
 			return o.parkApplyAttention(child, journal, entry, entry.Diagnostics)
 		}
 
-		// Mark the entry as applied immediately after the CAS succeeds so
-		// a crash or worktree-sync failure can recognize and roll back
-		// the ref that was just updated.
+		// Mark the entry as applied immediately after the CAS succeeds so a
+		// crash or worktree-sync failure preserves the durable ref update and
+		// closure can finish syncing it idempotently.
 		entry.ApplyState = feature.RepoApplyApplied
 		entry.MergeHEAD = entry.CandidateSHA
 		entry.ObservedSHA = entry.CandidateSHA
@@ -348,15 +350,19 @@ func (o *Orchestrator) applyTransactionCandidates(child, parent *feature.Feature
 		// Sync the parent worktree to the new ref so the merge commit is
 		// visible in the working directory. The worktree was verified clean
 		// during preparation, so a hard reset is safe. If this fails, the
-		// ref is already at the candidate and must be rolled back —
-		// including this entry, whose CAS succeeded.
+		// ref is already durably at the candidate: preserve the successful
+		// CAS and let the idempotent closure sync retry the worktree.
 		parentWorktree = parentRepo.WorktreePath
 		if parentWorktree == "" {
 			parentWorktree = parentRepo.Path
 		}
 		if err := o.deps.Worktrees.ResetToCommit(parentWorktree, entry.CandidateSHA); err != nil {
-			entry.Diagnostics = fmt.Sprintf("syncing parent worktree after apply for repo %s: %v", entry.Repo, err)
-			return o.rollbackTransaction(child, parent, journal, -1)
+			entry.Diagnostics = fmt.Sprintf("worktree sync pending after apply for repo %s: %v", entry.Repo, err)
+			pendingWorktreeSync = true
+			if err := o.persistTransaction(child.ID, journal); err != nil {
+				return fmt.Errorf("recording pending worktree sync for repo %s: %w", entry.Repo, err)
+			}
+			continue
 		}
 	}
 
@@ -364,6 +370,15 @@ func (o *Orchestrator) applyTransactionCandidates(child, parent *feature.Feature
 	journal.Phase = feature.TransactionPhaseApplied
 	if err := o.persistTransaction(child.ID, journal); err != nil {
 		return fmt.Errorf("recording applied transaction: %w", err)
+	}
+	if pendingWorktreeSync {
+		o.emitEvent(ports.Event{
+			Type:      ports.RelationshipIntegrationChanged,
+			FeatureID: child.ID,
+			ParentID:  child.Parent.ParentID,
+			ChildID:   child.ID,
+			Message:   "worktree sync pending; will retry at closure",
+		})
 	}
 	return nil
 }

--- a/internal/orchestrator/child_transaction_internal_test.go
+++ b/internal/orchestrator/child_transaction_internal_test.go
@@ -661,10 +661,11 @@ type failingResetWorktrees struct {
 	*git.WorktreeManager
 	failRepoDir string
 	failed      bool
+	failAlways  bool
 }
 
 func (w *failingResetWorktrees) ResetToCommit(worktreePath, commitSHA string) error {
-	if !w.failed && worktreePath == w.failRepoDir {
+	if worktreePath == w.failRepoDir && (w.failAlways || !w.failed) {
 		w.failed = true
 		return fmt.Errorf("simulated worktree sync failure")
 	}
@@ -711,12 +712,10 @@ func TestTransactionFirstApplyFailureRollsBack(t *testing.T) {
 	}
 }
 
-// TestTransactionApplySyncFailureRollsBackAll proves a worktree-sync failure
-// after a successful apply CAS compensates ALL applied refs — including the
-// one whose worktree sync failed — so the all-or-nothing transaction invariant
-// holds. Without the fix, the failed repo's ref remains at the candidate while
-// its worktree is stale, violating recoverable compensation.
-func TestTransactionApplySyncFailureRollsBackAll(t *testing.T) {
+// TestTransactionApplySyncFailureContinuesForward proves an environmental
+// worktree-sync failure after a successful CAS preserves the applied ref,
+// finishes the candidate vector, surfaces closure attention, and resumes.
+func TestTransactionApplySyncFailureContinuesForward(t *testing.T) {
 	if testing.Short() {
 		t.Skip("real-git integration test")
 	}
@@ -735,18 +734,13 @@ func TestTransactionApplySyncFailureRollsBackAll(t *testing.T) {
 		t.Fatal("journal is nil")
 	}
 
-	// Record old SHAs for rollback verification.
-	oldSHAs := make([]string, len(journal.Entries))
-	for i := range journal.Entries {
-		oldSHAs[i] = journal.Entries[i].ParentAnchorSHA
-	}
-
 	// Apply with a worktree manager that fails ResetToCommit for repo 1
-	// (the second repo). Repo 0 applies fully (CAS + worktree sync); repo
-	// 1's CAS succeeds but the worktree sync fails; repo 2 is never reached.
+	// (the second repo). The failure persists through the immediate closure
+	// attempt so its durable LastError can be asserted.
 	resetWT := &failingResetWorktrees{
 		WorktreeManager: fx.wm,
 		failRepoDir:     fx.repoDirs[1],
+		failAlways:      true,
 	}
 	applyO := New(Deps{
 		Lifecycle: fx.mgr,
@@ -758,21 +752,78 @@ func TestTransactionApplySyncFailureRollsBackAll(t *testing.T) {
 		t.Fatalf("applyTransactionCandidates() error = %v, want nil with attention", err)
 	}
 
-	// All refs should be rolled back to their old SHAs, including repo 1
-	// whose CAS succeeded but whose worktree sync failed.
+	// Every ref advances despite the environmental sync failure.
 	for i := range fx.repoDirs {
 		got := fx.refSHA(i, "refs/heads/feature/parent")
-		if got != oldSHAs[i] {
-			t.Fatalf("repo %d: ref = %s after rollback, want old SHA %s (worktree sync failure must be compensated)", i, got, oldSHAs[i])
+		if got != journal.Entries[i].CandidateSHA {
+			t.Fatalf("repo %d: ref = %s, want candidate %s", i, got, journal.Entries[i].CandidateSHA)
 		}
 	}
+	stored, _ := fx.store.Load(fx.child.ID)
+	if stored.Parent.Transaction.Phase != feature.TransactionPhaseApplied {
+		t.Fatalf("phase = %s, want applied", stored.Parent.Transaction.Phase)
+	}
+	failedEntry := stored.Parent.Transaction.EntryByRepo(journal.Entries[1].Repo)
+	if failedEntry.ApplyState != feature.RepoApplyApplied || !strings.Contains(failedEntry.Diagnostics, "worktree sync pending after apply") {
+		t.Fatalf("failed entry = %+v, want applied with pending-sync diagnostics", failedEntry)
+	}
 
-	// Worktrees for repos 0 and 1 should be reset to the old SHA.
-	for i := 0; i < 2; i++ {
-		wtHead := txGit(t, fx.repoDirs[i], "rev-parse", "HEAD")
-		if wtHead != oldSHAs[i] {
-			t.Fatalf("repo %d: worktree HEAD = %s, want old SHA %s after rollback", i, wtHead, oldSHAs[i])
+	if err := applyO.closeTransactionAfterApply(fx.child.ID, fx.parent.ID); err == nil {
+		t.Fatal("closeTransactionAfterApply() error = nil, want persistent sync failure")
+	}
+	stored, _ = fx.store.Load(fx.child.ID)
+	if !strings.Contains(stored.LastError, "syncing parent worktree for repo") {
+		t.Fatalf("LastError = %q, want closure sync diagnostic", stored.LastError)
+	}
+
+	// Swap in the healthy manager and re-enter through the public integration
+	// path. Applied journals go directly to idempotent closure.
+	if err := o.RunChildIntegration(fx.child.ID); err != nil {
+		t.Fatalf("RunChildIntegration() resume error = %v", err)
+	}
+	_, stored = fx.reload()
+	if stored.Parent.Transaction.Phase != feature.TransactionPhaseMerged {
+		t.Fatalf("phase after resume = %s, want merged", stored.Parent.Transaction.Phase)
+	}
+	if stored.LastError != "" {
+		t.Fatalf("LastError after resume = %q, want cleared", stored.LastError)
+	}
+	for i := range fx.repoDirs {
+		if got := txGit(t, fx.repoDirs[i], "rev-parse", "HEAD"); got != journal.Entries[i].CandidateSHA {
+			t.Fatalf("repo %d worktree HEAD = %s, want candidate %s", i, got, journal.Entries[i].CandidateSHA)
 		}
+	}
+}
+
+func TestTransactionApplyingJournalSkipsParentTipRebuild(t *testing.T) {
+	if testing.Short() {
+		t.Skip("real-git integration test")
+	}
+	fx := newMultiRepoTransactionFixture(t, 2)
+	o := fx.orchestrator()
+	child, _ := fx.store.Load(fx.child.ID)
+	parent, _ := fx.store.Load(fx.parent.ID)
+	journal, err := o.prepareTransactionCandidates(child, parent)
+	if err != nil {
+		t.Fatalf("prepareTransactionCandidates() error = %v", err)
+	}
+	originalCandidate := journal.Entries[0].CandidateSHA
+	journal.Phase = feature.TransactionPhaseApplying
+	if err := o.persistTransaction(child.ID, journal); err != nil {
+		t.Fatalf("persist applying journal: %v", err)
+	}
+
+	// Move the first parent tip after the interrupted apply journal is durable.
+	testutil.CommitFile(t, fx.repoDirs[0], "external.txt", "external\n", "external parent move")
+	if err := o.RunChildIntegration(child.ID); err != nil {
+		t.Fatalf("RunChildIntegration() error = %v, want retryable attention", err)
+	}
+	stored, _ := fx.store.Load(child.ID)
+	if stored.Parent.Transaction.Entries[0].CandidateSHA != originalCandidate {
+		t.Fatalf("applying journal candidate was rebuilt from %s to %s", originalCandidate, stored.Parent.Transaction.Entries[0].CandidateSHA)
+	}
+	if stored.Parent.Transaction.Phase != feature.TransactionPhaseAttention {
+		t.Fatalf("phase = %s, want attention after CAS detects moved ref", stored.Parent.Transaction.Phase)
 	}
 }
 

--- a/internal/server/read_model.go
+++ b/internal/server/read_model.go
@@ -370,12 +370,11 @@ func (h *apiHandler) dirtyRepoDiagnostics(repos []feature.FeatureRepo) ([]map[st
 			defer wg.Done()
 			report, err := h.cleanliness.InspectCleanliness(path, feature.DefaultDirtyPathLimit)
 			if err != nil || report == nil {
-				// A probe that merely ran out of time says nothing about the
-				// worktree — a repo slower than the bound would be blocked on
-				// every attempt, with retrying futile. Only an unreadable
-				// worktree is treated as unverifiable; launch-time inspection
-				// re-checks against the uncached authority either way.
-				if !errors.Is(err, git.ErrProbeTimeout) {
+				// A probe that timed out or yielded to a mutation says nothing
+				// about the worktree. Only an unreadable worktree is treated as
+				// unverifiable; launch-time inspection re-checks against the
+				// uncached authority either way.
+				if !errors.Is(err, git.ErrProbeTimeout) && !errors.Is(err, git.ErrWorktreeBusy) {
 					unknown[i] = name
 				}
 				return

--- a/test/e2e/refactor_child_transactional_multirepo_journey_test.go
+++ b/test/e2e/refactor_child_transactional_multirepo_journey_test.go
@@ -912,16 +912,10 @@ func TestRefactorChildTransactionalMultiRepoCrashCutPointConvergence(t *testing.
 	})
 
 	// Cut point: apply worktree-sync failure — the CAS succeeds for repo 1
-	// but the worktree sync fails. Rollback must compensate ALL applied
-	// refs including repo 1 (whose CAS succeeded), proving the
-	// all-or-nothing transaction invariant.
+	// but its first worktree sync fails. The ref vector continues forward and
+	// idempotent closure retries the sync before completing.
 	t.Run("apply_sync_failure", func(t *testing.T) {
 		fx := newMultiRepoE2EFixture(t, 3)
-
-		oldSHAs := make([]string, len(fx.repoDirs))
-		for i := range fx.repoDirs {
-			oldSHAs[i] = fx.refSHA(i, "refs/heads/feature/parent")
-		}
 
 		resetWT := &resetFailingWorktrees{
 			WorktreeManager: fx.wm,
@@ -930,22 +924,28 @@ func TestRefactorChildTransactionalMultiRepoCrashCutPointConvergence(t *testing.
 		o := fx.orchestratorWithWorktrees(resetWT)
 
 		if err := o.RunChildIntegration(fx.child.ID); err != nil {
-			t.Fatalf("RunChildIntegration() error = %v, want nil with attention", err)
+			t.Fatalf("RunChildIntegration() error = %v, want closure retry to converge", err)
 		}
 
-		// All refs should be rolled back to their old SHAs, including
-		// repo 1 whose CAS succeeded but whose worktree sync failed.
-		for i := range fx.repoDirs {
-			got := fx.refSHA(i, "refs/heads/feature/parent")
-			if got != oldSHAs[i] {
-				t.Fatalf("repo %d: ref = %s after rollback, want old SHA %s (worktree sync failure must be compensated)", i, got, oldSHAs[i])
-			}
+		_, child := fx.reload()
+		if child.Parent.CloseOutcome != feature.ChildCloseOutcomeCompleted {
+			t.Fatalf("close outcome = %q, want completed", child.Parent.CloseOutcome)
 		}
-		// Worktrees for repos 0 and 1 should be reset to the old SHA.
-		for i := 0; i < 2; i++ {
+		if child.Parent.Transaction.Phase != feature.TransactionPhaseMerged {
+			t.Fatalf("phase = %s, want merged", child.Parent.Transaction.Phase)
+		}
+
+		// All refs and parent worktrees converge to their candidates; none
+		// are compensated merely because the post-CAS sync was transient.
+		for i := range fx.repoDirs {
+			candidate := child.Parent.Transaction.Entries[i].CandidateSHA
+			got := fx.refSHA(i, "refs/heads/feature/parent")
+			if got != candidate {
+				t.Fatalf("repo %d: ref = %s, want candidate %s", i, got, candidate)
+			}
 			wtHead := multiRepoGit(t, fx.repoDirs[i], "rev-parse", "HEAD")
-			if wtHead != oldSHAs[i] {
-				t.Fatalf("repo %d: worktree HEAD = %s, want old SHA %s after rollback", i, wtHead, oldSHAs[i])
+			if wtHead != candidate {
+				t.Fatalf("repo %d: worktree HEAD = %s, want candidate %s", i, wtHead, candidate)
 			}
 		}
 	})
@@ -1054,31 +1054,30 @@ func TestRefactorChildTransactionalMultiRepoCrashCutPointConvergence(t *testing.
 	}
 
 	// Rollback persistence-failure crash matrix: inject a Store.Modify
-	// failure at each rollback boundary in a 3-repo transaction where the
-	// third repo's worktree-sync failure triggers conditional rollback.
+	// failure at each rollback boundary in a 3-repo transaction where an
+	// external ref race on the third repo triggers semantic rollback.
 	// This proves convergence at every crash cut point during rollback,
-	// including the aggregate rolled_back phase write whose failure
-	// previously stranded the transaction.
+	// including the aggregate attention-phase write after compensation.
 	//
 	// The 3-repo rollback scenario issues these Store.Modify calls:
 	//   1-3. persist preparing (candidates 0, 1, 2)
 	//   4. persist prepared phase
 	//   5. persist applying phase
-	//   6-8. persist apply progress (repos 0, 1, 2 applied)
-	// (repo 2 worktree sync fails → rollbackTransaction)
-	//   9. persist rolling_back phase
-	//  10-12. persist rollback progress (repos 0, 1, 2 rolled back)
-	//  13. persist rolled_back phase
+	//   6-7. persist apply progress (repos 0, 1 applied)
+	// (repo 2 ref moves externally → rollbackTransaction)
+	//   8. persist rolling_back phase
+	//   9-10. persist rollback progress (repos 0, 1 rolled back)
+	//  11. persist attention phase preserving repo 2's external ref
 	const (
-		numRollbackRepos             = 3
-		rbWriteThirdCandidate        = numRollbackRepos
-		rbWritePreparedPhase         = rbWriteThirdCandidate + 1
-		rbWriteApplyingPhase         = rbWritePreparedPhase + 1
-		rbWriteThirdApplyProgress    = rbWriteApplyingPhase + numRollbackRepos
-		rbWriteRollingBackPhase      = rbWriteThirdApplyProgress + 1
-		rbWriteFirstRollbackProgress = rbWriteRollingBackPhase + 1
-		rbWriteThirdRollbackProgress = rbWriteFirstRollbackProgress + numRollbackRepos - 1
-		rbWriteRolledBackPhase       = rbWriteThirdRollbackProgress + 1
+		numRollbackRepos              = 3
+		rbWriteThirdCandidate         = numRollbackRepos
+		rbWritePreparedPhase          = rbWriteThirdCandidate + 1
+		rbWriteApplyingPhase          = rbWritePreparedPhase + 1
+		rbWriteSecondApplyProgress    = rbWriteApplyingPhase + 2
+		rbWriteRollingBackPhase       = rbWriteSecondApplyProgress + 1
+		rbWriteFirstRollbackProgress  = rbWriteRollingBackPhase + 1
+		rbWriteSecondRollbackProgress = rbWriteFirstRollbackProgress + 1
+		rbWriteAttentionPhase         = rbWriteSecondRollbackProgress + 1
 	)
 	rollbackCrashCases := []struct {
 		name   string
@@ -1086,27 +1085,22 @@ func TestRefactorChildTransactionalMultiRepoCrashCutPointConvergence(t *testing.
 	}{
 		{"fail_at_rolling_back_phase", rbWriteRollingBackPhase},
 		{"fail_after_first_rollback_progress", rbWriteFirstRollbackProgress},
-		{"fail_after_second_rollback_progress", rbWriteFirstRollbackProgress + 1},
-		{"fail_after_third_rollback_progress", rbWriteThirdRollbackProgress},
-		{"fail_before_rolled_back_phase", rbWriteRolledBackPhase},
+		{"fail_after_second_rollback_progress", rbWriteSecondRollbackProgress},
+		{"fail_before_attention_phase", rbWriteAttentionPhase},
 	}
 	for _, tc := range rollbackCrashCases {
 		t.Run(tc.name, func(t *testing.T) {
 			fx := newMultiRepoE2EFixture(t, 3)
 
-			oldSHAs := make([]string, len(fx.repoDirs))
-			for i := range fx.repoDirs {
-				oldSHAs[i] = fx.refSHA(i, "refs/heads/feature/parent")
-			}
-
-			// Use a worktree manager that fails the first ResetToCommit
-			// for repo 2 to trigger rollback after all three refs are
-			// applied.
-			resetWT := &resetFailingWorktrees{
+			// Inject an external ref movement when repo 2 is inspected,
+			// after the first two refs have been applied.
+			raceWT := &raceInjectingWorktrees{
 				WorktreeManager: fx.wm,
-				failRepoDir:     fx.repoDirs[2],
+				t:               t,
+				raceRepoDir:     fx.repoDirs[2],
+				raceBranch:      "feature/parent",
 			}
-			failO := fx.orchestratorWithFailingStoreAndWorktree(tc.failAt, resetWT)
+			failO := fx.orchestratorWithFailingStoreAndWorktree(tc.failAt, raceWT)
 
 			// Run the transaction — it should fail at the injected
 			// rollback persistence boundary.


### PR DESCRIPTION
## Summary

- prevent read-only Git probes from taking optional locks and make cached probes yield to active worktree mutations
- generalize Git lock contention detection, recover stale locks, preserve fresh locks, and retry stdin-based ref CAS updates
- keep successful post-CAS ref updates moving forward when only parent worktree synchronization fails
- durably surface closure synchronization failures and retry them without rebuilding applying journals
- update unit and E2E coverage for stale/fresh locks, ref-lock retry, probe quiescing, forward closure convergence, and semantic rollback

## Root cause

Bounded read probes could refresh the index and be SIGKILLed while holding an optional Git lock, leaving a stale zero-byte lock behind. Mutation retries only recognized `index.lock`, expired after five seconds, and never recovered stale lock files. During child integration, a worktree reset failure after a successful ref CAS was then treated as a semantic transaction failure, causing rollback to encounter the same lock and park the relationship at attention indefinitely.

## Impact

Read-only probes no longer create optional Git locks. Stale mutation locks can self-heal while fresh locks remain protected. Once a candidate ref CAS succeeds, environmental worktree-sync failures preserve the correct ref vector and converge through the existing idempotent closure path. True semantic failures such as CAS mismatches and external ref movement still roll back.

## Verification

- Fast suite: `make test-fast`
- Focused internal packages: `go test ./internal/git/... ./internal/orchestrator/... ./internal/server/... -count=1`
- E2E transaction journeys: `go test ./test/e2e/ -run 'TransactionalMultiRepo|ChildDiscard' -count=1`
- Full suite: `go test ./...`
- Race regression: `go test ./... -count=1 -race`
- Go static-analysis gate: `go vet ./...`
- Go build gate: `go build ./...`
- Focused scratch-repository stale/fresh lock and transient ref-lock tests
- `git diff --check`

Generated with [Codex](https://openai.com/codex/).
