### PR TITLE
Cut CI wall time with parallel and tiered packaged E2E

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,8 @@ jobs:
       # above with the real bundled server. Full journey suite on ubuntu-latest
       # x64; @smoke subset on macOS and arm. Electron needs a display on Linux,
       # so both Linux legs run under xvfb.
+      # Invoked directly on the desktop workspace: forwarding --grep through
+      # the root passthrough script adds a second npm layer that eats it.
       - name: Packaged E2E journeys
         run: |
           if [ "${{ matrix.os }}" = "ubuntu-latest" ]; then
@@ -94,9 +96,9 @@ jobs:
             GREP_ARGS='--grep @smoke'
           fi
           if [ "$RUNNER_OS" = "Linux" ]; then
-            xvfb-run -a --server-args="-screen 0 1600x1000x24" npm run test:e2e:packaged -- $GREP_ARGS
+            xvfb-run -a --server-args="-screen 0 1600x1000x24" npm run test:e2e:packaged --workspace desktop -- $GREP_ARGS
           else
-            npm run test:e2e:packaged -- $GREP_ARGS
+            npm run test:e2e:packaged --workspace desktop -- $GREP_ARGS
           fi
 
       - name: Preserve packaging evidence on failure

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,13 +28,13 @@ jobs:
       - name: go test
         run: go test ./... -short -count=1
 
-  # Native package gate per platform: strict checks (typecheck, lint, format,
-  # OpenAPI->TypeScript drift), unit/component/security suites, production
-  # build, then construct and inspect the unsigned package for this host
-  # (universal DMG on macOS; x64 AppImage + deb on ubuntu-latest x64; arm64
-  # AppImage + deb on ubuntu-24.04-arm). Every supported Linux architecture
-  # is built and inspected on a native runner so delivered package coverage
-  # spans Linux x64 and arm64 without gaps.
+  # Native package gate per platform. Platform-independent checks (typecheck,
+  # lint, format, API drift, unit/component/security suites) run once on
+  # ubuntu-latest. Each leg then packages and inspects the unsigned app for
+  # its host: PRs build the unpacked variant, pushes to main build the full
+  # installers (universal DMG on macOS; x64 AppImage + deb on ubuntu-latest;
+  # arm64 AppImage + deb on ubuntu-24.04-arm). Packaged E2E runs the full
+  # journey suite on ubuntu-latest x64 and the @smoke subset on macOS/arm.
   desktop:
     strategy:
       fail-fast: false
@@ -63,29 +63,40 @@ jobs:
         run: npm ci
 
       - name: Check (typecheck, lint, format, API drift)
+        if: matrix.os == 'ubuntu-latest'
         run: npm run check
 
       - name: Unit and component tests
+        if: matrix.os == 'ubuntu-latest'
         run: npm test
 
       - name: Security tests
+        if: matrix.os == 'ubuntu-latest'
         run: npm run test:security
 
-      - name: Build
-        run: npm run build
+      - name: Package and verify (unpacked, PRs)
+        if: github.event_name == 'pull_request'
+        run: npm run package:verify:e2e
 
-      - name: Package and verify (native target)
+      - name: Package and verify (full installers, main)
+        if: github.event_name != 'pull_request'
         run: npm run package:verify
 
-      # Packaged E2E journeys (Task 6b): Playwright drives the unpacked app
-      # verified above with the real bundled server. Electron needs a display
-      # on Linux, so the ubuntu leg runs under xvfb.
+      # Packaged E2E journeys: Playwright drives the unpacked app verified
+      # above with the real bundled server. Full journey suite on ubuntu-latest
+      # x64; @smoke subset on macOS and arm. Electron needs a display on Linux,
+      # so both Linux legs run under xvfb.
       - name: Packaged E2E journeys
         run: |
-          if [ "$RUNNER_OS" = "Linux" ]; then
-            xvfb-run -a --server-args="-screen 0 1600x1000x24" npm run test:e2e:packaged
+          if [ "${{ matrix.os }}" = "ubuntu-latest" ]; then
+            GREP_ARGS=""
           else
-            npm run test:e2e:packaged
+            GREP_ARGS='--grep @smoke'
+          fi
+          if [ "$RUNNER_OS" = "Linux" ]; then
+            xvfb-run -a --server-args="-screen 0 1600x1000x24" npm run test:e2e:packaged -- $GREP_ARGS
+          else
+            npm run test:e2e:packaged -- $GREP_ARGS
           fi
 
       - name: Preserve packaging evidence on failure

--- a/desktop/test/e2e/global-setup.ts
+++ b/desktop/test/e2e/global-setup.ts
@@ -18,6 +18,13 @@ import { collectProcessTree } from './helpers/processes';
 
 export default function globalSetup(): void {
   sweepOrphanedE2eProcesses();
+  // Electron 43 installs its runtime lazily on first import; workers launch
+  // in parallel and must never race that extraction (idempotent when done).
+  execFileSync('npm', ['run', 'install:electron-runtime'], {
+    cwd: desktopDir,
+    stdio: 'inherit',
+    timeout: 5 * 60_000,
+  });
   const reason = stalenessReason();
   if (reason === null) {
     console.log('e2e global-setup: reusing the verified package in dist/');

--- a/desktop/test/e2e/helpers/app.ts
+++ b/desktop/test/e2e/helpers/app.ts
@@ -117,16 +117,21 @@ export async function launchApp(
     args.push('--no-sandbox');
   }
   args.unshift(packagedAppAsar(installExecutablePath));
-  const app = await electron.launch({
-    args,
-    env: {
-      ...minimalEnv(world),
-      AGENTICO_E2E_RESOURCES_PATH: resourcesPath,
-      AGENTICO_E2E_INSTALL_EXECUTABLE: installExecutablePath,
-      ...(options.env ?? {}),
-    },
-    timeout: 60_000,
-  });
+  // Concurrent workers exec the same binary; Linux can transiently report
+  // ETXTBSY when a spawn races a fork that briefly inherits a write fd
+  // (nodejs/node#22811-style), so that one error is retried briefly.
+  const app = await retryingEtxtbsy(() =>
+    electron.launch({
+      args,
+      env: {
+        ...minimalEnv(world),
+        AGENTICO_E2E_RESOURCES_PATH: resourcesPath,
+        AGENTICO_E2E_INSTALL_EXECUTABLE: installExecutablePath,
+        ...(options.env ?? {}),
+      },
+      timeout: 60_000,
+    }),
+  );
   const logs: string[] = [];
   const appProcess = app.process();
   appProcess.stdout?.on('data', (chunk: Buffer) => logs.push(chunk.toString()));
@@ -301,6 +306,19 @@ function testLooksFailed(testInfo: TestInfo): boolean {
   const hasError = (list: Step[]): boolean =>
     list.some((step) => step.error !== undefined || hasError(step.steps));
   return hasError(steps);
+}
+
+async function retryingEtxtbsy<T>(launch: () => Promise<T>): Promise<T> {
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return await launch();
+    } catch (error) {
+      if (attempt >= 3 || !(error instanceof Error) || !error.message.includes('ETXTBSY')) {
+        throw error;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 250 * attempt));
+    }
+  }
 }
 
 /** Rejects if `work` has not settled within `ms`, naming the step that stuck. */

--- a/desktop/test/e2e/helpers/app.ts
+++ b/desktop/test/e2e/helpers/app.ts
@@ -1,10 +1,11 @@
 /**
  * Launch/teardown plumbing for the packaged app under Playwright. Every
- * launch records a full trace (screenshots + DOM snapshots); teardown stops
- * the trace, closes the app through the normal quit path, and asserts the
- * app process actually exited. Evidence artifacts (named screenshots and
- * trace zips) are additionally copied to AGENTICO_E2E_EVIDENCE_DIR when the
- * run is an evidence run.
+ * launch records a trace; teardown stops the trace, closes the app through
+ * the normal quit path, and asserts the app process actually exited. On
+ * evidence runs (AGENTICO_E2E_EVIDENCE_DIR set) the trace is full
+ * (screenshots + DOM snapshots), always saved, and copied to the evidence
+ * directory; otherwise it is snapshot-only and saved only when the test
+ * failed.
  */
 import type { ChildProcess } from 'node:child_process';
 import fs from 'node:fs';
@@ -130,7 +131,9 @@ export async function launchApp(
   const appProcess = app.process();
   appProcess.stdout?.on('data', (chunk: Buffer) => logs.push(chunk.toString()));
   appProcess.stderr?.on('data', (chunk: Buffer) => logs.push(chunk.toString()));
-  await app.context().tracing.start({ screenshots: true, snapshots: true });
+  // Screenshots multiply the trace's cost and are only consumed by evidence
+  // runs; snapshots stay on so a saved failure trace still explains itself.
+  await app.context().tracing.start({ screenshots: evidenceDir() !== null, snapshots: true });
   const page = await app.firstWindow({ timeout: 30_000 });
   // Actions (click/check/fill) otherwise inherit the whole test budget, so a
   // control that never becomes actionable — disabled while work is in flight,
@@ -164,22 +167,27 @@ export async function launchApp(
 }
 
 /**
- * Stops tracing (saving the zip, plus an evidence copy) and quits the app
- * through the regular quit path, asserting the process really exited so a
- * hung shutdown can never pass silently.
+ * Stops tracing (saving the zip when it will be consumed: evidence runs
+ * always, other runs only on failure) and quits the app through the regular
+ * quit path, asserting the process really exited so a hung shutdown can
+ * never pass silently.
  */
 export async function closeApp(handle: AppHandle): Promise<void> {
   if (handle.closed) {
     return;
   }
   handle.closed = true;
-  const tracePath = handle.testInfo.outputPath(`${handle.traceName}-trace.zip`);
   try {
     // Bounded: against a wedged app these calls never settle, and an unbounded
     // await here costs the worker its whole teardown budget and loses the trace
     // — the one artifact that would explain the wedge.
-    await bounded(handle.app.context().tracing.stop({ path: tracePath }), 60_000, 'tracing.stop');
-    copyTraceToEvidence(tracePath, `${handle.traceName}-trace.zip`);
+    if (evidenceDir() !== null || testLooksFailed(handle.testInfo)) {
+      const tracePath = handle.testInfo.outputPath(`${handle.traceName}-trace.zip`);
+      await bounded(handle.app.context().tracing.stop({ path: tracePath }), 60_000, 'tracing.stop');
+      copyTraceToEvidence(tracePath, `${handle.traceName}-trace.zip`);
+    } else {
+      await bounded(handle.app.context().tracing.stop(), 60_000, 'tracing.stop');
+    }
   } catch {
     // Tracing is evidence, not correctness — never fail teardown on it.
   }
@@ -277,6 +285,22 @@ async function installTeardownQuitDialogAnswer(handle: AppHandle): Promise<void>
       return { response: 0, checkboxChecked: false };
     }) as typeof dialog.showMessageBox;
   });
+}
+
+/**
+ * Whether the test has already failed by teardown time. closeApp runs inside
+ * the journey's own finally block, before the runner records the in-flight
+ * error onto testInfo — a hard expect failure still reads status "passed"
+ * here. Its error is already on the failed step, though, so the (private)
+ * step tree is scanned as the in-flight failure signal.
+ */
+function testLooksFailed(testInfo: TestInfo): boolean {
+  if (testInfo.status !== testInfo.expectedStatus || testInfo.errors.length > 0) return true;
+  type Step = { error?: unknown; steps: Step[] };
+  const steps = (testInfo as unknown as { _steps?: Step[] })._steps ?? [];
+  const hasError = (list: Step[]): boolean =>
+    list.some((step) => step.error !== undefined || hasError(step.steps));
+  return hasError(steps);
 }
 
 /** Rejects if `work` has not settled within `ms`, naming the step that stuck. */

