### PR TITLE
Commit every implementation and fix round instead of one commit per phase

### DIFF
--- a/internal/agent/final_review_loop.go
+++ b/internal/agent/final_review_loop.go
@@ -366,6 +366,29 @@ func (s *featureFinalReviewLoopState) run() (*FeatureFinalReviewResult, error) {
 			s.setReviewFixing(true)
 			fixStatus, fixErr := s.runFix(i, iterDir, feedback)
 
+			// The fix round's work commits immediately, whatever the
+			// session's outcome. FR has no later absorbing round before the
+			// next review, so a FAILED or protocol-violating fixer's partial
+			// edits must not strand the worktree dirty: the next review
+			// reads that state, and an approval over dirt fails the feature.
+			// A fix session that never started (dispatch error) left the
+			// tree untouched, so the hook no-ops on the clean worktree.
+			if s.cfg.RoundCommitHook != nil {
+				if err := s.cfg.RoundCommitHook(RoundCommitInput{
+					FeatureID: cfg.Feature.ID,
+					Iteration: i,
+					Kind:      RoundCommitFinalReviewFix,
+					FixNumber: roundCommits.changesRequested,
+					Repos:     s.workspace.RepoPaths,
+				}); err != nil {
+					return &FeatureFinalReviewResult{
+						FinalStatus: "failed",
+						Iterations:  i,
+						LastError:   fmt.Sprintf("committing final review fix round %d: %v", roundCommits.changesRequested, err),
+					}, nil
+				}
+			}
+
 			if fixStatus == agentStatusProtocolViolation {
 				violations := protocolViolationsFromError(fixErr)
 				if done := s.recordFixProtocolViolation(iterDir, i, violations, &consecutiveFailures); done != nil {
@@ -380,7 +403,7 @@ func (s *featureFinalReviewLoopState) run() (*FeatureFinalReviewResult, error) {
 				if fixErr == nil {
 					agentStatus = fixStatus
 				}
-				s.writeIterationMetaWithAgent(iterDir, i, agentStatus, "changes_requested")
+				s.writeIterationMetaWithAgent(iterDir, i, agentStatus, frMetaChangesRequested)
 				if consecutiveFailures >= maxConsecFails {
 					return &FeatureFinalReviewResult{
 						FinalStatus: "safety_rail",
@@ -402,26 +425,8 @@ func (s *featureFinalReviewLoopState) run() (*FeatureFinalReviewResult, error) {
 				continue
 			}
 
-			// The fix round's work commits immediately — the next review
-			// must read committed state, and a crash between fix and review
-			// must leave a clean commit boundary.
-			if s.cfg.RoundCommitHook != nil {
-				if err := s.cfg.RoundCommitHook(RoundCommitInput{
-					FeatureID: cfg.Feature.ID,
-					Iteration: i,
-					Kind:      RoundCommitFinalReviewFix,
-					FixNumber: roundCommits.changesRequested,
-					Repos:     s.workspace.RepoPaths,
-				}); err != nil {
-					return &FeatureFinalReviewResult{
-						FinalStatus: "failed",
-						Iterations:  i,
-						LastError:   fmt.Sprintf("committing final review fix round %d: %v", roundCommits.changesRequested, err),
-					}, nil
-				}
-			}
 			consecutiveFailures = 0
-			s.writeIterationMeta(iterDir, i, "changes_requested")
+			s.writeIterationMeta(iterDir, i, frMetaChangesRequested)
 			continue
 
 		default:
@@ -668,7 +673,13 @@ func (s *featureFinalReviewLoopState) rejectDirtyWorktreesAtApproval() error {
 		if path == "" {
 			continue
 		}
-		if git.HasUncommittedChangesExcludingUntracked(path, FinalReviewRootOrchestrationArtifacts...) {
+		dirtyNow, err := git.HasUncommittedChangesExcludingUntracked(path, FinalReviewRootOrchestrationArtifacts...)
+		if err != nil {
+			// An indeterminate worktree must never read as clean at an
+			// approval gate.
+			return fmt.Errorf("final review approval cleanliness check failed for repo %s: %w", name, err)
+		}
+		if dirtyNow {
 			dirty = append(dirty, name)
 		}
 	}
@@ -808,7 +819,7 @@ func (s *featureFinalReviewLoopState) runFix(iteration int, iterDir, feedback st
 func (s *featureFinalReviewLoopState) recordFixProtocolViolation(iterDir string, iteration int, violations []ProtocolViolation, consecutiveFailures *int) *FeatureFinalReviewResult {
 	*consecutiveFailures = *consecutiveFailures + 1
 	lastErr := formatProtocolViolationError(RoleFinalReviewFixer, iterDir, violations)
-	s.writeIterationMetaWithAgent(iterDir, iteration, agentStatusProtocolViolation, "changes_requested")
+	s.writeIterationMetaWithAgent(iterDir, iteration, agentStatusProtocolViolation, frMetaChangesRequested)
 	if *consecutiveFailures >= s.maxConsecFails() {
 		return &FeatureFinalReviewResult{
 			FinalStatus: BoundedHelperStatusProtocolViolation,

--- a/internal/agent/final_review_loop.go
+++ b/internal/agent/final_review_loop.go
@@ -29,9 +29,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -297,6 +297,11 @@ func (s *featureFinalReviewLoopState) run() (*FeatureFinalReviewResult, error) {
 		}
 	}
 
+	// Fix-round counter recovered from persisted iteration metas so a
+	// crash-resumed loop numbers fix rounds identically to the interrupted
+	// run: the fix following the Nth changes-requested review is "fix N".
+	roundCommits := newFRRoundCommitTracker(am, s.artifactDir, startIter)
+
 	maxConsecFails := cfg.MaxConsecFails
 	if maxConsecFails == 0 {
 		maxConsecFails = 3
@@ -346,11 +351,18 @@ func (s *featureFinalReviewLoopState) run() (*FeatureFinalReviewResult, error) {
 
 		switch reviewStatus {
 		case ReviewApproved:
-			s.commitReviewLeftovers(i, "Final review leftover sweep")
+			// Review-approved code must already be committed code: every fix
+			// round commits through RoundCommitHook, so a dirty worktree at
+			// approval is a fixer bug, not a sweep condition. Fail loudly
+			// instead of silently stranding changes past CodeReady.
+			if err := s.rejectDirtyWorktreesAtApproval(); err != nil {
+				return &FeatureFinalReviewResult{FinalStatus: "failed", Iterations: i, LastError: err.Error()}, nil
+			}
 			s.writeIterationMeta(iterDir, i, "approved")
 			return &FeatureFinalReviewResult{FinalStatus: finalStatusReviewPassed, Iterations: i}, nil
 
 		case ReviewChangesRequested:
+			roundCommits.changesRequested++
 			s.setReviewFixing(true)
 			fixStatus, fixErr := s.runFix(i, iterDir, feedback)
 
@@ -390,7 +402,24 @@ func (s *featureFinalReviewLoopState) run() (*FeatureFinalReviewResult, error) {
 				continue
 			}
 
-			s.commitReviewLeftovers(i, "Final review fix sweep")
+			// The fix round's work commits immediately — the next review
+			// must read committed state, and a crash between fix and review
+			// must leave a clean commit boundary.
+			if s.cfg.RoundCommitHook != nil {
+				if err := s.cfg.RoundCommitHook(RoundCommitInput{
+					FeatureID: cfg.Feature.ID,
+					Iteration: i,
+					Kind:      RoundCommitFinalReviewFix,
+					FixNumber: roundCommits.changesRequested,
+					Repos:     s.workspace.RepoPaths,
+				}); err != nil {
+					return &FeatureFinalReviewResult{
+						FinalStatus: "failed",
+						Iterations:  i,
+						LastError:   fmt.Sprintf("committing final review fix round %d: %v", roundCommits.changesRequested, err),
+					}, nil
+				}
+			}
 			consecutiveFailures = 0
 			s.writeIterationMeta(iterDir, i, "changes_requested")
 			continue
@@ -622,25 +651,34 @@ func (s *featureFinalReviewLoopState) previousAggregateFeedback(iteration int) s
 	return strings.TrimSpace(string(data))
 }
 
-// commitReviewLeftovers commits any repo-worktree changes a final-review
-// session left uncommitted. The completion protocol validates run artifacts,
-// not git state, so a fixer (or any FR session) that edits files and ends its
-// turn without committing would otherwise strand the feature at CodeReady
-// with a dirty worktree — blocking every aftercare follow-up that demands a
-// clean tree (rebase and refactor passes). Swept after each fix session and
-// again at approval so review-approved code is always committed code. A clean
-// worktree is a no-op; a commit failure is logged, never fatal, because the
-// publish path can still sweep the same changes.
-func (s *featureFinalReviewLoopState) commitReviewLeftovers(iteration int, reason string) {
+// rejectDirtyWorktreesAtApproval enforces the invariant that a Final Review
+// approval is only emitted over committed code. Every fix round commits
+// through RoundCommitHook; a fixer that edits files and ends its turn without
+// the round commit landing would strand the feature at CodeReady with a
+// dirty worktree, blocking every aftercare follow-up that demands a clean
+// tree (rebase and refactor passes). Known untracked root orchestration
+// artifacts (scrubbed by the publish path) are tolerated. No-op when no
+// RoundCommitHook is wired (per-round commits disabled).
+func (s *featureFinalReviewLoopState) rejectDirtyWorktreesAtApproval() error {
+	if s.cfg.RoundCommitHook == nil {
+		return nil
+	}
+	var dirty []string
 	for name, path := range s.workspace.RepoPaths {
-		if path == "" || !git.HasUncommittedChanges(path) {
+		if path == "" {
 			continue
 		}
-		message := fmt.Sprintf("%s (final review iteration %d)", reason, iteration)
-		if err := git.CommitAll(path, message); err != nil {
-			log.Printf("feature %s: final review leftover commit in repo %s: %v", s.cfg.Feature.ID, name, err)
+		if git.HasUncommittedChangesExcludingUntracked(path, FinalReviewRootOrchestrationArtifacts...) {
+			dirty = append(dirty, name)
 		}
 	}
+	if len(dirty) == 0 {
+		return nil
+	}
+	sort.Strings(dirty)
+	return fmt.Errorf(
+		"final review approved but repo(s) still have uncommitted changes — the fix round failed to commit its work: %s",
+		strings.Join(dirty, ", "))
 }
 
 // runFix launches one feature-level fix session for iteration i. Same

--- a/internal/agent/implement.go
+++ b/internal/agent/implement.go
@@ -703,6 +703,17 @@ func RunImplementationLoop(cfg ImplementConfig, sm ports.SessionManager) (result
 			exitCode = exitCodeFromAgentStatus(agentStatus)
 		}
 
+		meta := IterationMeta{
+			Iteration:    i,
+			StartedAt:    iterStart,
+			Duration:     duration,
+			ExitCode:     exitCode,
+			AgentStatus:  agentStatus,
+			MadeProgress: madeProgress,
+			CostUSD:      cost.TotalCostUSD,
+			Context:      iterationContextMeta(sess, waitResult.Handoff),
+		}
+
 		// Per-round commit: fire as soon as the round's session has fully
 		// ended (including any crash-resume replacement session) and ended
 		// with a semantic outcome. The skipImplement resume branch also
@@ -729,20 +740,17 @@ func RunImplementationLoop(cfg ImplementConfig, sm ports.SessionManager) (result
 					input.FirstImplementCommit = false
 				}
 				if err := cfg.RoundCommitHook(input); err != nil {
+					// The session reached semantic completion; persist its
+					// iteration record before failing the phase so the
+					// durable history (and the meta-scan round trackers on
+					// resume) matches what the live run produced. The review
+					// gate never runs, so ReviewStatus stays empty.
+					_ = am.WriteMeta(iterDir, meta)
+					_ = am.WriteSummary(summaryPath, meta)
 					cfg.Observer.IterationEnded(iterCtx, i, toSessionUsage(cost), time.Since(iterStart), "round_commit_error")
 					return nil, fmt.Errorf("committing implementation round %d: %w", i, err)
 				}
 			}
-		}
-		meta := IterationMeta{
-			Iteration:    i,
-			StartedAt:    iterStart,
-			Duration:     duration,
-			ExitCode:     exitCode,
-			AgentStatus:  agentStatus,
-			MadeProgress: madeProgress,
-			CostUSD:      cost.TotalCostUSD,
-			Context:      iterationContextMeta(sess, waitResult.Handoff),
 		}
 
 		// Accumulate iteration cost into the latest active timing key rather
@@ -764,7 +772,7 @@ func RunImplementationLoop(cfg ImplementConfig, sm ports.SessionManager) (result
 				violations = completionIntentViolations(rootCompletionIntent(sess), []string{"progress.md"})
 			}
 			lastErr := formatProtocolViolationError(RoleImplementer, iterDir, violations)
-			if done := recordProtocolViolationIteration(am, summaryPath, iterDir, aggregateLogPath, &meta, i, cfg, iterCtx, cost, iterStart, violations, lastErr, &consecutiveFailures, &reviewerFeedback); done != nil {
+			if done := recordProtocolViolationIteration(am, summaryPath, iterDir, aggregateLogPath, &meta, i, cfg, iterCtx, cost, iterStart, violations, lastErr, &consecutiveFailures, &reviewerFeedback, roundCommits); done != nil {
 				return done, nil
 			}
 			continue
@@ -841,7 +849,7 @@ func RunImplementationLoop(cfg ImplementConfig, sm ports.SessionManager) (result
 			}
 			if !outcome.OK {
 				lastErr := formatProtocolViolationError(RoleImplementer, iterDir, violations)
-				if done := recordProtocolViolationIteration(am, summaryPath, iterDir, aggregateLogPath, &meta, i, cfg, iterCtx, cost, iterStart, violations, lastErr, &consecutiveFailures, &reviewerFeedback); done != nil {
+				if done := recordProtocolViolationIteration(am, summaryPath, iterDir, aggregateLogPath, &meta, i, cfg, iterCtx, cost, iterStart, violations, lastErr, &consecutiveFailures, &reviewerFeedback, roundCommits); done != nil {
 					return done, nil
 				}
 				continue
@@ -864,7 +872,7 @@ func RunImplementationLoop(cfg ImplementConfig, sm ports.SessionManager) (result
 				if gate.Rejected {
 					gateViolations := reportGateViolations(gate)
 					lastErr := formatProtocolViolationError(RoleImplementer, iterDir, gateViolations)
-					if done := recordProtocolViolationIteration(am, summaryPath, iterDir, aggregateLogPath, &meta, i, cfg, iterCtx, cost, iterStart, gateViolations, lastErr, &consecutiveFailures, &reviewerFeedback); done != nil {
+					if done := recordProtocolViolationIteration(am, summaryPath, iterDir, aggregateLogPath, &meta, i, cfg, iterCtx, cost, iterStart, gateViolations, lastErr, &consecutiveFailures, &reviewerFeedback, roundCommits); done != nil {
 						return done, nil
 					}
 					continue
@@ -1255,6 +1263,7 @@ func recordProtocolViolationIteration(
 	lastErr string,
 	consecutiveFailures *int,
 	reviewerFeedback *string,
+	roundCommits *implementRoundCommitTracker,
 ) *LoopResult {
 	*consecutiveFailures = *consecutiveFailures + 1
 	feedback := formatContractViolationFeedback(RoleImplementer, violations)
@@ -1265,6 +1274,10 @@ func recordProtocolViolationIteration(
 	_ = am.WriteMeta(iterDir, *meta)
 	_ = am.WriteSummary(summaryPath, *meta)
 	*reviewerFeedback = feedback
+	// The persisted CHANGES_REQUESTED review status drives the next round's
+	// fix-round labeling; keep the live counter in lockstep so a crash
+	// resume (which counts metas) labels rounds identically.
+	roundCommits.changesRequested++
 	cfg.Observer.IterationEnded(iterCtx, iteration, toSessionUsage(cost), time.Since(iterStart), BoundedHelperStatusProtocolViolation)
 	if *consecutiveFailures >= cfg.MaxConsecFails {
 		return &LoopResult{FinalStatus: BoundedHelperStatusProtocolViolation, Iterations: iteration, LastError: lastErr}
@@ -1305,17 +1318,14 @@ func observeVerifiedImplementationOutcome(pt *ProgressTracker, blockers int, cfg
 }
 
 // implementWorktreePaths returns the repo paths whose git state evidences
-// implementation progress: each feature repo's worktree (or checkout path),
+// implementation progress: each feature repo's edit surface (repoEditPath),
 // falling back to the session work dir for repo-less configurations.
 func implementWorktreePaths(cfg ImplementConfig) []string {
 	if cfg.Feature != nil && len(cfg.Feature.Repos) > 0 {
 		paths := make([]string, 0, len(cfg.Feature.Repos))
 		for _, r := range cfg.Feature.Repos {
-			switch {
-			case r.WorktreePath != "":
-				paths = append(paths, r.WorktreePath)
-			case r.Path != "":
-				paths = append(paths, r.Path)
+			if p := repoEditPath(r); p != "" {
+				paths = append(paths, p)
 			}
 		}
 		return paths

--- a/internal/agent/implement.go
+++ b/internal/agent/implement.go
@@ -152,6 +152,17 @@ type ImplementConfig struct {
 	// ports.ErrSessionShuttingDown to exit the loop cleanly.
 	SessionStartFunc func(id, featureID string, phase feature.Phase, command []string, workdir string, env []string, opts ...*ports.SessionOpts) (ports.SessionHandle, error)
 
+	// RoundCommitHook, when non-nil, is invoked once per implementation or
+	// fix round right after the round's agent session ends (before the
+	// review gate). The orchestrator layer owns the actual git commit; the
+	// loop only reports the round identity and candidate worktrees. Nil
+	// disables per-round commits.
+	RoundCommitHook RoundCommitHook
+
+	// RoundCommitRepos maps repo name -> worktree path for the repos a
+	// round may have dirtied. Empty derives from Feature.Repos / WorkDir.
+	RoundCommitRepos map[string]string
+
 	// AskingClause is the pre-resolved "Asking Questions" prompt section
 	// from the PromptAdapter for the implementation model. Set by PhaseRunner
 	// before launching the loop.
@@ -316,6 +327,10 @@ func RunImplementationLoop(cfg ImplementConfig, sm ports.SessionManager) (result
 		}
 	}
 
+	// Per-round commit accounting recovered from durable iteration metas so
+	// a crash-resumed loop labels rounds identically to the interrupted run.
+	roundCommits := newImplementRoundCommitTracker(am, cfg.ArtifactDir, startIter)
+
 	for i := startIter + 1; i <= cfg.MaxIterations; i++ {
 		iterStart := time.Now()
 		iterCtx := phaseCtx.Child()
@@ -325,6 +340,20 @@ func RunImplementationLoop(cfg ImplementConfig, sm ports.SessionManager) (result
 			cfg.Observer.IterationEnded(iterCtx, i, observe.SessionUsage{}, time.Since(iterStart), "interrupted")
 			return &LoopResult{FinalStatus: "interrupted", Iterations: i - 1}, nil
 		}
+
+		// Round identity for the per-round commit: a round that starts with
+		// pending reviewer feedback is a fix round; the first round of the
+		// phase whose session ends semantically is the unlabeled
+		// implementation commit. The driving CHANGES_REQUESTED review has
+		// already incremented the counter by the time the fix round starts,
+		// so the fix number is the counter itself (clamped to 1 for the
+		// rare pending-feedback-without-changes-requested-review case).
+		roundIsFix := strings.TrimSpace(reviewerFeedback) != ""
+		roundFixNumber := roundCommits.changesRequested
+		if roundIsFix && roundFixNumber < 1 {
+			roundFixNumber = 1
+		}
+		roundFirstImplement := !roundIsFix && !roundCommits.semanticSessions
 
 		// Update iteration counter so the desktop app dashboard reflects progress
 		if cfg.FeatureStore != nil {
@@ -673,6 +702,38 @@ func RunImplementationLoop(cfg ImplementConfig, sm ports.SessionManager) (result
 			// intentional cleanup.
 			exitCode = exitCodeFromAgentStatus(agentStatus)
 		}
+
+		// Per-round commit: fire as soon as the round's session has fully
+		// ended (including any crash-resume replacement session) and ended
+		// with a semantic outcome. The skipImplement resume branch also
+		// lands here with agentStatus=SUCCESS, absorbing a crashed round's
+		// uncommitted changes into its own commit. FAILED and
+		// protocol-violation rounds do not commit; their partial work is
+		// absorbed by the next round, mirroring the crash-recovery policy.
+		if agentStatus == agentStatusSuccess {
+			roundCommits.semanticSessions = true
+			if cfg.RoundCommitHook != nil {
+				input := RoundCommitInput{
+					FeatureID:            cfg.Feature.ID,
+					PhaseNumber:          cfg.Feature.CurrentRoadmapPhase,
+					TotalPhases:          cfg.Feature.TotalRoadmapPhases,
+					PhaseType:            cfg.Feature.RoadmapPhaseType,
+					Iteration:            i,
+					Kind:                 RoundCommitImplement,
+					FixNumber:            roundFixNumber,
+					FirstImplementCommit: roundFirstImplement,
+					Repos:                implementRoundCommitRepos(cfg),
+				}
+				if roundIsFix {
+					input.Kind = RoundCommitFix
+					input.FirstImplementCommit = false
+				}
+				if err := cfg.RoundCommitHook(input); err != nil {
+					cfg.Observer.IterationEnded(iterCtx, i, toSessionUsage(cost), time.Since(iterStart), "round_commit_error")
+					return nil, fmt.Errorf("committing implementation round %d: %w", i, err)
+				}
+			}
+		}
 		meta := IterationMeta{
 			Iteration:    i,
 			StartedAt:    iterStart,
@@ -872,6 +933,7 @@ func RunImplementationLoop(cfg ImplementConfig, sm ports.SessionManager) (result
 					reviewerFeedback = fmt.Sprintf(
 						"Harness verification detected regressions: %s. These commands pass at the contract base commit but fail with your changes. See verification-report.yaml in the iteration directory for evidence; fix the regressions before declaring SUCCESS.",
 						strings.Join(harnessVerification.RegressionItems, ", "))
+					roundCommits.changesRequested++
 					if pt.NoProgressCount() >= cfg.MaxConsecNoProgress {
 						cfg.Observer.IterationEnded(iterCtx, i, toSessionUsage(cost), time.Since(iterStart), "harness_regression")
 						return &LoopResult{
@@ -964,6 +1026,7 @@ func RunImplementationLoop(cfg ImplementConfig, sm ports.SessionManager) (result
 					}
 					reviewerFeedback = feedback
 					lastChangesRequestedIter = i
+					roundCommits.changesRequested++
 					meta.AgentStatus = agentStatusProtocolViolation
 					meta.ReviewStatus = ReviewChangesRequested.String()
 					_ = am.WriteMeta(iterDir, meta)
@@ -1023,6 +1086,7 @@ func RunImplementationLoop(cfg ImplementConfig, sm ports.SessionManager) (result
 				consecutiveFailures = 0
 				reviewerFeedback = feedback
 				lastChangesRequestedIter = i
+				roundCommits.changesRequested++
 				// Check no-progress safety rail
 				if pt.NoProgressCount() >= cfg.MaxConsecNoProgress {
 					cfg.Observer.IterationEnded(iterCtx, i, toSessionUsage(cost), time.Since(iterStart), "changes_requested")

--- a/internal/agent/orchestrator.go
+++ b/internal/agent/orchestrator.go
@@ -129,6 +129,12 @@ type OrchestratorConfig struct {
 	// OnVerificationProgress is called after each persisted harness
 	// verification status transition so API clients can refresh live state.
 	OnVerificationProgress func(featureID string)
+
+	// RoundCommitHook, when non-nil, is invoked by the phase-implement and
+	// final-review loops once per implementation/fix round, right after the
+	// round's session ends and before the review gate. The orchestrator
+	// layer owns the git commit; nil disables per-round commits.
+	RoundCommitHook RoundCommitHook
 }
 
 func resolveOrchestratorSessionConfig(cfg OrchestratorConfig, role llm.PhaseRole) (SessionRuntimeConfig, error) {

--- a/internal/agent/phase.go
+++ b/internal/agent/phase.go
@@ -57,6 +57,12 @@ type PhaseRunner struct {
 	// clients while verification runs without an active agent session.
 	OnVerificationProgress func(featureID string)
 
+	// RoundCommitHook, when non-nil, is forwarded into the phase-implement
+	// and final-review loop configs so every implementation/fix round
+	// commits as soon as its session ends. The orchestrator layer installs
+	// its commit implementation here (see orchestrator.New).
+	RoundCommitHook RoundCommitHook
+
 	// BuildSessionFn, if non-nil, overrides the production BuildSession logic.
 	// Used exclusively for test injection.
 	BuildSessionFn func(BuildSessionOpts) ([]string, []string, *ports.SessionOpts, error)
@@ -943,6 +949,7 @@ func (pr *PhaseRunner) RunImplementation(f *feature.Feature, planPath string, kb
 		SkipIterationReview:        f.EffectivePipeline().ShouldSkipIterationReview(),
 		Observer:                   pr.Observer,
 		OnVerificationProgress:     pr.OnVerificationProgress,
+		RoundCommitHook:            pr.RoundCommitHook,
 	}
 
 	resultCh := make(chan *LoopResult, 1)
@@ -1007,6 +1014,7 @@ func (pr *PhaseRunner) RunMultiRepoImplementation(
 		GuidelinesDir:              pr.GuidelinesDir,
 		Observer:                   pr.Observer,
 		OnVerificationProgress:     pr.OnVerificationProgress,
+		RoundCommitHook:            pr.RoundCommitHook,
 		RunImplementFn:             pr.RunImplementFn,
 		RunFinalReviewFn:           pr.RunFinalReviewFn,
 	}
@@ -1069,6 +1077,7 @@ func (pr *PhaseRunner) RunMultiRepoFinalReview(
 		GuidelinesDir:              pr.GuidelinesDir,
 		Observer:                   pr.Observer,
 		OnVerificationProgress:     pr.OnVerificationProgress,
+		RoundCommitHook:            pr.RoundCommitHook,
 		RunFinalReviewFn:           pr.RunFinalReviewFn,
 	}
 

--- a/internal/agent/phase_implement_loop.go
+++ b/internal/agent/phase_implement_loop.go
@@ -167,6 +167,8 @@ func RunPhaseImplementLoop(cfg OrchestratorConfig, sm ports.SessionManager) (*Ph
 		GuidelinesDir:              cfg.GuidelinesDir,
 		Observer:                   cfg.Observer,
 		OnVerificationProgress:     cfg.OnVerificationProgress,
+		RoundCommitHook:            cfg.RoundCommitHook,
+		RoundCommitRepos:           workspace.RepoPaths,
 		// Per-iteration review stays on the same gating policy as the
 		// per-repo path historically used: Medium/Large skip per-
 		// iteration review and rely on Final Review for quality gating;

--- a/internal/agent/round_commit.go
+++ b/internal/agent/round_commit.go
@@ -17,7 +17,8 @@ package agent
 import (
 	"fmt"
 	"path/filepath"
-	"strings"
+
+	"github.com/doordash-oss/agentic-orchestrator/internal/feature"
 )
 
 // RoundCommitKind classifies a completed loop round for commit messaging.
@@ -87,6 +88,20 @@ var FinalReviewRootOrchestrationArtifacts = []string{
 	"meta.yaml",
 }
 
+// scanIterationMetas walks the persisted iteration metas 1..startIter in
+// order, skipping missing or unreadable entries. Both round-commit trackers
+// rebuild their accounting through it so a crash-resumed loop labels rounds
+// identically to the interrupted run.
+func scanIterationMetas(am *ArtifactManager, artifactDir string, startIter int, visit func(IterationMeta)) {
+	for j := 1; j <= startIter; j++ {
+		meta, err := am.ReadMeta(filepath.Join(artifactDir, fmt.Sprintf("iteration-%02d", j)))
+		if err != nil {
+			continue
+		}
+		visit(meta)
+	}
+}
+
 // implementRoundCommitTracker carries the per-phase round-commit accounting
 // for the implementation loop. Both counters are recovered from durable
 // iteration metas so a crash-resumed loop labels rounds identically to the
@@ -106,45 +121,49 @@ type implementRoundCommitTracker struct {
 // (1..startIter) to rebuild the round-commit accounting after a restart.
 func newImplementRoundCommitTracker(am *ArtifactManager, artifactDir string, startIter int) *implementRoundCommitTracker {
 	t := &implementRoundCommitTracker{}
-	for j := 1; j <= startIter; j++ {
-		meta, err := am.ReadMeta(filepath.Join(artifactDir, fmt.Sprintf("iteration-%02d", j)))
-		if err != nil {
-			continue
-		}
+	scanIterationMetas(am, artifactDir, startIter, func(meta IterationMeta) {
 		if meta.ReviewStatus == agentStatusChangesRequested {
 			t.changesRequested++
 		}
 		if meta.AgentStatus == agentStatusSuccess || meta.AgentStatus == "RETRY" {
 			t.semanticSessions = true
 		}
-	}
+	})
 	return t
 }
 
+// repoEditPath returns the path a feature repo's edits land in: the worktree
+// when set, falling back to the checkout path — the same resolution
+// BuildWorkspace uses to mount repos into agent sessions.
+func repoEditPath(r feature.FeatureRepo) string {
+	if r.WorktreePath != "" {
+		return r.WorktreePath
+	}
+	return r.Path
+}
+
 // implementRoundCommitRepos resolves the repo name -> worktree path map a
-// round commit should consider. Explicit RoundCommitRepos (unified flow)
-// wins; otherwise derive from Feature.Repos, falling back to WorkDir.
+// round commit should consider, mirroring the session's actual edit surface
+// (repoEditPath per repo). The repo-less fallback is the session WorkDir.
 func implementRoundCommitRepos(cfg ImplementConfig) map[string]string {
 	if len(cfg.RoundCommitRepos) > 0 {
 		return cfg.RoundCommitRepos
 	}
-	if cfg.Feature == nil || len(cfg.Feature.Repos) == 0 {
-		if cfg.WorkDir == "" {
-			return nil
+	if cfg.Feature != nil && len(cfg.Feature.Repos) > 0 {
+		repos := make(map[string]string, len(cfg.Feature.Repos))
+		for _, r := range cfg.Feature.Repos {
+			if path := repoEditPath(r); path != "" {
+				repos[r.Name] = path
+			}
 		}
-		return map[string]string{"": cfg.WorkDir}
-	}
-	repos := make(map[string]string, len(cfg.Feature.Repos))
-	for _, r := range cfg.Feature.Repos {
-		path := r.WorktreePath
-		if path == "" {
-			path = r.Path
-		}
-		if path != "" {
-			repos[r.Name] = path
+		if len(repos) > 0 {
+			return repos
 		}
 	}
-	return repos
+	if cfg.WorkDir == "" {
+		return nil
+	}
+	return map[string]string{"": cfg.WorkDir}
 }
 
 // frMetaChangesRequested is the review status the Final Review loop writes
@@ -161,14 +180,10 @@ type frRoundCommitTracker struct {
 
 func newFRRoundCommitTracker(am *ArtifactManager, artifactDir string, startIter int) *frRoundCommitTracker {
 	t := &frRoundCommitTracker{}
-	for j := 1; j <= startIter; j++ {
-		meta, err := am.ReadMeta(filepath.Join(artifactDir, fmt.Sprintf("iteration-%02d", j)))
-		if err != nil {
-			continue
-		}
-		if strings.EqualFold(meta.ReviewStatus, frMetaChangesRequested) {
+	scanIterationMetas(am, artifactDir, startIter, func(meta IterationMeta) {
+		if meta.ReviewStatus == frMetaChangesRequested {
 			t.changesRequested++
 		}
-	}
+	})
 	return t
 }

--- a/internal/agent/round_commit.go
+++ b/internal/agent/round_commit.go
@@ -1,0 +1,174 @@
+// Copyright 2026 DoorDash, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agent
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+// RoundCommitKind classifies a completed loop round for commit messaging.
+type RoundCommitKind string
+
+const (
+	// RoundCommitImplement is a round that started without pending reviewer
+	// feedback (initial implementation work or a fresh continuation).
+	RoundCommitImplement RoundCommitKind = "implement"
+	// RoundCommitFix is a phase-implement round that started with pending
+	// reviewer feedback from a CHANGES_REQUESTED review cycle.
+	RoundCommitFix RoundCommitKind = "fix"
+	// RoundCommitFinalReviewFix is a feature-level Final Review fix round.
+	RoundCommitFinalReviewFix RoundCommitKind = "final_review_fix"
+)
+
+// RoundCommitInput is the per-round completion event the phase-implement and
+// final-review loops emit right after a round's agent session ends (before
+// the review gate runs). The orchestrator layer owns the actual git commit;
+// the loop only reports the round identity and the worktrees the round could
+// have dirtied.
+type RoundCommitInput struct {
+	FeatureID string
+
+	// PhaseNumber is the roadmap phase the round ran in (0 for non-roadmap
+	// features); TotalPhases and PhaseType carry the rest of the phase
+	// identity used by the commit message prefix.
+	PhaseNumber int
+	TotalPhases int
+	PhaseType   string
+
+	// Iteration is the loop iteration the round ran in.
+	Iteration int
+
+	// Kind classifies the round (implement / fix / final-review fix).
+	Kind RoundCommitKind
+
+	// FixNumber is the per-phase (or feature-level for Final Review) fix
+	// counter when Kind is a fix kind; 0 otherwise.
+	FixNumber int
+
+	// FirstImplementCommit marks the phase's first implementation commit.
+	// The hook renders it unlabeled so the happy-path log reads like the
+	// historical single-commit-per-phase format.
+	FirstImplementCommit bool
+
+	// Repos maps repo name -> worktree path for every repo the round could
+	// have dirtied. The hook commits only those with uncommitted changes.
+	Repos map[string]string
+}
+
+// RoundCommitHook commits a completed round's work. It is invoked once per
+// implementation/fix round; a clean worktree is a no-op inside the hook.
+// A returned error fails the loop loudly — a round whose changes cannot be
+// committed must not silently strand a dirty worktree mid-phase.
+type RoundCommitHook func(RoundCommitInput) error
+
+// FinalReviewRootOrchestrationArtifacts lists repo-root files that review
+// sessions have historically stranded as untracked files. The publish path
+// scrubs them; the Final Review approval dirty-check ignores them so a known
+// orchestration artifact never fails an otherwise clean approval.
+var FinalReviewRootOrchestrationArtifacts = []string{
+	PhaseCompleteFile,
+	"progress.md",
+	"verification-report.yaml",
+	"review-feedback.md",
+	"meta.yaml",
+}
+
+// implementRoundCommitTracker carries the per-phase round-commit accounting
+// for the implementation loop. Both counters are recovered from durable
+// iteration metas so a crash-resumed loop labels rounds identically to the
+// interrupted run.
+type implementRoundCommitTracker struct {
+	// changesRequested counts CHANGES_REQUESTED review cycles completed so
+	// far this phase. The fix round following the Nth such review is
+	// labeled "fix round N".
+	changesRequested int
+	// semanticSessions records whether any prior round ended its session
+	// with a semantic outcome (SUCCESS/RETRY). The first such round of the
+	// phase is the unlabeled implementation commit.
+	semanticSessions bool
+}
+
+// newImplementRoundCommitTracker scans the phase's persisted iteration metas
+// (1..startIter) to rebuild the round-commit accounting after a restart.
+func newImplementRoundCommitTracker(am *ArtifactManager, artifactDir string, startIter int) *implementRoundCommitTracker {
+	t := &implementRoundCommitTracker{}
+	for j := 1; j <= startIter; j++ {
+		meta, err := am.ReadMeta(filepath.Join(artifactDir, fmt.Sprintf("iteration-%02d", j)))
+		if err != nil {
+			continue
+		}
+		if meta.ReviewStatus == agentStatusChangesRequested {
+			t.changesRequested++
+		}
+		if meta.AgentStatus == agentStatusSuccess || meta.AgentStatus == "RETRY" {
+			t.semanticSessions = true
+		}
+	}
+	return t
+}
+
+// implementRoundCommitRepos resolves the repo name -> worktree path map a
+// round commit should consider. Explicit RoundCommitRepos (unified flow)
+// wins; otherwise derive from Feature.Repos, falling back to WorkDir.
+func implementRoundCommitRepos(cfg ImplementConfig) map[string]string {
+	if len(cfg.RoundCommitRepos) > 0 {
+		return cfg.RoundCommitRepos
+	}
+	if cfg.Feature == nil || len(cfg.Feature.Repos) == 0 {
+		if cfg.WorkDir == "" {
+			return nil
+		}
+		return map[string]string{"": cfg.WorkDir}
+	}
+	repos := make(map[string]string, len(cfg.Feature.Repos))
+	for _, r := range cfg.Feature.Repos {
+		path := r.WorktreePath
+		if path == "" {
+			path = r.Path
+		}
+		if path != "" {
+			repos[r.Name] = path
+		}
+	}
+	return repos
+}
+
+// frMetaChangesRequested is the review status the Final Review loop writes
+// into iteration meta.yaml for a changes-requested iteration (lowercase,
+// unlike the implement loop's agentStatusChangesRequested).
+const frMetaChangesRequested = "changes_requested"
+
+// frRoundCommitTracker carries the feature-level fix-round counter for the
+// Final Review loop, seeded from persisted iteration metas so a crash resume
+// keeps numbering stable.
+type frRoundCommitTracker struct {
+	changesRequested int
+}
+
+func newFRRoundCommitTracker(am *ArtifactManager, artifactDir string, startIter int) *frRoundCommitTracker {
+	t := &frRoundCommitTracker{}
+	for j := 1; j <= startIter; j++ {
+		meta, err := am.ReadMeta(filepath.Join(artifactDir, fmt.Sprintf("iteration-%02d", j)))
+		if err != nil {
+			continue
+		}
+		if strings.EqualFold(meta.ReviewStatus, frMetaChangesRequested) {
+			t.changesRequested++
+		}
+	}
+	return t
+}

--- a/internal/agent/round_commit_loop_test.go
+++ b/internal/agent/round_commit_loop_test.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/doordash-oss/agentic-orchestrator/internal/git"
 	"github.com/doordash-oss/agentic-orchestrator/internal/session"
 	"github.com/doordash-oss/agentic-orchestrator/test/testutil"
 )
@@ -302,6 +303,18 @@ echo "iteration 1" >> "`+progressFile+`"
 	if !strings.Contains(err.Error(), "committing implementation round 1") {
 		t.Errorf("error = %v, want round commit failure surfaced", err)
 	}
+
+	// The session reached semantic completion before the commit failed; its
+	// iteration record must be persisted so crash recovery and the
+	// meta-scan round trackers see the same history the live run produced.
+	metaPath := filepath.Join(artifactDir, "iteration-01", "meta.yaml")
+	data, readErr := os.ReadFile(metaPath)
+	if readErr != nil {
+		t.Fatalf("read iteration meta after round commit failure: %v", readErr)
+	}
+	if !strings.Contains(string(data), "agent_status: SUCCESS") {
+		t.Errorf("iteration meta = %s, want agent_status SUCCESS (semantic completion recorded)", data)
+	}
 }
 
 // TestRunFeatureFinalReviewLoop_RoundCommitHook_FiresPerFixRound drives the
@@ -525,6 +538,204 @@ func TestRunFeatureFinalReviewLoop_DirtyWorktreeAtApprovalToleratesRootArtifacts
 	}
 	if result.FinalStatus != finalStatusReviewPassed {
 		t.Fatalf("FinalStatus = %q, want review_passed (LastError=%q)", result.FinalStatus, result.LastError)
+	}
+}
+
+// TestRunImplementationLoop_RoundCommitHook_ProtocolViolationsCountFixRounds
+// pins the live-counter/meta-scan invariant: implementer protocol violations
+// write meta.ReviewStatus=CHANGES_REQUESTED and arm reviewer feedback, so
+// each one must advance the live fix-round counter exactly like a
+// crash-resume meta scan would. Two violations make the following round fix
+// round 2, not a repeated fix round 1.
+func TestRunImplementationLoop_RoundCommitHook_ProtocolViolationsCountFixRounds(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	tmpDir := t.TempDir()
+	workDir := filepath.Join(tmpDir, "work")
+	artifactDir := filepath.Join(tmpDir, "artifacts")
+	stateDir := filepath.Join(tmpDir, "state", "test-feat-001")
+	scriptsDir := filepath.Join(tmpDir, "scripts")
+	for _, d := range []string{workDir, artifactDir, stateDir, scriptsDir} {
+		os.MkdirAll(d, 0o755)
+	}
+
+	// Iterations 1-2 emit success without writing the required artifacts
+	// (implementer contract violation); iteration 3 writes them.
+	agentScript := testutil.WriteScript(t, scriptsDir, "agent.sh", `
+if [ -d "`+artifactDir+`/iteration-03" ]; then
+`+testutil.JSONLInit+`
+`+testutil.WriteImplementSuccessArtifacts(artifactDir)+`
+`+testutil.JSONLSuccess+`
+else
+`+testutil.JSONLInit+`
+`+testutil.JSONLSuccess+`
+fi
+`)
+
+	reviewScript := testutil.WriteScript(t, scriptsDir, "review.sh", `
+for _d in "`+artifactDir+`"/iteration-*; do :; done
+`+testutil.JSONLInit+`
+if [ "$(basename "$_d")" = "iteration-03" ]; then
+    `+testutil.WriteReviewApproved(artifactDir)+`
+else
+    `+testutil.WriteReviewChangesRequested(artifactDir, "- **High**: missing artifacts")+`
+fi
+`+testutil.JSONLSuccess+`
+`)
+
+	eventCh := make(chan interface{}, 100)
+	sm := session.NewManager(eventCh)
+	defer sm.Shutdown()
+
+	f := newTestFeature(t, workDir)
+	hook, inputs := recordingRoundCommitHook(t)
+
+	planPath := writePlanFile(t, artifactDir, "Violate twice then fix")
+
+	cfg := ImplementConfig{
+		Feature:             f,
+		WorkDir:             workDir,
+		PlanPath:            planPath,
+		MaxIterations:       5,
+		MaxConsecFails:      3,
+		MaxConsecNoProgress: 3,
+		ExitCriteria:        "Tests pass",
+		Model:               "agent",
+		ReviewModel:         "reviewer",
+		ArtifactDir:         artifactDir,
+		StateDir:            stateDir,
+		BuildSession:        mockBuildSession(agentScript, reviewScript),
+		RoundCommitHook:     hook,
+	}
+
+	result, err := RunImplementationLoop(cfg, sm)
+	if err != nil {
+		t.Fatalf("RunImplementationLoop error: %v", err)
+	}
+	if result.FinalStatus != finalStatusReviewPassed {
+		t.Fatalf("FinalStatus = %q, want review_passed (LastError=%q)", result.FinalStatus, result.LastError)
+	}
+
+	// Protocol-violation rounds do not commit; only iteration 3's fix round
+	// fires the hook, and it must be fix round 2 (two CHANGES_REQUESTED
+	// metas precede it).
+	if len(*inputs) != 1 {
+		t.Fatalf("round commit hook fired %d times, want 1; inputs: %+v", len(*inputs), *inputs)
+	}
+	got := (*inputs)[0]
+	if got.Kind != RoundCommitFix {
+		t.Errorf("Kind = %q, want fix", got.Kind)
+	}
+	if got.FixNumber != 2 {
+		t.Errorf("FixNumber = %d, want 2 (two protocol-violation CHANGES_REQUESTED iterations precede it)", got.FixNumber)
+	}
+
+	// The persisted metas must agree with the live counter: a crash resume
+	// scanning them seeds the same fix number.
+	am := NewArtifactManager(artifactDir)
+	tr := newImplementRoundCommitTracker(am, artifactDir, 3)
+	if tr.changesRequested != 2 {
+		t.Errorf("meta-scan changesRequested = %d, want 2 (live/meta divergence)", tr.changesRequested)
+	}
+}
+
+// TestRunFeatureFinalReviewLoop_RoundCommitHook_FailedFixRoundStillCommits:
+// a FAILED fix round's partial edits must not strand the worktree dirty —
+// FR has no later absorbing round, so the fix-round commit fires whatever
+// the session outcome. The follow-up review approves over the committed
+// state instead of tripping the approval dirty-check.
+func TestRunFeatureFinalReviewLoop_RoundCommitHook_FailedFixRoundStillCommits(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	env := newFRLoopEnv(t)
+	store, f, _ := newFRTestFeature(t, env.stateDir, "fr-failed-fix-commit", []string{testRepoNameAPI})
+	repo := testutil.InitGitRepo(t)
+	f.Repos[0].Path = repo
+	f.Repos[0].WorktreePath = repo
+	if err := store.Save(f); err != nil {
+		t.Fatalf("save feature with git repo: %v", err)
+	}
+
+	artDir := frArtifactDir(env.stateDir, f)
+	if err := os.MkdirAll(artDir, 0o755); err != nil {
+		t.Fatalf("mkdir artifact: %v", err)
+	}
+
+	// Iteration 1's fixer applies a real edit but dies before completing
+	// (FAILED); iteration 2's review approves the (committed) partial fix.
+	reviewScript := testutil.WriteScript(t, env.scriptsDir, "review.sh",
+		fmt.Sprintf(`if [ -d "%s/iteration-02" ]; then
+%s
+%s
+%s
+else
+%s
+%s
+%s
+fi`,
+			artDir,
+			testutil.JSONLInit,
+			testutil.WriteFinalReviewApproved(artDir),
+			testutil.JSONLSuccess,
+			testutil.JSONLInit,
+			testutil.WriteFinalReviewChangesRequested(artDir, "- **High**: needs a fix"),
+			testutil.JSONLSuccess))
+
+	fixScript := testutil.WriteScript(t, env.scriptsDir, "fix.sh",
+		fmt.Sprintf(`%s
+cat > %s <<'EOF'
+partial fix
+EOF
+exit 1
+`,
+			testutil.JSONLInit,
+			filepath.Join(repo, "fix.txt")))
+
+	eventCh := make(chan any, 100)
+	sm := session.NewManager(eventCh)
+	defer sm.Shutdown()
+
+	// The hook commits the failed fixer's partial work, mirroring the
+	// orchestrator's behavior.
+	hook := func(input RoundCommitInput) error {
+		for _, path := range input.Repos {
+			if path == "" {
+				continue
+			}
+			if _, err := git.CommitAllAndGetHead(path, "Final review fix 1 (address review feedback)"); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	cfg := OrchestratorConfig{
+		Feature:        f,
+		FeatureStore:   store,
+		StateDir:       env.stateDir,
+		Model:          "agent",
+		ReviewModel:    "reviewer",
+		MaxIterations:  5,
+		MaxConsecFails: 3,
+		BuildSession: mockBuildSessionByModel(map[string]string{
+			"reviewer": reviewScript,
+			"agent":    fixScript,
+		}),
+		RoundCommitHook: hook,
+	}
+
+	result, err := RunFeatureFinalReviewLoop(cfg, sm)
+	if err != nil {
+		t.Fatalf("loop: %v", err)
+	}
+	if result.FinalStatus != finalStatusReviewPassed {
+		t.Fatalf("FinalStatus = %q, want review_passed (LastError=%q)", result.FinalStatus, result.LastError)
+	}
+	if _, err := os.Stat(filepath.Join(repo, "fix.txt")); err != nil {
+		t.Errorf("partial fix edit missing; the failed fix round's work disappeared: %v", err)
 	}
 }
 

--- a/internal/agent/round_commit_loop_test.go
+++ b/internal/agent/round_commit_loop_test.go
@@ -1,0 +1,602 @@
+// Copyright 2026 DoorDash, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agent
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/doordash-oss/agentic-orchestrator/internal/session"
+	"github.com/doordash-oss/agentic-orchestrator/test/testutil"
+)
+
+// recordingRoundCommitHook captures every round completion event the loops
+// emit. It deliberately performs no git work: these tests assert the loops'
+// reporting contract, not the orchestrator's commit behavior.
+func recordingRoundCommitHook(t *testing.T) (RoundCommitHook, *[]RoundCommitInput) {
+	t.Helper()
+	inputs := &[]RoundCommitInput{}
+	return func(input RoundCommitInput) error {
+		*inputs = append(*inputs, input)
+		return nil
+	}, inputs
+}
+
+// TestRunImplementationLoop_RoundCommitHook_ImplementThenFixRound drives the
+// canonical fix cycle: iteration 1 implements (review requests changes),
+// iteration 2 addresses the feedback (review approves). The hook must fire
+// once per round, right after each session ends, with the agreed round
+// identity: first implement round unlabeled, the feedback-driven round a
+// fix round with the per-phase counter.
+func TestRunImplementationLoop_RoundCommitHook_ImplementThenFixRound(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	tmpDir := t.TempDir()
+	workDir := filepath.Join(tmpDir, "work")
+	artifactDir := filepath.Join(tmpDir, "artifacts")
+	stateDir := filepath.Join(tmpDir, "state", "test-feat-001")
+	scriptsDir := filepath.Join(tmpDir, "scripts")
+	for _, d := range []string{workDir, artifactDir, stateDir, scriptsDir} {
+		os.MkdirAll(d, 0o755)
+	}
+
+	progressFile := filepath.Join(workDir, "progress.md")
+
+	agentScript := testutil.WriteScript(t, scriptsDir, "agent.sh", `
+PROGRESS_FILE="`+progressFile+`"
+ITER=$(($(cat "$PROGRESS_FILE" 2>/dev/null | wc -l) + 1))
+echo "iteration $ITER" >> "$PROGRESS_FILE"
+`+testutil.JSONLInit+`
+`+testutil.WriteImplementSuccessArtifacts(artifactDir)+`
+`+testutil.JSONLSuccess+`
+`)
+
+	reviewScript := testutil.WriteScript(t, scriptsDir, "review.sh", `
+for _d in "`+artifactDir+`"/iteration-*; do :; done
+`+testutil.JSONLInit+`
+if [ "$(basename "$_d")" = "iteration-01" ]; then
+    `+testutil.WriteReviewChangesRequested(artifactDir, "- **High**: Please add error handling")+`
+else
+    `+testutil.WriteReviewApproved(artifactDir)+`
+fi
+`+testutil.JSONLSuccess+`
+`)
+
+	eventCh := make(chan interface{}, 100)
+	sm := session.NewManager(eventCh)
+	defer sm.Shutdown()
+
+	f := newTestFeature(t, workDir)
+	f.CurrentRoadmapPhase = 1
+	f.TotalRoadmapPhases = 2
+	f.RoadmapPhaseType = "tracer-bullet"
+
+	hook, inputs := recordingRoundCommitHook(t)
+
+	planPath := writePlanFile(t, artifactDir, "Implement with error handling")
+
+	cfg := ImplementConfig{
+		Feature:             f,
+		WorkDir:             workDir,
+		PlanPath:            planPath,
+		MaxIterations:       5,
+		MaxConsecFails:      3,
+		MaxConsecNoProgress: 3,
+		ExitCriteria:        "Tests pass with error handling",
+		Model:               "agent",
+		ReviewModel:         "reviewer",
+		ArtifactDir:         artifactDir,
+		StateDir:            stateDir,
+		BuildSession:        mockBuildSession(agentScript, reviewScript),
+		RoundCommitHook:     hook,
+	}
+
+	result, err := RunImplementationLoop(cfg, sm)
+	if err != nil {
+		t.Fatalf("RunImplementationLoop error: %v", err)
+	}
+	if result.FinalStatus != finalStatusReviewPassed {
+		t.Fatalf("FinalStatus = %q, want review_passed", result.FinalStatus)
+	}
+	if result.Iterations != 2 {
+		t.Fatalf("Iterations = %d, want 2", result.Iterations)
+	}
+
+	if len(*inputs) != 2 {
+		t.Fatalf("round commit hook fired %d times, want 2; inputs: %+v", len(*inputs), *inputs)
+	}
+	first, second := (*inputs)[0], (*inputs)[1]
+
+	if first.Kind != RoundCommitImplement {
+		t.Errorf("round 1 Kind = %q, want implement", first.Kind)
+	}
+	if !first.FirstImplementCommit {
+		t.Error("round 1 must be the phase's first (unlabeled) implementation commit")
+	}
+	if first.Iteration != 1 {
+		t.Errorf("round 1 Iteration = %d, want 1", first.Iteration)
+	}
+	if first.PhaseNumber != 1 || first.TotalPhases != 2 || first.PhaseType != "tracer-bullet" {
+		t.Errorf("round 1 phase identity = %d/%d %q, want 1/2 tracer-bullet", first.PhaseNumber, first.TotalPhases, first.PhaseType)
+	}
+	if first.Repos["test-repo"] != workDir {
+		t.Errorf("round 1 Repos[test-repo] = %q, want %q", first.Repos["test-repo"], workDir)
+	}
+
+	if second.Kind != RoundCommitFix {
+		t.Errorf("round 2 Kind = %q, want fix", second.Kind)
+	}
+	if second.FixNumber != 1 {
+		t.Errorf("round 2 FixNumber = %d, want 1", second.FixNumber)
+	}
+	if second.FirstImplementCommit {
+		t.Error("round 2 must not be labeled as the first implementation commit")
+	}
+	if second.Iteration != 2 {
+		t.Errorf("round 2 Iteration = %d, want 2", second.Iteration)
+	}
+}
+
+// TestRunImplementationLoop_RoundCommitHook_SecondFixRoundNumbersPerPhase
+// verifies the separate per-phase fix counter: two consecutive fix rounds
+// addressing two distinct CHANGES_REQUESTED reviews are fix rounds 1 and 2.
+func TestRunImplementationLoop_RoundCommitHook_SecondFixRoundNumbersPerPhase(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	tmpDir := t.TempDir()
+	workDir := filepath.Join(tmpDir, "work")
+	artifactDir := filepath.Join(tmpDir, "artifacts")
+	stateDir := filepath.Join(tmpDir, "state", "test-feat-001")
+	scriptsDir := filepath.Join(tmpDir, "scripts")
+	for _, d := range []string{workDir, artifactDir, stateDir, scriptsDir} {
+		os.MkdirAll(d, 0o755)
+	}
+
+	progressFile := filepath.Join(workDir, "progress.md")
+
+	agentScript := testutil.WriteScript(t, scriptsDir, "agent.sh", `
+PROGRESS_FILE="`+progressFile+`"
+ITER=$(($(cat "$PROGRESS_FILE" 2>/dev/null | wc -l) + 1))
+echo "iteration $ITER" >> "$PROGRESS_FILE"
+`+testutil.JSONLInit+`
+`+testutil.WriteImplementSuccessArtifacts(artifactDir)+`
+`+testutil.JSONLSuccess+`
+`)
+
+	// Review requests changes on iterations 1 and 2, approves on 3.
+	reviewScript := testutil.WriteScript(t, scriptsDir, "review.sh", `
+for _d in "`+artifactDir+`"/iteration-*; do :; done
+`+testutil.JSONLInit+`
+if [ "$(basename "$_d")" = "iteration-03" ]; then
+    `+testutil.WriteReviewApproved(artifactDir)+`
+else
+    `+testutil.WriteReviewChangesRequested(artifactDir, "- **High**: Still not right")+`
+fi
+`+testutil.JSONLSuccess+`
+`)
+
+	eventCh := make(chan interface{}, 100)
+	sm := session.NewManager(eventCh)
+	defer sm.Shutdown()
+
+	f := newTestFeature(t, workDir)
+	hook, inputs := recordingRoundCommitHook(t)
+
+	planPath := writePlanFile(t, artifactDir, "Implement with two fix rounds")
+
+	cfg := ImplementConfig{
+		Feature:             f,
+		WorkDir:             workDir,
+		PlanPath:            planPath,
+		MaxIterations:       5,
+		MaxConsecFails:      3,
+		MaxConsecNoProgress: 3,
+		ExitCriteria:        "Tests pass",
+		Model:               "agent",
+		ReviewModel:         "reviewer",
+		ArtifactDir:         artifactDir,
+		StateDir:            stateDir,
+		BuildSession:        mockBuildSession(agentScript, reviewScript),
+		RoundCommitHook:     hook,
+	}
+
+	result, err := RunImplementationLoop(cfg, sm)
+	if err != nil {
+		t.Fatalf("RunImplementationLoop error: %v", err)
+	}
+	if result.FinalStatus != finalStatusReviewPassed {
+		t.Fatalf("FinalStatus = %q, want review_passed", result.FinalStatus)
+	}
+	if len(*inputs) != 3 {
+		t.Fatalf("round commit hook fired %d times, want 3; inputs: %+v", len(*inputs), *inputs)
+	}
+	if got := (*inputs)[1].FixNumber; got != 1 {
+		t.Errorf("round 2 FixNumber = %d, want 1", got)
+	}
+	if got := (*inputs)[2].FixNumber; got != 2 {
+		t.Errorf("round 3 FixNumber = %d, want 2", got)
+	}
+	if (*inputs)[2].Kind != RoundCommitFix {
+		t.Errorf("round 3 Kind = %q, want fix", (*inputs)[2].Kind)
+	}
+}
+
+// TestRunImplementationLoop_RoundCommitHook_ErrorFailsLoop: a round whose
+// changes cannot be committed must fail the loop loudly instead of
+// continuing to the review gate over uncommitted state.
+func TestRunImplementationLoop_RoundCommitHook_ErrorFailsLoop(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	tmpDir := t.TempDir()
+	workDir := filepath.Join(tmpDir, "work")
+	artifactDir := filepath.Join(tmpDir, "artifacts")
+	stateDir := filepath.Join(tmpDir, "state", "test-feat-001")
+	scriptsDir := filepath.Join(tmpDir, "scripts")
+	for _, d := range []string{workDir, artifactDir, stateDir, scriptsDir} {
+		os.MkdirAll(d, 0o755)
+	}
+
+	progressFile := filepath.Join(workDir, "progress.md")
+
+	agentScript := testutil.WriteScript(t, scriptsDir, "agent.sh", `
+echo "iteration 1" >> "`+progressFile+`"
+`+testutil.JSONLInit+`
+`+testutil.WriteImplementSuccessArtifacts(artifactDir)+`
+`+testutil.JSONLSuccess+`
+`)
+
+	reviewScript := testutil.WriteScript(t, scriptsDir, "review.sh",
+		testutil.JSONLInit+"\n"+testutil.WriteReviewApproved(artifactDir)+"\n"+testutil.JSONLSuccess+"\n")
+
+	eventCh := make(chan interface{}, 100)
+	sm := session.NewManager(eventCh)
+	defer sm.Shutdown()
+
+	f := newTestFeature(t, workDir)
+
+	planPath := writePlanFile(t, artifactDir, "Implement something")
+
+	cfg := ImplementConfig{
+		Feature:             f,
+		WorkDir:             workDir,
+		PlanPath:            planPath,
+		MaxIterations:       5,
+		MaxConsecFails:      3,
+		MaxConsecNoProgress: 3,
+		ExitCriteria:        "Tests pass",
+		Model:               "agent",
+		ReviewModel:         "reviewer",
+		ArtifactDir:         artifactDir,
+		StateDir:            stateDir,
+		BuildSession:        mockBuildSession(agentScript, reviewScript),
+		RoundCommitHook: func(input RoundCommitInput) error {
+			return fmt.Errorf("simulated commit failure")
+		},
+	}
+
+	result, err := RunImplementationLoop(cfg, sm)
+	if err == nil {
+		t.Fatalf("expected loop error on round commit failure; got result %+v", result)
+	}
+	if !strings.Contains(err.Error(), "committing implementation round 1") {
+		t.Errorf("error = %v, want round commit failure surfaced", err)
+	}
+}
+
+// TestRunFeatureFinalReviewLoop_RoundCommitHook_FiresPerFixRound drives the
+// inverted FR order (review → fix → review) with a real git worktree and
+// asserts the fix round reports the feature-level fix counter.
+func TestRunFeatureFinalReviewLoop_RoundCommitHook_FiresPerFixRound(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	env := newFRLoopEnv(t)
+	store, f, _ := newFRTestFeature(t, env.stateDir, "fr-round-commit", []string{testRepoNameAPI})
+	repo := testutil.InitGitRepo(t)
+	f.Repos[0].Path = repo
+	f.Repos[0].WorktreePath = repo
+	if err := store.Save(f); err != nil {
+		t.Fatalf("save feature with git repo: %v", err)
+	}
+
+	artDir := frArtifactDir(env.stateDir, f)
+	if err := os.MkdirAll(artDir, 0o755); err != nil {
+		t.Fatalf("mkdir artifact: %v", err)
+	}
+
+	reviewScript := testutil.WriteScript(t, env.scriptsDir, "review.sh",
+		fmt.Sprintf(`if [ -d "%s/iteration-02" ]; then
+%s
+%s
+%s
+else
+%s
+%s
+%s
+fi`,
+			artDir,
+			testutil.JSONLInit,
+			testutil.WriteFinalReviewApproved(artDir),
+			testutil.JSONLSuccess,
+			testutil.JSONLInit,
+			testutil.WriteFinalReviewChangesRequested(artDir, "- **High**: needs a fix"),
+			testutil.JSONLSuccess))
+
+	fixScript := testutil.WriteScript(t, env.scriptsDir, "fix.sh",
+		testutil.JSONLInit+"\n"+testutil.JSONLSuccess+"\n")
+
+	eventCh := make(chan any, 100)
+	sm := session.NewManager(eventCh)
+	defer sm.Shutdown()
+
+	hook, inputs := recordingRoundCommitHook(t)
+
+	cfg := OrchestratorConfig{
+		Feature:        f,
+		FeatureStore:   store,
+		StateDir:       env.stateDir,
+		Model:          "agent",
+		ReviewModel:    "reviewer",
+		MaxIterations:  5,
+		MaxConsecFails: 3,
+		BuildSession: mockBuildSessionByModel(map[string]string{
+			"reviewer": reviewScript,
+			"agent":    fixScript,
+		}),
+		RoundCommitHook: hook,
+	}
+
+	result, err := RunFeatureFinalReviewLoop(cfg, sm)
+	if err != nil {
+		t.Fatalf("loop: %v", err)
+	}
+	if result.FinalStatus != finalStatusReviewPassed {
+		t.Fatalf("FinalStatus = %q, want review_passed (LastError=%q)", result.FinalStatus, result.LastError)
+	}
+	if len(*inputs) != 1 {
+		t.Fatalf("round commit hook fired %d times, want 1; inputs: %+v", len(*inputs), *inputs)
+	}
+	got := (*inputs)[0]
+	if got.Kind != RoundCommitFinalReviewFix {
+		t.Errorf("Kind = %q, want final_review_fix", got.Kind)
+	}
+	if got.FixNumber != 1 {
+		t.Errorf("FixNumber = %d, want 1", got.FixNumber)
+	}
+	if got.Iteration != 1 {
+		t.Errorf("Iteration = %d, want 1", got.Iteration)
+	}
+	if got.Repos[testRepoNameAPI] != repo {
+		t.Errorf("Repos[api] = %q, want %q", got.Repos[testRepoNameAPI], repo)
+	}
+}
+
+// TestRunFeatureFinalReviewLoop_DirtyWorktreeAtApprovalFailsLoudly: with
+// per-round commits wired, an approval over a dirty worktree is a fixer bug.
+// The loop must fail the feature instead of sweeping the changes.
+func TestRunFeatureFinalReviewLoop_DirtyWorktreeAtApprovalFailsLoudly(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	env := newFRLoopEnv(t)
+	store, f, _ := newFRTestFeature(t, env.stateDir, "fr-dirty-approval", []string{testRepoNameAPI})
+	repo := testutil.InitGitRepo(t)
+	f.Repos[0].Path = repo
+	f.Repos[0].WorktreePath = repo
+	if err := store.Save(f); err != nil {
+		t.Fatalf("save feature with git repo: %v", err)
+	}
+
+	artDir := frArtifactDir(env.stateDir, f)
+	if err := os.MkdirAll(artDir, 0o755); err != nil {
+		t.Fatalf("mkdir artifact: %v", err)
+	}
+
+	reviewScript := testutil.WriteScript(t, env.scriptsDir, "review.sh",
+		fmt.Sprintf(`if [ -d "%s/iteration-02" ]; then
+%s
+%s
+%s
+else
+%s
+%s
+%s
+fi`,
+			artDir,
+			testutil.JSONLInit,
+			testutil.WriteFinalReviewApproved(artDir),
+			testutil.JSONLSuccess,
+			testutil.JSONLInit,
+			testutil.WriteFinalReviewChangesRequested(artDir, "- **High**: needs a fix"),
+			testutil.JSONLSuccess))
+
+	// The fixer edits the repo but the (recording, non-committing) hook
+	// leaves the worktree dirty — simulating a fix round whose commit
+	// never landed.
+	fixScript := testutil.WriteScript(t, env.scriptsDir, "fix.sh",
+		fmt.Sprintf("%s\ncat > %s <<'EOF'\nfix applied\nEOF\n%s\n",
+			testutil.JSONLInit,
+			filepath.Join(repo, "fix.txt"),
+			testutil.JSONLSuccess))
+
+	eventCh := make(chan any, 100)
+	sm := session.NewManager(eventCh)
+	defer sm.Shutdown()
+
+	hook, _ := recordingRoundCommitHook(t)
+
+	cfg := OrchestratorConfig{
+		Feature:        f,
+		FeatureStore:   store,
+		StateDir:       env.stateDir,
+		Model:          "agent",
+		ReviewModel:    "reviewer",
+		MaxIterations:  5,
+		MaxConsecFails: 3,
+		BuildSession: mockBuildSessionByModel(map[string]string{
+			"reviewer": reviewScript,
+			"agent":    fixScript,
+		}),
+		RoundCommitHook: hook,
+	}
+
+	result, err := RunFeatureFinalReviewLoop(cfg, sm)
+	if err != nil {
+		t.Fatalf("loop: %v", err)
+	}
+	if result.FinalStatus != "failed" {
+		t.Fatalf("FinalStatus = %q, want failed", result.FinalStatus)
+	}
+	if !strings.Contains(result.LastError, testRepoNameAPI) || !strings.Contains(result.LastError, "uncommitted changes") {
+		t.Errorf("LastError = %q, want dirty-worktree failure naming repo %q", result.LastError, testRepoNameAPI)
+	}
+}
+
+// TestRunFeatureFinalReviewLoop_DirtyWorktreeAtApprovalToleratesRootArtifacts:
+// a stranded untracked progress.md at the repo root is a known orchestration
+// artifact (the publish path scrubs it) and must not fail an otherwise clean
+// approval.
+func TestRunFeatureFinalReviewLoop_DirtyWorktreeAtApprovalToleratesRootArtifacts(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	env := newFRLoopEnv(t)
+	store, f, _ := newFRTestFeature(t, env.stateDir, "fr-stray-artifact", []string{testRepoNameAPI})
+	repo := testutil.InitGitRepo(t)
+	f.Repos[0].Path = repo
+	f.Repos[0].WorktreePath = repo
+	if err := store.Save(f); err != nil {
+		t.Fatalf("save feature with git repo: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "progress.md"), []byte("stray\n"), 0o644); err != nil {
+		t.Fatalf("write stray artifact: %v", err)
+	}
+
+	artDir := frArtifactDir(env.stateDir, f)
+	if err := os.MkdirAll(artDir, 0o755); err != nil {
+		t.Fatalf("mkdir artifact: %v", err)
+	}
+
+	reviewScript := testutil.WriteScript(t, env.scriptsDir, "review.sh",
+		testutil.JSONLInit+"\n"+
+			testutil.WriteFinalReviewApproved(artDir)+"\n"+
+			testutil.JSONLSuccess+"\n")
+
+	eventCh := make(chan any, 100)
+	sm := session.NewManager(eventCh)
+	defer sm.Shutdown()
+
+	cfg := OrchestratorConfig{
+		Feature:         f,
+		FeatureStore:    store,
+		StateDir:        env.stateDir,
+		Model:           "agent",
+		ReviewModel:     "reviewer",
+		MaxIterations:   1,
+		MaxConsecFails:  3,
+		BuildSession:    mockBuildSessionByModel(map[string]string{"reviewer": reviewScript}),
+		RoundCommitHook: func(input RoundCommitInput) error { return nil },
+	}
+
+	result, err := RunFeatureFinalReviewLoop(cfg, sm)
+	if err != nil {
+		t.Fatalf("loop: %v", err)
+	}
+	if result.FinalStatus != finalStatusReviewPassed {
+		t.Fatalf("FinalStatus = %q, want review_passed (LastError=%q)", result.FinalStatus, result.LastError)
+	}
+}
+
+// TestNewImplementRoundCommitTracker_RecoveryFromMetas seeds the tracker from
+// persisted iteration metas so a crash-resumed loop keeps the round labeling
+// of the interrupted run.
+func TestNewImplementRoundCommitTracker_RecoveryFromMetas(t *testing.T) {
+	artifactDir := t.TempDir()
+	am := NewArtifactManager(artifactDir)
+
+	writeMeta := func(iter int, agentStatus, reviewStatus string) {
+		t.Helper()
+		iterDir := filepath.Join(artifactDir, fmt.Sprintf("iteration-%02d", iter))
+		if err := os.MkdirAll(iterDir, 0o755); err != nil {
+			t.Fatalf("mkdir iteration dir: %v", err)
+		}
+		if err := am.WriteMeta(iterDir, IterationMeta{Iteration: iter, AgentStatus: agentStatus, ReviewStatus: reviewStatus}); err != nil {
+			t.Fatalf("write meta: %v", err)
+		}
+	}
+	// Phase history: implement (1), fix (2, changes_requested review at 1),
+	// failed fix attempt (3), fix (4, second changes_requested at 3... no —
+	// review at 2 approved nothing yet). Realistic sequence:
+	//   1: SUCCESS / CHANGES_REQUESTED  → fix round 1 follows
+	//   2: FAILED  / (empty)             → fix round 1 failed, no commit
+	//   3: SUCCESS / CHANGES_REQUESTED   → fix round 2 follows
+	//   4: SUCCESS / (pending review)
+	writeMeta(1, agentStatusSuccess, agentStatusChangesRequested)
+	writeMeta(2, agentStatusFailed, "")
+	writeMeta(3, agentStatusSuccess, agentStatusChangesRequested)
+	writeMeta(4, agentStatusSuccess, "")
+
+	tr := newImplementRoundCommitTracker(am, artifactDir, 4)
+	if tr.changesRequested != 2 {
+		t.Errorf("changesRequested = %d, want 2", tr.changesRequested)
+	}
+	if !tr.semanticSessions {
+		t.Error("semanticSessions = false, want true after a SUCCESS round")
+	}
+
+	// A phase with only a FAILED round: the next round is still the
+	// unlabeled first implementation commit.
+	emptyDir := t.TempDir()
+	am2 := NewArtifactManager(emptyDir)
+	iterDir := filepath.Join(emptyDir, "iteration-01")
+	os.MkdirAll(iterDir, 0o755)
+	_ = am2.WriteMeta(iterDir, IterationMeta{Iteration: 1, AgentStatus: agentStatusFailed})
+	tr2 := newImplementRoundCommitTracker(am2, emptyDir, 1)
+	if tr2.semanticSessions {
+		t.Error("semanticSessions = true, want false after only a FAILED round")
+	}
+	if tr2.changesRequested != 0 {
+		t.Errorf("changesRequested = %d, want 0", tr2.changesRequested)
+	}
+}
+
+// TestNewFRRoundCommitTracker_RecoveryFromMetas seeds the FR fix counter from
+// lowercase "changes_requested" review statuses.
+func TestNewFRRoundCommitTracker_RecoveryFromMetas(t *testing.T) {
+	artifactDir := t.TempDir()
+	am := NewArtifactManager(artifactDir)
+	for iter, reviewStatus := range map[int]string{1: "changes_requested", 2: "changes_requested", 3: "approved"} {
+		iterDir := filepath.Join(artifactDir, fmt.Sprintf("iteration-%02d", iter))
+		if err := os.MkdirAll(iterDir, 0o755); err != nil {
+			t.Fatalf("mkdir iteration dir: %v", err)
+		}
+		if err := am.WriteMeta(iterDir, IterationMeta{Iteration: iter, ReviewStatus: reviewStatus}); err != nil {
+			t.Fatalf("write meta: %v", err)
+		}
+	}
+	tr := newFRRoundCommitTracker(am, artifactDir, 3)
+	if tr.changesRequested != 2 {
+		t.Errorf("changesRequested = %d, want 2", tr.changesRequested)
+	}
+}

--- a/internal/git/publish.go
+++ b/internal/git/publish.go
@@ -197,30 +197,40 @@ func HasUncommittedChanges(worktreePath string) bool {
 
 // HasUncommittedChangesExcludingUntracked reports whether the worktree has
 // staged, unstaged, or untracked changes, disregarding untracked entries
-// whose relative path is in names. Tracked changes to those paths still
-// count — only never-committed files matching the known-artifact names are
-// ignored.
-func HasUncommittedChangesExcludingUntracked(worktreePath string, names ...string) bool {
+// whose path is in names. Tracked changes to those paths still count — only
+// never-committed files matching the known-artifact names are ignored. A
+// probe failure is surfaced as an error so an indeterminate worktree never
+// reads as clean.
+func HasUncommittedChangesExcludingUntracked(worktreePath string, names ...string) (bool, error) {
+	wm := &WorktreeManager{}
+	report, err := wm.InspectCleanliness(worktreePath, 0)
+	if err != nil {
+		return false, fmt.Errorf("checking uncommitted changes in %s: %w", worktreePath, err)
+	}
+	if report.StagedTotal > 0 || report.UnstagedTotal > 0 {
+		return true, nil
+	}
+	if report.UntrackedTotal == 0 {
+		return false, nil
+	}
+	// The bounded untracked list may have truncated; re-probe unbounded so
+	// every untracked path is classified against the ignore set.
+	if report.UntrackedTotal > len(report.Untracked) {
+		report, err = wm.InspectCleanliness(worktreePath, report.UntrackedTotal)
+		if err != nil {
+			return false, fmt.Errorf("checking untracked files in %s: %w", worktreePath, err)
+		}
+	}
 	ignore := make(map[string]bool, len(names))
 	for _, n := range names {
 		ignore[n] = true
 	}
-	cmd := readGitCmd(worktreePath, "status", "--porcelain")
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		return false
-	}
-	for _, line := range strings.Split(string(out), "\n") {
-		if len(line) < 4 {
-			continue
+	for _, p := range report.Untracked {
+		if !ignore[p] {
+			return true, nil
 		}
-		path := strings.TrimSpace(line[3:])
-		if line[:2] == "??" && ignore[path] {
-			continue
-		}
-		return true
 	}
-	return false
+	return false, nil
 }
 
 // CommitAll stages all changes (including untracked files) and creates a commit.

--- a/internal/git/publish.go
+++ b/internal/git/publish.go
@@ -195,6 +195,34 @@ func HasUncommittedChanges(worktreePath string) bool {
 	return strings.TrimSpace(string(out)) != ""
 }
 
+// HasUncommittedChangesExcludingUntracked reports whether the worktree has
+// staged, unstaged, or untracked changes, disregarding untracked entries
+// whose relative path is in names. Tracked changes to those paths still
+// count — only never-committed files matching the known-artifact names are
+// ignored.
+func HasUncommittedChangesExcludingUntracked(worktreePath string, names ...string) bool {
+	ignore := make(map[string]bool, len(names))
+	for _, n := range names {
+		ignore[n] = true
+	}
+	cmd := readGitCmd(worktreePath, "status", "--porcelain")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return false
+	}
+	for _, line := range strings.Split(string(out), "\n") {
+		if len(line) < 4 {
+			continue
+		}
+		path := strings.TrimSpace(line[3:])
+		if line[:2] == "??" && ignore[path] {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
 // CommitAll stages all changes (including untracked files) and creates a commit.
 // The Agentic signature trailer is automatically appended to the commit message.
 func CommitAll(worktreePath, message string) error {

--- a/internal/git/publish_exclusion_test.go
+++ b/internal/git/publish_exclusion_test.go
@@ -1,0 +1,59 @@
+// Copyright 2026 DoorDash, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package git_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/doordash-oss/agentic-orchestrator/internal/git"
+	"github.com/doordash-oss/agentic-orchestrator/test/testutil"
+)
+
+func TestHasUncommittedChangesExcludingUntracked(t *testing.T) {
+	repo := testutil.InitGitRepo(t)
+
+	if git.HasUncommittedChangesExcludingUntracked(repo, "progress.md") {
+		t.Fatal("clean repo reported dirty")
+	}
+
+	// Known orchestration artifact stranded untracked at the root: ignored.
+	if err := os.WriteFile(filepath.Join(repo, "progress.md"), []byte("stray\n"), 0o644); err != nil {
+		t.Fatalf("write stray artifact: %v", err)
+	}
+	if git.HasUncommittedChangesExcludingUntracked(repo, "progress.md", "meta.yaml") {
+		t.Fatal("untracked known artifact must be ignored")
+	}
+	if !git.HasUncommittedChanges(repo) {
+		t.Fatal("sanity: HasUncommittedChanges must still see the stray file")
+	}
+
+	// An unrelated untracked file still counts.
+	if err := os.WriteFile(filepath.Join(repo, "notes.md"), []byte("x\n"), 0o644); err != nil {
+		t.Fatalf("write unrelated file: %v", err)
+	}
+	if !git.HasUncommittedChangesExcludingUntracked(repo, "progress.md") {
+		t.Fatal("untracked unknown file must count as dirty")
+	}
+
+	// A tracked modification of an excluded name still counts.
+	if err := os.WriteFile(filepath.Join(repo, "README.md"), []byte("# changed\n"), 0o644); err != nil {
+		t.Fatalf("modify tracked file: %v", err)
+	}
+	if !git.HasUncommittedChangesExcludingUntracked(repo, "README.md") {
+		t.Fatal("tracked change to an excluded-name path must count as dirty")
+	}
+}

--- a/internal/git/publish_exclusion_test.go
+++ b/internal/git/publish_exclusion_test.go
@@ -26,7 +26,11 @@ import (
 func TestHasUncommittedChangesExcludingUntracked(t *testing.T) {
 	repo := testutil.InitGitRepo(t)
 
-	if git.HasUncommittedChangesExcludingUntracked(repo, "progress.md") {
+	dirty, err := git.HasUncommittedChangesExcludingUntracked(repo, "progress.md")
+	if err != nil {
+		t.Fatalf("clean repo probe: %v", err)
+	}
+	if dirty {
 		t.Fatal("clean repo reported dirty")
 	}
 
@@ -34,7 +38,11 @@ func TestHasUncommittedChangesExcludingUntracked(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(repo, "progress.md"), []byte("stray\n"), 0o644); err != nil {
 		t.Fatalf("write stray artifact: %v", err)
 	}
-	if git.HasUncommittedChangesExcludingUntracked(repo, "progress.md", "meta.yaml") {
+	dirty, err = git.HasUncommittedChangesExcludingUntracked(repo, "progress.md", "meta.yaml")
+	if err != nil {
+		t.Fatalf("stray artifact probe: %v", err)
+	}
+	if dirty {
 		t.Fatal("untracked known artifact must be ignored")
 	}
 	if !git.HasUncommittedChanges(repo) {
@@ -45,7 +53,11 @@ func TestHasUncommittedChangesExcludingUntracked(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(repo, "notes.md"), []byte("x\n"), 0o644); err != nil {
 		t.Fatalf("write unrelated file: %v", err)
 	}
-	if !git.HasUncommittedChangesExcludingUntracked(repo, "progress.md") {
+	dirty, err = git.HasUncommittedChangesExcludingUntracked(repo, "progress.md")
+	if err != nil {
+		t.Fatalf("unrelated file probe: %v", err)
+	}
+	if !dirty {
 		t.Fatal("untracked unknown file must count as dirty")
 	}
 
@@ -53,7 +65,20 @@ func TestHasUncommittedChangesExcludingUntracked(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(repo, "README.md"), []byte("# changed\n"), 0o644); err != nil {
 		t.Fatalf("modify tracked file: %v", err)
 	}
-	if !git.HasUncommittedChangesExcludingUntracked(repo, "README.md") {
+	dirty, err = git.HasUncommittedChangesExcludingUntracked(repo, "README.md")
+	if err != nil {
+		t.Fatalf("tracked change probe: %v", err)
+	}
+	if !dirty {
 		t.Fatal("tracked change to an excluded-name path must count as dirty")
+	}
+}
+
+// An indeterminate probe (broken git state) must surface as an error, never
+// as a clean worktree — the approval gate treats errors as failures.
+func TestHasUncommittedChangesExcludingUntracked_ProbeFailureIsError(t *testing.T) {
+	_, err := git.HasUncommittedChangesExcludingUntracked("/nonexistent/repo/path", "progress.md")
+	if err == nil {
+		t.Fatal("probe over a missing worktree must return an error, not clean")
 	}
 }

--- a/internal/orchestrator/completion.go
+++ b/internal/orchestrator/completion.go
@@ -1150,10 +1150,12 @@ func (o *Orchestrator) scrubFinalReviewRootArtifacts(ctx context.Context, workDi
 // round commit produced. Per-round commits replaced the former end-of-phase
 // squash commit, so phase completion no longer mutates git: each round
 // already committed through the RoundCommitHook, and a repo no round dirtied
-// anchors at its existing HEAD. Repos whose HEAD cannot be read are omitted
-// from the anchor map (advisory, matching the old phase-commit failure
-// handling: the phase still advances, but rewind tooling will not pretend an
-// anchor exists).
+// anchors at its existing HEAD. Known untracked root orchestration artifacts
+// stranded by the post-commit review sessions are scrubbed here so they
+// cannot leak across the phase boundary into the next phase's first round
+// commit. Repos whose HEAD cannot be read are omitted from the anchor map
+// (advisory, matching the old phase-commit failure handling: the phase still
+// advances, but rewind tooling will not pretend an anchor exists).
 func (o *Orchestrator) roadmapPhaseAnchors(f *feature.Feature) map[string]string {
 	if len(f.Repos) == 0 {
 		return nil
@@ -1162,6 +1164,17 @@ func (o *Orchestrator) roadmapPhaseAnchors(f *feature.Feature) map[string]string
 	for _, repo := range roadmapPhaseCommitRepos(f) {
 		if repo.WorktreePath == "" {
 			continue
+		}
+		if err := o.scrubFinalReviewRootArtifacts(context.Background(), repo.WorktreePath); err != nil {
+			// Best-effort hygiene: the anchor is still recorded, but the
+			// leak risk is surfaced on the event bus.
+			o.emitEvent(ports.Event{
+				Type:      ports.RepoStatusChanged,
+				FeatureID: f.ID,
+				RepoName:  repo.Name,
+				Error:     err,
+				Message:   fmt.Sprintf("roadmap phase %d artifact scrub failed", f.CurrentRoadmapPhase),
+			})
 		}
 		sha, err := git.CurrentHeadSHA(repo.WorktreePath)
 		if err != nil || sha == "" {

--- a/internal/orchestrator/completion.go
+++ b/internal/orchestrator/completion.go
@@ -63,13 +63,10 @@ func isTerminalForCompletion(f *feature.Feature) bool {
 // to give that caller an unambiguous short-circuit signal.
 var errFinalReviewInterrupted = errors.New("final review interrupted")
 
-var finalReviewRootOrchestrationArtifacts = []string{
-	agent.PhaseCompleteFile,
-	"progress.md",
-	"verification-report.yaml",
-	"review-feedback.md",
-	"meta.yaml",
-}
+// finalReviewRootOrchestrationArtifacts are the repo-root files the publish
+// path scrubs and the Final Review approval dirty-check tolerates; the
+// canonical list lives with the agent-side round-commit contract.
+var finalReviewRootOrchestrationArtifacts = agent.FinalReviewRootOrchestrationArtifacts
 
 // emitPhaseCompleted emits a PhaseCompleted event and fires the hook. This
 // is the sole emission site for phase completion in completion handlers.
@@ -926,9 +923,10 @@ func (o *Orchestrator) onMultiReposPassed(featureID string, f *feature.Feature) 
 	if f.Status != feature.StatusImplementing {
 		return nil
 	}
-	// A roadmap phase crosses a synchronous per-repo git boundary below. Flag
-	// it before StatusReviewPassed becomes observable, so no reader sees a
-	// startable steady state while the commit loop is still running.
+	// A roadmap phase crosses a synchronous per-repo boundary below (anchor
+	// recording + phase advance). Flag it before StatusReviewPassed becomes
+	// observable, so no reader sees a startable steady state while that
+	// boundary is still running.
 	if f.CurrentRoadmapPhase > 0 {
 		o.setFinalizingPhaseStatus(featureID, true)
 		defer o.setFinalizingPhaseStatus(featureID, false)
@@ -938,9 +936,9 @@ func (o *Orchestrator) onMultiReposPassed(featureID string, f *feature.Feature) 
 	}
 	o.emitPhaseCompleted(featureID, feature.PhaseImplement, nil)
 
-	// Roadmap mid-flight: commit + advance.
+	// Roadmap mid-flight: record anchors + advance.
 	if f.CurrentRoadmapPhase > 0 && f.CurrentRoadmapPhase < f.TotalRoadmapPhases {
-		anchors := o.commitRoadmapPhase(f)
+		anchors := o.roadmapPhaseAnchors(f)
 		o.setFinalizingPhaseStatus(featureID, false)
 		if err := o.recordRoadmapPhaseCommitAnchors(featureID, f.CurrentRoadmapPhase, anchors); err != nil {
 			return err
@@ -958,9 +956,9 @@ func (o *Orchestrator) onMultiReposPassed(featureID string, f *feature.Feature) 
 		return nil
 	}
 
-	// Roadmap final phase: commit + fall through to review / publish.
+	// Roadmap final phase: record anchors + fall through to review / publish.
 	if f.CurrentRoadmapPhase > 0 && f.CurrentRoadmapPhase == f.TotalRoadmapPhases {
-		anchors := o.commitRoadmapPhase(f)
+		anchors := o.roadmapPhaseAnchors(f)
 		o.setFinalizingPhaseStatus(featureID, false)
 		if err := o.recordRoadmapPhaseCommitAnchors(featureID, f.CurrentRoadmapPhase, anchors); err != nil {
 			return err
@@ -1148,55 +1146,35 @@ func (o *Orchestrator) scrubFinalReviewRootArtifacts(ctx context.Context, workDi
 	return nil
 }
 
-// commitRoadmapPhase creates per-repo commits for a completed roadmap phase
-// and returns the full HEAD SHA for each repo whose commit-or-anchor operation
-// succeeded. Commit failures remain advisory for pipeline progress, but failed
-// repos are omitted from the returned anchor map.
-func (o *Orchestrator) commitRoadmapPhase(f *feature.Feature) map[string]string {
+// roadmapPhaseAnchors records the per-repo HEAD SHA that the phase's last
+// round commit produced. Per-round commits replaced the former end-of-phase
+// squash commit, so phase completion no longer mutates git: each round
+// already committed through the RoundCommitHook, and a repo no round dirtied
+// anchors at its existing HEAD. Repos whose HEAD cannot be read are omitted
+// from the anchor map (advisory, matching the old phase-commit failure
+// handling: the phase still advances, but rewind tooling will not pretend an
+// anchor exists).
+func (o *Orchestrator) roadmapPhaseAnchors(f *feature.Feature) map[string]string {
 	if len(f.Repos) == 0 {
 		return nil
 	}
-	phaseName := ""
-	if roadmapPath := o.resolveArtifactPath(f, "roadmap"); roadmapPath != "" {
-		if data, err := os.ReadFile(roadmapPath); err == nil {
-			if phases, err := agent.ParseRoadmap(string(data)); err == nil {
-				for _, p := range phases {
-					if p.Number == f.CurrentRoadmapPhase {
-						phaseName = p.Name
-						break
-					}
-				}
-			}
-		}
-	}
-	msg := fmt.Sprintf("Phase %d/%d (%s)", f.CurrentRoadmapPhase, f.TotalRoadmapPhases, f.RoadmapPhaseType)
-	if phaseName != "" {
-		msg += ": " + phaseName
-	}
-	msg += "\n\nFeature: " + f.Slug
 	anchors := make(map[string]string)
 	for _, repo := range roadmapPhaseCommitRepos(f) {
 		if repo.WorktreePath == "" {
 			continue
 		}
-		sha, err := git.CommitAllAndGetHead(repo.WorktreePath, msg)
+		sha, err := git.CurrentHeadSHA(repo.WorktreePath)
 		if err != nil || sha == "" {
 			o.emitEvent(ports.Event{
 				Type:      ports.RepoStatusChanged,
 				FeatureID: f.ID,
 				RepoName:  repo.Name,
 				Error:     err,
-				Message:   fmt.Sprintf("roadmap phase %d commit did not produce an anchor", f.CurrentRoadmapPhase),
+				Message:   fmt.Sprintf("roadmap phase %d anchor unavailable", f.CurrentRoadmapPhase),
 			})
 			continue
 		}
 		anchors[repo.Name] = sha
-		o.emitEvent(ports.Event{
-			Type:      ports.RepoStatusChanged,
-			FeatureID: f.ID,
-			RepoName:  repo.Name,
-			Message:   fmt.Sprintf("committed roadmap phase %d", f.CurrentRoadmapPhase),
-		})
 	}
 	if len(anchors) == 0 {
 		return nil
@@ -1226,9 +1204,10 @@ func roadmapPhaseCommitRepos(f *feature.Feature) []feature.FeatureRepo {
 	return repos
 }
 
-// setFinalizingPhaseStatus flags or clears the end-of-phase git boundary.
-// Clearing only touches the finalizing token so a status written by a later
-// phase step is never clobbered.
+// setFinalizingPhaseStatus flags or clears the end-of-phase boundary (anchor
+// recording + phase advance; per-round commits happen earlier, inside the
+// implementation loops). Clearing only touches the finalizing token so a
+// status written by a later phase step is never clobbered.
 func (o *Orchestrator) setFinalizingPhaseStatus(featureID string, finalizing bool) {
 	if o.deps.Store == nil {
 		return

--- a/internal/orchestrator/completion_test.go
+++ b/internal/orchestrator/completion_test.go
@@ -1929,6 +1929,10 @@ func TestOrchestrator_HandlePhaseCompletion_Implement_Multi_RoadmapMidflight_Emi
 	}
 }
 
+// Per-round commits replaced the end-of-phase squash commit: phase
+// completion records each touched repo's HEAD as the anchor without
+// mutating git. Dirty worktrees at this boundary would indicate a round
+// commit that never fired; the anchors must match the pre-boundary HEADs.
 func TestOrchestrator_HandlePhaseCompletion_Implement_RoadmapRecordsCommitAnchors(t *testing.T) {
 	changedRepo := testutil.InitGitRepo(t)
 	unchangedRepo := testutil.InitGitRepo(t)
@@ -1937,6 +1941,8 @@ func TestOrchestrator_HandlePhaseCompletion_Implement_RoadmapRecordsCommitAnchor
 			t.Fatalf("write phase change: %v", err)
 		}
 	}
+	changedHeadBefore, _ := git.CurrentHeadSHA(changedRepo)
+	unchangedHeadBefore, _ := git.CurrentHeadSHA(unchangedRepo)
 	roadmapPath := writeTempFile(t, "roadmap.md",
 		"# Roadmap\n\n## Phase 1: Tracer\n### Goal\nFirst phase.\n\n## Phase 2: Fill\n### Goal\nSecond phase.\n")
 	f := &feature.Feature{
@@ -1982,16 +1988,24 @@ func TestOrchestrator_HandlePhaseCompletion_Implement_RoadmapRecordsCommitAnchor
 	if recordedPhase != 1 {
 		t.Fatalf("recorded phase = %d, want 1", recordedPhase)
 	}
-	changedSHA, _ := git.CurrentHeadSHA(changedRepo)
-	unchangedSHA, _ := git.CurrentHeadSHA(unchangedRepo)
-	want := map[string]string{"changed": changedSHA, "unchanged": unchangedSHA}
+	want := map[string]string{"changed": changedHeadBefore, "unchanged": unchangedHeadBefore}
 	for repo, wantSHA := range want {
 		if got := recordedAnchors[repo]; got != wantSHA {
 			t.Errorf("anchor[%s] = %q, want %q", repo, got, wantSHA)
 		}
 	}
+	// Phase completion must not mutate git: per-round commits own that.
+	changedHeadAfter, _ := git.CurrentHeadSHA(changedRepo)
+	if changedHeadAfter != changedHeadBefore {
+		t.Errorf("changed repo HEAD moved at phase boundary: %q -> %q", changedHeadBefore, changedHeadAfter)
+	}
+	if !git.HasUncommittedChanges(changedRepo) {
+		t.Error("changed repo worktree unexpectedly clean; the stray phase.txt should remain uncommitted")
+	}
 }
 
+// A repo whose HEAD cannot be read gets no anchor: the phase still advances,
+// but rewind tooling must not pretend an anchor exists.
 func TestOrchestrator_HandlePhaseCompletion_Implement_SkipsAnchorOnCommitFailure(t *testing.T) {
 	okRepo := testutil.InitGitRepo(t)
 	if err := os.WriteFile(filepath.Join(okRepo, "phase.txt"), []byte("complete\n"), 0o644); err != nil {
@@ -2228,10 +2242,9 @@ func TestOrchestrator_HandlePhaseCompletion_Implement_Multi_AllPassed_Idempotent
 	}
 }
 
-// Bug 5B: the roadmap phase commit must only visit repos the phase actually
-// touched. `git add -A` over an untouched worktree costs seconds per repo for
-// no anchor, and the hidden scan happens while the UI already shows
-// "Review passed".
+// Bug 5B: the phase boundary must only visit repos the phase actually
+// touched. Reading HEAD over an untouched multi-gigabyte worktree is cheap,
+// but the anchor set must not lie about which repos carry phase work.
 func TestOrchestrator_HandlePhaseCompletion_Implement_RoadmapSkipsUntouchedRepos(t *testing.T) {
 	touchedRepo := testutil.InitGitRepo(t)
 	untouchedRepo := testutil.InitGitRepo(t)
@@ -2286,10 +2299,10 @@ func TestOrchestrator_HandlePhaseCompletion_Implement_RoadmapSkipsUntouchedRepos
 	}
 
 	if _, ok := recordedAnchors["touched"]; !ok {
-		t.Errorf("touched repo must be committed; anchors = %v", recordedAnchors)
+		t.Errorf("touched repo must be anchored; anchors = %v", recordedAnchors)
 	}
 	if _, ok := recordedAnchors["untouched"]; ok {
-		t.Errorf("untouched repo must not be committed; anchors = %v", recordedAnchors)
+		t.Errorf("untouched repo must not be anchored; anchors = %v", recordedAnchors)
 	}
 	untouchedHeadAfter, err := git.CurrentHeadSHA(untouchedRepo)
 	if err != nil {
@@ -2308,8 +2321,8 @@ func TestOrchestrator_HandlePhaseCompletion_Implement_RoadmapSkipsUntouchedRepos
 }
 
 // With no repo state at all the touched set carries no information, so the
-// phase commit must fall back to every configured repo rather than skipping
-// the phase silently.
+// phase boundary must fall back to every configured repo rather than
+// skipping anchor recording silently.
 func TestOrchestrator_HandlePhaseCompletion_Implement_RoadmapCommitsAllReposWithoutRepoStates(t *testing.T) {
 	repo := testutil.InitGitRepo(t)
 	if err := os.WriteFile(filepath.Join(repo, "phase.txt"), []byte("complete\n"), 0o644); err != nil {
@@ -2349,13 +2362,14 @@ func TestOrchestrator_HandlePhaseCompletion_Implement_RoadmapCommitsAllReposWith
 		t.Fatalf("HandlePhaseCompletion: %v", err)
 	}
 	if _, ok := recordedAnchors["solo"]; !ok {
-		t.Errorf("repo must be committed when no touched state exists; anchors = %v", recordedAnchors)
+		t.Errorf("repo must be anchored when no touched state exists; anchors = %v", recordedAnchors)
 	}
 }
 
 // Bug 5B: StatusReviewPassed becomes observable before the synchronous
-// per-repo git boundary finishes. The finalizing phase status must already be
-// set at that transition, and cleared before the phase advances.
+// per-repo boundary finishes (anchor recording + phase advance). The
+// finalizing phase status must already be set at that transition, and
+// cleared before the phase advances.
 func TestOrchestrator_HandlePhaseCompletion_Implement_RoadmapMarksFinalizingAcrossCommitBoundary(t *testing.T) {
 	repo := testutil.InitGitRepo(t)
 	if err := os.WriteFile(filepath.Join(repo, "phase.txt"), []byte("complete\n"), 0o644); err != nil {
@@ -2411,17 +2425,6 @@ func TestOrchestrator_HandlePhaseCompletion_Implement_RoadmapMarksFinalizingAcro
 	}
 	if f.IsFinalizingPhase() {
 		t.Error("feature must not remain finalizing after the commit boundary")
-	}
-
-	events := drainEvents(o)
-	sawRepoCommit := false
-	for _, ev := range events {
-		if ev.Type == ports.RepoStatusChanged && ev.RepoName == "solo" {
-			sawRepoCommit = true
-		}
-	}
-	if !sawRepoCommit {
-		t.Errorf("expected a per-repo RepoStatusChanged event for the phase commit; got %+v", events)
 	}
 }
 

--- a/internal/orchestrator/lifecycle_delegates.go
+++ b/internal/orchestrator/lifecycle_delegates.go
@@ -190,33 +190,6 @@ func (o *Orchestrator) MarkPublished(featureID, prURL string) error {
 	return nil
 }
 
-// CommitRoadmapPhase commits the completed roadmap phase across every repo in
-// the feature.
-// Errors on individual repos are swallowed — this is a best-effort pipeline
-// step whose failure should not block the lifecycle.
-func (o *Orchestrator) CommitRoadmapPhase(featureID string, phase int) error {
-	f, err := o.deps.Lifecycle.Get(featureID)
-	if err != nil {
-		return fmt.Errorf("load feature: %w", err)
-	}
-	if len(f.Repos) == 0 {
-		return nil
-	}
-	phaseName := o.lookupRoadmapPhaseName(f, phase)
-	commitMsg := fmt.Sprintf("Phase %d/%d (%s)", phase, f.TotalRoadmapPhases, f.RoadmapPhaseType)
-	if phaseName != "" {
-		commitMsg += ": " + phaseName
-	}
-	commitMsg += "\n\nFeature: " + f.Slug
-	for _, repo := range f.Repos {
-		if repo.WorktreePath == "" {
-			continue
-		}
-		_ = git.CommitAll(repo.WorktreePath, commitMsg)
-	}
-	return nil
-}
-
 // TransitionTo transitions a feature to a caller-selected status while keeping
 // lifecycle mutations behind the orchestrator boundary.
 func (o *Orchestrator) TransitionTo(featureID string, status feature.Status) error {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -311,6 +311,19 @@ func New(deps Deps, hooks Hooks) *Orchestrator {
 			}
 			o.emitEvent(ports.Event{Type: ports.VerificationProgress, FeatureID: featureID})
 		}
+		// Per-round commits: the implementation and final-review loops emit
+		// a round completion event; this layer owns the git commit. Chained
+		// behind any pre-existing hook exactly once (the PhaseRunner is
+		// shared state and New is the single production wiring site).
+		existingRoundCommitHook := o.deps.PhaseRunner.RoundCommitHook
+		o.deps.PhaseRunner.RoundCommitHook = func(input agent.RoundCommitInput) error {
+			if existingRoundCommitHook != nil {
+				if err := existingRoundCommitHook(input); err != nil {
+					return err
+				}
+			}
+			return o.commitRound(input)
+		}
 	}
 	o.runMultiRepoImplFn = func(
 		f *feature.Feature,

--- a/internal/orchestrator/round_commits.go
+++ b/internal/orchestrator/round_commits.go
@@ -1,0 +1,132 @@
+// Copyright 2026 DoorDash, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package orchestrator
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/doordash-oss/agentic-orchestrator/internal/agent"
+	"github.com/doordash-oss/agentic-orchestrator/internal/feature"
+	"github.com/doordash-oss/agentic-orchestrator/internal/git"
+	"github.com/doordash-oss/agentic-orchestrator/internal/ports"
+)
+
+// commitRound is the agent.RoundCommitHook implementation the orchestrator
+// installs on the PhaseRunner (see New). The implementation and final-review
+// loops report each completed round here; this layer owns the git commit:
+// only repos the round actually dirtied are committed, each with the
+// round-specific message. A clean worktree is a no-op. Commit failures fail
+// the round loudly — the loops surface the error and fail their phase —
+// rather than silently stranding a dirty worktree mid-phase.
+func (o *Orchestrator) commitRound(input agent.RoundCommitInput) error {
+	if len(input.Repos) == 0 {
+		return nil
+	}
+	f, err := o.deps.Lifecycle.Get(input.FeatureID)
+	if err != nil {
+		return fmt.Errorf("load feature %s for round commit: %w", input.FeatureID, err)
+	}
+	msg := o.roundCommitMessage(f, input)
+
+	names := make([]string, 0, len(input.Repos))
+	for name := range input.Repos {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	var failed []string
+	for _, name := range names {
+		path := input.Repos[name]
+		if path == "" || !git.HasUncommittedChanges(path) {
+			continue
+		}
+		if _, err := git.CommitAllAndGetHead(path, msg); err != nil {
+			failed = append(failed, name)
+			o.emitEvent(ports.Event{
+				Type:      ports.RepoStatusChanged,
+				FeatureID: input.FeatureID,
+				RepoName:  name,
+				Error:     err,
+				Message:   fmt.Sprintf("round commit failed (%s): %v", roundCommitEventLabel(input), err),
+			})
+			continue
+		}
+		o.emitEvent(ports.Event{
+			Type:      ports.RepoStatusChanged,
+			FeatureID: input.FeatureID,
+			RepoName:  name,
+			Message:   "committed " + roundCommitEventLabel(input),
+		})
+	}
+	if len(failed) > 0 {
+		return fmt.Errorf("round commit failed in repo(s) %s", strings.Join(failed, ", "))
+	}
+	return nil
+}
+
+// roundCommitMessage renders the commit message for a completed round.
+//
+// Roadmap features carry the historical phase prefix; the phase's first
+// implementation commit keeps the unlabeled "Phase N/M (type): Name" subject
+// so the happy-path log reads like the former single-commit-per-phase flow,
+// while every later round is labeled:
+//
+//	Phase 1/3 (tracer-bullet): Tracer
+//	Phase 1/3 (tracer-bullet): Tracer - implementation round 2
+//	Phase 1/3 (tracer-bullet): Tracer - fix round 1 (address review feedback)
+//
+// Final Review fixes are feature-level and use their own counter:
+//
+//	Final review fix 2 (address review feedback)
+//
+// Non-roadmap features have no phase prefix, so every round is labeled.
+func (o *Orchestrator) roundCommitMessage(f *feature.Feature, input agent.RoundCommitInput) string {
+	featureLine := "\n\nFeature: " + f.Slug
+	if input.Kind == agent.RoundCommitFinalReviewFix {
+		return fmt.Sprintf("Final review fix %d (address review feedback)%s", input.FixNumber, featureLine)
+	}
+	if input.PhaseNumber <= 0 {
+		if input.Kind == agent.RoundCommitFix {
+			return fmt.Sprintf("Fix round %d (address review feedback)%s", input.FixNumber, featureLine)
+		}
+		return fmt.Sprintf("Implementation round %d%s", input.Iteration, featureLine)
+	}
+	base := fmt.Sprintf("Phase %d/%d (%s)", input.PhaseNumber, input.TotalPhases, input.PhaseType)
+	if phaseName := o.lookupRoadmapPhaseName(f, input.PhaseNumber); phaseName != "" {
+		base += ": " + phaseName
+	}
+	switch {
+	case input.Kind == agent.RoundCommitFix:
+		base += fmt.Sprintf(" - fix round %d (address review feedback)", input.FixNumber)
+	case !input.FirstImplementCommit:
+		base += fmt.Sprintf(" - implementation round %d", input.Iteration)
+	}
+	return base + featureLine
+}
+
+// roundCommitEventLabel renders the human-facing round label used in
+// RepoStatusChanged event messages.
+func roundCommitEventLabel(input agent.RoundCommitInput) string {
+	switch input.Kind {
+	case agent.RoundCommitFinalReviewFix:
+		return fmt.Sprintf("final review fix round %d", input.FixNumber)
+	case agent.RoundCommitFix:
+		return fmt.Sprintf("fix round %d", input.FixNumber)
+	default:
+		return fmt.Sprintf("implementation round %d", input.Iteration)
+	}
+}

--- a/internal/orchestrator/round_commits.go
+++ b/internal/orchestrator/round_commits.go
@@ -15,6 +15,7 @@
 package orchestrator
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"strings"
@@ -29,18 +30,15 @@ import (
 // installs on the PhaseRunner (see New). The implementation and final-review
 // loops report each completed round here; this layer owns the git commit:
 // only repos the round actually dirtied are committed, each with the
-// round-specific message. A clean worktree is a no-op. Commit failures fail
-// the round loudly — the loops surface the error and fail their phase —
-// rather than silently stranding a dirty worktree mid-phase.
+// round-specific message. A clean worktree is a no-op (and costs no feature
+// load or message render). Known untracked root orchestration artifacts are
+// scrubbed before staging so `git add -A` can never track them. Commit
+// failures fail the round loudly — the loops surface the error and fail
+// their phase — rather than silently stranding a dirty worktree mid-phase.
 func (o *Orchestrator) commitRound(input agent.RoundCommitInput) error {
 	if len(input.Repos) == 0 {
 		return nil
 	}
-	f, err := o.deps.Lifecycle.Get(input.FeatureID)
-	if err != nil {
-		return fmt.Errorf("load feature %s for round commit: %w", input.FeatureID, err)
-	}
-	msg := o.roundCommitMessage(f, input)
 
 	names := make([]string, 0, len(input.Repos))
 	for name := range input.Repos {
@@ -48,18 +46,44 @@ func (o *Orchestrator) commitRound(input agent.RoundCommitInput) error {
 	}
 	sort.Strings(names)
 
-	var failed []string
+	// Pass 1: resolve which repos still carry uncommitted round work after
+	// scrubbing known orchestration artifacts. Typically empty — a clean
+	// round pays only the status probe, no feature load or roadmap parse.
+	type pendingCommit struct {
+		name string
+		path string
+	}
+	var pending []pendingCommit
 	for _, name := range names {
 		path := input.Repos[name]
 		if path == "" || !git.HasUncommittedChanges(path) {
 			continue
 		}
-		if _, err := git.CommitAllAndGetHead(path, msg); err != nil {
-			failed = append(failed, name)
+		if err := o.scrubFinalReviewRootArtifacts(context.Background(), path); err != nil {
+			return fmt.Errorf("scrubbing round-commit artifacts in repo %s: %w", name, err)
+		}
+		if git.HasUncommittedChanges(path) {
+			pending = append(pending, pendingCommit{name: name, path: path})
+		}
+	}
+	if len(pending) == 0 {
+		return nil
+	}
+
+	f, err := o.deps.Lifecycle.Get(input.FeatureID)
+	if err != nil {
+		return fmt.Errorf("load feature %s for round commit: %w", input.FeatureID, err)
+	}
+	msg := o.roundCommitMessage(f, input)
+
+	var failed []string
+	for _, pc := range pending {
+		if _, err := git.CommitAllAndGetHead(pc.path, msg); err != nil {
+			failed = append(failed, pc.name)
 			o.emitEvent(ports.Event{
 				Type:      ports.RepoStatusChanged,
 				FeatureID: input.FeatureID,
-				RepoName:  name,
+				RepoName:  pc.name,
 				Error:     err,
 				Message:   fmt.Sprintf("round commit failed (%s): %v", roundCommitEventLabel(input), err),
 			})
@@ -68,7 +92,7 @@ func (o *Orchestrator) commitRound(input agent.RoundCommitInput) error {
 		o.emitEvent(ports.Event{
 			Type:      ports.RepoStatusChanged,
 			FeatureID: input.FeatureID,
-			RepoName:  name,
+			RepoName:  pc.name,
 			Message:   "committed " + roundCommitEventLabel(input),
 		})
 	}

--- a/internal/orchestrator/round_commits_test.go
+++ b/internal/orchestrator/round_commits_test.go
@@ -1,0 +1,274 @@
+// Copyright 2026 DoorDash, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package orchestrator_test
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/doordash-oss/agentic-orchestrator/internal/agent"
+	"github.com/doordash-oss/agentic-orchestrator/internal/feature"
+	"github.com/doordash-oss/agentic-orchestrator/internal/git"
+	"github.com/doordash-oss/agentic-orchestrator/internal/orchestrator"
+	"github.com/doordash-oss/agentic-orchestrator/internal/ports"
+	"github.com/doordash-oss/agentic-orchestrator/test/testutil"
+)
+
+// newRoundCommitHarness wires an Orchestrator with the round-commit hook
+// installed on a PhaseRunner (as production New does) and returns the hook
+// plus the orchestrator whose event bus the hook emits onto.
+func newRoundCommitHarness(t *testing.T, f *feature.Feature) (agent.RoundCommitHook, *orchestrator.Orchestrator) {
+	t.Helper()
+	pr := &agent.PhaseRunner{}
+	lc := lifecycleForFeature(f)
+	o := orchestrator.New(orchestrator.Deps{Lifecycle: lc, Store: newFeatureStore(f), PhaseRunner: pr}, orchestrator.Hooks{})
+	if pr.RoundCommitHook == nil {
+		t.Fatal("orchestrator.New must install the round commit hook on the PhaseRunner")
+	}
+	return pr.RoundCommitHook, o
+}
+
+func roadmapFeature(t *testing.T, repoPath string) *feature.Feature {
+	t.Helper()
+	roadmapPath := writeTempFile(t, "roadmap.md",
+		"# Roadmap\n\n## Phase 1: Tracer\n### Goal\nFirst phase.\n\n## Phase 2: Fill\n### Goal\nSecond phase.\n")
+	return &feature.Feature{
+		ID:                  "feat-round-commits",
+		Slug:                "round-commit-messages",
+		Status:              feature.StatusImplementing,
+		CurrentPhase:        feature.PhaseImplement,
+		CurrentRoadmapPhase: 1,
+		TotalRoadmapPhases:  2,
+		RoadmapPhaseType:    "tracer-bullet",
+		Artifacts:           map[string]string{"roadmap": roadmapPath},
+		Repos:               []feature.FeatureRepo{{Name: "solo", Path: repoPath, WorktreePath: repoPath}},
+	}
+}
+
+func repoCommitBodies(t *testing.T, repoPath string) []string {
+	t.Helper()
+	out, err := exec.Command("git", "-C", repoPath, "log", "--format=%B%n---commit---").CombinedOutput()
+	if err != nil {
+		t.Fatalf("git log: %v", err)
+	}
+	var bodies []string
+	for _, body := range strings.Split(string(out), "---commit---") {
+		if strings.TrimSpace(body) != "" {
+			bodies = append(bodies, strings.TrimSpace(body))
+		}
+	}
+	// Newest first; reverse so bodies read in commit order.
+	for i, j := 0, len(bodies)-1; i < j; i, j = i+1, j-1 {
+		bodies[i], bodies[j] = bodies[j], bodies[i]
+	}
+	return bodies
+}
+
+func dirtyRepo(t *testing.T, repoPath, name, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(repoPath, name), []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+}
+
+// The round-commit message sequence must read like the agreed git history:
+// unlabeled first implementation round, labeled extra implementation rounds,
+// per-phase fix-round counter, and feature-level final-review fixes.
+func TestOrchestrator_RoundCommitHook_MessageSequence(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	repo := testutil.InitGitRepo(t)
+	f := roadmapFeature(t, repo)
+	hook, _ := newRoundCommitHarness(t, f)
+
+	type round struct {
+		input agent.RoundCommitInput
+		file  string
+	}
+	rounds := []round{
+		{
+			input: agent.RoundCommitInput{FeatureID: f.ID, PhaseNumber: 1, TotalPhases: 2, PhaseType: "tracer-bullet", Iteration: 1, Kind: agent.RoundCommitImplement, FirstImplementCommit: true},
+			file:  "round-1.txt",
+		},
+		{
+			input: agent.RoundCommitInput{FeatureID: f.ID, PhaseNumber: 1, TotalPhases: 2, PhaseType: "tracer-bullet", Iteration: 3, Kind: agent.RoundCommitImplement, FirstImplementCommit: false},
+			file:  "round-3.txt",
+		},
+		{
+			input: agent.RoundCommitInput{FeatureID: f.ID, PhaseNumber: 1, TotalPhases: 2, PhaseType: "tracer-bullet", Iteration: 4, Kind: agent.RoundCommitFix, FixNumber: 1},
+			file:  "fix-1.txt",
+		},
+		{
+			input: agent.RoundCommitInput{FeatureID: f.ID, PhaseNumber: 1, TotalPhases: 2, PhaseType: "tracer-bullet", Iteration: 5, Kind: agent.RoundCommitFix, FixNumber: 2},
+			file:  "fix-2.txt",
+		},
+		{
+			input: agent.RoundCommitInput{FeatureID: f.ID, Iteration: 6, Kind: agent.RoundCommitFinalReviewFix, FixNumber: 1},
+			file:  "fr-fix-1.txt",
+		},
+	}
+	for _, r := range rounds {
+		r.input.Repos = map[string]string{"solo": repo}
+		dirtyRepo(t, repo, r.file, "change\n")
+		if err := hook(r.input); err != nil {
+			t.Fatalf("round commit (%s): %v", r.file, err)
+		}
+	}
+
+	bodies := repoCommitBodies(t, repo)
+	// One body is the repo's initial commit.
+	want := []string{
+		"Phase 1/2 (tracer-bullet): Tracer\n\nFeature: round-commit-messages\n\nGenerated-by: Agentic (https://github.com/doordash-oss/agentic-orchestrator)",
+		"Phase 1/2 (tracer-bullet): Tracer - implementation round 3\n\nFeature: round-commit-messages\n\nGenerated-by: Agentic (https://github.com/doordash-oss/agentic-orchestrator)",
+		"Phase 1/2 (tracer-bullet): Tracer - fix round 1 (address review feedback)\n\nFeature: round-commit-messages\n\nGenerated-by: Agentic (https://github.com/doordash-oss/agentic-orchestrator)",
+		"Phase 1/2 (tracer-bullet): Tracer - fix round 2 (address review feedback)\n\nFeature: round-commit-messages\n\nGenerated-by: Agentic (https://github.com/doordash-oss/agentic-orchestrator)",
+		"Final review fix 1 (address review feedback)\n\nFeature: round-commit-messages\n\nGenerated-by: Agentic (https://github.com/doordash-oss/agentic-orchestrator)",
+	}
+	if len(bodies) != len(want)+1 {
+		t.Fatalf("commit count = %d, want %d (rounds + initial); bodies:\n%s", len(bodies), len(want)+1, strings.Join(bodies, "\n---\n"))
+	}
+	// bodies[0] is the initial commit; round commits follow in order.
+	for i, w := range want {
+		if got := bodies[i+1]; got != w {
+			t.Errorf("round commit %d message:\n got: %q\nwant: %q", i+1, got, w)
+		}
+	}
+}
+
+// Non-roadmap features have no phase prefix; every round is labeled.
+func TestOrchestrator_RoundCommitHook_NonRoadmapMessages(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	repo := testutil.InitGitRepo(t)
+	f := &feature.Feature{
+		ID:     "feat-nonroadmap-rounds",
+		Slug:   "nonroadmap-rounds",
+		Status: feature.StatusImplementing,
+		Repos:  []feature.FeatureRepo{{Name: "solo", Path: repo, WorktreePath: repo}},
+	}
+	hook, _ := newRoundCommitHarness(t, f)
+
+	dirtyRepo(t, repo, "round-1.txt", "change\n")
+	if err := hook(agent.RoundCommitInput{FeatureID: f.ID, Iteration: 1, Kind: agent.RoundCommitImplement, FirstImplementCommit: true, Repos: map[string]string{"solo": repo}}); err != nil {
+		t.Fatalf("implement round commit: %v", err)
+	}
+	dirtyRepo(t, repo, "fix-1.txt", "change\n")
+	if err := hook(agent.RoundCommitInput{FeatureID: f.ID, Iteration: 2, Kind: agent.RoundCommitFix, FixNumber: 1, Repos: map[string]string{"solo": repo}}); err != nil {
+		t.Fatalf("fix round commit: %v", err)
+	}
+
+	bodies := repoCommitBodies(t, repo)
+	want := []string{
+		"Implementation round 1\n\nFeature: nonroadmap-rounds\n\nGenerated-by: Agentic (https://github.com/doordash-oss/agentic-orchestrator)",
+		"Fix round 1 (address review feedback)\n\nFeature: nonroadmap-rounds\n\nGenerated-by: Agentic (https://github.com/doordash-oss/agentic-orchestrator)",
+	}
+	if len(bodies) != len(want)+1 {
+		t.Fatalf("commit count = %d, want %d; bodies:\n%s", len(bodies), len(want)+1, strings.Join(bodies, "\n---\n"))
+	}
+	for i, w := range want {
+		if got := bodies[i+1]; got != w {
+			t.Errorf("round commit %d message:\n got: %q\nwant: %q", i+1, got, w)
+		}
+	}
+}
+
+// Only repos the round actually dirtied are committed; clean repos are
+// untouched no-ops, and each commit emits a RepoStatusChanged event.
+func TestOrchestrator_RoundCommitHook_CommitsOnlyDirtyRepos(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	dirtyRepoPath := testutil.InitGitRepo(t)
+	cleanRepoPath := testutil.InitGitRepo(t)
+	cleanHeadBefore, err := git.CurrentHeadSHA(cleanRepoPath)
+	if err != nil {
+		t.Fatalf("clean repo head: %v", err)
+	}
+
+	f := roadmapFeature(t, dirtyRepoPath)
+	f.Repos = append(f.Repos, feature.FeatureRepo{Name: "clean", Path: cleanRepoPath, WorktreePath: cleanRepoPath})
+	hook, o := newRoundCommitHarness(t, f)
+
+	dirtyRepo(t, dirtyRepoPath, "round-1.txt", "change\n")
+	input := agent.RoundCommitInput{
+		FeatureID:            f.ID,
+		PhaseNumber:          1,
+		TotalPhases:          2,
+		PhaseType:            "tracer-bullet",
+		Iteration:            1,
+		Kind:                 agent.RoundCommitImplement,
+		FirstImplementCommit: true,
+		Repos: map[string]string{
+			"solo":  dirtyRepoPath,
+			"clean": cleanRepoPath,
+		},
+	}
+	if err := hook(input); err != nil {
+		t.Fatalf("round commit: %v", err)
+	}
+
+	if git.HasUncommittedChanges(dirtyRepoPath) {
+		t.Error("dirty repo still has uncommitted changes after the round commit")
+	}
+	cleanHeadAfter, _ := git.CurrentHeadSHA(cleanRepoPath)
+	if cleanHeadAfter != cleanHeadBefore {
+		t.Errorf("clean repo HEAD moved: %q -> %q", cleanHeadBefore, cleanHeadAfter)
+	}
+
+	events := drainEvents(o)
+	found := false
+	for _, ev := range events {
+		if ev.Type == ports.RepoStatusChanged && ev.RepoName == "solo" && ev.Message == "committed implementation round 1" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected RepoStatusChanged(implementation round 1) for solo; got %+v", events)
+	}
+}
+
+// A feature that cannot be loaded fails the round loudly instead of
+// committing with a degraded message.
+func TestOrchestrator_RoundCommitHook_FailsWhenFeatureMissing(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	repo := testutil.InitGitRepo(t)
+	dirtyRepo(t, repo, "round-1.txt", "change\n")
+
+	pr := &agent.PhaseRunner{}
+	lc := lifecycleForFeature(&feature.Feature{ID: "feat-gone"})
+	lc.GetFn = func(id string) (*feature.Feature, error) { return nil, fmt.Errorf("feature not found") }
+	orchestrator.New(orchestrator.Deps{Lifecycle: lc, Store: newFeatureStore(), PhaseRunner: pr}, orchestrator.Hooks{})
+
+	err := pr.RoundCommitHook(agent.RoundCommitInput{
+		FeatureID: "feat-gone",
+		Iteration: 1,
+		Kind:      agent.RoundCommitImplement,
+		Repos:     map[string]string{"solo": repo},
+	})
+	if err == nil {
+		t.Fatal("round commit must fail when the feature cannot be loaded")
+	}
+	if !strings.Contains(err.Error(), "feature not found") {
+		t.Errorf("error = %v, want load failure surfaced", err)
+	}
+}

--- a/internal/orchestrator/round_commits_test.go
+++ b/internal/orchestrator/round_commits_test.go
@@ -35,9 +35,14 @@ import (
 // plus the orchestrator whose event bus the hook emits onto.
 func newRoundCommitHarness(t *testing.T, f *feature.Feature) (agent.RoundCommitHook, *orchestrator.Orchestrator) {
 	t.Helper()
-	pr := &agent.PhaseRunner{}
+	pr := &agent.PhaseRunner{CommandRunner: agent.NewExecCommandRunner()}
 	lc := lifecycleForFeature(f)
-	o := orchestrator.New(orchestrator.Deps{Lifecycle: lc, Store: newFeatureStore(f), PhaseRunner: pr}, orchestrator.Hooks{})
+	o := orchestrator.New(orchestrator.Deps{
+		Lifecycle:   lc,
+		Store:       newFeatureStore(f),
+		PhaseRunner: pr,
+		CmdRunner:   pr.CommandRunner,
+	}, orchestrator.Hooks{})
 	if pr.RoundCommitHook == nil {
 		t.Fatal("orchestrator.New must install the round commit hook on the PhaseRunner")
 	}
@@ -270,5 +275,89 @@ func TestOrchestrator_RoundCommitHook_FailsWhenFeatureMissing(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "feature not found") {
 		t.Errorf("error = %v, want load failure surfaced", err)
+	}
+}
+
+// A clean round must cost neither a feature load nor a commit: the hook
+// resolves dirtiness first and short-circuits before any store access.
+func TestOrchestrator_RoundCommitHook_CleanRoundSkipsFeatureLoad(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	repo := testutil.InitGitRepo(t)
+	headBefore, err := git.CurrentHeadSHA(repo)
+	if err != nil {
+		t.Fatalf("repo head: %v", err)
+	}
+
+	f := roadmapFeature(t, repo)
+	pr := &agent.PhaseRunner{CommandRunner: agent.NewExecCommandRunner()}
+	lc := lifecycleForFeature(f)
+	getCalls := 0
+	lc.GetFn = func(id string) (*feature.Feature, error) {
+		getCalls++
+		return f, nil
+	}
+	orchestrator.New(orchestrator.Deps{
+		Lifecycle:   lc,
+		Store:       newFeatureStore(f),
+		PhaseRunner: pr,
+		CmdRunner:   pr.CommandRunner,
+	}, orchestrator.Hooks{})
+
+	if err := pr.RoundCommitHook(agent.RoundCommitInput{
+		FeatureID: f.ID,
+		Iteration: 1,
+		Kind:      agent.RoundCommitImplement,
+		Repos:     map[string]string{"solo": repo},
+	}); err != nil {
+		t.Fatalf("clean round commit: %v", err)
+	}
+
+	if getCalls != 0 {
+		t.Errorf("lifecycle Get called %d times on a clean round, want 0", getCalls)
+	}
+	headAfter, _ := git.CurrentHeadSHA(repo)
+	if headAfter != headBefore {
+		t.Errorf("clean round created a commit: %q -> %q", headBefore, headAfter)
+	}
+}
+
+// A repo dirtied only by a known untracked root orchestration artifact must
+// not have that artifact committed by `git add -A`: the round commit scrubs
+// it (publish-path behavior) and creates no commit at all.
+func TestOrchestrator_RoundCommitHook_ScrubsStrayArtifactsInsteadOfCommitting(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	repo := testutil.InitGitRepo(t)
+	headBefore, err := git.CurrentHeadSHA(repo)
+	if err != nil {
+		t.Fatalf("repo head: %v", err)
+	}
+	dirtyRepo(t, repo, "progress.md", "stray orchestration artifact\n")
+
+	f := roadmapFeature(t, repo)
+	hook, _ := newRoundCommitHarness(t, f)
+
+	if err := hook(agent.RoundCommitInput{
+		FeatureID:            f.ID,
+		PhaseNumber:          1,
+		TotalPhases:          2,
+		PhaseType:            "tracer-bullet",
+		Iteration:            1,
+		Kind:                 agent.RoundCommitImplement,
+		FirstImplementCommit: true,
+		Repos:                map[string]string{"solo": repo},
+	}); err != nil {
+		t.Fatalf("round commit over stray artifact: %v", err)
+	}
+
+	headAfter, _ := git.CurrentHeadSHA(repo)
+	if headAfter != headBefore {
+		t.Errorf("stray artifact was committed: HEAD moved %q -> %q", headBefore, headAfter)
+	}
+	if _, err := os.Stat(filepath.Join(repo, "progress.md")); !os.IsNotExist(err) {
+		t.Errorf("stray artifact still present (stat err = %v); the scrub must remove it", err)
 	}
 }


### PR DESCRIPTION
## What

Replaces the single squash commit per roadmap phase with one commit per round, so the git history shows actual progress through review iterations:

- **Implement loop**: a `RoundCommitHook` fires the moment each round's session ends (before the review gate). The first implementation round of a phase stays unlabeled (`Phase 1/3 (tracer-bullet): Tracer`); later rounds are labeled (`... - implementation round 3`, `... - fix round 2 (address review feedback)` with a separate per-phase fix counter).
- **Final Review**: leftover/fix sweeps are removed; every completed fix session commits immediately (`Final review fix N (address review feedback)`) — including FAILED/protocol-violating fixers, whose partial edits must not strand the worktree dirty (FR has no later absorbing round). A dirty worktree at approval fails loudly; known untracked root orchestration artifacts are tolerated.
- **Orchestrator owns commits**: `orchestrator.New()` installs the hook on the PhaseRunner; it commits only repos the round actually dirtied (clean tree = no-op, and no feature load / roadmap parse for clean rounds) and fails the round loudly on commit errors. Known untracked root orchestration artifacts are scrubbed before staging so `git add -A` can never track them. Round labeling is derived from durable iteration metas with the live counters kept in lockstep, so crash-resumed loops keep identical numbering; a crashed round's uncommitted work is absorbed into its own round commit on resume.
- **Phase boundary**: `commitRoadmapPhase` is gone — phase completion scrubs stray root artifacts (so reviewer-stranded files cannot leak across the phase boundary) and records anchors (per-repo HEAD of the last round commit; existing HEAD for untouched repos). The legacy no-caller `CommitRoadmapPhase` delegate is deleted. Publish/merge catch-all commits are unchanged.
- Non-roadmap features (no phase prefix) label every round: `Implementation round N` / `Fix round N (address review feedback)`.
- Cleanliness gating is fail-closed: the approval dirty-check reuses `InspectCleanliness` (rename/quote-aware porcelain parsing, bounded probe) and surfaces probe errors instead of reading broken git state as clean.

## Verification

- Fast suite (`make test-fast`): green, except the pre-existing load-sensitive `TestProbeTimeoutKillsProcessGroup` flake in `internal/git` (untouched by this diff; passes 5/5 in isolation and full-package on both this diff and baseline)
- Static: `go vet ./...`, `go build ./...`: clean
- Full non-short `internal/agent`, `internal/orchestrator`, `internal/git` packages: passed
- Isolated integration (`go test ./test/integration/... -count=1`): passed
- E2E Go (`go test ./test/e2e/... -count=1 -race`): passed
- Skipped Race regression (full `go test ./... -race` sweep): the E2E race tier above already covered the touched server/orchestrator paths.