### PR TITLE
Co-author programmatic commits as Agentico

### DIFF
--- a/internal/git/signature.go
+++ b/internal/git/signature.go
@@ -20,8 +20,19 @@ const (
 	// AgenticURL is the public repository URL for attribution.
 	AgenticURL = "https://github.com/doordash-oss/agentic-orchestrator"
 
-	// CommitSignatureTrailer is appended to programmatic commit messages as a git trailer.
-	CommitSignatureTrailer = "Generated-by: Agentic (" + AgenticURL + ")"
+	// AgenticoCommitEmail is the noreply address Agentico co-authors
+	// programmatic commits under. GitHub matches co-author trailers to
+	// profiles by email; a noreply address keeps attribution without
+	// implying a human mailbox.
+	AgenticoCommitEmail = "noreply@doordash-oss.github.com"
+
+	// AgenticoName is the display name for Agentico's commit attribution.
+	AgenticoName = "Agentico"
+
+	// CommitSignatureTrailer is appended to programmatic commit messages as
+	// a git trailer. Uses the Co-authored-by convention so GitHub renders
+	// Agentico as a co-author on commits and pull requests.
+	CommitSignatureTrailer = "Co-authored-by: " + AgenticoName + " <" + AgenticoCommitEmail + ">"
 
 	// PRSignature is the markdown signature appended to PR bodies and comments.
 	PRSignature = "\n\n---\n\n*Generated with [agentic orchestrator](" + AgenticURL + ")*"

--- a/internal/git/signature_test.go
+++ b/internal/git/signature_test.go
@@ -89,14 +89,12 @@ func TestInjectPRSignature_Idempotent(t *testing.T) {
 }
 
 func TestConstants(t *testing.T) {
-	if !strings.Contains(CommitSignatureTrailer, AgenticURL) {
-		t.Errorf("CommitSignatureTrailer should contain AgenticURL")
+	wantTrailer := "Co-authored-by: Agentico <noreply@doordash-oss.github.com>"
+	if CommitSignatureTrailer != wantTrailer {
+		t.Errorf("CommitSignatureTrailer = %q, want %q (Co-authored-by convention so GitHub renders Agentico as a co-author)", CommitSignatureTrailer, wantTrailer)
 	}
 	if !strings.Contains(PRSignature, AgenticURL) {
 		t.Errorf("PRSignature should contain AgenticURL")
-	}
-	if !strings.Contains(CommitSignatureTrailer, "Generated-by: Agentic") {
-		t.Errorf("CommitSignatureTrailer should contain 'Generated-by: Agentic'")
 	}
 	if !strings.Contains(PRSignature, "Generated with [agentic orchestrator]") {
 		t.Errorf("PRSignature should contain 'Generated with [agentic orchestrator]'")

--- a/internal/orchestrator/round_commits_test.go
+++ b/internal/orchestrator/round_commits_test.go
@@ -140,11 +140,11 @@ func TestOrchestrator_RoundCommitHook_MessageSequence(t *testing.T) {
 	bodies := repoCommitBodies(t, repo)
 	// One body is the repo's initial commit.
 	want := []string{
-		"Phase 1/2 (tracer-bullet): Tracer\n\nFeature: round-commit-messages\n\nGenerated-by: Agentic (https://github.com/doordash-oss/agentic-orchestrator)",
-		"Phase 1/2 (tracer-bullet): Tracer - implementation round 3\n\nFeature: round-commit-messages\n\nGenerated-by: Agentic (https://github.com/doordash-oss/agentic-orchestrator)",
-		"Phase 1/2 (tracer-bullet): Tracer - fix round 1 (address review feedback)\n\nFeature: round-commit-messages\n\nGenerated-by: Agentic (https://github.com/doordash-oss/agentic-orchestrator)",
-		"Phase 1/2 (tracer-bullet): Tracer - fix round 2 (address review feedback)\n\nFeature: round-commit-messages\n\nGenerated-by: Agentic (https://github.com/doordash-oss/agentic-orchestrator)",
-		"Final review fix 1 (address review feedback)\n\nFeature: round-commit-messages\n\nGenerated-by: Agentic (https://github.com/doordash-oss/agentic-orchestrator)",
+		"Phase 1/2 (tracer-bullet): Tracer\n\nFeature: round-commit-messages\n\nCo-authored-by: Agentico <noreply@doordash-oss.github.com>",
+		"Phase 1/2 (tracer-bullet): Tracer - implementation round 3\n\nFeature: round-commit-messages\n\nCo-authored-by: Agentico <noreply@doordash-oss.github.com>",
+		"Phase 1/2 (tracer-bullet): Tracer - fix round 1 (address review feedback)\n\nFeature: round-commit-messages\n\nCo-authored-by: Agentico <noreply@doordash-oss.github.com>",
+		"Phase 1/2 (tracer-bullet): Tracer - fix round 2 (address review feedback)\n\nFeature: round-commit-messages\n\nCo-authored-by: Agentico <noreply@doordash-oss.github.com>",
+		"Final review fix 1 (address review feedback)\n\nFeature: round-commit-messages\n\nCo-authored-by: Agentico <noreply@doordash-oss.github.com>",
 	}
 	if len(bodies) != len(want)+1 {
 		t.Fatalf("commit count = %d, want %d (rounds + initial); bodies:\n%s", len(bodies), len(want)+1, strings.Join(bodies, "\n---\n"))
@@ -182,8 +182,8 @@ func TestOrchestrator_RoundCommitHook_NonRoadmapMessages(t *testing.T) {
 
 	bodies := repoCommitBodies(t, repo)
 	want := []string{
-		"Implementation round 1\n\nFeature: nonroadmap-rounds\n\nGenerated-by: Agentic (https://github.com/doordash-oss/agentic-orchestrator)",
-		"Fix round 1 (address review feedback)\n\nFeature: nonroadmap-rounds\n\nGenerated-by: Agentic (https://github.com/doordash-oss/agentic-orchestrator)",
+		"Implementation round 1\n\nFeature: nonroadmap-rounds\n\nCo-authored-by: Agentico <noreply@doordash-oss.github.com>",
+		"Fix round 1 (address review feedback)\n\nFeature: nonroadmap-rounds\n\nCo-authored-by: Agentico <noreply@doordash-oss.github.com>",
 	}
 	if len(bodies) != len(want)+1 {
 		t.Fatalf("commit count = %d, want %d; bodies:\n%s", len(bodies), len(want)+1, strings.Join(bodies, "\n---\n"))


### PR DESCRIPTION
## What

Replaces the `Generated-by: Agentic (...)` commit trailer with the GitHub `Co-authored-by` convention so Agentico is rendered as a co-author on commits and pull requests:

```
Co-authored-by: Agentico <noreply@doordash-oss.github.com>
```

- Single-chokepoint change: `CommitSignatureTrailer` in `internal/git/signature.go` is appended by `CommitAll`/`CommitAllAndGetHead`, so every programmatic commit (round commits, publish leftovers, merge-local, refactor-child integration) picks it up with no caller changes.
- `AgenticoName` / `AgenticoCommitEmail` constants keep the identity tunable in one place.
- The PR-body signature badge (`PRSignature`) is intentionally unchanged; rebranding that surface is a separate decision.

Same convention used by Claude Code (`Co-authored-by: Claude <noreply@anthropic.com>`) and Codex CLI (`Co-authored-by: Codex <noreply@openai.com>`).

## Verification

- Fast suite (`make test-fast`): green, except one `TestPendingToolWatchdogAllowsPromptResultAfterCompletedTool` timing flake in `internal/session` (untouched package; passes 5/5 in isolation and full-package)
- Static: `go vet ./...`, `go build ./...`: clean
- Targeted: `internal/git` signature/commit tests and `internal/orchestrator` round-commit message tests pass
- Skipped extended tiers: change is a commit-message constant plus test expectations; no behavioral or concurrency surface touched.