--- a/desktop/test/e2e/journeys/distribution-update-validation.spec.ts
+++ b/desktop/test/e2e/journeys/distribution-update-validation.spec.ts
@@ -10,37 +10,41 @@ import { Transcript } from '../helpers/transcript';
 import { createRepo, createWorld, destroyWorld, type JourneyWorld } from '../helpers/world';
 import { writeSignedUpdateFixture } from '../helpers/update-fixtures';
 
-test('update validation rejects malformed metadata, signature tamper, downgrades, and prereleases', async ({}, testInfo) => {
-  test.setTimeout(180_000);
-  const transcript = new Transcript(
-    'distribution-update-validation',
-    'Packaged update metadata validation',
-  );
+test(
+  'update validation rejects malformed metadata, signature tamper, downgrades, and prereleases',
+  { tag: '@smoke' },
+  async ({}, testInfo) => {
+    test.setTimeout(180_000);
+    const transcript = new Transcript(
+      'distribution-update-validation',
+      'Packaged update metadata validation',
+    );
 
-  await runValidationCase(testInfo, transcript, 'malformed schema', (world) =>
-    writeSignedUpdateFixture(world.root, { malformedFeed: true }),
-  );
-  await runValidationCase(testInfo, transcript, 'altered signed release envelope', (world) =>
-    writeSignedUpdateFixture(world.root, {
-      servedEnvelopeBytes: Buffer.from('{"tampered":true}\n'),
-      packageText: 'package bytes',
-    }),
-  );
-  await runValidationCase(testInfo, transcript, 'downgrade with prerelease ignored', (world) =>
-    writeSignedUpdateFixture(world.root, {
-      tag: 'v0.0.9',
-      includePrerelease: true,
-      packageText: 'old package bytes',
-    }),
-  );
-  await runValidationCase(testInfo, transcript, 'prerelease-only feed', (world) =>
-    writeSignedUpdateFixture(world.root, {
-      onlyPrerelease: true,
-      packageText: 'prerelease package bytes',
-    }),
-  );
-  transcript.write(testInfo);
-});
+    await runValidationCase(testInfo, transcript, 'malformed schema', (world) =>
+      writeSignedUpdateFixture(world.root, { malformedFeed: true }),
+    );
+    await runValidationCase(testInfo, transcript, 'altered signed release envelope', (world) =>
+      writeSignedUpdateFixture(world.root, {
+        servedEnvelopeBytes: Buffer.from('{"tampered":true}\n'),
+        packageText: 'package bytes',
+      }),
+    );
+    await runValidationCase(testInfo, transcript, 'downgrade with prerelease ignored', (world) =>
+      writeSignedUpdateFixture(world.root, {
+        tag: 'v0.0.9',
+        includePrerelease: true,
+        packageText: 'old package bytes',
+      }),
+    );
+    await runValidationCase(testInfo, transcript, 'prerelease-only feed', (world) =>
+      writeSignedUpdateFixture(world.root, {
+        onlyPrerelease: true,
+        packageText: 'prerelease package bytes',
+      }),
+    );
+    transcript.write(testInfo);
+  },
+);
 
 async function runValidationCase(
   testInfo: TestInfo,

--- a/desktop/test/e2e/journeys/first-launch.spec.ts
+++ b/desktop/test/e2e/journeys/first-launch.spec.ts
@@ -50,219 +50,227 @@ const RUN_NAME = `first-launch-${
   process.env['AGENTICO_E2E_VARIANT'] ?? (process.platform === 'darwin' ? 'macos' : 'linux')
 }`;
 
-test('first launch: provider-gated creation reaches Ready to start', async ({}, testInfo) => {
-  const transcript = new Transcript(
-    RUN_NAME,
-    'Journey 1 — first launch creation (packaged app, real bundled server)',
-  );
-  const world = createWorld('first-launch', { auth: { loggedIn: false }, authDelaySeconds: 6 });
-  const demoApp = createPlainFolder(world, 'demo-app');
-  transcript.section('World');
-  transcript.step(`isolated world at \`${world.root}\` (HOME, userData, runtime dir, workspace)`);
-  transcript.step(
-    'runtime config redirects providers.claude.cli to a stub reporting installed but NOT authenticated; codex/opencode point at nonexistent paths',
-  );
-  transcript.codeBlock('config.yaml', fs.readFileSync(world.configPath, 'utf8'));
-
-  let handle: AppHandle | null = null;
-  try {
-    transcript.section('Launch: connection shell, app-owned server');
-    handle = await launchApp(world, testInfo, { traceName: RUN_NAME });
-    transcript.step('launched the verified unpacked packaged app via Playwright _electron.launch');
-
-    // The stub delays its first auth probe, holding the gateway in
-    // wait-health long enough to capture the connection shell.
-    const shell = handle.page.getByLabel('Agentico connection');
-    await expect(shell).toBeVisible();
-    await expect(
-      handle.page.locator('.shell-card__status-label[data-status="waiting-health"]'),
-    ).toBeVisible({ timeout: 30_000 });
-    await evidenceShotBothThemes(handle, 'connection-shell');
+test(
+  'first launch: provider-gated creation reaches Ready to start',
+  { tag: '@smoke' },
+  async ({}, testInfo) => {
+    const transcript = new Transcript(
+      RUN_NAME,
+      'Journey 1 — first launch creation (packaged app, real bundled server)',
+    );
+    const world = createWorld('first-launch', { auth: { loggedIn: false }, authDelaySeconds: 6 });
+    const demoApp = createPlainFolder(world, 'demo-app');
+    transcript.section('World');
+    transcript.step(`isolated world at \`${world.root}\` (HOME, userData, runtime dir, workspace)`);
     transcript.step(
-      'connection shell visible in waiting-health stage (app-owned launch); captured light+dark',
+      'runtime config redirects providers.claude.cli to a stub reporting installed but NOT authenticated; codex/opencode point at nonexistent paths',
     );
-    fs.rmSync(world.authDelayPath, { force: true }); // later probes answer instantly
+    transcript.codeBlock('config.yaml', fs.readFileSync(world.configPath, 'utf8'));
 
-    transcript.section('Wizard blocks creation while the provider is unauthenticated');
-    await expect(handle.page.getByRole('heading', { name: 'Set up Agentico' })).toBeVisible({
-      timeout: 60_000,
-    });
-    const claudeRow = handle.page.locator('.provider-row', { hasText: 'claude' });
-    await expect(claudeRow).toContainText('Needs attention');
-    await expect(claudeRow).toContainText('not signed in');
-    await expect(claudeRow).toContainText("Run 'claude auth login' or set ANTHROPIC_API_KEY");
-    await evidenceShotBothThemes(handle, 'wizard-providers');
+    let handle: AppHandle | null = null;
+    try {
+      transcript.section('Launch: connection shell, app-owned server');
+      handle = await launchApp(world, testInfo, { traceName: RUN_NAME });
+      transcript.step(
+        'launched the verified unpacked packaged app via Playwright _electron.launch',
+      );
 
-    const readiness = await handle.page.evaluate(() => window.agentico.getReadiness());
-    expect(readiness.ready).toBe(false);
-    transcript.json('GET /api/v1/readiness (via IPC) while unauthenticated', readiness);
+      // The stub delays its first auth probe, holding the gateway in
+      // wait-health long enough to capture the connection shell.
+      const shell = handle.page.getByLabel('Agentico connection');
+      await expect(shell).toBeVisible();
+      await expect(
+        handle.page.locator('.shell-card__status-label[data-status="waiting-health"]'),
+      ).toBeVisible({ timeout: 30_000 });
+      await evidenceShotBothThemes(handle, 'connection-shell');
+      transcript.step(
+        'connection shell visible in waiting-health stage (app-owned launch); captured light+dark',
+      );
+      fs.rmSync(world.authDelayPath, { force: true }); // later probes answer instantly
 
-    // The server itself refuses creation while not ready — not just the UI.
-    const rejection = await handle.page.evaluate(() =>
-      window.agentico
-        .createFeature({
-          name: 'premature',
-          description: '',
-          repoKeys: ['none'],
-          useCurrentBranch: false,
-        })
-        .then(() => 'created')
-        .catch((err: unknown) => String(err)),
-    );
-    expect(rejection).toContain('not_ready');
-    transcript.step(`feature creation rejected while not ready: \`${rejection}\``);
+      transcript.section('Wizard blocks creation while the provider is unauthenticated');
+      await expect(handle.page.getByRole('heading', { name: 'Set up Agentico' })).toBeVisible({
+        timeout: 60_000,
+      });
+      const claudeRow = handle.page.locator('.provider-row', { hasText: 'claude' });
+      await expect(claudeRow).toContainText('Needs attention');
+      await expect(claudeRow).toContainText('not signed in');
+      await expect(claudeRow).toContainText("Run 'claude auth login' or set ANTHROPIC_API_KEY");
+      await evidenceShotBothThemes(handle, 'wizard-providers');
 
-    // Narrow/wide layout evidence with a real keyboard focus ring.
-    await setWindowSize(handle, 500, 760);
-    await focusButtonByKeyboard(handle, 'Check again');
-    await evidenceShot(handle, 'first-launch-narrow');
-    await setWindowSize(handle, 1400, 900);
-    await evidenceShot(handle, 'first-launch-wide');
-    await setWindowSize(handle, 1080, 720);
-    transcript.step(
-      'captured narrow (500px, keyboard focus ring on Check again) and wide (1400px) wizard layouts',
-    );
+      const readiness = await handle.page.evaluate(() => window.agentico.getReadiness());
+      expect(readiness.ready).toBe(false);
+      transcript.json('GET /api/v1/readiness (via IPC) while unauthenticated', readiness);
 
-    transcript.section('External remediation, then Check again');
-    setStubAuthenticated(world, true);
-    transcript.step(
-      'flipped the stub auth-state file to authenticated (stands in for the user completing `claude auth login` in their own terminal)',
-    );
-    const app = handle;
-    await app.page.getByRole('button', { name: /Check again/ }).click();
-    await expect(app.page.getByRole('button', { name: 'New feature' })).toBeVisible({
-      timeout: 30_000,
-    });
-    transcript.step(
-      'the only readiness gates are provider and model availability: one refresh satisfied both and setup handed straight to Home — no workspace or repository step in between',
-    );
+      // The server itself refuses creation while not ready — not just the UI.
+      const rejection = await handle.page.evaluate(() =>
+        window.agentico
+          .createFeature({
+            name: 'premature',
+            description: '',
+            repoKeys: ['none'],
+            useCurrentBranch: false,
+          })
+          .then(() => 'created')
+          .catch((err: unknown) => String(err)),
+      );
+      expect(rejection).toContain('not_ready');
+      transcript.step(`feature creation rejected while not ready: \`${rejection}\``);
 
-    transcript.section('Where: adopt a folder, consent to initialization, select the repository');
-    await mockDirectoryPicker(app, demoApp);
-    const consent = app.page.getByRole('dialog', { name: 'Initialize a new repository?' });
+      // Narrow/wide layout evidence with a real keyboard focus ring.
+      await setWindowSize(handle, 500, 760);
+      await focusButtonByKeyboard(handle, 'Check again');
+      await evidenceShot(handle, 'first-launch-narrow');
+      await setWindowSize(handle, 1400, 900);
+      await evidenceShot(handle, 'first-launch-wide');
+      await setWindowSize(handle, 1080, 720);
+      transcript.step(
+        'captured narrow (500px, keyboard focus ring on Check again) and wide (1400px) wizard layouts',
+      );
 
-    transcript.section('Create the feature (name/description/repo/branch)');
-    transcript.section('Ordered setup tasks → Ready to start');
-    const cockpit = await createFeatureViaForm(app, {
-      name: 'Tracer Bullet',
-      description: 'First packaged end-to-end feature creation.',
-      repoPatterns: [/demo-app/],
-      waitForReady: true,
-      beforeRepoSelect: async () => {
-        // A clean install has no repositories, so Where leads with the picker.
-        await expect(
-          app.page.getByRole('heading', { name: 'Add your first repository' }),
-        ).toBeVisible();
-        await app.page.getByRole('button', { name: 'Browse for folder' }).click();
-        await app.page.getByRole('button', { name: 'Use this folder' }).click();
-        await expect(app.page.getByText(/holds no git repository yet/i)).toBeVisible();
-        await app.page.getByRole('button', { name: /Initialize it as a repository/ }).click();
-        await expect(consent).toBeVisible();
-        await expect(consent).toContainText(demoApp);
-        await evidenceShot(app, 'repo-init-consent-light');
-        // The modal scrim blocks the theme switcher, so cancel (the folder
-        // choice is kept), flip the theme, and reopen the same consent dialog.
-        await consent.getByRole('button', { name: 'Cancel' }).click();
-        await setTheme(app, 'dark');
-        await app.page.getByRole('button', { name: /Initialize it as a repository/ }).click();
-        await expect(consent).toBeVisible();
-        await evidenceShot(app, 'repo-init-consent-dark');
-        await consent.getByRole('button', { name: 'Initialize repository' }).click();
-        // One unambiguous discovery selects itself, so Where is already valid.
-        await expect(app.page.getByRole('checkbox', { name: /demo-app/ })).toBeChecked({
-          timeout: 30_000,
-        });
-        await setTheme(app, 'light');
-        transcript.step(
-          'consented; the server initialized the repository (git init + initial empty commit), rediscovered the workspace, and the single discovery selected itself',
-        );
-      },
-    });
-    await expect(cockpit.getByText('Ready to start')).toBeVisible();
-    await expect(handle.page.getByRole('button', { name: 'Start', exact: true })).toBeVisible();
-    await expect(handle.page.getByRole('button', { name: 'Start', exact: true })).toBeEnabled();
-    await expect(cockpit.getByText("Starting isn't available in this version yet.")).toHaveCount(0);
-    await evidenceShotBothThemes(handle, 'ready-to-start');
+      transcript.section('External remediation, then Check again');
+      setStubAuthenticated(world, true);
+      transcript.step(
+        'flipped the stub auth-state file to authenticated (stands in for the user completing `claude auth login` in their own terminal)',
+      );
+      const app = handle;
+      await app.page.getByRole('button', { name: /Check again/ }).click();
+      await expect(app.page.getByRole('button', { name: 'New feature' })).toBeVisible({
+        timeout: 30_000,
+      });
+      transcript.step(
+        'the only readiness gates are provider and model availability: one refresh satisfied both and setup handed straight to Home — no workspace or repository step in between',
+      );
 
-    const features = await handle.page.evaluate(() => window.agentico.listFeatures());
-    expect(features).toHaveLength(1);
-    const feature = await handle.page.evaluate(
-      (id) => window.agentico.getFeature(id),
-      features[0]!.id,
-    );
-    transcript.json('authoritative feature snapshot (via IPC)', feature);
-    expect(feature.setup?.status).toBe('done');
-    const startAction = feature.actions.find((action) => action.id === 'start');
-    expect(startAction?.enabled).toBe(true);
+      transcript.section('Where: adopt a folder, consent to initialization, select the repository');
+      await mockDirectoryPicker(app, demoApp);
+      const consent = app.page.getByRole('dialog', { name: 'Initialize a new repository?' });
 
-    transcript.section('Nothing started: no orchestration, no sessions');
-    // The action catalogue authorizes start but nothing invoked it; the
-    // state dir must contain no session or run-log material for the feature.
-    expect(['created', 'ready']).toContain(feature.status.toLowerCase());
-    const sessionEntries = findEntries(world.stateDir, /session/i);
-    expect(sessionEntries).toEqual([]);
-    transcript.step(
-      `feature status \`${feature.status}\`, start enabled but never invoked; no session files under the state dir`,
-    );
+      transcript.section('Create the feature (name/description/repo/branch)');
+      transcript.section('Ordered setup tasks → Ready to start');
+      const cockpit = await createFeatureViaForm(app, {
+        name: 'Tracer Bullet',
+        description: 'First packaged end-to-end feature creation.',
+        repoPatterns: [/demo-app/],
+        waitForReady: true,
+        beforeRepoSelect: async () => {
+          // A clean install has no repositories, so Where leads with the picker.
+          await expect(
+            app.page.getByRole('heading', { name: 'Add your first repository' }),
+          ).toBeVisible();
+          await app.page.getByRole('button', { name: 'Browse for folder' }).click();
+          await app.page.getByRole('button', { name: 'Use this folder' }).click();
+          await expect(app.page.getByText(/holds no git repository yet/i)).toBeVisible();
+          await app.page.getByRole('button', { name: /Initialize it as a repository/ }).click();
+          await expect(consent).toBeVisible();
+          await expect(consent).toContainText(demoApp);
+          await evidenceShot(app, 'repo-init-consent-light');
+          // The modal scrim blocks the theme switcher, so cancel (the folder
+          // choice is kept), flip the theme, and reopen the same consent dialog.
+          await consent.getByRole('button', { name: 'Cancel' }).click();
+          await setTheme(app, 'dark');
+          await app.page.getByRole('button', { name: /Initialize it as a repository/ }).click();
+          await expect(consent).toBeVisible();
+          await evidenceShot(app, 'repo-init-consent-dark');
+          await consent.getByRole('button', { name: 'Initialize repository' }).click();
+          // One unambiguous discovery selects itself, so Where is already valid.
+          await expect(app.page.getByRole('checkbox', { name: /demo-app/ })).toBeChecked({
+            timeout: 30_000,
+          });
+          await setTheme(app, 'light');
+          transcript.step(
+            'consented; the server initialized the repository (git init + initial empty commit), rediscovered the workspace, and the single discovery selected itself',
+          );
+        },
+      });
+      await expect(cockpit.getByText('Ready to start')).toBeVisible();
+      await expect(handle.page.getByRole('button', { name: 'Start', exact: true })).toBeVisible();
+      await expect(handle.page.getByRole('button', { name: 'Start', exact: true })).toBeEnabled();
+      await expect(cockpit.getByText("Starting isn't available in this version yet.")).toHaveCount(
+        0,
+      );
+      await evidenceShotBothThemes(handle, 'ready-to-start');
 
-    transcript.section('Ownership and graceful shutdown (app-owned)');
-    const discovery = readDiscovery(world);
-    expect(discovery).not.toBeNull();
-    const serverPid = discovery!.pid;
-    const connection = await handle.page.evaluate(() => window.agentico.getConnectionStatus());
-    expect(connection.status).toBe('ready');
-    expect(connection.ownership).toBe('app-owned');
-    transcript.json('connection state (via IPC)', connection);
-    transcript.json('discovery record (auth_token redacted)', {
-      ...discovery,
-      auth_token: '[redacted]',
-    });
+      const features = await handle.page.evaluate(() => window.agentico.listFeatures());
+      expect(features).toHaveLength(1);
+      const feature = await handle.page.evaluate(
+        (id) => window.agentico.getFeature(id),
+        features[0]!.id,
+      );
+      transcript.json('authoritative feature snapshot (via IPC)', feature);
+      expect(feature.setup?.status).toBe('done');
+      const startAction = feature.actions.find((action) => action.id === 'start');
+      expect(startAction?.enabled).toBe(true);
 
-    const logText = persistAppLogs(handle, 'first-launch-app');
-    if (discovery!.auth_token !== undefined && discovery!.auth_token !== '') {
-      expect(logText).not.toContain(discovery!.auth_token);
+      transcript.section('Nothing started: no orchestration, no sessions');
+      // The action catalogue authorizes start but nothing invoked it; the
+      // state dir must contain no session or run-log material for the feature.
+      expect(['created', 'ready']).toContain(feature.status.toLowerCase());
+      const sessionEntries = findEntries(world.stateDir, /session/i);
+      expect(sessionEntries).toEqual([]);
+      transcript.step(
+        `feature status \`${feature.status}\`, start enabled but never invoked; no session files under the state dir`,
+      );
+
+      transcript.section('Ownership and graceful shutdown (app-owned)');
+      const discovery = readDiscovery(world);
+      expect(discovery).not.toBeNull();
+      const serverPid = discovery!.pid;
+      const connection = await handle.page.evaluate(() => window.agentico.getConnectionStatus());
+      expect(connection.status).toBe('ready');
+      expect(connection.ownership).toBe('app-owned');
+      transcript.json('connection state (via IPC)', connection);
+      transcript.json('discovery record (auth_token redacted)', {
+        ...discovery,
+        auth_token: '[redacted]',
+      });
+
+      const logText = persistAppLogs(handle, 'first-launch-app');
+      if (discovery!.auth_token !== undefined && discovery!.auth_token !== '') {
+        expect(logText).not.toContain(discovery!.auth_token);
+      }
+      const logExcerpt = nonemptyLogExcerpt(logText, 30);
+      transcript.codeBlock('app/server log excerpt (redacted at source)', logExcerpt);
+
+      await closeApp(handle);
+      await waitFor(
+        () => !processAlive(serverPid),
+        `app-owned server ${serverPid} to be reaped`,
+        15_000,
+      );
+      transcript.step(
+        `app quit gracefully; app-owned server pid ${serverPid} received SIGTERM and was reaped (process no longer alive)`,
+      );
+      assertNoLeakedProcesses(world);
+      transcript.step('no processes referencing the journey world remain');
+      transcript.write(testInfo);
+
+      // Ownership evidence doc: contribute the app-owned shutdown proof
+      // (journeys 3 and 4 contribute the external-server sections).
+      const ownership = new Transcript(
+        'ownership-compatibility',
+        'App-owned graceful shutdown (journey 1 teardown)',
+        { append: true },
+      );
+      ownership.step(
+        `app-owned server pid ${serverPid} (from the discovery record) was alive while connected ` +
+          'and no longer exists after app quit — the bounded SIGTERM→reap path ran',
+      );
+      ownership.step(`ownership reported over IPC while connected: \`${connection.ownership}\``);
+      ownership.codeBlock(
+        'app/server log tail at shutdown (redacted at source)',
+        nonemptyLogExcerpt(logText, 15),
+      );
+      ownership.write(testInfo);
+    } finally {
+      if (handle !== null) {
+        await closeApp(handle).catch(() => {});
+      }
+      assertNoLeakedProcesses(world);
+      destroyWorld(world);
     }
-    const logExcerpt = nonemptyLogExcerpt(logText, 30);
-    transcript.codeBlock('app/server log excerpt (redacted at source)', logExcerpt);
-
-    await closeApp(handle);
-    await waitFor(
-      () => !processAlive(serverPid),
-      `app-owned server ${serverPid} to be reaped`,
-      15_000,
-    );
-    transcript.step(
-      `app quit gracefully; app-owned server pid ${serverPid} received SIGTERM and was reaped (process no longer alive)`,
-    );
-    assertNoLeakedProcesses(world);
-    transcript.step('no processes referencing the journey world remain');
-    transcript.write(testInfo);
-
-    // Ownership evidence doc: contribute the app-owned shutdown proof
-    // (journeys 3 and 4 contribute the external-server sections).
-    const ownership = new Transcript(
-      'ownership-compatibility',
-      'App-owned graceful shutdown (journey 1 teardown)',
-      { append: true },
-    );
-    ownership.step(
-      `app-owned server pid ${serverPid} (from the discovery record) was alive while connected ` +
-        'and no longer exists after app quit — the bounded SIGTERM→reap path ran',
-    );
-    ownership.step(`ownership reported over IPC while connected: \`${connection.ownership}\``);
-    ownership.codeBlock(
-      'app/server log tail at shutdown (redacted at source)',
-      nonemptyLogExcerpt(logText, 15),
-    );
-    ownership.write(testInfo);
-  } finally {
-    if (handle !== null) {
-      await closeApp(handle).catch(() => {});
-    }
-    assertNoLeakedProcesses(world);
-    destroyWorld(world);
-  }
-});
+  },
+);
 
 function nonemptyLogExcerpt(logText: string, lines: number): string {
   const excerpt = tailText(logText, lines).trim();

--- a/desktop/test/e2e/journeys/menu-bar.spec.ts
+++ b/desktop/test/e2e/journeys/menu-bar.spec.ts
@@ -131,261 +131,267 @@ async function featureItem(handle: AppHandle, id: string): Promise<boolean> {
   return item.enabled;
 }
 
-test('the application menu bar drives New Feature, the View toggles, and the Feature catalogue', async ({}, testInfo) => {
-  // A real run is started and stopped through the menu, so this needs more than
-  // the suite's default per-test budget. The number is a backstop, not the
-  // enforcement mechanism: every action, wait, and round trip below carries its
-  // own bound, generous against its real duration, so a stalled step fails by
-  // name in seconds instead of quietly soaking this budget.
-  test.setTimeout(420_000);
-  const transcript = new Transcript('menu-bar', 'Application menu bar — File, View, and Feature');
-  const world = createWorld('menu-bar', {
-    auth: { loggedIn: true, authMethod: 'oauth', email: 'e2e@example.invalid' },
-    presetWorkspaceRoot: true,
-    // Deterministic provider output, so the run this journey starts through the
-    // menu is genuinely live — and therefore genuinely stoppable — rather than
-    // racing its own completion.
-    workflowProvider: true,
-  });
-  createRepo(world, 'menu-lab', { commit: true });
-  let handle: AppHandle | null = null;
-  let failed = true;
-
-  try {
-    handle = await launchApp(world, testInfo, { traceName: 'menu-bar' });
-    await expect(handle.page.getByRole('button', { name: 'New feature' })).toBeVisible({
-      timeout: 60_000,
+test(
+  'the application menu bar drives New Feature, the View toggles, and the Feature catalogue',
+  { tag: '@smoke' },
+  async ({}, testInfo) => {
+    // A real run is started and stopped through the menu, so this needs more than
+    // the suite's default per-test budget. The number is a backstop, not the
+    // enforcement mechanism: every action, wait, and round trip below carries its
+    // own bound, generous against its real duration, so a stalled step fails by
+    // name in seconds instead of quietly soaking this budget.
+    test.setTimeout(420_000);
+    const transcript = new Transcript('menu-bar', 'Application menu bar — File, View, and Feature');
+    const world = createWorld('menu-bar', {
+      auth: { loggedIn: true, authMethod: 'oauth', email: 'e2e@example.invalid' },
+      presetWorkspaceRoot: true,
+      // Deterministic provider output, so the run this journey starts through the
+      // menu is genuinely live — and therefore genuinely stoppable — rather than
+      // racing its own completion.
+      workflowProvider: true,
     });
-    transcript.step('app launched and reached the ready workspace');
+    createRepo(world, 'menu-lab', { commit: true });
+    let handle: AppHandle | null = null;
+    let failed = true;
 
-    transcript.section('The menu bar reads as a Mac app: Feature sits between View and Window');
-    const initial = await menuState(handle);
-    expect(initial.topLevel.slice(1)).toEqual([
-      'File',
-      'Navigate',
-      'Edit',
-      'View',
-      'Feature',
-      'Window',
-    ]);
-    expect(initial.file.map((item) => item.label)).toEqual(['New Feature', 'Close Window']);
-    expect(initial.view.map((item) => item.label)).toEqual([
-      'Hide Sidebar',
-      'Show Inspector',
-      'Reload',
-      'Force Reload',
-      'Zoom In',
-      'Zoom Out',
-      'Actual Size',
-      'Toggle Full Screen',
-    ]);
-    transcript.step('File, View, Feature, and Window are in the standard order with their items');
+    try {
+      handle = await launchApp(world, testInfo, { traceName: 'menu-bar' });
+      await expect(handle.page.getByRole('button', { name: 'New feature' })).toBeVisible({
+        timeout: 60_000,
+      });
+      transcript.step('app launched and reached the ready workspace');
 
-    transcript.section('On Overview the whole Feature menu is disabled — visible, never hidden');
-    expect(initial.feature.map((item) => item.label)).toEqual(EXPECTED_FEATURE_LABELS);
-    expect(initial.feature.every((item) => item.visible)).toBe(true);
-    expect(initial.feature.every((item) => !item.enabled)).toBe(true);
-    // Overview has no inspector to show or hide; New Feature works regardless.
-    expect(initial.view.find((item) => item.id === 'global.toggle-inspector')?.enabled).toBe(false);
-    expect(initial.file.find((item) => item.id === 'global.new-feature')?.enabled).toBe(true);
-    transcript.step(
-      'all fifteen verbs present and dimmed on Overview, with Show Inspector dimmed too',
-    );
+      transcript.section('The menu bar reads as a Mac app: Feature sits between View and Window');
+      const initial = await menuState(handle);
+      expect(initial.topLevel.slice(1)).toEqual([
+        'File',
+        'Navigate',
+        'Edit',
+        'View',
+        'Feature',
+        'Window',
+      ]);
+      expect(initial.file.map((item) => item.label)).toEqual(['New Feature', 'Close Window']);
+      expect(initial.view.map((item) => item.label)).toEqual([
+        'Hide Sidebar',
+        'Show Inspector',
+        'Reload',
+        'Force Reload',
+        'Zoom In',
+        'Zoom Out',
+        'Actual Size',
+        'Toggle Full Screen',
+      ]);
+      transcript.step('File, View, Feature, and Window are in the standard order with their items');
 
-    transcript.section('File ▸ New Feature opens the creation sheet');
-    await clickMenuItem(handle, 'global.new-feature');
-    await expect(handle.page.getByRole('form', { name: 'Create a feature' })).toBeVisible({
-      timeout: 30_000,
-    });
-    await handle.page.getByRole('button', { name: 'Cancel' }).click();
-    await expect(handle.page.getByRole('form', { name: 'Create a feature' })).toHaveCount(0);
-    transcript.step('the File item opened the same creation sheet the toolbar button does');
+      transcript.section('On Overview the whole Feature menu is disabled — visible, never hidden');
+      expect(initial.feature.map((item) => item.label)).toEqual(EXPECTED_FEATURE_LABELS);
+      expect(initial.feature.every((item) => item.visible)).toBe(true);
+      expect(initial.feature.every((item) => !item.enabled)).toBe(true);
+      // Overview has no inspector to show or hide; New Feature works regardless.
+      expect(initial.view.find((item) => item.id === 'global.toggle-inspector')?.enabled).toBe(
+        false,
+      );
+      expect(initial.file.find((item) => item.id === 'global.new-feature')?.enabled).toBe(true);
+      transcript.step(
+        'all fifteen verbs present and dimmed on Overview, with Show Inspector dimmed too',
+      );
 
-    transcript.section('A selected feature lights the menu up from its action catalogue');
-    const cockpit = await createFeatureViaForm(handle, {
-      name: 'Menu Bar Feature',
-      description: 'Exercises the native Feature menu against a real action catalogue.',
-      repoPatterns: [/menu-lab/],
-      waitForReady: true,
-    });
-    await waitFor(
-      async () => await featureItem(handle!, 'feature.start'),
-      'Feature ▸ Start to enable for the selected feature',
-      60_000,
-    );
-    const selected = await menuState(handle);
-    expect(selected.feature.map((item) => item.label)).toEqual(EXPECTED_FEATURE_LABELS);
-    expect(selected.feature.every((item) => item.visible)).toBe(true);
-    const enabledById = new Map(selected.feature.map((item) => [item.id, item.enabled]));
-    // Configuration is a local editor: available whenever a feature is selected.
-    expect(enabledById.get('feature.configuration')).toBe(true);
-    // A pre-start feature has nothing to stop or merge — dimmed, still listed.
-    expect(enabledById.get('feature.pause-stop')).toBe(false);
-    expect(enabledById.get('feature.merge')).toBe(false);
-    // Enablement matches the authoritative catalogue verb for verb.
-    const catalogue = await probe('the authoritative action catalogue', () =>
-      handle!.page.evaluate(async () => {
-        const settings = await window.agentico.getSettings();
-        const state = await window.agentico.getConnectionStatus();
-        const id =
-          state.serverKey == null
-            ? null
-            : (settings.shell.featureByServer[state.serverKey] ?? null);
-        if (id === null) throw new Error('no feature is selected');
-        return (await window.agentico.getFeature(id)).actions;
-      }),
-    );
-    for (const action of catalogue) {
-      const id = `feature.${action.id}`;
-      if (!enabledById.has(id)) continue;
-      expect(enabledById.get(id), `${id} drifted from the action catalogue`).toBe(action.enabled);
-    }
-    await evidenceShot(handle, 'menu-bar-feature-selected');
-    transcript.step(
-      'the Feature menu mirrored the selected feature’s action catalogue verb by verb',
-    );
+      transcript.section('File ▸ New Feature opens the creation sheet');
+      await clickMenuItem(handle, 'global.new-feature');
+      await expect(handle.page.getByRole('form', { name: 'Create a feature' })).toBeVisible({
+        timeout: 30_000,
+      });
+      await handle.page.getByRole('button', { name: 'Cancel' }).click();
+      await expect(handle.page.getByRole('form', { name: 'Create a feature' })).toHaveCount(0);
+      transcript.step('the File item opened the same creation sheet the toolbar button does');
 
-    transcript.section('The View toggles drive the real sidebar and inspector, labels and all');
-    const sidebar = handle.page.locator('nav.sidebar');
-    await expect(sidebar).toHaveAttribute('data-collapsed', 'false');
-    await clickMenuItem(handle, 'global.toggle-sidebar');
-    await expect(sidebar).toHaveAttribute('data-collapsed', 'true');
-    await waitFor(
-      async () =>
-        (await menuState(handle!)).view.find((item) => item.id === 'global.toggle-sidebar')
-          ?.label === 'Show Sidebar',
-      'the sidebar item label to flip to Show Sidebar',
-      15_000,
-    );
-    const persisted = await probe('the persisted shell settings', () =>
-      handle!.page.evaluate(() => window.agentico.getSettings()),
-    );
-    expect(persisted.shell.sidebarCollapsed).toBe(true);
-    await clickMenuItem(handle, 'global.toggle-sidebar');
-    await expect(sidebar).toHaveAttribute('data-collapsed', 'false');
-    transcript.step('View ▸ Show/Hide Sidebar collapsed and restored the same persisted state');
-
-    const inspectorToggle = handle.page.getByRole('button', { name: 'Toggle inspector' });
-    await expect(inspectorToggle).toHaveAttribute('aria-pressed', 'false');
-    await clickMenuItem(handle, 'global.toggle-inspector');
-    await expect(inspectorToggle).toHaveAttribute('aria-pressed', 'true');
-    await waitFor(
-      async () =>
-        (await menuState(handle!)).view.find((item) => item.id === 'global.toggle-inspector')
-          ?.label === 'Hide Inspector',
-      'the inspector item label to flip to Hide Inspector',
-      15_000,
-    );
-    await clickMenuItem(handle, 'global.toggle-inspector');
-    await expect(inspectorToggle).toHaveAttribute('aria-pressed', 'false');
-    transcript.step('View ▸ Show/Hide Inspector flipped the cockpit inspector and its own label');
-
-    transcript.section('Feature ▸ Start then Stop runs the cockpit’s own confirmation');
-    await clickMenuItem(handle, 'feature.start');
-    await expect(cockpit.getByText(/Start accepted|Starting from/)).toBeVisible({
-      timeout: 30_000,
-    });
-    // Three separate facts, waited for separately so a failure says which one
-    // broke: the provider process really started, the cockpit's own Stop control
-    // agrees the run is live, and only then the Feature menu's enabled map
-    // caught up through the renderer→main push.
-    await waitFor(
-      () => providerInvocationCount(world.providerInvocationLog) >= 1,
-      'the real provider process the menu-invoked Start produced',
-      60_000,
-    );
-    // The cockpit's own Stop control lives in the feature header, outside the
-    // cockpit region — the same locator start-watch-stop uses.
-    await expect(handle.page.getByRole('button', { name: 'Stop', exact: true })).toBeEnabled({
-      timeout: 60_000,
-    });
-    await waitFor(
-      async () => await featureItem(handle!, 'feature.pause-stop'),
-      'Feature ▸ Stop to follow the live run through the UI-state push',
-      30_000,
-    );
-    await clickMenuItem(handle, 'feature.pause-stop');
-    const stopDialog = handle.page.getByRole('dialog', { name: /^Stop Menu Bar Feature\?/ });
-    await expect(stopDialog).toBeVisible({ timeout: 30_000 });
-    await evidenceShot(handle, 'menu-bar-stop-confirmation');
-    transcript.step(
-      'the menu-invoked Stop surfaced the cockpit’s confirmation, not a raw dispatch',
-    );
-
-    await stopDialog.getByRole('button', { name: 'Confirm stop' }).click();
-    await expect(stopDialog).toHaveCount(0, { timeout: 60_000 });
-    await waitFor(
-      async () => {
-        const snapshot = await probe('the authoritative feature snapshot', () =>
-          handle!.page.evaluate(async () => {
-            const settings = await window.agentico.getSettings();
-            const state = await window.agentico.getConnectionStatus();
-            const id =
-              state.serverKey == null
-                ? null
-                : (settings.shell.featureByServer[state.serverKey] ?? null);
-            return id === null ? null : await window.agentico.getFeature(id);
-          }),
-        );
-        return (
-          snapshot !== null &&
-          !['running', 'starting', 'stopping'].includes(snapshot.status.toLowerCase())
-        );
-      },
-      'the authoritative terminal snapshot after the menu-invoked stop',
-      90_000,
-    );
-    transcript.step('the confirmed stop dispatched and the feature reached a terminal state');
-
-    transcript.section('Navigate and the tray still route exactly as before');
-    await clickMenuItem(handle, 'global.home');
-    await expect(handle.page.getByRole('option', { name: 'Overview' })).toHaveAttribute(
-      'aria-selected',
-      'true',
-      { timeout: 30_000 },
-    );
-    await expect(cockpit).toHaveCount(0);
-    // Back on Overview the Feature menu goes dark again, still listing fifteen.
-    await waitFor(
-      async () => (await menuState(handle!)).feature.every((item) => !item.enabled),
-      'the Feature menu to go dark on Overview',
-      15_000,
-    );
-    const trayState = await probe('the native-command controller state', () =>
-      handle!.app.evaluate(() => {
-        const global = globalThis as typeof globalThis & {
-          __agenticoNativeCommandState?: { trayInstalled: boolean; trayFallbackActive: boolean };
-        };
-        return global.__agenticoNativeCommandState ?? null;
-      }),
-    );
-    expect(trayState).not.toBeNull();
-    expect(trayState!.trayInstalled || trayState!.trayFallbackActive).toBe(true);
-    transcript.step('Navigate ▸ Overview routed as before and the tray is still installed');
-
-    transcript.step('journey complete');
-    failed = false;
-  } finally {
-    // Diagnostics before teardown, on both outcomes: a failed run is exactly
-    // when the transcript and the app's own log are worth having, and the last
-    // failure left nothing behind to post-mortem.
-    if (handle !== null) {
-      persistAppLogs(handle, 'menu-bar');
-      if (failed) {
-        await probe('the failure screenshot', () =>
-          evidenceShot(handle!, 'menu-bar-failure'),
-        ).catch(() => undefined);
-        const state = await probe(
-          'the failure menu read',
-          () => readMenuState(handle!),
-          10_000,
-        ).catch(() => null);
-        if (state !== null) transcript.json('live menu state at failure', state);
+      transcript.section('A selected feature lights the menu up from its action catalogue');
+      const cockpit = await createFeatureViaForm(handle, {
+        name: 'Menu Bar Feature',
+        description: 'Exercises the native Feature menu against a real action catalogue.',
+        repoPatterns: [/menu-lab/],
+        waitForReady: true,
+      });
+      await waitFor(
+        async () => await featureItem(handle!, 'feature.start'),
+        'Feature ▸ Start to enable for the selected feature',
+        60_000,
+      );
+      const selected = await menuState(handle);
+      expect(selected.feature.map((item) => item.label)).toEqual(EXPECTED_FEATURE_LABELS);
+      expect(selected.feature.every((item) => item.visible)).toBe(true);
+      const enabledById = new Map(selected.feature.map((item) => [item.id, item.enabled]));
+      // Configuration is a local editor: available whenever a feature is selected.
+      expect(enabledById.get('feature.configuration')).toBe(true);
+      // A pre-start feature has nothing to stop or merge — dimmed, still listed.
+      expect(enabledById.get('feature.pause-stop')).toBe(false);
+      expect(enabledById.get('feature.merge')).toBe(false);
+      // Enablement matches the authoritative catalogue verb for verb.
+      const catalogue = await probe('the authoritative action catalogue', () =>
+        handle!.page.evaluate(async () => {
+          const settings = await window.agentico.getSettings();
+          const state = await window.agentico.getConnectionStatus();
+          const id =
+            state.serverKey == null
+              ? null
+              : (settings.shell.featureByServer[state.serverKey] ?? null);
+          if (id === null) throw new Error('no feature is selected');
+          return (await window.agentico.getFeature(id)).actions;
+        }),
+      );
+      for (const action of catalogue) {
+        const id = `feature.${action.id}`;
+        if (!enabledById.has(id)) continue;
+        expect(enabledById.get(id), `${id} drifted from the action catalogue`).toBe(action.enabled);
       }
+      await evidenceShot(handle, 'menu-bar-feature-selected');
+      transcript.step(
+        'the Feature menu mirrored the selected feature’s action catalogue verb by verb',
+      );
+
+      transcript.section('The View toggles drive the real sidebar and inspector, labels and all');
+      const sidebar = handle.page.locator('nav.sidebar');
+      await expect(sidebar).toHaveAttribute('data-collapsed', 'false');
+      await clickMenuItem(handle, 'global.toggle-sidebar');
+      await expect(sidebar).toHaveAttribute('data-collapsed', 'true');
+      await waitFor(
+        async () =>
+          (await menuState(handle!)).view.find((item) => item.id === 'global.toggle-sidebar')
+            ?.label === 'Show Sidebar',
+        'the sidebar item label to flip to Show Sidebar',
+        15_000,
+      );
+      const persisted = await probe('the persisted shell settings', () =>
+        handle!.page.evaluate(() => window.agentico.getSettings()),
+      );
+      expect(persisted.shell.sidebarCollapsed).toBe(true);
+      await clickMenuItem(handle, 'global.toggle-sidebar');
+      await expect(sidebar).toHaveAttribute('data-collapsed', 'false');
+      transcript.step('View ▸ Show/Hide Sidebar collapsed and restored the same persisted state');
+
+      const inspectorToggle = handle.page.getByRole('button', { name: 'Toggle inspector' });
+      await expect(inspectorToggle).toHaveAttribute('aria-pressed', 'false');
+      await clickMenuItem(handle, 'global.toggle-inspector');
+      await expect(inspectorToggle).toHaveAttribute('aria-pressed', 'true');
+      await waitFor(
+        async () =>
+          (await menuState(handle!)).view.find((item) => item.id === 'global.toggle-inspector')
+            ?.label === 'Hide Inspector',
+        'the inspector item label to flip to Hide Inspector',
+        15_000,
+      );
+      await clickMenuItem(handle, 'global.toggle-inspector');
+      await expect(inspectorToggle).toHaveAttribute('aria-pressed', 'false');
+      transcript.step('View ▸ Show/Hide Inspector flipped the cockpit inspector and its own label');
+
+      transcript.section('Feature ▸ Start then Stop runs the cockpit’s own confirmation');
+      await clickMenuItem(handle, 'feature.start');
+      await expect(cockpit.getByText(/Start accepted|Starting from/)).toBeVisible({
+        timeout: 30_000,
+      });
+      // Three separate facts, waited for separately so a failure says which one
+      // broke: the provider process really started, the cockpit's own Stop control
+      // agrees the run is live, and only then the Feature menu's enabled map
+      // caught up through the renderer→main push.
+      await waitFor(
+        () => providerInvocationCount(world.providerInvocationLog) >= 1,
+        'the real provider process the menu-invoked Start produced',
+        60_000,
+      );
+      // The cockpit's own Stop control lives in the feature header, outside the
+      // cockpit region — the same locator start-watch-stop uses.
+      await expect(handle.page.getByRole('button', { name: 'Stop', exact: true })).toBeEnabled({
+        timeout: 60_000,
+      });
+      await waitFor(
+        async () => await featureItem(handle!, 'feature.pause-stop'),
+        'Feature ▸ Stop to follow the live run through the UI-state push',
+        30_000,
+      );
+      await clickMenuItem(handle, 'feature.pause-stop');
+      const stopDialog = handle.page.getByRole('dialog', { name: /^Stop Menu Bar Feature\?/ });
+      await expect(stopDialog).toBeVisible({ timeout: 30_000 });
+      await evidenceShot(handle, 'menu-bar-stop-confirmation');
+      transcript.step(
+        'the menu-invoked Stop surfaced the cockpit’s confirmation, not a raw dispatch',
+      );
+
+      await stopDialog.getByRole('button', { name: 'Confirm stop' }).click();
+      await expect(stopDialog).toHaveCount(0, { timeout: 60_000 });
+      await waitFor(
+        async () => {
+          const snapshot = await probe('the authoritative feature snapshot', () =>
+            handle!.page.evaluate(async () => {
+              const settings = await window.agentico.getSettings();
+              const state = await window.agentico.getConnectionStatus();
+              const id =
+                state.serverKey == null
+                  ? null
+                  : (settings.shell.featureByServer[state.serverKey] ?? null);
+              return id === null ? null : await window.agentico.getFeature(id);
+            }),
+          );
+          return (
+            snapshot !== null &&
+            !['running', 'starting', 'stopping'].includes(snapshot.status.toLowerCase())
+          );
+        },
+        'the authoritative terminal snapshot after the menu-invoked stop',
+        90_000,
+      );
+      transcript.step('the confirmed stop dispatched and the feature reached a terminal state');
+
+      transcript.section('Navigate and the tray still route exactly as before');
+      await clickMenuItem(handle, 'global.home');
+      await expect(handle.page.getByRole('option', { name: 'Overview' })).toHaveAttribute(
+        'aria-selected',
+        'true',
+        { timeout: 30_000 },
+      );
+      await expect(cockpit).toHaveCount(0);
+      // Back on Overview the Feature menu goes dark again, still listing fifteen.
+      await waitFor(
+        async () => (await menuState(handle!)).feature.every((item) => !item.enabled),
+        'the Feature menu to go dark on Overview',
+        15_000,
+      );
+      const trayState = await probe('the native-command controller state', () =>
+        handle!.app.evaluate(() => {
+          const global = globalThis as typeof globalThis & {
+            __agenticoNativeCommandState?: { trayInstalled: boolean; trayFallbackActive: boolean };
+          };
+          return global.__agenticoNativeCommandState ?? null;
+        }),
+      );
+      expect(trayState).not.toBeNull();
+      expect(trayState!.trayInstalled || trayState!.trayFallbackActive).toBe(true);
+      transcript.step('Navigate ▸ Overview routed as before and the tray is still installed');
+
+      transcript.step('journey complete');
+      failed = false;
+    } finally {
+      // Diagnostics before teardown, on both outcomes: a failed run is exactly
+      // when the transcript and the app's own log are worth having, and the last
+      // failure left nothing behind to post-mortem.
+      if (handle !== null) {
+        persistAppLogs(handle, 'menu-bar');
+        if (failed) {
+          await probe('the failure screenshot', () =>
+            evidenceShot(handle!, 'menu-bar-failure'),
+          ).catch(() => undefined);
+          const state = await probe(
+            'the failure menu read',
+            () => readMenuState(handle!),
+            10_000,
+          ).catch(() => null);
+          if (state !== null) transcript.json('live menu state at failure', state);
+        }
+      }
+      transcript.write(testInfo);
+      if (handle !== null) await closeApp(handle);
+      await assertNoLeakedProcesses(world);
+      destroyWorld(world);
     }
-    transcript.write(testInfo);
-    if (handle !== null) await closeApp(handle);
-    await assertNoLeakedProcesses(world);
-    destroyWorld(world);
-  }
-});
+  },
+);

--- a/desktop/test/e2e/journeys/overview-evidence.spec.ts
+++ b/desktop/test/e2e/journeys/overview-evidence.spec.ts
@@ -35,6 +35,10 @@ import {
 } from '../helpers/world';
 
 test.skip(process.platform !== 'darwin', 'macOS-only chrome evidence');
+test.skip(
+  process.env['AGENTICO_EVIDENCE_DIR'] === undefined || process.env['AGENTICO_EVIDENCE_DIR'] === '',
+  'evidence-only journey: contractEvidenceShot writes nothing without AGENTICO_EVIDENCE_DIR',
+);
 
 test('Overview evidence: populated four seedable lanes, recovery/bulk below the lanes', async ({}, testInfo) => {
   const world = createWorld('overview-evidence', {

--- a/desktop/test/e2e/journeys/settings-window.spec.ts
+++ b/desktop/test/e2e/journeys/settings-window.spec.ts
@@ -35,134 +35,138 @@ import { Transcript } from '../helpers/transcript';
 import { createRepo, createWorld, destroyWorld, waitFor } from '../helpers/world';
 import type { SettingsPaneId } from '../../../src/shared/ipc';
 
-test('Settings is its own window: single instance, panes, deep links, restore, and ⌘W', async ({}, testInfo) => {
-  // Two full packaged launches (the relaunch proves the pane restore), so this
-  // journey needs more than the suite's single-launch default budget.
-  test.setTimeout(360_000);
-  const transcript = new Transcript(
-    'settings-window',
-    'Settings window — ownership, panes, deep links, restore, close',
-  );
-  const world = createWorld('settings-window', {
-    auth: { loggedIn: true, authMethod: 'oauth', email: 'e2e@example.invalid' },
-    presetWorkspaceRoot: true,
-  });
-  createRepo(world, 'alpha', { commit: true });
-  let handle: AppHandle | null = null;
-
-  try {
-    transcript.section('Launch: one window, no settings surface in it');
-    handle = await launchApp(world, testInfo, { traceName: 'settings-window' });
-    await expect(handle.page.getByRole('button', { name: 'New feature' })).toBeVisible({
-      timeout: 60_000,
+test(
+  'Settings is its own window: single instance, panes, deep links, restore, and ⌘W',
+  { tag: '@smoke' },
+  async ({}, testInfo) => {
+    // Two full packaged launches (the relaunch proves the pane restore), so this
+    // journey needs more than the suite's single-launch default budget.
+    test.setTimeout(360_000);
+    const transcript = new Transcript(
+      'settings-window',
+      'Settings window — ownership, panes, deep links, restore, close',
+    );
+    const world = createWorld('settings-window', {
+      auth: { loggedIn: true, authMethod: 'oauth', email: 'e2e@example.invalid' },
+      presetWorkspaceRoot: true,
     });
-    expect(handle.app.windows()).toHaveLength(1);
-    await expect(handle.page.locator('.settings-window')).toHaveCount(0);
-    transcript.step('app launched with exactly one window and no in-shell settings surface');
+    createRepo(world, 'alpha', { commit: true });
+    let handle: AppHandle | null = null;
 
-    transcript.section('The native Settings menu item opens the Settings window');
-    const settings = await openSettings(handle);
-    expect(await settings.evaluate(() => window.agentico.windowPurpose)).toBe('settings');
-    expect(handle.app.windows()).toHaveLength(2);
-    // First-ever open lands on Workspace roots, and the main window is
-    // untouched behind it.
-    await expectPane(handle, settings, 'Workspace roots');
-    await expect(handle.page.getByRole('button', { name: 'New feature' })).toBeVisible();
-    await expect(handle.page.locator('.settings-window')).toHaveCount(0);
-    await evidenceShot(handle, 'settings-window-workspace-roots', settings);
-    transcript.step(
-      'Settings opened as a second window (purpose "settings") on the Workspace roots pane',
-    );
+    try {
+      transcript.section('Launch: one window, no settings surface in it');
+      handle = await launchApp(world, testInfo, { traceName: 'settings-window' });
+      await expect(handle.page.getByRole('button', { name: 'New feature' })).toBeVisible({
+        timeout: 60_000,
+      });
+      expect(handle.app.windows()).toHaveLength(1);
+      await expect(handle.page.locator('.settings-window')).toHaveCount(0);
+      transcript.step('app launched with exactly one window and no in-shell settings surface');
 
-    transcript.section('A second open focuses the existing window; it never duplicates');
-    const reopened = await openSettings(handle);
-    expect(reopened).toBe(settings);
-    expect(handle.app.windows()).toHaveLength(2);
-    expect(await browserWindowCount(handle)).toBe(2);
-    transcript.step('the second Settings open focused the one window — still two windows total');
+      transcript.section('The native Settings menu item opens the Settings window');
+      const settings = await openSettings(handle);
+      expect(await settings.evaluate(() => window.agentico.windowPurpose)).toBe('settings');
+      expect(handle.app.windows()).toHaveLength(2);
+      // First-ever open lands on Workspace roots, and the main window is
+      // untouched behind it.
+      await expectPane(handle, settings, 'Workspace roots');
+      await expect(handle.page.getByRole('button', { name: 'New feature' })).toBeVisible();
+      await expect(handle.page.locator('.settings-window')).toHaveCount(0);
+      await evidenceShot(handle, 'settings-window-workspace-roots', settings);
+      transcript.step(
+        'Settings opened as a second window (purpose "settings") on the Workspace roots pane',
+      );
 
-    transcript.section('Switching panes moves the title and the rendered pane together');
-    await selectSettingsPane(settings, 'Notifications');
-    await expectPane(handle, settings, 'Notifications');
-    await expect(settings.locator('section[aria-label="Workspace roots"]')).toHaveCount(0);
-    await selectSettingsPane(settings, 'Appearance');
-    await expectPane(handle, settings, 'Appearance');
-    await expect(settings.getByRole('radiogroup', { name: 'Appearance theme' })).toBeVisible();
-    transcript.step('pane switches carried the window title and the rendered pane with them');
+      transcript.section('A second open focuses the existing window; it never duplicates');
+      const reopened = await openSettings(handle);
+      expect(reopened).toBe(settings);
+      expect(handle.app.windows()).toHaveLength(2);
+      expect(await browserWindowCount(handle)).toBe(2);
+      transcript.step('the second Settings open focused the one window — still two windows total');
 
-    transcript.section('Deep links land on their pane while the window is open');
-    await deepLink(handle, 'agentico://diagnostics');
-    await expectPane(handle, settings, 'Diagnostics');
-    await deepLink(handle, 'agentico://updates');
-    await expectPane(handle, settings, 'Updates');
-    expect(handle.app.windows()).toHaveLength(2);
-    transcript.step(
-      'agentico://diagnostics and agentico://updates switched the open window to their panes',
-    );
+      transcript.section('Switching panes moves the title and the rendered pane together');
+      await selectSettingsPane(settings, 'Notifications');
+      await expectPane(handle, settings, 'Notifications');
+      await expect(settings.locator('section[aria-label="Workspace roots"]')).toHaveCount(0);
+      await selectSettingsPane(settings, 'Appearance');
+      await expectPane(handle, settings, 'Appearance');
+      await expect(settings.getByRole('radiogroup', { name: 'Appearance theme' })).toBeVisible();
+      transcript.step('pane switches carried the window title and the rendered pane with them');
 
-    transcript.section('Deep links open the window on their pane from the closed state');
-    await closeSettings(handle);
-    expect(handle.app.windows()).toHaveLength(1);
-    await deepLink(handle, 'agentico://diagnostics');
-    const fromDiagnostics = await awaitSettingsWindow(handle);
-    await expectPane(handle, fromDiagnostics, 'Diagnostics');
-    await evidenceShot(handle, 'settings-window-diagnostics-deep-link', fromDiagnostics);
-    await closeSettings(handle);
-    await deepLink(handle, 'agentico://updates');
-    const fromUpdates = await awaitSettingsWindow(handle);
-    await expectPane(handle, fromUpdates, 'Updates');
-    expect(handle.app.windows()).toHaveLength(2);
-    transcript.step(
-      'from the closed state both deep links opened exactly one Settings window on their pane',
-    );
+      transcript.section('Deep links land on their pane while the window is open');
+      await deepLink(handle, 'agentico://diagnostics');
+      await expectPane(handle, settings, 'Diagnostics');
+      await deepLink(handle, 'agentico://updates');
+      await expectPane(handle, settings, 'Updates');
+      expect(handle.app.windows()).toHaveLength(2);
+      transcript.step(
+        'agentico://diagnostics and agentico://updates switched the open window to their panes',
+      );
 
-    transcript.section('Closing saves the pane and the geometry');
-    // A pane no deep link can produce, so the restore below can only come
-    // from what was persisted.
-    await selectSettingsPane(fromUpdates, 'Notifications');
-    await expectStoredPane(world.userData, 'notifications');
-    await closeSettings(handle);
-    const stored = readSettings(world.userData);
-    expect(stored.settingsWindow.bounds?.width).toBeGreaterThan(0);
-    expect(stored.settingsWindow.bounds?.height).toBeGreaterThan(0);
-    transcript.json('persisted settingsWindow preferences', stored.settingsWindow);
+      transcript.section('Deep links open the window on their pane from the closed state');
+      await closeSettings(handle);
+      expect(handle.app.windows()).toHaveLength(1);
+      await deepLink(handle, 'agentico://diagnostics');
+      const fromDiagnostics = await awaitSettingsWindow(handle);
+      await expectPane(handle, fromDiagnostics, 'Diagnostics');
+      await evidenceShot(handle, 'settings-window-diagnostics-deep-link', fromDiagnostics);
+      await closeSettings(handle);
+      await deepLink(handle, 'agentico://updates');
+      const fromUpdates = await awaitSettingsWindow(handle);
+      await expectPane(handle, fromUpdates, 'Updates');
+      expect(handle.app.windows()).toHaveLength(2);
+      transcript.step(
+        'from the closed state both deep links opened exactly one Settings window on their pane',
+      );
 
-    transcript.section('The last-viewed pane is restored across a relaunch');
-    persistAppLogs(handle, 'settings-window-first-launch');
-    await closeApp(handle);
-    handle = await launchApp(world, testInfo, { traceName: 'settings-window-relaunch' });
-    await expect(handle.page.getByRole('button', { name: 'New feature' })).toBeVisible({
-      timeout: 60_000,
-    });
-    // Nothing reopens Settings at launch; it comes back only when asked for.
-    expect(handle.app.windows()).toHaveLength(1);
-    const restored = await openSettings(handle);
-    await expectPane(handle, restored, 'Notifications');
-    transcript.step('after relaunch the Settings window reopened on the last-viewed pane');
+      transcript.section('Closing saves the pane and the geometry');
+      // A pane no deep link can produce, so the restore below can only come
+      // from what was persisted.
+      await selectSettingsPane(fromUpdates, 'Notifications');
+      await expectStoredPane(world.userData, 'notifications');
+      await closeSettings(handle);
+      const stored = readSettings(world.userData);
+      expect(stored.settingsWindow.bounds?.width).toBeGreaterThan(0);
+      expect(stored.settingsWindow.bounds?.height).toBeGreaterThan(0);
+      transcript.json('persisted settingsWindow preferences', stored.settingsWindow);
 
-    transcript.section('⌘W closes Settings without quitting the app');
-    await closeSettings(handle);
-    expect(settingsPageOrNull(handle)).toBeNull();
-    expect(handle.app.windows()).toHaveLength(1);
-    expect(handle.appProcess.exitCode).toBeNull();
-    expect(handle.appProcess.signalCode).toBeNull();
-    expect(await mainWindowVisible(handle)).toBe(true);
-    await expect(handle.page.getByRole('button', { name: 'New feature' })).toBeVisible();
-    const connection = await handle.page.evaluate(() => window.agentico.getConnectionStatus());
-    expect(connection.status).toBe('ready');
-    transcript.step(
-      'File ▸ Close Window closed Settings only: the main window is still visible and ready, ' +
-        'and the app process never entered the quit-decision flow',
-    );
+      transcript.section('The last-viewed pane is restored across a relaunch');
+      persistAppLogs(handle, 'settings-window-first-launch');
+      await closeApp(handle);
+      handle = await launchApp(world, testInfo, { traceName: 'settings-window-relaunch' });
+      await expect(handle.page.getByRole('button', { name: 'New feature' })).toBeVisible({
+        timeout: 60_000,
+      });
+      // Nothing reopens Settings at launch; it comes back only when asked for.
+      expect(handle.app.windows()).toHaveLength(1);
+      const restored = await openSettings(handle);
+      await expectPane(handle, restored, 'Notifications');
+      transcript.step('after relaunch the Settings window reopened on the last-viewed pane');
 
-    persistAppLogs(handle, 'settings-window-relaunch');
-    transcript.write(testInfo);
-  } finally {
-    if (handle !== null) await closeApp(handle).catch(() => {});
-    assertNoLeakedProcesses(world);
-    destroyWorld(world);
-  }
-});
+      transcript.section('⌘W closes Settings without quitting the app');
+      await closeSettings(handle);
+      expect(settingsPageOrNull(handle)).toBeNull();
+      expect(handle.app.windows()).toHaveLength(1);
+      expect(handle.appProcess.exitCode).toBeNull();
+      expect(handle.appProcess.signalCode).toBeNull();
+      expect(await mainWindowVisible(handle)).toBe(true);
+      await expect(handle.page.getByRole('button', { name: 'New feature' })).toBeVisible();
+      const connection = await handle.page.evaluate(() => window.agentico.getConnectionStatus());
+      expect(connection.status).toBe('ready');
+      transcript.step(
+        'File ▸ Close Window closed Settings only: the main window is still visible and ready, ' +
+          'and the app process never entered the quit-decision flow',
+      );
+
+      persistAppLogs(handle, 'settings-window-relaunch');
+      transcript.write(testInfo);
+    } finally {
+      if (handle !== null) await closeApp(handle).catch(() => {});
+      assertNoLeakedProcesses(world);
+      destroyWorld(world);
+    }
+  },
+);
 
 /** The pane is selected, rendered, and named by the window title. */
 async function expectPane(

--- a/desktop/test/e2e/journeys/shell-evidence.spec.ts
+++ b/desktop/test/e2e/journeys/shell-evidence.spec.ts
@@ -35,6 +35,10 @@ import {
 } from '../helpers/world';
 
 test.skip(process.platform !== 'darwin', 'macOS-only chrome evidence');
+test.skip(
+  process.env['AGENTICO_EVIDENCE_DIR'] === undefined || process.env['AGENTICO_EVIDENCE_DIR'] === '',
+  'evidence-only journey: contractEvidenceShot writes nothing without AGENTICO_EVIDENCE_DIR',
+);
 
 test('Bench shell evidence: five-lane sidebar, themes, inspector, collapse, minimum size', async ({}, testInfo) => {
   const world = createWorld('shell-evidence', {

--- a/desktop/test/e2e/journeys/window-chrome.spec.ts
+++ b/desktop/test/e2e/journeys/window-chrome.spec.ts
@@ -43,146 +43,152 @@ import { createRepo, createWorld, destroyWorld } from '../helpers/world';
 
 test.skip(process.platform !== 'darwin', 'macOS-only window chrome');
 
-test('window chrome: first paint, drag region, header controls, appearance toggle', async ({}, testInfo) => {
-  const transcript = new Transcript('window-chrome', 'macOS window-chrome smoke journey');
-  const world = createWorld('window-chrome', {
-    auth: { loggedIn: true, authMethod: 'oauth', email: 'e2e@example.invalid' },
-    presetWorkspaceRoot: true,
-  });
-  createRepo(world, 'chrome-lab', { commit: true });
-  let handle: AppHandle | null = null;
-
-  try {
-    handle = await launchApp(world, testInfo, { traceName: 'window-chrome' });
-    await expect(handle.page.getByRole('button', { name: 'New feature' })).toBeVisible({
-      timeout: 60_000,
+test(
+  'window chrome: first paint, drag region, header controls, appearance toggle',
+  { tag: '@smoke' },
+  async ({}, testInfo) => {
+    const transcript = new Transcript('window-chrome', 'macOS window-chrome smoke journey');
+    const world = createWorld('window-chrome', {
+      auth: { loggedIn: true, authMethod: 'oauth', email: 'e2e@example.invalid' },
+      presetWorkspaceRoot: true,
     });
+    createRepo(world, 'chrome-lab', { commit: true });
+    let handle: AppHandle | null = null;
 
-    transcript.section('First paint matches the resolved theme');
-    const resolvedTheme = await handle.page.evaluate(
-      () => document.documentElement.dataset['theme'],
-    );
-    expect(resolvedTheme === 'dark' || resolvedTheme === 'light').toBe(true);
-    const platform = await handle.page.evaluate(() => window.agentico.platform);
-    expect(platform).toBe('darwin');
-    transcript.json('resolved theme at first paint', { resolvedTheme, platform });
+    try {
+      handle = await launchApp(world, testInfo, { traceName: 'window-chrome' });
+      await expect(handle.page.getByRole('button', { name: 'New feature' })).toBeVisible({
+        timeout: 60_000,
+      });
 
-    transcript.section('The toolbar and sidebar header are traffic-light-clearing drag regions');
-    const toolbar = handle.page.locator('.toolbar');
-    const toolbarDragStyle = await toolbar.evaluate((element) =>
-      getComputedStyle(element).getPropertyValue('-webkit-app-region'),
-    );
-    expect(toolbarDragStyle).toBe('drag');
-    const sidebarHeader = handle.page.locator('.sidebar__header');
-    const sidebarHeaderDragStyle = await sidebarHeader.evaluate((element) =>
-      getComputedStyle(element).getPropertyValue('-webkit-app-region'),
-    );
-    expect(sidebarHeaderDragStyle).toBe('drag');
-    // The sidebar sits at x:0 clearing the traffic lights on its own; the
-    // toolbar starts to its right at every width above the ~700px
-    // auto-collapse breakpoint, so it carries no left padding of its own here.
-    const sidebarHeaderLeft = await sidebarHeader.evaluate(
-      (element) => element.getBoundingClientRect().left,
-    );
-    expect(sidebarHeaderLeft).toBe(0);
+      transcript.section('First paint matches the resolved theme');
+      const resolvedTheme = await handle.page.evaluate(
+        () => document.documentElement.dataset['theme'],
+      );
+      expect(resolvedTheme === 'dark' || resolvedTheme === 'light').toBe(true);
+      const platform = await handle.page.evaluate(() => window.agentico.platform);
+      expect(platform).toBe('darwin');
+      transcript.json('resolved theme at first paint', { resolvedTheme, platform });
 
-    transcript.section(
-      'Every toolbar control excludes itself from the drag region and stays clickable',
-    );
-    // A raw CSS-class locator, not getByRole with a fixed name: this
-    // button's accessible name flips between "Hide sidebar" and "Show
-    // sidebar" depending on collapse state (an auto-collapse breakpoint
-    // around 700px means the 400px check below hits the "Show sidebar"
-    // label even though nothing was explicitly toggled) — a name-bound
-    // locator would stop resolving once the label flips.
-    const sidebarToggle = handle.page.locator('.toolbar__sidebar-toggle');
-    await expect(sidebarToggle).toBeVisible();
-    expect(
-      await sidebarToggle.evaluate((element) =>
+      transcript.section('The toolbar and sidebar header are traffic-light-clearing drag regions');
+      const toolbar = handle.page.locator('.toolbar');
+      const toolbarDragStyle = await toolbar.evaluate((element) =>
         getComputedStyle(element).getPropertyValue('-webkit-app-region'),
-      ),
-    ).toBe('no-drag');
+      );
+      expect(toolbarDragStyle).toBe('drag');
+      const sidebarHeader = handle.page.locator('.sidebar__header');
+      const sidebarHeaderDragStyle = await sidebarHeader.evaluate((element) =>
+        getComputedStyle(element).getPropertyValue('-webkit-app-region'),
+      );
+      expect(sidebarHeaderDragStyle).toBe('drag');
+      // The sidebar sits at x:0 clearing the traffic lights on its own; the
+      // toolbar starts to its right at every width above the ~700px
+      // auto-collapse breakpoint, so it carries no left padding of its own here.
+      const sidebarHeaderLeft = await sidebarHeader.evaluate(
+        (element) => element.getBoundingClientRect().left,
+      );
+      expect(sidebarHeaderLeft).toBe(0);
 
-    transcript.section('Collapsing the sidebar hands the toolbar the traffic-light clearance');
-    await sidebarToggle.click();
-    await expect(handle.page.getByRole('button', { name: 'Show sidebar' })).toBeVisible();
-    const toolbarLeadingLeft = await handle.page
-      .locator('.toolbar__leading')
-      .evaluate((element) => element.getBoundingClientRect().left);
-    // Traffic lights sit at x:18 with a ~54px cluster; the collapsed
-    // toolbar's own leading control must clear that.
-    expect(toolbarLeadingLeft).toBeGreaterThanOrEqual(72);
-    await handle.page.getByRole('button', { name: 'Show sidebar' }).click();
-    await expect(sidebarToggle).toBeVisible();
+      transcript.section(
+        'Every toolbar control excludes itself from the drag region and stays clickable',
+      );
+      // A raw CSS-class locator, not getByRole with a fixed name: this
+      // button's accessible name flips between "Hide sidebar" and "Show
+      // sidebar" depending on collapse state (an auto-collapse breakpoint
+      // around 700px means the 400px check below hits the "Show sidebar"
+      // label even though nothing was explicitly toggled) — a name-bound
+      // locator would stop resolving once the label flips.
+      const sidebarToggle = handle.page.locator('.toolbar__sidebar-toggle');
+      await expect(sidebarToggle).toBeVisible();
+      expect(
+        await sidebarToggle.evaluate((element) =>
+          getComputedStyle(element).getPropertyValue('-webkit-app-region'),
+        ),
+      ).toBe('no-drag');
 
-    transcript.section('The appearance switcher lives in the Settings window and stays reachable');
-    const settings = await openSettings(handle);
-    await selectSettingsPane(settings, 'Appearance');
-    const themeGroup = settings.locator('.settings-panel__theme');
-    for (const label of ['Light', 'Dark', 'System'] as const) {
-      const radio = themeGroup.getByRole('radio', { name: label });
-      await expect(radio).toBeVisible();
-      await expect(radio).toBeEnabled();
+      transcript.section('Collapsing the sidebar hands the toolbar the traffic-light clearance');
+      await sidebarToggle.click();
+      await expect(handle.page.getByRole('button', { name: 'Show sidebar' })).toBeVisible();
+      const toolbarLeadingLeft = await handle.page
+        .locator('.toolbar__leading')
+        .evaluate((element) => element.getBoundingClientRect().left);
+      // Traffic lights sit at x:18 with a ~54px cluster; the collapsed
+      // toolbar's own leading control must clear that.
+      expect(toolbarLeadingLeft).toBeGreaterThanOrEqual(72);
+      await handle.page.getByRole('button', { name: 'Show sidebar' }).click();
+      await expect(sidebarToggle).toBeVisible();
+
+      transcript.section(
+        'The appearance switcher lives in the Settings window and stays reachable',
+      );
+      const settings = await openSettings(handle);
+      await selectSettingsPane(settings, 'Appearance');
+      const themeGroup = settings.locator('.settings-panel__theme');
+      for (const label of ['Light', 'Dark', 'System'] as const) {
+        const radio = themeGroup.getByRole('radio', { name: label });
+        await expect(radio).toBeVisible();
+        await expect(radio).toBeEnabled();
+      }
+
+      transcript.section('A theme picked in the Settings window restyles the main window live');
+      // The real radiogroup, not the setTheme helper: this is the one place that
+      // proves the main process's cross-window theme broadcast: the preference is
+      // changed in the Settings window, and the main window — a different
+      // renderer with its own useTheme() instance, unreachable from the first
+      // window's own sync event — must follow it.
+      for (const theme of ['dark', 'light'] as const) {
+        await themeGroup.getByRole('radio', { name: theme === 'dark' ? 'Dark' : 'Light' }).click();
+        await expect(settings.locator(`html[data-theme="${theme}"]`)).toBeAttached();
+        await expect(handle.page.locator(`html[data-theme="${theme}"]`)).toBeAttached();
+        transcript.step(`"${theme}" chosen in Settings ▸ Appearance reached both windows`);
+      }
+
+      // The main window's own chrome is what the rest of this journey measures,
+      // so leave no second window standing over it.
+      await closeSettings(handle);
+
+      transcript.section('Every toolbar control stays inside the viewport at the 400px minimum');
+      await setWindowSize(handle, 400, 480);
+      await expect(sidebarToggle).toBeVisible();
+      const toggleBox = await sidebarToggle.boundingBox();
+      expect(toggleBox).not.toBeNull();
+      expect(toggleBox!.x + toggleBox!.width).toBeLessThanOrEqual(400);
+      await setWindowSize(handle, 1440, 900);
+
+      transcript.section('Appearance toggle updates the resolved theme live');
+      await setTheme(handle, 'dark');
+      await expect(handle.page.locator('html[data-theme="dark"]')).toBeAttached();
+      await setTheme(handle, 'light');
+      await expect(handle.page.locator('html[data-theme="light"]')).toBeAttached();
+
+      await contractEvidenceShot(
+        handle,
+        'macos-main-window-light-appearance-same-framing-1440x900',
+        1440,
+        900,
+        'light',
+      );
+      await contractEvidenceShot(
+        handle,
+        'macos-main-window-dark-appearance-inset-traffic-lights-over-the-translucent-head-1440x900',
+        1440,
+        900,
+        'dark',
+      );
+      await contractEvidenceShot(
+        handle,
+        'macos-main-window-at-the-minimum-window-size-dark-appearance-traffic-lights-clea-400x480',
+        400,
+        480,
+        'dark',
+      );
+
+      persistAppLogs(handle, 'window-chrome');
+      transcript.write(testInfo);
+    } finally {
+      if (handle !== null) await closeApp(handle);
+      await assertNoLeakedProcesses(world);
+      destroyWorld(world);
     }
-
-    transcript.section('A theme picked in the Settings window restyles the main window live');
-    // The real radiogroup, not the setTheme helper: this is the one place that
-    // proves the main process's cross-window theme broadcast: the preference is
-    // changed in the Settings window, and the main window — a different
-    // renderer with its own useTheme() instance, unreachable from the first
-    // window's own sync event — must follow it.
-    for (const theme of ['dark', 'light'] as const) {
-      await themeGroup.getByRole('radio', { name: theme === 'dark' ? 'Dark' : 'Light' }).click();
-      await expect(settings.locator(`html[data-theme="${theme}"]`)).toBeAttached();
-      await expect(handle.page.locator(`html[data-theme="${theme}"]`)).toBeAttached();
-      transcript.step(`"${theme}" chosen in Settings ▸ Appearance reached both windows`);
-    }
-
-    // The main window's own chrome is what the rest of this journey measures,
-    // so leave no second window standing over it.
-    await closeSettings(handle);
-
-    transcript.section('Every toolbar control stays inside the viewport at the 400px minimum');
-    await setWindowSize(handle, 400, 480);
-    await expect(sidebarToggle).toBeVisible();
-    const toggleBox = await sidebarToggle.boundingBox();
-    expect(toggleBox).not.toBeNull();
-    expect(toggleBox!.x + toggleBox!.width).toBeLessThanOrEqual(400);
-    await setWindowSize(handle, 1440, 900);
-
-    transcript.section('Appearance toggle updates the resolved theme live');
-    await setTheme(handle, 'dark');
-    await expect(handle.page.locator('html[data-theme="dark"]')).toBeAttached();
-    await setTheme(handle, 'light');
-    await expect(handle.page.locator('html[data-theme="light"]')).toBeAttached();
-
-    await contractEvidenceShot(
-      handle,
-      'macos-main-window-light-appearance-same-framing-1440x900',
-      1440,
-      900,
-      'light',
-    );
-    await contractEvidenceShot(
-      handle,
-      'macos-main-window-dark-appearance-inset-traffic-lights-over-the-translucent-head-1440x900',
-      1440,
-      900,
-      'dark',
-    );
-    await contractEvidenceShot(
-      handle,
-      'macos-main-window-at-the-minimum-window-size-dark-appearance-traffic-lights-clea-400x480',
-      400,
-      480,
-      'dark',
-    );
-
-    persistAppLogs(handle, 'window-chrome');
-    transcript.write(testInfo);
-  } finally {
-    if (handle !== null) await closeApp(handle);
-    await assertNoLeakedProcesses(world);
-    destroyWorld(world);
-  }
-});
+  },
+);

--- a/desktop/test/e2e/playwright.config.ts
+++ b/desktop/test/e2e/playwright.config.ts
@@ -7,21 +7,22 @@
  * CI.
  *
  * Determinism/bounds:
- *  - one worker, no parallelism: journeys share the host's process table and
- *    each launches a packaged Electron app + server;
+ *  - parallel workers are safe: every journey runs in its own throwaway
+ *    HOME/userData/runtime/workspace with its own server port (per-world
+ *    discovery file), leak assertions are scoped to that world's root, and
+ *    the only global step — the orphan sweep — runs once in global-setup
+ *    before any test;
  *  - one packaged build reused across all journeys (global-setup builds only
  *    when dist is missing or stale vs HEAD);
- *  - every journey runs in its own throwaway HOME/userData/runtime/workspace
- *    and must leave no processes behind (asserted in its teardown);
- *  - traces are always recorded (evidence runs consume them).
+ *  - every journey must leave no processes behind (asserted in its teardown).
  */
 import { defineConfig } from '@playwright/test';
 
 export default defineConfig({
   testDir: './journeys',
   globalSetup: './global-setup.ts',
-  fullyParallel: false,
-  workers: 1,
+  fullyParallel: true,
+  workers: 3,
   retries: 0,
   forbidOnly: !!process.env['CI'],
   // Generous but bounded: a journey covers launch → server boot → full UI

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "build": "npm run build --workspace desktop",
     "package:build": "npm run package:build --workspace desktop",
     "package:verify": "npm run package:verify --workspace desktop",
+    "package:verify:e2e": "npm run package:verify:e2e --workspace desktop",
     "generate:api": "npm run generate:api --workspace desktop",
     "audit:release": "npm run audit:release --workspace desktop",
     "test:performance": "npm run test:performance --workspace desktop",


### PR DESCRIPTION
## Why

A PR run costs ~28 min wall clock, dominated by the Packaged E2E journeys step: 66 journeys run strictly serially (`workers: 1`), identically on all three platforms (macOS 20.9m, ubuntu 14.0m, arm 12.7m). macOS runner demand also causes queue waits up to ~1 hour. The suite's own config comment promised it would stay "well under ten minutes."

## What

- **Parallel E2E (`workers: 3`, `fullyParallel`)** — journeys were already parallel-safe by design: each runs in a throwaway HOME/userData/runtime/workspace, gets its server port from a per-world discovery file, and leak assertions are scoped to the world root. The global orphan sweep runs once in global-setup before any test.
- **Tiered platform matrix** — ubuntu-latest x64 runs the full journey suite; macOS and ubuntu-24.04-arm run a 5-journey `@smoke` subset (first-launch, window chrome, menu bar, settings window, update validation) that exercises the platform-specific surface. Native packaging is still verified on every leg.
- **Unpacked packaging on PRs** — PRs run `package:verify:e2e` (unpacked app, what E2E actually consumes); pushes to main still build and inspect the full installers (universal DMG, AppImage + deb).
- **Evidence-only journeys skip in CI** — `shell-evidence` and `overview-evidence` are self-described non-behavioral evidence captures whose screenshots are discarded unless `AGENTICO_EVIDENCE_DIR` is set; they now skip when it isn't.
- **Trace gating** — traces were full (screenshots + DOM snapshots) and always saved. Now: evidence runs keep full always-saved traces; other runs record snapshot-only traces and persist the zip only when the test failed. (`closeApp` runs in the journey's `finally` before Playwright records the in-flight error, so failure detection also scans `testInfo.errors` and the step tree.)
- **Dropped the standalone `Build` step** — `package-build.mjs` re-runs the electron-vite build anyway (visible as a double vite build in CI logs).
- **Check/unit/security run once** — typecheck, lint, format, API drift, unit/component and security suites are platform-independent; they now run on the ubuntu-latest leg only.

## Expected effect

| | Before | After (est.) |
|---|---|---|
| PR wall time | ~28 min | ~8–10 min |
| macOS leg | 28m (21m E2E) | ~6–8m (smoke + package) |
| Billable compute | 3× full suite | ~35–40% of current |

macOS queue contention should also drop sharply since the mac leg shrinks ~4×.

## Validation

- `npm run check` (typecheck ×3 tsconfigs, eslint, prettier, API drift) green.
- Real packaged parallel run of the smoke subset locally: 5 passed in 29.8s with 3 genuinely overlapping workers.
- `--grep @smoke --list` → exactly 5 tests in 5 files; evidence specs report skipped without `AGENTICO_EVIDENCE_DIR`.
- Workflow YAML parse-checked; `if:` expressions and matrix conditionals reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
