### PR TITLE
Anchor rebase passes to their worktrees and gate parent-ref drift

### DIFF
--- a/internal/agent/implement.go
+++ b/internal/agent/implement.go
@@ -174,6 +174,36 @@ type ImplementConfig struct {
 	// single-repo path, relying on the Final Review for quality gating.
 	// Multi-repo orchestration keeps per-iteration review enabled.
 	SkipIterationReview bool
+
+	// PhaseExitGate, when non-nil, re-verifies mechanical exit facts at every
+	// success exit before the loop returns review_passed. Non-empty feedback
+	// routes into a fix round like a deterministic regression and counts
+	// toward the no-progress and iteration rails. Nil disables the gate.
+	PhaseExitGate PhaseExitGate
+}
+
+// PhaseExitGate reports mechanical phase-exit violations as fix-round
+// feedback; "" means all checks passed. The implementation loop invokes it at
+// every success exit.
+type PhaseExitGate func() string
+
+// phaseExitGateFeedback invokes the config's phase-exit gate, returning the
+// trimmed violation feedback ("" when the gate is nil or satisfied).
+func phaseExitGateFeedback(cfg ImplementConfig) string {
+	if cfg.PhaseExitGate == nil {
+		return ""
+	}
+	return strings.TrimSpace(cfg.PhaseExitGate())
+}
+
+// phaseExitGateBlockers derives the open-blocker count fed to the progress
+// tracker from gate feedback: the structured finding count, floored at one so
+// a violated gate is never mistaken for a clean outcome.
+func phaseExitGateBlockers(feedback string) int {
+	if n := CountBlockingReviewFindings(feedback); n > 0 {
+		return n
+	}
+	return 1
 }
 
 // SessionRuntimeConfig is the role-specific configuration snapshot used to
@@ -953,6 +983,27 @@ func RunImplementationLoop(cfg ImplementConfig, sm ports.SessionManager) (result
 					cfg.Observer.IterationEnded(iterCtx, i, toSessionUsage(cost), time.Since(iterStart), "harness_regression")
 					continue
 				}
+				// Phase-exit gate: mechanical exit facts re-verified before
+				// declaring success. Violations route back to the implementer
+				// exactly like a deterministic harness regression.
+				if gateFeedback := phaseExitGateFeedback(cfg); gateFeedback != "" {
+					meta.MadeProgress = observeVerifiedImplementationOutcome(pt, phaseExitGateBlockers(gateFeedback), cfg)
+					meta.ReviewStatus = ReviewChangesRequested.String()
+					_ = am.WriteMeta(iterDir, meta)
+					_ = am.WriteSummary(summaryPath, meta)
+					consecutiveFailures = 0
+					reviewerFeedback = gateFeedback
+					roundCommits.changesRequested++
+					cfg.Observer.IterationEnded(iterCtx, i, toSessionUsage(cost), time.Since(iterStart), "phase_exit_gate")
+					if pt.NoProgressCount() >= cfg.MaxConsecNoProgress {
+						return &LoopResult{
+							FinalStatus: "safety_rail",
+							Iterations:  i,
+							LastError:   fmt.Sprintf("no progress for %d consecutive iterations", pt.NoProgressCount()),
+						}, nil
+					}
+					continue
+				}
 				meta.MadeProgress = observeVerifiedImplementationOutcome(pt, 0, cfg)
 				meta.ReviewStatus = reviewStatusSkipped
 				_ = am.WriteMeta(iterDir, meta)
@@ -1065,6 +1116,26 @@ func RunImplementationLoop(cfg ImplementConfig, sm ports.SessionManager) (result
 
 			switch reviewStatus {
 			case ReviewApproved:
+				// Phase-exit gate: an approving review does not override
+				// violated mechanical exit facts.
+				if gateFeedback := phaseExitGateFeedback(cfg); gateFeedback != "" {
+					meta.MadeProgress = observeVerifiedImplementationOutcome(pt, phaseExitGateBlockers(gateFeedback), cfg)
+					meta.ReviewStatus = ReviewChangesRequested.String()
+					_ = am.WriteMeta(iterDir, meta)
+					_ = am.WriteSummary(summaryPath, meta)
+					consecutiveFailures = 0
+					reviewerFeedback = gateFeedback
+					roundCommits.changesRequested++
+					cfg.Observer.IterationEnded(iterCtx, i, toSessionUsage(cost), time.Since(iterStart), "phase_exit_gate")
+					if pt.NoProgressCount() >= cfg.MaxConsecNoProgress {
+						return &LoopResult{
+							FinalStatus: "safety_rail",
+							Iterations:  i,
+							LastError:   fmt.Sprintf("no progress for %d consecutive iterations", pt.NoProgressCount()),
+						}, nil
+					}
+					continue
+				}
 				meta.MadeProgress = observeVerifiedImplementationOutcome(pt, 0, cfg)
 				meta.ReviewStatus = reviewStatus.String()
 				_ = am.WriteMeta(iterDir, meta)

--- a/internal/agent/implement.go
+++ b/internal/agent/implement.go
@@ -956,6 +956,29 @@ func RunImplementationLoop(cfg ImplementConfig, sm ports.SessionManager) (result
 				continue
 			}
 
+			// Phase-exit gate: mechanical exit facts re-verified at every
+			// success exit before the loop returns review_passed. Violations
+			// route back to the implementer exactly like a deterministic
+			// harness regression; nil result means the gate passed.
+			gateFixRound := func(gateFeedback string) *LoopResult {
+				meta.MadeProgress = observeVerifiedImplementationOutcome(pt, phaseExitGateBlockers(gateFeedback), cfg)
+				meta.ReviewStatus = ReviewChangesRequested.String()
+				_ = am.WriteMeta(iterDir, meta)
+				_ = am.WriteSummary(summaryPath, meta)
+				consecutiveFailures = 0
+				reviewerFeedback = gateFeedback
+				roundCommits.changesRequested++
+				cfg.Observer.IterationEnded(iterCtx, i, toSessionUsage(cost), time.Since(iterStart), "phase_exit_gate")
+				if pt.NoProgressCount() >= cfg.MaxConsecNoProgress {
+					return &LoopResult{
+						FinalStatus: "safety_rail",
+						Iterations:  i,
+						LastError:   fmt.Sprintf("no progress for %d consecutive iterations", pt.NoProgressCount()),
+					}
+				}
+				return nil
+			}
+
 			// Fall through: SUCCESS — run the review gate.
 			if cfg.SkipIterationReview {
 				// Medium/Large: skip per-iteration review, rely on Final Review.
@@ -983,24 +1006,9 @@ func RunImplementationLoop(cfg ImplementConfig, sm ports.SessionManager) (result
 					cfg.Observer.IterationEnded(iterCtx, i, toSessionUsage(cost), time.Since(iterStart), "harness_regression")
 					continue
 				}
-				// Phase-exit gate: mechanical exit facts re-verified before
-				// declaring success. Violations route back to the implementer
-				// exactly like a deterministic harness regression.
 				if gateFeedback := phaseExitGateFeedback(cfg); gateFeedback != "" {
-					meta.MadeProgress = observeVerifiedImplementationOutcome(pt, phaseExitGateBlockers(gateFeedback), cfg)
-					meta.ReviewStatus = ReviewChangesRequested.String()
-					_ = am.WriteMeta(iterDir, meta)
-					_ = am.WriteSummary(summaryPath, meta)
-					consecutiveFailures = 0
-					reviewerFeedback = gateFeedback
-					roundCommits.changesRequested++
-					cfg.Observer.IterationEnded(iterCtx, i, toSessionUsage(cost), time.Since(iterStart), "phase_exit_gate")
-					if pt.NoProgressCount() >= cfg.MaxConsecNoProgress {
-						return &LoopResult{
-							FinalStatus: "safety_rail",
-							Iterations:  i,
-							LastError:   fmt.Sprintf("no progress for %d consecutive iterations", pt.NoProgressCount()),
-						}, nil
+					if rail := gateFixRound(gateFeedback); rail != nil {
+						return rail, nil
 					}
 					continue
 				}
@@ -1118,21 +1126,11 @@ func RunImplementationLoop(cfg ImplementConfig, sm ports.SessionManager) (result
 			case ReviewApproved:
 				// Phase-exit gate: an approving review does not override
 				// violated mechanical exit facts.
+				// An approving review does not override violated mechanical
+				// exit facts.
 				if gateFeedback := phaseExitGateFeedback(cfg); gateFeedback != "" {
-					meta.MadeProgress = observeVerifiedImplementationOutcome(pt, phaseExitGateBlockers(gateFeedback), cfg)
-					meta.ReviewStatus = ReviewChangesRequested.String()
-					_ = am.WriteMeta(iterDir, meta)
-					_ = am.WriteSummary(summaryPath, meta)
-					consecutiveFailures = 0
-					reviewerFeedback = gateFeedback
-					roundCommits.changesRequested++
-					cfg.Observer.IterationEnded(iterCtx, i, toSessionUsage(cost), time.Since(iterStart), "phase_exit_gate")
-					if pt.NoProgressCount() >= cfg.MaxConsecNoProgress {
-						return &LoopResult{
-							FinalStatus: "safety_rail",
-							Iterations:  i,
-							LastError:   fmt.Sprintf("no progress for %d consecutive iterations", pt.NoProgressCount()),
-						}, nil
+					if rail := gateFixRound(gateFeedback); rail != nil {
+						return rail, nil
 					}
 					continue
 				}

--- a/internal/agent/orchestrator.go
+++ b/internal/agent/orchestrator.go
@@ -135,6 +135,10 @@ type OrchestratorConfig struct {
 	// round's session ends and before the review gate. The orchestrator
 	// layer owns the git commit; nil disables per-round commits.
 	RoundCommitHook RoundCommitHook
+
+	// PhaseExitGate, when non-nil, is forwarded into the phase-implement
+	// loop's ImplementConfig (see ImplementConfig.PhaseExitGate).
+	PhaseExitGate PhaseExitGate
 }
 
 func resolveOrchestratorSessionConfig(cfg OrchestratorConfig, role llm.PhaseRole) (SessionRuntimeConfig, error) {

--- a/internal/agent/phase.go
+++ b/internal/agent/phase.go
@@ -63,6 +63,11 @@ type PhaseRunner struct {
 	// its commit implementation here (see orchestrator.New).
 	RoundCommitHook RoundCommitHook
 
+	// PhaseExitGateFor, when non-nil, resolves a feature's mechanical
+	// phase-exit gate for the implement loop; a nil gate disables the check.
+	// The orchestrator installs kind-specific gates here (see orchestrator.New).
+	PhaseExitGateFor func(f *feature.Feature) PhaseExitGate
+
 	// BuildSessionFn, if non-nil, overrides the production BuildSession logic.
 	// Used exclusively for test injection.
 	BuildSessionFn func(BuildSessionOpts) ([]string, []string, *ports.SessionOpts, error)
@@ -91,6 +96,15 @@ func (pr *PhaseRunner) askingQuestionsClauseForModel(model string) string {
 		return ""
 	}
 	return pa.AskingQuestionsClause()
+}
+
+// phaseExitGate resolves the feature's phase-exit gate; nil when no factory
+// is installed or the factory declines to gate the feature.
+func (pr *PhaseRunner) phaseExitGate(f *feature.Feature) PhaseExitGate {
+	if pr.PhaseExitGateFor == nil {
+		return nil
+	}
+	return pr.PhaseExitGateFor(f)
 }
 
 func (pr *PhaseRunner) defaultModelForRole(role llm.PhaseRole) string {
@@ -950,6 +964,7 @@ func (pr *PhaseRunner) RunImplementation(f *feature.Feature, planPath string, kb
 		Observer:                   pr.Observer,
 		OnVerificationProgress:     pr.OnVerificationProgress,
 		RoundCommitHook:            pr.RoundCommitHook,
+		PhaseExitGate:              pr.phaseExitGate(f),
 	}
 
 	resultCh := make(chan *LoopResult, 1)
@@ -1015,6 +1030,7 @@ func (pr *PhaseRunner) RunMultiRepoImplementation(
 		Observer:                   pr.Observer,
 		OnVerificationProgress:     pr.OnVerificationProgress,
 		RoundCommitHook:            pr.RoundCommitHook,
+		PhaseExitGate:              pr.phaseExitGate(f),
 		RunImplementFn:             pr.RunImplementFn,
 		RunFinalReviewFn:           pr.RunFinalReviewFn,
 	}

--- a/internal/agent/phase_exit_gate_test.go
+++ b/internal/agent/phase_exit_gate_test.go
@@ -1,0 +1,211 @@
+// Copyright 2026 DoorDash, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/doordash-oss/agentic-orchestrator/internal/feature"
+	"github.com/doordash-oss/agentic-orchestrator/internal/session"
+	"github.com/doordash-oss/agentic-orchestrator/test/testutil"
+)
+
+const testGateFeedback = "Mechanical exit gate violation: the creation-time target is not merged into the child branch."
+
+// countingGate returns a PhaseExitGate that reports feedback for the first
+// failFor calls and clean afterwards, plus a pointer to the call count.
+func countingGate(failFor int) (func() string, *int) {
+	calls := 0
+	return func() string {
+		calls++
+		if calls <= failFor {
+			return testGateFeedback
+		}
+		return ""
+	}, &calls
+}
+
+// phaseExitGateLoopConfig builds the shared script-driven ImplementConfig the
+// gate tests drive RunImplementationLoop with.
+func phaseExitGateLoopConfig(t *testing.T, id string, skipReview bool) (ImplementConfig, *[]BuildSessionOpts, *session.Manager) {
+	t.Helper()
+	tmpDir := t.TempDir()
+	workDir := filepath.Join(tmpDir, "work")
+	artifactDir := filepath.Join(tmpDir, "artifacts")
+	stateDir := filepath.Join(tmpDir, "state", id)
+	scriptsDir := filepath.Join(tmpDir, "scripts")
+	for _, d := range []string{workDir, artifactDir, stateDir, scriptsDir} {
+		os.MkdirAll(d, 0o755)
+	}
+
+	agentScript := testutil.WriteScript(t, scriptsDir, "agent.sh",
+		testutil.JSONLInit+"\n"+testutil.JSONLAssistant("Working...")+"\n"+
+			testutil.WriteImplementSuccessArtifacts(artifactDir)+"\n"+testutil.JSONLSuccess+"\n")
+	reviewScript := testutil.WriteScript(t, scriptsDir, "review.sh",
+		testutil.JSONLInit+"\n"+testutil.WriteReviewApproved(artifactDir)+"\n"+testutil.JSONLSuccess+"\n")
+
+	planPath := filepath.Join(artifactDir, "plan.md")
+	_ = os.WriteFile(planPath, []byte("# Plan\nImplement something"), 0o644)
+
+	f := &feature.Feature{
+		SchemaVersion: feature.SchemaVersionCurrent,
+		ID:            id,
+		Name:          "Phase exit gate test",
+		Slug:          id,
+		Description:   "Phase exit gate test",
+		Status:        feature.StatusImplementing,
+		CurrentPhase:  feature.PhaseImplement,
+		Repos: []feature.FeatureRepo{
+			{Name: "test-repo", Path: workDir},
+		},
+	}
+	store := feature.NewStore(filepath.Join(tmpDir, "state"))
+	_ = store.Save(f)
+
+	buildSession, captured := capturingBuildSession(agentScript, reviewScript)
+
+	eventCh := make(chan interface{}, 100)
+	sm := session.NewManager(eventCh)
+	t.Cleanup(sm.Shutdown)
+
+	return ImplementConfig{
+		Feature:                    f,
+		FeatureStore:               store,
+		WorkDir:                    workDir,
+		PlanPath:                   planPath,
+		MaxIterations:              10,
+		MaxConsecFails:             3,
+		MaxConsecNoProgress:        3,
+		ExitCriteria:               "Relevant tests pass",
+		Model:                      "opus",
+		ReviewModel:                "reviewer",
+		ArtifactDir:                artifactDir,
+		StateDir:                   stateDir,
+		DangerouslySkipPermissions: true,
+		BuildSession:               buildSession,
+		CommandRunner:              NewExecCommandRunner(),
+		SkipIterationReview:        skipReview,
+	}, captured, sm
+}
+
+// TestRunImplementationLoop_PhaseExitGateFixRoundThenPass drives the
+// SkipIterationReview success exit: the gate rejects the first success, the
+// loop runs exactly one fix round carrying the gate feedback, and the second
+// success (gate clean) completes review_passed.
+func TestRunImplementationLoop_PhaseExitGateFixRoundThenPass(t *testing.T) {
+	cfg, captured, sm := phaseExitGateLoopConfig(t, "test-gate-fix-001", true)
+	gate, calls := countingGate(1)
+	cfg.PhaseExitGate = gate
+
+	result, err := RunImplementationLoop(cfg, sm)
+	if err != nil {
+		t.Fatalf("RunImplementationLoop error: %v", err)
+	}
+	if result.FinalStatus != finalStatusReviewPassed {
+		t.Fatalf("FinalStatus = %q, want review_passed", result.FinalStatus)
+	}
+	if result.Iterations != 2 {
+		t.Fatalf("Iterations = %d, want 2 (one fix round)", result.Iterations)
+	}
+	if *calls != 2 {
+		t.Errorf("gate calls = %d, want 2 (once per success exit)", *calls)
+	}
+	if len(*captured) != 2 {
+		t.Fatalf("BuildSession calls = %d, want 2 (implement + fix round)", len(*captured))
+	}
+	if !strings.Contains((*captured)[1].Prompt, testGateFeedback) {
+		t.Errorf("fix round prompt does not carry the gate feedback:\n%s", (*captured)[1].Prompt)
+	}
+}
+
+// TestRunImplementationLoop_PhaseExitGatePersistentFailureTripsRail proves a
+// never-passing gate cannot spin: with an unchanged worktree the no-progress
+// rail terminates the loop well before MaxIterations.
+func TestRunImplementationLoop_PhaseExitGatePersistentFailureTripsRail(t *testing.T) {
+	cfg, _, sm := phaseExitGateLoopConfig(t, "test-gate-rail-001", true)
+	cfg.MaxConsecNoProgress = 2
+	gate, calls := countingGate(1 << 30)
+	cfg.PhaseExitGate = gate
+
+	result, err := RunImplementationLoop(cfg, sm)
+	if err != nil {
+		t.Fatalf("RunImplementationLoop error: %v", err)
+	}
+	if result.FinalStatus != "safety_rail" {
+		t.Fatalf("FinalStatus = %q, want safety_rail", result.FinalStatus)
+	}
+	if result.Iterations >= cfg.MaxIterations {
+		t.Errorf("Iterations = %d, want rail trip before MaxIterations=%d", result.Iterations, cfg.MaxIterations)
+	}
+	if *calls != result.Iterations {
+		t.Errorf("gate calls = %d, want one per iteration (%d)", *calls, result.Iterations)
+	}
+}
+
+// TestRunImplementationLoop_PhaseExitGateAfterReviewApproved drives the
+// per-iteration-review success exit: the review approves, but the gate
+// rejects once, forcing a fix round before the loop completes.
+func TestRunImplementationLoop_PhaseExitGateAfterReviewApproved(t *testing.T) {
+	cfg, captured, sm := phaseExitGateLoopConfig(t, "test-gate-review-001", false)
+	gate, calls := countingGate(1)
+	cfg.PhaseExitGate = gate
+
+	result, err := RunImplementationLoop(cfg, sm)
+	if err != nil {
+		t.Fatalf("RunImplementationLoop error: %v", err)
+	}
+	if result.FinalStatus != finalStatusReviewPassed {
+		t.Fatalf("FinalStatus = %q, want review_passed", result.FinalStatus)
+	}
+	if result.Iterations != 2 {
+		t.Fatalf("Iterations = %d, want 2 (one fix round)", result.Iterations)
+	}
+	if *calls != 2 {
+		t.Errorf("gate calls = %d, want 2 (once per approved review)", *calls)
+	}
+	found := false
+	for _, opts := range *captured {
+		if strings.Contains(opts.Prompt, testGateFeedback) {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("no session prompt carries the gate feedback")
+	}
+}
+
+// TestRunImplementationLoop_PhaseExitGateNilUnchanged verifies a nil gate is
+// a no-op: the first success exits review_passed exactly as before.
+func TestRunImplementationLoop_PhaseExitGateNilUnchanged(t *testing.T) {
+	cfg, captured, sm := phaseExitGateLoopConfig(t, "test-gate-nil-001", true)
+
+	result, err := RunImplementationLoop(cfg, sm)
+	if err != nil {
+		t.Fatalf("RunImplementationLoop error: %v", err)
+	}
+	if result.FinalStatus != finalStatusReviewPassed {
+		t.Fatalf("FinalStatus = %q, want review_passed", result.FinalStatus)
+	}
+	if result.Iterations != 1 {
+		t.Fatalf("Iterations = %d, want 1", result.Iterations)
+	}
+	if len(*captured) != 1 {
+		t.Errorf("BuildSession calls = %d, want 1", len(*captured))
+	}
+}

--- a/internal/agent/phase_implement_loop.go
+++ b/internal/agent/phase_implement_loop.go
@@ -169,6 +169,7 @@ func RunPhaseImplementLoop(cfg OrchestratorConfig, sm ports.SessionManager) (*Ph
 		OnVerificationProgress:     cfg.OnVerificationProgress,
 		RoundCommitHook:            cfg.RoundCommitHook,
 		RoundCommitRepos:           workspace.RepoPaths,
+		PhaseExitGate:              cfg.PhaseExitGate,
 		// Per-iteration review stays on the same gating policy as the
 		// per-repo path historically used: Medium/Large skip per-
 		// iteration review and rely on Final Review for quality gating;

--- a/internal/agent/prompts/prompt_branch_iteration_test.go
+++ b/internal/agent/prompts/prompt_branch_iteration_test.go
@@ -288,6 +288,7 @@ func TestGoldenSnapshotsNoOrphanFiles(t *testing.T) {
 		"roadmap_revision_user":                                true,
 		"roadmap_user_multi_repo":                              true,
 		"roadmap_user_no_design":                               true,
+		"roadmap_user_refactor_pass":                           true,
 		"scout_user":                                           true,
 		"summary_user":                                         true,
 		"validate_specialized_grounding":                       true,

--- a/internal/agent/prompts/prompts_test.go
+++ b/internal/agent/prompts/prompts_test.go
@@ -389,6 +389,20 @@ func TestGoldenSnapshots(t *testing.T) {
 			},
 		},
 		{
+			// Refactor pass: the fork-point context block renders, including
+			// the worktree-confinement invariant.
+			name: "roadmap_user_refactor_pass",
+			render: func() string {
+				return RoadmapUserPrompt(RoadmapUserInput{
+					Name:                  "Rebase on latest main",
+					Description:           "Reconcile the feature with its base targets.",
+					Repos:                 []RepoView{{Name: "web", Path: "/state/wt/child/web"}},
+					RefactorPassForkPoint: "web @ 1111111111111111111111111111111111111111",
+					Inquireness:           GrillMeInquirenessInput{Level: "medium"},
+				})
+			},
+		},
+		{
 			// No design artifact (Medium mode): the raw Feature block
 			// renders, including its Exit criteria distillation guidance.
 			name: "roadmap_user_no_design",

--- a/internal/agent/prompts/templates/design.user.tmpl
+++ b/internal/agent/prompts/templates/design.user.tmpl
@@ -11,7 +11,7 @@
 
 {{ if .RefactorPassForkPoint }}## Refactor Pass Context
 
-This feature is a refactor pass forked from its parent feature's delivered state at {{ .RefactorPassForkPoint }}. The workspace already reflects everything the parent delivered, and that state is what the feature description refers to: resolve any language about prior, current, or existing state against the fork point, not the repository base branch or any earlier state. The description decides the delta — it may change anything the fork point contains.
+This feature is a refactor pass forked from its parent feature's delivered state at {{ .RefactorPassForkPoint }}. The workspace already reflects everything the parent delivered, and that state is what the feature description refers to: resolve any language about prior, current, or existing state against the fork point, not the repository base branch or any earlier state. The description decides the delta — it may change anything the fork point contains. All work is confined to the worktrees listed for this pass: other checkouts of the same repositories exist and are off-limits.
 
 Because reviewers later judge the assembled result as a whole, the design you produce must resolve any such relative language into absolute statements of the intended end state (what each affected artifact must look like when this pass completes), so no downstream reader has to guess which baseline a phrase refers to. If the description is genuinely ambiguous about the intended end state, ask rather than guess.
 

--- a/internal/agent/prompts/templates/final_fix.user.tmpl
+++ b/internal/agent/prompts/templates/final_fix.user.tmpl
@@ -15,7 +15,7 @@ This is fix iteration {{ .Iteration }}.
 
 {{ if .RefactorPassForkPoint }}## Refactor Pass Fork Point
 
-This feature is a refactor pass forked from its parent feature's delivered state at {{ .RefactorPassForkPoint }}. Anything that already exists at the fork point is the parent's approved work, not this pass's. Wherever the specification or reviewer feedback refers to prior, current, or existing state, resolve that reference against the fork point — this pass's own delta is `git diff <fork-sha>..HEAD` — never against the repository base branch. If feedback attributes fork-point content to this pass and asks you to change it beyond what the approved plan covers, that is misattribution: do not apply it silently — surface the conflict (AskUserQuestion if needed) instead of rewriting the parent's delivered state.
+This feature is a refactor pass forked from its parent feature's delivered state at {{ .RefactorPassForkPoint }}. Anything that already exists at the fork point is the parent's approved work, not this pass's. Wherever the specification or reviewer feedback refers to prior, current, or existing state, resolve that reference against the fork point — this pass's own delta is `git diff <fork-sha>..HEAD` — never against the repository base branch. If feedback attributes fork-point content to this pass and asks you to change it beyond what the approved plan covers, that is misattribution: do not apply it silently — surface the conflict (AskUserQuestion if needed) instead of rewriting the parent's delivered state. All work is confined to the worktrees listed for this pass: other checkouts of the same repositories exist and are off-limits.
 
 {{ end }}{{ if .AcceptanceClause }}**Acceptance**:
 {{ .AcceptanceClause }}

--- a/internal/agent/prompts/templates/implementation_review_axis.user.tmpl
+++ b/internal/agent/prompts/templates/implementation_review_axis.user.tmpl
@@ -33,7 +33,7 @@ Iteration artifacts directory: {{ .IterDir }}
 {{ end -}}
 {{ if .RefactorPassForkPoint }}## Refactor Pass Fork Point
 
-This feature is a refactor pass forked from its parent feature's delivered state at {{ .RefactorPassForkPoint }}. The cumulative diff therefore also contains the parent's approved, already-delivered changes: anything that already exists at the fork point belongs to the parent, not to this pass. Wherever the specification refers to prior, current, or existing state, resolve that reference against the fork point — this pass's own delta is `git diff <fork-sha>..HEAD` — never against the repository base branch. Judge the assembled result as a whole, but attribute each change to the record that made it: the parent's delivered state is not, by itself, a finding against this pass.
+This feature is a refactor pass forked from its parent feature's delivered state at {{ .RefactorPassForkPoint }}. The cumulative diff therefore also contains the parent's approved, already-delivered changes: anything that already exists at the fork point belongs to the parent, not to this pass. Wherever the specification refers to prior, current, or existing state, resolve that reference against the fork point — this pass's own delta is `git diff <fork-sha>..HEAD` — never against the repository base branch. Judge the assembled result as a whole, but attribute each change to the record that made it: the parent's delivered state is not, by itself, a finding against this pass. All work is confined to the worktrees listed for this pass: other checkouts of the same repositories exist and are off-limits.
 
 {{ end -}}
 {{ if .FinalGate }}## Final Review Scope

--- a/internal/agent/prompts/templates/roadmap.user.tmpl
+++ b/internal/agent/prompts/templates/roadmap.user.tmpl
@@ -18,7 +18,7 @@
 
 {{ if .RefactorPassForkPoint }}## Refactor Pass Context
 
-This feature is a refactor pass forked from its parent feature's delivered state at {{ .RefactorPassForkPoint }}. The workspace already reflects everything the parent delivered, and that state is what the feature description refers to: resolve any language about prior, current, or existing state against the fork point, not the repository base branch or any earlier state. The description decides the delta — it may change anything the fork point contains.
+This feature is a refactor pass forked from its parent feature's delivered state at {{ .RefactorPassForkPoint }}. The workspace already reflects everything the parent delivered, and that state is what the feature description refers to: resolve any language about prior, current, or existing state against the fork point, not the repository base branch or any earlier state. The description decides the delta — it may change anything the fork point contains. All work is confined to the worktrees listed for this pass: other checkouts of the same repositories exist and are off-limits.
 
 Because reviewers later judge the assembled result as a whole, the roadmap you produce must resolve any such relative language into absolute statements of the intended end state (what each affected artifact must look like when this pass completes), so no downstream reader has to guess which baseline a phrase refers to. If the description is genuinely ambiguous about the intended end state, ask rather than guess.
 

--- a/internal/agent/prompts/testdata/roadmap_user_refactor_pass.golden
+++ b/internal/agent/prompts/testdata/roadmap_user_refactor_pass.golden
@@ -1,0 +1,26 @@
+# Planning Context
+
+## Refactor Pass Context
+
+This feature is a refactor pass forked from its parent feature's delivered state at web @ 1111111111111111111111111111111111111111. The workspace already reflects everything the parent delivered, and that state is what the feature description refers to: resolve any language about prior, current, or existing state against the fork point, not the repository base branch or any earlier state. The description decides the delta — it may change anything the fork point contains. All work is confined to the worktrees listed for this pass: other checkouts of the same repositories exist and are off-limits.
+
+Because reviewers later judge the assembled result as a whole, the roadmap you produce must resolve any such relative language into absolute statements of the intended end state (what each affected artifact must look like when this pass completes), so no downstream reader has to guess which baseline a phrase refers to. If the description is genuinely ambiguous about the intended end state, ask rather than guess.
+
+## Feature
+
+**Name**: Rebase on latest main
+
+**Description**:
+> Reconcile the feature with its base targets.
+
+## Target Repositories
+
+This feature targets the repositories below. Treat this list as authoritative; ignore sibling directories that are not listed here.
+- **web** (/state/wt/child/web)
+
+## Ambiguity Resolution [grill-me]
+Interview me relentlessly about every aspect of this plan until we reach a shared understanding. Walk down each branch of the design tree, resolving dependencies between decisions one-by-one. For each question, provide your recommended answer.
+
+Ask the questions one at a time, waiting for feedback on each question before continuing.
+
+If a question can be answered by exploring the codebase, explore the codebase instead.

--- a/internal/feature/child.go
+++ b/internal/feature/child.go
@@ -439,6 +439,10 @@ type RefactorChildSpec struct {
 	// Inquireness is the submitted inquiry behavior; empty inherits the
 	// parent's setting.
 	Inquireness Inquireness
+	// RebaseMergeTargets maps behind repo name to the resolved target ref the
+	// setup runner must merge into that repo's worktree. Only set for rebase
+	// children.
+	RebaseMergeTargets map[string]string
 }
 
 // ReviewFeedbackComment is the complete selected GitHub comment payload that
@@ -624,11 +628,12 @@ func (m *Manager) CreateRebaseChild(parentID string, spec RebaseChildSpec) (*Fea
 			return nil, nil, err
 		}
 		child := m.buildRefactorChild(lockedParent, RefactorChildSpec{
-			Name:         RebaseChildName,
-			Description:  rebaseDescription(lockedParent, spec.Targets, spec.Behind),
-			Pipeline:     PipelineMedium,
-			Checkpoints:  lockedParent.Checkpoints,
-			ExitCriteria: rebaseExitCriteria(spec.Targets, spec.Behind),
+			Name:               RebaseChildName,
+			Description:        rebaseDescription(lockedParent, spec.Targets, spec.Behind),
+			Pipeline:           PipelineMedium,
+			Checkpoints:        lockedParent.Checkpoints,
+			ExitCriteria:       rebaseExitCriteria(spec.Targets, spec.Behind),
+			RebaseMergeTargets: rebaseMergeTargets(spec.Targets, spec.Behind),
 		}, bases, now)
 		child.Parent.Kind = ChildKindRebase
 		child.Parent.RebaseTargets = append([]RebaseRepoTarget(nil), spec.Targets...)
@@ -652,12 +657,35 @@ func (m *Manager) CreateRebaseChild(parentID string, spec RebaseChildSpec) (*Fea
 	return child, nil
 }
 
+// rebaseMergeTargets maps each behind repo to the ref its setup merge task
+// must apply: the creation-time pinned target SHA when captured (matching
+// exactly what the integration gate later checks), else the resolved ref.
+func rebaseMergeTargets(targets []RebaseRepoTarget, behind []string) map[string]string {
+	behindSet := make(map[string]bool, len(behind))
+	for _, r := range behind {
+		behindSet[r] = true
+	}
+	refs := make(map[string]string, len(behind))
+	for _, t := range targets {
+		if !behindSet[t.Repo] {
+			continue
+		}
+		ref := t.TargetSHA
+		if ref == "" {
+			ref = t.Ref
+		}
+		if ref != "" {
+			refs[t.Repo] = ref
+		}
+	}
+	return refs
+}
+
 // rebaseDescription generates the deterministic, machine-authored description
-// for a rebase child. It names each behind repo with its exact persisted
-// resolved target ref, instructs the pipeline to merge (never rebase) the
-// target into the working branch, adapt the feature's code to the base's new
-// APIs where they collide, keep trivial clean merges minimal, leave
-// up-to-date repos untouched, and never push to any remote.
+// for a rebase child. The mechanical merge already happened during setup, so
+// the text anchors every instruction to the pass's own worktrees and never
+// names any branch: the pass verifies or completes the merge in place,
+// adapting the feature's code to the base's new APIs.
 func rebaseDescription(parent *Feature, targets []RebaseRepoTarget, behind []string) string {
 	behindSet := make(map[string]bool, len(behind))
 	for _, r := range behind {
@@ -669,14 +697,15 @@ func rebaseDescription(parent *Feature, targets []RebaseRepoTarget, behind []str
 	}
 
 	var sb strings.Builder
-	sb.WriteString("This pass merge-reconciles the feature's branches against their resolved base targets.\n")
+	sb.WriteString("This pass reconciles the feature with its resolved base targets. For each behind repository listed below, the resolved target has already been merged into the branch checked out in this repository's worktree before this pass started.\n")
 	sb.WriteString("\n## Instructions\n\n")
-	sb.WriteString("- For each behind repository listed below, merge the resolved target into the repository's working branch using `git merge` (never rebase, no history rewrite).\n")
-	sb.WriteString("- Adapt the feature's code to the base's new APIs where they collide with the feature's changes.\n")
-	sb.WriteString("- Keep trivial clean merges minimal: do not opportunistically refactor or reformat code that merges cleanly.\n")
+	sb.WriteString("- If the merge completed cleanly, verify the feature still works against the base's changes and adapt the feature's code where the base's new APIs collide with it.\n")
+	sb.WriteString("- If the merge stopped on conflicts, the worktree contains an in-progress merge: resolve every conflict by adapting the feature's code to the base's new APIs, then complete the merge commit. Keep the merge commit — never squash or rewrite history.\n")
+	sb.WriteString("- Keep clean merges minimal: do not opportunistically refactor or reformat code that merged cleanly.\n")
 	sb.WriteString("- Leave up-to-date repositories completely untouched. Do not merge, rebase, or modify them in any way.\n")
 	sb.WriteString("- Never push to any remote. All work is local; integration lands through the parent merge transaction.\n")
 	sb.WriteString("- Do not fetch from any remote. The target refs were fetched at creation time and are already available in the shared object store.\n")
+	sb.WriteString("- All work happens inside the worktrees provisioned for this pass — never enter, inspect state from, or modify any other checkout of these repositories.\n")
 
 	for _, repo := range parent.Repos {
 		if !behindSet[repo.Name] {
@@ -687,14 +716,9 @@ func rebaseDescription(parent *Feature, targets []RebaseRepoTarget, behind []str
 		sb.WriteString(repo.Name)
 		sb.WriteString("\n\nResolved target ref: ")
 		sb.WriteString(t.Ref)
-		sb.WriteString(" (branch: ")
-		sb.WriteString(t.Target)
-		sb.WriteString(")\n\n")
-		sb.WriteString("Merge `")
+		sb.WriteString("\n\nThe target `")
 		sb.WriteString(t.Ref)
-		sb.WriteString("` into the working branch `")
-		sb.WriteString(repo.Branch)
-		sb.WriteString("`. Resolve any conflicts by adapting the feature's code to the base's new APIs. Keep the merge commit (do not squash).\n")
+		sb.WriteString("` has already been merged into the branch checked out in this repository's worktree. If that merge stopped on conflicts, resolve every conflict there by adapting the feature's code to the base's new APIs and complete the merge commit.\n")
 	}
 	return sb.String()
 }
@@ -714,22 +738,23 @@ func rebaseExitCriteria(targets []RebaseRepoTarget, behind []string) string {
 	}
 
 	var sb strings.Builder
-	sb.WriteString("This pass is complete when all of the following git-level completion facts hold for every behind repository:\n")
+	sb.WriteString("This pass is complete when all of the following git-level completion facts hold in this repository's worktree — the worktree provisioned for this pass — for every behind repository:\n")
 	for _, r := range behind {
 		t := targetByRepo[r]
 		sb.WriteString("\n### Repository: ")
 		sb.WriteString(r)
-		sb.WriteString("\n\n- The resolved target commit (`")
+		sb.WriteString("\n\n- In this repository's worktree, the resolved target commit (`")
 		sb.WriteString(t.Ref)
-		sb.WriteString("`) is an ancestor of the working-branch head (`git merge-base --is-ancestor ")
+		sb.WriteString("`) is an ancestor of HEAD (`git merge-base --is-ancestor ")
 		sb.WriteString(t.Ref)
-		sb.WriteString(" HEAD` succeeds).\n")
-		sb.WriteString("- No merge is in progress (no `rebase-merge` or `rebase-apply` directory, no `MERGE_HEAD`).\n")
-		sb.WriteString("- No conflict markers remain in any tracked file (content scan for literal `<<<<<<<`, `=======`, `>>>>>>>` sequences is empty).\n")
-		sb.WriteString("- The worktree is clean (`git status --porcelain` is empty).\n")
+		sb.WriteString(" HEAD` run in this repository's worktree succeeds).\n")
+		sb.WriteString("- No merge is in progress in this repository's worktree (no `rebase-merge` or `rebase-apply` directory, no `MERGE_HEAD`).\n")
+		sb.WriteString("- No conflict markers remain in any tracked file in this repository's worktree (content scan for literal `<<<<<<<`, `=======`, `>>>>>>>` sequences is empty).\n")
+		sb.WriteString("- This repository's worktree is clean (`git status --porcelain` is empty).\n")
 	}
 	sb.WriteString("\n## Invariants\n\n")
-	sb.WriteString("- Up-to-date repositories (not listed above) are completely unchanged: their worktree HEAD, branch, and content are byte-identical to the creation-time fork point.\n")
+	sb.WriteString("- Up-to-date repositories (not listed above) are completely unchanged: their worktree HEAD and content are byte-identical to the creation-time fork point.\n")
+	sb.WriteString("- No other checkout of any repository was modified at any stage; all work happened inside the worktrees provisioned for this pass.\n")
 	sb.WriteString("- Nothing was pushed to any remote at any stage. All work is local.\n")
 	return sb.String()
 }
@@ -1075,6 +1100,7 @@ func (m *Manager) buildRefactorChild(parent *Feature, spec RefactorChildSpec, ba
 	}
 	run.Setup = NewActiveSetupState(childRepos, spec.Images, spec.Attachments, now, SetupInitOptions{
 		ExactStartPointPerRepo: exactStart,
+		MergeTargetPerRepo:     spec.RebaseMergeTargets,
 	})
 	child.SetRun(run)
 	return child

--- a/internal/feature/child_test.go
+++ b/internal/feature/child_test.go
@@ -1193,3 +1193,90 @@ func TestIntegrationResumable(t *testing.T) {
 		})
 	}
 }
+
+// rebaseTextFixture builds a parent with one behind and one up-to-date repo
+// plus the resolved targets, for asserting the machine-generated child text.
+func rebaseTextFixture() (*feature.Feature, []feature.RebaseRepoTarget, []string) {
+	parent := &feature.Feature{
+		ID:     "p-text",
+		Slug:   "p-text",
+		Status: feature.StatusPublished,
+		Repos: []feature.FeatureRepo{
+			{Name: "repo-behind", Path: "/src/repo-behind", Branch: "feature/secret-branch-name", BaseBranch: "main"},
+			{Name: "repo-current", Path: "/src/repo-current", Branch: "feature/secret-branch-name", BaseBranch: "main"},
+		},
+	}
+	targets := []feature.RebaseRepoTarget{
+		{Repo: "repo-behind", Target: "main", Ref: "origin/main", Publishable: true, TargetSHA: "1111111111111111111111111111111111111111"},
+		{Repo: "repo-current", Target: "main", Ref: "origin/main", Publishable: true, TargetSHA: "2222222222222222222222222222222222222222"},
+	}
+	return parent, targets, []string{"repo-behind"}
+}
+
+func TestRebaseDescriptionIsWorktreeAnchored(t *testing.T) {
+	t.Parallel()
+	parent, targets, behind := rebaseTextFixture()
+	desc := feature.RebaseDescriptionForTest(parent, targets, behind)
+
+	if strings.Contains(desc, "feature/secret-branch-name") {
+		t.Errorf("description names the working branch:\n%s", desc)
+	}
+	if strings.Contains(desc, "working branch") {
+		t.Errorf("description still uses branch-anchored phrasing:\n%s", desc)
+	}
+	for _, want := range []string{
+		"already been merged",
+		"this repository's worktree",
+		"in-progress merge",
+		"resolve every conflict",
+		"complete the merge commit",
+		"never squash or rewrite history",
+		"Leave up-to-date repositories completely untouched",
+		"Never push to any remote",
+		"Do not fetch from any remote",
+		"worktrees provisioned for this pass",
+		"never enter, inspect state from, or modify any other checkout",
+	} {
+		if !strings.Contains(desc, want) {
+			t.Errorf("description missing %q:\n%s", want, desc)
+		}
+	}
+	if !strings.Contains(desc, "repo-behind") {
+		t.Errorf("description missing behind repo section:\n%s", desc)
+	}
+	if strings.Contains(desc, "## Repository: repo-current") {
+		t.Errorf("description has a section for the up-to-date repo:\n%s", desc)
+	}
+	if !strings.Contains(desc, "origin/main") {
+		t.Errorf("description missing resolved target ref:\n%s", desc)
+	}
+}
+
+func TestRebaseExitCriteriaIsWorktreeAnchored(t *testing.T) {
+	t.Parallel()
+	_, targets, behind := rebaseTextFixture()
+	criteria := feature.RebaseExitCriteriaForTest(targets, behind)
+
+	if strings.Contains(criteria, "feature/secret-branch-name") {
+		t.Errorf("exit criteria name a branch:\n%s", criteria)
+	}
+	if strings.Contains(criteria, "working branch") || strings.Contains(criteria, "working-branch") {
+		t.Errorf("exit criteria still use branch-anchored phrasing:\n%s", criteria)
+	}
+	for _, want := range []string{
+		"this repository's worktree",
+		"git merge-base --is-ancestor origin/main HEAD",
+		"No merge is in progress",
+		"No conflict markers remain",
+		"git status --porcelain",
+		"No other checkout of any repository was modified",
+		"Nothing was pushed to any remote",
+	} {
+		if !strings.Contains(criteria, want) {
+			t.Errorf("exit criteria missing %q:\n%s", want, criteria)
+		}
+	}
+	if strings.Contains(criteria, "repo-current") {
+		t.Errorf("exit criteria mention the up-to-date repo by section:\n%s", criteria)
+	}
+}

--- a/internal/feature/export_test.go
+++ b/internal/feature/export_test.go
@@ -55,6 +55,14 @@ func (s *Store) ResetSaveHook() {
 	s.testSaveInterceptor = nil
 }
 
+// RebaseDescriptionForTest exposes the machine-generated rebase child
+// description generator to the external feature_test package.
+var RebaseDescriptionForTest = rebaseDescription
+
+// RebaseExitCriteriaForTest exposes the machine-generated rebase child exit
+// criteria generator to the external feature_test package.
+var RebaseExitCriteriaForTest = rebaseExitCriteria
+
 // SwapFetchPRCommentsForTest replaces the GitHub comment resolver used by
 // draft-based review-feedback launch and returns a restore function.
 func SwapFetchPRCommentsForTest(fn func(repoPath, prURL string) ([]gitadapter.ReviewComment, error)) func() {

--- a/internal/feature/setup.go
+++ b/internal/feature/setup.go
@@ -34,6 +34,11 @@ const (
 	SetupTaskWorktree   SetupTaskKind = "worktree"
 	SetupTaskImage      SetupTaskKind = "image"
 	SetupTaskAttachment SetupTaskKind = "attachment"
+	// SetupTaskMerge mechanically merges the repo's resolved target ref
+	// (carried in StartPoint) into the freshly created worktree. A conflicted
+	// merge is an intended outcome: the task completes and the worktree keeps
+	// the in-progress merge for the pass to resolve.
+	SetupTaskMerge SetupTaskKind = "merge"
 )
 
 type SetupTask struct {
@@ -76,6 +81,10 @@ type SetupInitOptions struct {
 	// worktree is created at the exact captured parent tip even when base or
 	// parent branches later move.
 	ExactStartPointPerRepo map[string]string
+	// MergeTargetPerRepo queues a merge task (ordered after the repo's
+	// worktree task) that merges the given resolved target ref into the new
+	// worktree. Only rebase children set it, for their behind repos.
+	MergeTargetPerRepo map[string]string
 }
 
 func NewActiveSetupState(repos []FeatureRepo, images, attachments []string, now time.Time, opts ...SetupInitOptions) *SetupState {
@@ -113,6 +122,19 @@ func NewActiveSetupState(repos []FeatureRepo, images, attachments []string, now 
 			Attempt:          1,
 		}
 		order = append(order, key)
+		if ref := opt.MergeTargetPerRepo[repo.Name]; ref != "" {
+			mergeKey := "merge:" + repo.Name
+			tasks[mergeKey] = SetupTask{
+				Key:        mergeKey,
+				Kind:       SetupTaskMerge,
+				Label:      "Merge: " + repo.Name,
+				Repo:       repo.Name,
+				Status:     SetupStatusQueued,
+				StartPoint: ref,
+				Attempt:    1,
+			}
+			order = append(order, mergeKey)
+		}
 	}
 	for i := range images {
 		n := strconv.Itoa(i + 1)

--- a/internal/feature/setup_merge_test.go
+++ b/internal/feature/setup_merge_test.go
@@ -1,0 +1,258 @@
+// Copyright 2026 DoorDash, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package feature_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/doordash-oss/agentic-orchestrator/internal/config"
+	"github.com/doordash-oss/agentic-orchestrator/internal/feature"
+	"github.com/doordash-oss/agentic-orchestrator/internal/git"
+	"github.com/doordash-oss/agentic-orchestrator/test/testutil"
+)
+
+func mergeTestGit(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = append(testutil.GitTestEnv(),
+		"GIT_AUTHOR_NAME=Test", "GIT_AUTHOR_EMAIL=test@test.com",
+		"GIT_COMMITTER_NAME=Test", "GIT_COMMITTER_EMAIL=test@test.com",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, out)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// setupMergeRepo builds a real repo whose feature branch is behind main. When
+// conflicting is true main rewrites the same file the feature branch owns, so
+// merging main produces a conflict; otherwise main advances on a disjoint file.
+// Returns the repo path, the feature branch tip SHA, and the target (main) SHA.
+func setupMergeRepo(t *testing.T, conflicting bool) (string, string, string) {
+	t.Helper()
+	repoDir := testutil.InitGitRepo(t)
+	testutil.CreateBranch(t, repoDir, "feature/behind")
+	featureSHA := testutil.CommitFile(t, repoDir, "base.txt", "feature v1\n", "feature base commit")
+	mergeTestGit(t, repoDir, "checkout", "main")
+	var targetSHA string
+	if conflicting {
+		targetSHA = testutil.CommitFile(t, repoDir, "base.txt", "upstream conflicting v2\n", "upstream conflicting change")
+	} else {
+		targetSHA = testutil.CommitFile(t, repoDir, "upstream.txt", "upstream change\n", "upstream advancement")
+	}
+	mergeTestGit(t, repoDir, "checkout", "feature/behind")
+	return repoDir, featureSHA, targetSHA
+}
+
+// newRebaseSetupChild creates a rebase child of a real-git parent through
+// CreateRebaseChild, so RunSetup exercises the full queued setup intent.
+func newRebaseSetupChild(t *testing.T, repoDir, featureSHA, targetSHA string) (*feature.Manager, string) {
+	t.Helper()
+	store := feature.NewStore(t.TempDir())
+	mgr := feature.NewManager(store, config.NewDefault())
+	mgr.Worktrees = git.NewWorktreeManager(filepath.Join(t.TempDir(), "wt"))
+	saveChildTestParent(t, mgr, &feature.Feature{
+		ID:     "p-merge",
+		Slug:   "p-merge",
+		Status: feature.StatusPublished,
+		Repos: []feature.FeatureRepo{
+			{Name: "repo-a", Path: repoDir, WorktreePath: repoDir, Branch: "feature/behind", BaseBranch: "main"},
+		},
+	})
+	child, err := mgr.CreateRebaseChild("p-merge", feature.RebaseChildSpec{
+		Bases:   []feature.ChildRepoBase{{Repo: "repo-a", SHA: featureSHA, ParentBranch: "feature/behind"}},
+		Targets: []feature.RebaseRepoTarget{{Repo: "repo-a", Target: "main", Ref: "main", TargetSHA: targetSHA}},
+		Behind:  []string{"repo-a"},
+	})
+	if err != nil {
+		t.Fatalf("CreateRebaseChild: %v", err)
+	}
+	return mgr, child.ID
+}
+
+func TestRunSetupMergesRebaseTargetCleanly(t *testing.T) {
+	t.Parallel()
+	repoDir, featureSHA, targetSHA := setupMergeRepo(t, false)
+	mgr, childID := newRebaseSetupChild(t, repoDir, featureSHA, targetSHA)
+
+	child, err := mgr.Store.Load(childID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	setup := child.Run().Setup
+	wtIdx := slices.Index(setup.TaskOrder, "worktree:repo-a")
+	mergeIdx := slices.Index(setup.TaskOrder, "merge:repo-a")
+	if wtIdx < 0 || mergeIdx < 0 || mergeIdx < wtIdx {
+		t.Fatalf("task order = %v, want merge:repo-a after worktree:repo-a", setup.TaskOrder)
+	}
+
+	if err := mgr.RunSetup(childID); err != nil {
+		t.Fatalf("RunSetup: %v", err)
+	}
+
+	done, err := mgr.Store.Load(childID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if done.Status != feature.StatusCreated || done.Run().Setup.Status != feature.SetupStatusDone {
+		t.Fatalf("status=%v setup=%v, want Created/done", done.Status, done.Run().Setup.Status)
+	}
+	task := done.Run().Setup.Tasks["merge:repo-a"]
+	if task.Status != feature.SetupStatusDone {
+		t.Fatalf("merge task = %+v, want done", task)
+	}
+	wt := done.Repos[0].WorktreePath
+	if wt == "" || wt == repoDir {
+		t.Fatalf("child worktree path = %q, want a fresh child worktree", wt)
+	}
+	parents := mergeTestGit(t, wt, "rev-list", "--parents", "-n", "1", "HEAD")
+	if len(strings.Fields(parents)) != 3 {
+		t.Fatalf("child HEAD parents = %q, want a two-parent merge commit", parents)
+	}
+	if !git.IsAncestor(wt, targetSHA, "HEAD") {
+		t.Fatalf("target %s is not an ancestor of the child worktree HEAD", targetSHA)
+	}
+	// The parent branch itself is untouched.
+	if got := mergeTestGit(t, repoDir, "rev-parse", "feature/behind"); got != featureSHA {
+		t.Fatalf("parent branch moved: %s, want %s", got, featureSHA)
+	}
+}
+
+func TestRunSetupLeavesConflictedMergeInProgress(t *testing.T) {
+	t.Parallel()
+	repoDir, featureSHA, targetSHA := setupMergeRepo(t, true)
+	mgr, childID := newRebaseSetupChild(t, repoDir, featureSHA, targetSHA)
+
+	if err := mgr.RunSetup(childID); err != nil {
+		t.Fatalf("RunSetup: %v (a conflicted merge is not a setup failure)", err)
+	}
+
+	done, err := mgr.Store.Load(childID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if done.Status != feature.StatusCreated || done.Run().Setup.Status != feature.SetupStatusDone {
+		t.Fatalf("status=%v setup=%v, want Created/done", done.Status, done.Run().Setup.Status)
+	}
+	if task := done.Run().Setup.Tasks["merge:repo-a"]; task.Status != feature.SetupStatusDone {
+		t.Fatalf("merge task = %+v, want done despite conflicts", task)
+	}
+	wt := done.Repos[0].WorktreePath
+	if !git.MergeInProgress(wt) {
+		t.Fatalf("no in-progress merge (MERGE_HEAD) in child worktree %s", wt)
+	}
+	content, err := os.ReadFile(filepath.Join(wt, "base.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(content), "<<<<<<<") {
+		t.Fatalf("base.txt has no conflict markers:\n%s", content)
+	}
+}
+
+func TestNonRebaseChildEmitsNoMergeTask(t *testing.T) {
+	t.Parallel()
+	mgr := newChildTestManager(t, map[string]string{"/wt/repo-a": "aaaa"}, cleanEverywhere())
+	saveChildTestParent(t, mgr, &feature.Feature{
+		ID:     "p-plain",
+		Slug:   "p-plain",
+		Status: feature.StatusPublished,
+		Repos: []feature.FeatureRepo{
+			{Name: "repo-a", Path: "/src/repo-a", WorktreePath: "/wt/repo-a", BaseBranch: "main"},
+		},
+	})
+	child, err := mgr.CreateRefactorChild("p-plain", childTestSpec())
+	if err != nil {
+		t.Fatalf("CreateRefactorChild: %v", err)
+	}
+	for key, task := range child.Run().Setup.Tasks {
+		if task.Kind == feature.SetupTaskMerge || strings.HasPrefix(key, "merge:") {
+			t.Fatalf("non-rebase child has merge task %q", key)
+		}
+	}
+}
+
+func TestRetrySetupDoesNotReMerge(t *testing.T) {
+	t.Parallel()
+	repoDir, featureSHA, targetSHA := setupMergeRepo(t, false)
+	mgr, childID := newRebaseSetupChild(t, repoDir, featureSHA, targetSHA)
+
+	// Queue a failing image task after the merge so the first run fails
+	// mid-setup with the merge already performed.
+	goodImage := filepath.Join(t.TempDir(), "img.png")
+	if err := os.WriteFile(goodImage, []byte("png"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := mgr.Store.Modify(childID, func(f *feature.Feature) error {
+		setup := f.Run().Setup
+		setup.Tasks["image:1"] = feature.SetupTask{
+			Key: "image:1", Kind: feature.SetupTaskImage, Label: "Image 1",
+			Status: feature.SetupStatusQueued, SourcePath: filepath.Join(t.TempDir(), "missing.png"), Attempt: 1,
+		}
+		setup.TaskOrder = append(setup.TaskOrder, "image:1")
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := mgr.RunSetup(childID); err == nil {
+		t.Fatal("RunSetup succeeded, want image copy failure")
+	}
+
+	failed, err := mgr.Store.Load(childID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if failed.Run().Setup.Tasks["merge:repo-a"].Status != feature.SetupStatusDone {
+		t.Fatalf("merge task = %+v, want done before the failing task", failed.Run().Setup.Tasks["merge:repo-a"])
+	}
+	wt := failed.Repos[0].WorktreePath
+	headAfterMerge := mergeTestGit(t, wt, "rev-parse", "HEAD")
+
+	// Simulate a crash that lost the merge task's completion, then retry with
+	// the image source fixed: the re-executed merge must be a no-op.
+	if err := mgr.Store.Modify(childID, func(f *feature.Feature) error {
+		setup := f.Run().Setup
+		mergeTask := setup.Tasks["merge:repo-a"]
+		mergeTask.Status = feature.SetupStatusQueued
+		setup.Tasks["merge:repo-a"] = mergeTask
+		imageTask := setup.Tasks["image:1"]
+		imageTask.SourcePath = goodImage
+		setup.Tasks["image:1"] = imageTask
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := mgr.RetrySetup(childID); err != nil {
+		t.Fatalf("RetrySetup: %v", err)
+	}
+
+	done, err := mgr.Store.Load(childID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if done.Status != feature.StatusCreated || done.Run().Setup.Status != feature.SetupStatusDone {
+		t.Fatalf("status=%v setup=%v, want Created/done", done.Status, done.Run().Setup.Status)
+	}
+	if head := mergeTestGit(t, wt, "rev-parse", "HEAD"); head != headAfterMerge {
+		t.Fatalf("retry moved the child worktree HEAD: %s, want stable %s", head, headAfterMerge)
+	}
+}

--- a/internal/feature/setup_runner.go
+++ b/internal/feature/setup_runner.go
@@ -265,6 +265,8 @@ func (m *Manager) executeSetupTask(f *Feature, task SetupTask, logPath string) (
 	switch task.Kind {
 	case SetupTaskWorktree:
 		return m.executeWorktreeSetupTask(f, task, logPath)
+	case SetupTaskMerge:
+		return m.executeMergeSetupTask(f, task, logPath)
 	case SetupTaskImage:
 		return m.executeImageSetupTask(f, task, logPath)
 	case SetupTaskAttachment:
@@ -344,6 +346,36 @@ func (m *Manager) reuseExpectedWorktree(task SetupTask) error {
 		}
 	}
 	return nil
+}
+
+// executeMergeSetupTask merges the resolved target ref (task.StartPoint) into
+// the repo's freshly created child worktree. Conflicts complete the task: the
+// worktree keeps the in-progress merge for the pass to resolve. MergeInto is
+// idempotent, so re-execution after a lost completion never re-merges.
+func (m *Manager) executeMergeSetupTask(f *Feature, task SetupTask, logPath string) (SetupTask, error) {
+	idx := repoIndexByName(f, task.Repo)
+	if idx < 0 {
+		return task, fmt.Errorf("repo %q no longer exists on feature", task.Repo)
+	}
+	worktree := f.Repos[idx].WorktreePath
+	if worktree == "" {
+		return task, fmt.Errorf("repo %q has no worktree to merge into", task.Repo)
+	}
+	if task.StartPoint == "" {
+		return task, fmt.Errorf("merge setup task %s is missing a target ref", task.Key)
+	}
+	result := git.MergeInto(worktree, task.StartPoint, "Merge "+task.StartPoint)
+	switch result.Outcome {
+	case git.MergeIntoSuccess:
+		appendSetupLog(logPath, "merged %s into worktree %s", task.StartPoint, worktree)
+	case git.MergeIntoConflict:
+		appendSetupLog(logPath, "merge of %s stopped on conflicts; the worktree %s holds an in-progress merge for the pass to resolve (conflicts: %s)",
+			task.StartPoint, worktree, strings.Join(result.ConflictFiles, ", "))
+	default:
+		return task, fmt.Errorf("merging %s into worktree %s: %w", task.StartPoint, worktree, result.Err)
+	}
+	task.Path = worktree
+	return task, nil
 }
 
 func (m *Manager) executeImageSetupTask(f *Feature, task SetupTask, logPath string) (SetupTask, error) {

--- a/internal/feature/transaction.go
+++ b/internal/feature/transaction.go
@@ -130,7 +130,8 @@ type RepoTransactionEntry struct {
 const (
 	// GateCodeParentDrift: a parent branch tip moved from its creation-time
 	// base — parent refs must not move while a pass runs, except through the
-	// transaction itself.
+	// transaction itself. Drift parks integration once; retrying at the
+	// unchanged tip is the operator's acknowledgment to absorb it.
 	GateCodeParentDrift = "parent_ref_drift"
 	// GateCodeNotAncestor: the persisted creation-time target commit is not
 	// an ancestor of the child branch head — the child did not merge the

--- a/internal/feature/transaction.go
+++ b/internal/feature/transaction.go
@@ -123,10 +123,15 @@ type RepoTransactionEntry struct {
 	GateCode string `yaml:"gate_code,omitempty"`
 }
 
-// Stable gate-failure codes recorded by the rebase mechanical integration
-// gate. They are distinct, machine-stable reason strings so review tooling
-// can classify a parked rebase child without parsing free-form diagnostics.
+// Stable gate-failure codes recorded by integration gates before any
+// candidate or ref is touched. They are distinct, machine-stable reason
+// strings so review tooling can classify a parked child without parsing
+// free-form diagnostics.
 const (
+	// GateCodeParentDrift: a parent branch tip moved from its creation-time
+	// base — parent refs must not move while a pass runs, except through the
+	// transaction itself.
+	GateCodeParentDrift = "parent_ref_drift"
 	// GateCodeNotAncestor: the persisted creation-time target commit is not
 	// an ancestor of the child branch head — the child did not merge the
 	// creation-time target.

--- a/internal/git/merge.go
+++ b/internal/git/merge.go
@@ -45,6 +45,65 @@ func MergeNoFF(worktreePath, ref, message string) error {
 	return fmt.Errorf("merge failed (aborted: %v): %s: %w", abortMerge(worktreePath), failure, err)
 }
 
+// MergeIntoOutcome categorises the result of a MergeInto operation.
+type MergeIntoOutcome int
+
+const (
+	// MergeIntoSuccess means the merge completed (or ref was already merged).
+	MergeIntoSuccess MergeIntoOutcome = iota
+	// MergeIntoConflict means conflicts remain in the worktree.
+	MergeIntoConflict
+	// MergeIntoFailed means a non-conflict failure occurred and the merge was aborted.
+	MergeIntoFailed
+)
+
+// MergeIntoResult is the outcome, conflict files, and error from MergeInto.
+type MergeIntoResult struct {
+	Outcome       MergeIntoOutcome
+	ConflictFiles []string
+	Err           error
+}
+
+// MergeInto merges ref into the branch checked out in the worktree with an
+// explicit --no-ff merge commit. Unlike MergeNoFF, on conflict the merge is
+// NOT aborted — MERGE_HEAD and conflict markers are left in place so an agent
+// can resolve them and commit. Re-entry while a merge is already in progress
+// returns Conflict again; a ref already reachable from HEAD returns Success
+// without a new commit.
+func MergeInto(worktreePath, ref, message string) MergeIntoResult {
+	if MergeInProgress(worktreePath) {
+		return MergeIntoResult{
+			Outcome:       MergeIntoConflict,
+			ConflictFiles: listConflictFiles(worktreePath),
+			Err:           fmt.Errorf("merge already in progress in %s", worktreePath),
+		}
+	}
+	if IsAncestor(worktreePath, ref, "HEAD") {
+		return MergeIntoResult{Outcome: MergeIntoSuccess}
+	}
+
+	args := append([]string{"-C", worktreePath}, identityFallbackArgs(worktreePath)...)
+	args = append(args, "merge", "--no-ff", "-m", message, ref)
+	out, err := exec.Command("git", args...).CombinedOutput()
+	if err == nil {
+		return MergeIntoResult{Outcome: MergeIntoSuccess}
+	}
+
+	if MergeInProgress(worktreePath) {
+		return MergeIntoResult{
+			Outcome:       MergeIntoConflict,
+			ConflictFiles: listConflictFiles(worktreePath),
+			Err:           fmt.Errorf("merge conflicts: %s", strings.TrimSpace(string(out))),
+		}
+	}
+
+	_ = abortMerge(worktreePath)
+	return MergeIntoResult{
+		Outcome: MergeIntoFailed,
+		Err:     fmt.Errorf("merge failed: %s: %w", strings.TrimSpace(string(out)), err),
+	}
+}
+
 // abortMerge attempts `git merge --abort`; nil means the worktree is back at
 // its pre-merge state, an error means there was no merge in progress (which
 // equally means no ref movement) or the abort itself failed.

--- a/internal/git/merge_test.go
+++ b/internal/git/merge_test.go
@@ -121,6 +121,164 @@ func TestMergeNoFFConflictAbortsCleanly(t *testing.T) {
 	}
 }
 
+// TestMergeIntoCleanMergeCreatesTwoParentCommit pins the happy path: a clean
+// MergeInto produces an explicit two-parent merge commit with the given
+// message and leaves the worktree clean.
+func TestMergeIntoCleanMergeCreatesTwoParentCommit(t *testing.T) {
+	repo := testutil.InitGitRepo(t)
+	testutil.CommitFile(t, repo, "base.txt", "base\n", "parent base")
+
+	runGitMergeTest(t, repo, "checkout", "-b", "child-branch")
+	testutil.CommitFile(t, repo, "child.txt", "child work\n", "child commit")
+	runGitMergeTest(t, repo, "checkout", "main")
+	testutil.CommitFile(t, repo, "other.txt", "parent moved\n", "parent advanced")
+
+	res := gitpkg.MergeInto(repo, "child-branch", "merge child into parent")
+	if res.Outcome != gitpkg.MergeIntoSuccess {
+		t.Fatalf("MergeInto() outcome = %v, err = %v, want success", res.Outcome, res.Err)
+	}
+
+	parents := runGitMergeTest(t, repo, "rev-list", "--parents", "-n", "1", "HEAD")
+	if fields := len(strings.Fields(parents)); fields != 3 {
+		t.Fatalf("merge HEAD parents = %q, want two-parent merge commit", parents)
+	}
+	if got := runGitMergeTest(t, repo, "log", "-n", "1", "--format=%s"); got != "merge child into parent" {
+		t.Fatalf("merge commit subject = %q, want %q", got, "merge child into parent")
+	}
+	if status := runGitMergeTest(t, repo, "status", "--porcelain"); status != "" {
+		t.Fatalf("worktree status = %q after clean merge, want clean", status)
+	}
+}
+
+// TestMergeIntoConflictLeavesMergeInProgress pins the core contract: a
+// conflicting merge is NOT aborted — MERGE_HEAD stays, conflict files are
+// reported, and the files contain literal conflict markers for resolution.
+func TestMergeIntoConflictLeavesMergeInProgress(t *testing.T) {
+	repo := testutil.InitGitRepo(t)
+	testutil.CommitFile(t, repo, "shared.txt", "base\n", "parent base")
+
+	runGitMergeTest(t, repo, "checkout", "-b", "child-branch")
+	testutil.CommitFile(t, repo, "shared.txt", "child edit\n", "child commit")
+	runGitMergeTest(t, repo, "checkout", "main")
+	testutil.CommitFile(t, repo, "shared.txt", "parent edit\n", "conflicting parent commit")
+
+	res := gitpkg.MergeInto(repo, "child-branch", "merge child")
+	if res.Outcome != gitpkg.MergeIntoConflict {
+		t.Fatalf("MergeInto() outcome = %v, err = %v, want conflict", res.Outcome, res.Err)
+	}
+	if !gitpkg.MergeInProgress(repo) {
+		t.Fatal("MergeInProgress() = false after conflict, want merge left in progress")
+	}
+	if len(res.ConflictFiles) != 1 || res.ConflictFiles[0] != "shared.txt" {
+		t.Fatalf("ConflictFiles = %v, want [shared.txt]", res.ConflictFiles)
+	}
+	content, err := os.ReadFile(filepath.Join(repo, "shared.txt"))
+	if err != nil {
+		t.Fatalf("reading conflicted file: %v", err)
+	}
+	// Markers built from split strings so this file does not match marker scans.
+	start := "<" + "<<<<" + "<<"
+	end := ">" + ">>>>" + ">>"
+	if !strings.Contains(string(content), start) || !strings.Contains(string(content), end) {
+		t.Fatalf("conflicted file content = %q, want literal conflict markers", content)
+	}
+}
+
+// TestMergeIntoIdempotentWhileConflicted pins re-entry: calling MergeInto
+// while a conflicted merge is in progress returns Conflict again without
+// aborting or corrupting the sequencer state.
+func TestMergeIntoIdempotentWhileConflicted(t *testing.T) {
+	repo := testutil.InitGitRepo(t)
+	testutil.CommitFile(t, repo, "shared.txt", "base\n", "parent base")
+
+	runGitMergeTest(t, repo, "checkout", "-b", "child-branch")
+	testutil.CommitFile(t, repo, "shared.txt", "child edit\n", "child commit")
+	runGitMergeTest(t, repo, "checkout", "main")
+	testutil.CommitFile(t, repo, "shared.txt", "parent edit\n", "conflicting parent commit")
+
+	first := gitpkg.MergeInto(repo, "child-branch", "merge child")
+	if first.Outcome != gitpkg.MergeIntoConflict {
+		t.Fatalf("first MergeInto() outcome = %v, want conflict", first.Outcome)
+	}
+
+	second := gitpkg.MergeInto(repo, "child-branch", "merge child")
+	if second.Outcome != gitpkg.MergeIntoConflict {
+		t.Fatalf("second MergeInto() outcome = %v, err = %v, want conflict", second.Outcome, second.Err)
+	}
+	if !gitpkg.MergeInProgress(repo) {
+		t.Fatal("MergeInProgress() = false after re-entry, want merge still in progress")
+	}
+	if len(second.ConflictFiles) != 1 || second.ConflictFiles[0] != "shared.txt" {
+		t.Fatalf("re-entry ConflictFiles = %v, want [shared.txt]", second.ConflictFiles)
+	}
+}
+
+// TestMergeIntoAncestorIsNoOp pins the no-op path: a ref already reachable
+// from HEAD returns Success without moving HEAD.
+func TestMergeIntoAncestorIsNoOp(t *testing.T) {
+	repo := testutil.InitGitRepo(t)
+	testutil.CommitFile(t, repo, "base.txt", "base\n", "parent base")
+
+	runGitMergeTest(t, repo, "checkout", "-b", "child-branch")
+	runGitMergeTest(t, repo, "checkout", "main")
+	testutil.CommitFile(t, repo, "other.txt", "parent moved\n", "parent advanced")
+	preMerge := runGitMergeTest(t, repo, "rev-parse", "HEAD")
+
+	res := gitpkg.MergeInto(repo, "child-branch", "merge child")
+	if res.Outcome != gitpkg.MergeIntoSuccess {
+		t.Fatalf("MergeInto() outcome = %v, err = %v, want success no-op", res.Outcome, res.Err)
+	}
+	if got := runGitMergeTest(t, repo, "rev-parse", "HEAD"); got != preMerge {
+		t.Fatalf("HEAD = %s after ancestor no-op, want unchanged %s", got, preMerge)
+	}
+}
+
+// TestMergeIntoWithoutConfiguredIdentity pins the CI contract: the merge
+// commit succeeds with the Agentico fallback identity when neither the repo
+// nor any git config supplies one (fresh CI runners).
+func TestMergeIntoWithoutConfiguredIdentity(t *testing.T) {
+	repo := testutil.InitGitRepo(t)
+	testutil.CommitFile(t, repo, "base.txt", "base\n", "parent base")
+
+	runGitMergeTest(t, repo, "checkout", "-b", "child-branch")
+	testutil.CommitFile(t, repo, "child.txt", "child work\n", "child commit")
+	runGitMergeTest(t, repo, "checkout", "main")
+	testutil.CommitFile(t, repo, "other.txt", "parent moved\n", "parent advanced")
+	runGitMergeTest(t, repo, "config", "--unset", "user.email")
+	runGitMergeTest(t, repo, "config", "--unset", "user.name")
+
+	res := gitpkg.MergeInto(repo, "child-branch", "merge child")
+	if res.Outcome != gitpkg.MergeIntoSuccess {
+		t.Fatalf("MergeInto() outcome = %v, err = %v, want success via identity fallback", res.Outcome, res.Err)
+	}
+	parents := runGitMergeTest(t, repo, "rev-list", "--parents", "-n", "1", "HEAD")
+	if fields := len(strings.Fields(parents)); fields != 3 {
+		t.Fatalf("merge HEAD parents = %q, want two-parent merge commit", parents)
+	}
+}
+
+// TestMergeIntoBogusRefFailsClean pins the non-conflict failure path: a ref
+// that does not exist returns Failed with a clean worktree and no merge left
+// in progress.
+func TestMergeIntoBogusRefFailsClean(t *testing.T) {
+	repo := testutil.InitGitRepo(t)
+	testutil.CommitFile(t, repo, "base.txt", "base\n", "parent base")
+
+	res := gitpkg.MergeInto(repo, "no-such-ref", "merge nothing")
+	if res.Outcome != gitpkg.MergeIntoFailed {
+		t.Fatalf("MergeInto() outcome = %v, err = %v, want failed", res.Outcome, res.Err)
+	}
+	if res.Err == nil {
+		t.Fatal("MergeInto() Err = nil, want failure error")
+	}
+	if gitpkg.MergeInProgress(repo) {
+		t.Fatal("MergeInProgress() = true after non-conflict failure, want clean")
+	}
+	if status := runGitMergeTest(t, repo, "status", "--porcelain"); status != "" {
+		t.Fatalf("worktree status = %q after failure, want clean", status)
+	}
+}
+
 // TestMergeFeatureBranchWithoutConfiguredIdentity pins the CI contract: the
 // no-ff merge commit succeeds with the Agentico fallback identity when
 // neither the repo nor any git config supplies one (fresh CI runners).

--- a/internal/orchestrator/child_integration_internal_test.go
+++ b/internal/orchestrator/child_integration_internal_test.go
@@ -428,6 +428,13 @@ func TestChildIntegrationConflictAttentionAndRetry(t *testing.T) {
 	// file with the same name.
 	testutil.CommitFile(t, fx.repoDir, "child.txt", "parent-side conflict\n", "conflicting parent commit")
 	preHEAD := childIntegrationGit(t, fx.repoDir, "rev-parse", "HEAD")
+	// Pin the persisted base to the new tip so the parent-drift gate does not
+	// fire and the merge-conflict path is exercised.
+	pinned, _ := fx.store.Load(fx.child.ID)
+	pinned.Parent.Bases[0].SHA = preHEAD
+	if err := fx.store.Save(pinned); err != nil {
+		t.Fatalf("save child with pinned base: %v", err)
+	}
 
 	if err := o.RunChildIntegration(fx.child.ID); err != nil {
 		t.Fatalf("runChildIntegration() error = %v, want nil with recorded attention", err)
@@ -455,8 +462,14 @@ func TestChildIntegrationConflictAttentionAndRetry(t *testing.T) {
 		t.Fatal("child branch was deleted on conflicted integration")
 	}
 
-	// Resolve the divergence on the parent side and retry via Restart.
+	// Resolve the divergence on the parent side and retry via Restart,
+	// re-pinning the base to the restored tip.
 	childIntegrationGit(t, fx.repoDir, "reset", "--hard", preHEAD+"^")
+	pinned, _ = fx.store.Load(fx.child.ID)
+	pinned.Parent.Bases[0].SHA = childIntegrationGit(t, fx.repoDir, "rev-parse", "HEAD")
+	if err := fx.store.Save(pinned); err != nil {
+		t.Fatalf("re-pin child base: %v", err)
+	}
 	outcome, err := fx.orchestrator().RestartPhase(fx.child.ID, 0, 0)
 	if err != nil {
 		t.Fatalf("RestartPhase() error = %v", err)

--- a/internal/orchestrator/child_transaction.go
+++ b/internal/orchestrator/child_transaction.go
@@ -119,12 +119,15 @@ func (o *Orchestrator) prepareTransactionCandidates(child, parent *feature.Featu
 
 		// A tip away from the creation-time base is external drift unless it
 		// is a candidate this child's transaction produced (a resumed or
-		// partially applied transaction being rebuilt).
+		// partially applied transaction being rebuilt) or a tip a prior drift
+		// attention already reported — retrying integration at the same tip
+		// is the operator's explicit acknowledgment to absorb it.
 		if base := child.BaseSHA(childRepo.Name); base != "" && parentTip != base &&
-			!transactionProducedSHA(child.Parent.Transaction, parentTip) {
+			!transactionProducedSHA(child.Parent.Transaction, parentTip) &&
+			!transactionAcknowledgedDrift(child.Parent.Transaction, childRepo.Name, parentTip) {
 			entry.PrepState = feature.RepoPrepFailed
 			entry.GateCode = feature.GateCodeParentDrift
-			entry.Diagnostics = fmt.Sprintf("parent branch tip moved from %s to %s while the pass was running; the parent is locked during a pass, so this usually means something wrote to the parent's checkout outside the integration transaction; parent refs were left untouched", base, parentTip)
+			entry.Diagnostics = fmt.Sprintf("parent branch tip moved from %s to %s while the pass was running; the parent is locked during a pass, so this usually means something wrote to the parent's checkout outside the integration transaction; parent refs were left untouched — retry integration to accept the moved tip, or reset the parent branch before retrying", base, parentTip)
 			driftedRepos = append(driftedRepos, childRepo.Name)
 		}
 
@@ -147,8 +150,19 @@ func (o *Orchestrator) prepareTransactionCandidates(child, parent *feature.Featu
 	}
 
 	// If any parent tip drifted, park the transaction with aggregated drift
-	// diagnostics before any staging. All parent refs are unchanged.
+	// diagnostics before any staging. All parent refs are unchanged. Carry
+	// candidate provenance from the prior journal across the overwrite so a
+	// ref this transaction already moved is not reclassified as drift on
+	// retry.
 	if len(driftedRepos) > 0 {
+		if prior := child.Parent.Transaction; prior != nil {
+			for i := range journal.Entries {
+				if pe := prior.EntryByRepo(journal.Entries[i].Repo); pe != nil && journal.Entries[i].CandidateSHA == "" {
+					journal.Entries[i].CandidateSHA = pe.CandidateSHA
+					journal.Entries[i].ApplyState = pe.ApplyState
+				}
+			}
+		}
 		journal.Phase = feature.TransactionPhaseAttention
 		journal.Attention = "parent branch tips moved outside the integration transaction: " + strings.Join(driftedRepos, ", ")
 		if err := o.persistTransaction(child.ID, journal); err != nil {
@@ -681,6 +695,18 @@ func transactionProducedSHA(journal *feature.TransactionJournal, sha string) boo
 		}
 	}
 	return false
+}
+
+// transactionAcknowledgedDrift reports whether a prior drift attention
+// already recorded sha as the repo's moved tip: drift parks integration
+// exactly once, and a retry at the unchanged tip absorbs it. Any further
+// movement parks again.
+func transactionAcknowledgedDrift(journal *feature.TransactionJournal, repo, sha string) bool {
+	if journal == nil || sha == "" {
+		return false
+	}
+	entry := journal.EntryByRepo(repo)
+	return entry != nil && entry.GateCode == feature.GateCodeParentDrift && entry.ParentAnchorSHA == sha
 }
 
 // transactionNeedsRebuild checks whether the parent-tip vector has changed

--- a/internal/orchestrator/child_transaction.go
+++ b/internal/orchestrator/child_transaction.go
@@ -38,10 +38,12 @@ import (
 // initial parent anchor, latest expected target ref, candidate commit, and
 // preparation outcome is persisted before application.
 //
-// A clean parent advancement before application is harmless: the complete
-// candidate set is rebuilt from the latest clean parent-tip vector. A dirty
-// repository, conflict, or preparation failure leaves every parent ref
-// unchanged and records all affected repositories as attention.
+// The parent is locked while a pass runs, so a parent tip that moved away
+// from its creation-time base — other than to a commit this transaction
+// itself produced — is external drift: preparation parks at attention with
+// GateCodeParentDrift before any staging. A dirty repository, conflict, or
+// preparation failure likewise leaves every parent ref unchanged and records
+// all affected repositories as attention.
 func (o *Orchestrator) prepareTransactionCandidates(child, parent *feature.Feature) (*feature.TransactionJournal, error) {
 	if o.deps.Worktrees == nil {
 		return nil, fmt.Errorf("transaction: worktree operations are not configured")
@@ -69,6 +71,7 @@ func (o *Orchestrator) prepareTransactionCandidates(child, parent *feature.Featu
 
 	// Validate every parent repo and capture per-repo entries.
 	var allDirty []feature.RepoDirtyDiagnostics
+	var driftedRepos []string
 	for _, childRepo := range child.Repos {
 		parentRepo := featureRepoByName(parent, childRepo.Name)
 		if parentRepo == nil {
@@ -114,6 +117,17 @@ func (o *Orchestrator) prepareTransactionCandidates(child, parent *feature.Featu
 			PrepState:       feature.RepoPrepPending,
 		}
 
+		// A tip away from the creation-time base is external drift unless it
+		// is a candidate this child's transaction produced (a resumed or
+		// partially applied transaction being rebuilt).
+		if base := child.BaseSHA(childRepo.Name); base != "" && parentTip != base &&
+			!transactionProducedSHA(child.Parent.Transaction, parentTip) {
+			entry.PrepState = feature.RepoPrepFailed
+			entry.GateCode = feature.GateCodeParentDrift
+			entry.Diagnostics = fmt.Sprintf("parent branch tip moved from %s to %s while the pass was running; the parent is locked during a pass, so this usually means something wrote to the parent's checkout outside the integration transaction; parent refs were left untouched", base, parentTip)
+			driftedRepos = append(driftedRepos, childRepo.Name)
+		}
+
 		if report.Dirty() {
 			entry.PrepState = feature.RepoPrepFailed
 			entry.Dirty = []feature.RepoDirtyDiagnostics{{
@@ -130,6 +144,17 @@ func (o *Orchestrator) prepareTransactionCandidates(child, parent *feature.Featu
 		}
 
 		journal.Entries = append(journal.Entries, entry)
+	}
+
+	// If any parent tip drifted, park the transaction with aggregated drift
+	// diagnostics before any staging. All parent refs are unchanged.
+	if len(driftedRepos) > 0 {
+		journal.Phase = feature.TransactionPhaseAttention
+		journal.Attention = "parent branch tips moved outside the integration transaction: " + strings.Join(driftedRepos, ", ")
+		if err := o.persistTransaction(child.ID, journal); err != nil {
+			return nil, fmt.Errorf("recording parent drift attention: %w", err)
+		}
+		return nil, o.emitTransactionAttention(child, journal.Attention)
 	}
 
 	// If any parent is dirty, park the transaction with aggregated dirty
@@ -641,6 +666,21 @@ func (o *Orchestrator) transactionParentTipVector(parent *feature.Feature, journ
 		tips = append(tips, sha)
 	}
 	return tips, nil
+}
+
+// transactionProducedSHA reports whether the prior persisted journal staged
+// sha as a candidate, so a resumed or partially applied transaction is not
+// mistaken for external parent drift.
+func transactionProducedSHA(journal *feature.TransactionJournal, sha string) bool {
+	if journal == nil || sha == "" {
+		return false
+	}
+	for i := range journal.Entries {
+		if journal.Entries[i].CandidateSHA == sha {
+			return true
+		}
+	}
+	return false
 }
 
 // transactionNeedsRebuild checks whether the parent-tip vector has changed

--- a/internal/orchestrator/child_transaction_internal_test.go
+++ b/internal/orchestrator/child_transaction_internal_test.go
@@ -336,8 +336,15 @@ func TestTransactionPreparationFailureLeavesRefsUnchanged(t *testing.T) {
 	fx := newMultiRepoTransactionFixture(t, 2)
 	o := fx.orchestrator()
 
-	// Create a conflicting change on the second repo's parent branch.
+	// Create a conflicting change on the second repo's parent branch and pin
+	// the persisted base to the new tip so the drift gate does not fire and
+	// the merge-conflict path is exercised.
 	testutil.CommitFile(t, fx.repoDirs[1], "child.txt", "parent-side conflict\n", "conflicting parent commit")
+	child, _ := fx.store.Load(fx.child.ID)
+	child.Parent.Bases[1].SHA = fx.refSHA(1, "refs/heads/feature/parent")
+	if err := fx.store.Save(child); err != nil {
+		t.Fatalf("save child with pinned base: %v", err)
+	}
 
 	preRefs := make([]string, len(fx.repoDirs))
 	for i := range fx.repoDirs {
@@ -355,7 +362,7 @@ func TestTransactionPreparationFailureLeavesRefsUnchanged(t *testing.T) {
 		}
 	}
 
-	_, child := fx.reload()
+	_, child = fx.reload()
 	tx := child.Parent.Transaction
 	if tx == nil || tx.Phase != feature.TransactionPhaseAttention {
 		t.Fatalf("transaction phase = %+v, want attention", tx)
@@ -367,33 +374,189 @@ func TestTransactionPreparationFailureLeavesRefsUnchanged(t *testing.T) {
 	}
 }
 
-// TestTransactionCleanParentAdvancementRebuilds proves a clean parent
-// advancement before application is harmless: candidates are rebuilt from
-// the latest clean parent-tip vector.
-func TestTransactionCleanParentAdvancementRebuilds(t *testing.T) {
+// TestTransactionExternalParentAdvancementParksDrift proves an external
+// commit that moves a parent branch tip away from its creation-time base is
+// no longer silently absorbed: preparation parks the transaction at attention
+// with the typed parent-drift gate code, stages no candidates, and leaves
+// every parent ref byte-identical.
+func TestTransactionExternalParentAdvancementParksDrift(t *testing.T) {
 	if testing.Short() {
 		t.Skip("real-git integration test")
 	}
 	fx := newMultiRepoTransactionFixture(t, 2)
 	o := fx.orchestrator()
 
-	// Advance the first repo's parent branch cleanly.
-	testutil.CommitFile(t, fx.repoDirs[0], "parent-advance.txt", "clean advance\n", "parent advanced")
+	// Advance the first repo's parent branch outside the transaction.
+	testutil.CommitFile(t, fx.repoDirs[0], "parent-advance.txt", "external advance\n", "parent advanced")
+
+	preRefs := make([]string, len(fx.repoDirs))
+	for i := range fx.repoDirs {
+		preRefs[i] = fx.refSHA(i, "refs/heads/feature/parent")
+	}
 
 	if err := o.RunChildIntegration(fx.child.ID); err != nil {
-		t.Fatalf("runChildIntegration() error = %v", err)
+		t.Fatalf("runChildIntegration() error = %v, want nil with attention", err)
+	}
+
+	// All parent refs unchanged.
+	for i := range fx.repoDirs {
+		if got := fx.refSHA(i, "refs/heads/feature/parent"); got != preRefs[i] {
+			t.Fatalf("repo %d: parent ref moved from %s to %s on drift", i, preRefs[i], got)
+		}
 	}
 
 	_, child := fx.reload()
-	if child.Parent.CloseOutcome != feature.ChildCloseOutcomeCompleted {
-		t.Fatalf("child close outcome = %q, want completed after clean advancement", child.Parent.CloseOutcome)
+	if child.Parent.CloseOutcome != "" {
+		t.Fatalf("child close outcome = %q, want open relationship", child.Parent.CloseOutcome)
 	}
-	// The first repo's merge should include the parent advancement.
-	for i, dir := range fx.repoDirs {
-		parents := txGit(t, dir, "rev-list", "--parents", "-n", "1", "HEAD")
-		if fields := len(strings.Fields(parents)); fields != 3 {
-			t.Fatalf("repo %d: merge parents = %q, want two-parent merge commit", i, parents)
+	tx := child.Parent.Transaction
+	if tx == nil || tx.Phase != feature.TransactionPhaseAttention {
+		t.Fatalf("transaction phase = %+v, want attention", tx)
+	}
+	entry := tx.EntryByRepo(child.Repos[0].Name)
+	if entry == nil || entry.GateCode != feature.GateCodeParentDrift {
+		t.Fatalf("repo 0: gate code = %+v, want %s", entry, feature.GateCodeParentDrift)
+	}
+	if entry.PrepState != feature.RepoPrepFailed {
+		t.Fatalf("repo 0: prep state = %s, want failed", entry.PrepState)
+	}
+	for i := range tx.Entries {
+		if tx.Entries[i].CandidateSHA != "" {
+			t.Fatalf("repo %d: candidate %s staged despite drift", i, tx.Entries[i].CandidateSHA)
 		}
+	}
+}
+
+// TestTransactionParentDriftMultiRepoAggregation proves drift is evaluated
+// for every repository in one preflight: drifted repos carry the typed gate
+// code, clean repos do not, and no candidate is staged for either.
+func TestTransactionParentDriftMultiRepoAggregation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("real-git integration test")
+	}
+	fx := newMultiRepoTransactionFixture(t, 3)
+	o := fx.orchestrator()
+
+	// Advance the first and third parent branches; the second stays clean.
+	testutil.CommitFile(t, fx.repoDirs[0], "drift-a.txt", "external\n", "external parent commit A")
+	testutil.CommitFile(t, fx.repoDirs[2], "drift-c.txt", "external\n", "external parent commit C")
+
+	preRefs := make([]string, len(fx.repoDirs))
+	for i := range fx.repoDirs {
+		preRefs[i] = fx.refSHA(i, "refs/heads/feature/parent")
+	}
+
+	if err := o.RunChildIntegration(fx.child.ID); err != nil {
+		t.Fatalf("runChildIntegration() error = %v, want nil with attention", err)
+	}
+
+	for i := range fx.repoDirs {
+		if got := fx.refSHA(i, "refs/heads/feature/parent"); got != preRefs[i] {
+			t.Fatalf("repo %d: parent ref moved from %s to %s on drift", i, preRefs[i], got)
+		}
+	}
+
+	_, child := fx.reload()
+	tx := child.Parent.Transaction
+	if tx == nil || tx.Phase != feature.TransactionPhaseAttention {
+		t.Fatalf("transaction phase = %+v, want attention", tx)
+	}
+	for i := range tx.Entries {
+		entry := &tx.Entries[i]
+		drifted := i == 0 || i == 2
+		if drifted && entry.GateCode != feature.GateCodeParentDrift {
+			t.Fatalf("repo %d: gate code = %q, want %s", i, entry.GateCode, feature.GateCodeParentDrift)
+		}
+		if !drifted && entry.GateCode != "" {
+			t.Fatalf("repo %d: gate code = %q, want empty for clean repo", i, entry.GateCode)
+		}
+		if entry.CandidateSHA != "" {
+			t.Fatalf("repo %d: candidate %s staged despite drift", i, entry.CandidateSHA)
+		}
+	}
+}
+
+// TestTransactionParentDriftExemptsPriorCandidate proves a resumed rebuild
+// after a partial apply — where a parent tip equals a candidate the
+// transaction itself produced — is not mistaken for external drift and the
+// integration completes.
+func TestTransactionParentDriftExemptsPriorCandidate(t *testing.T) {
+	if testing.Short() {
+		t.Skip("real-git integration test")
+	}
+	fx := newMultiRepoTransactionFixture(t, 2)
+
+	child, _ := fx.store.Load(fx.child.ID)
+	parent, _ := fx.store.Load(fx.parent.ID)
+	o := fx.orchestrator()
+	journal, err := o.prepareTransactionCandidates(child, parent)
+	if err != nil {
+		t.Fatalf("prepareTransactionCandidates() error = %v", err)
+	}
+	if journal == nil {
+		t.Fatal("journal is nil")
+	}
+
+	// Manually apply only the first repo (simulating a crash after its ref
+	// CAS and worktree sync but before durable apply progress).
+	entry := &journal.Entries[0]
+	ref := "refs/heads/" + entry.ParentBranch
+	if err := git.UpdateRefCAS(fx.repoDirs[0], ref, entry.ExpectedRefSHA, entry.CandidateSHA); err != nil {
+		t.Fatalf("manual apply repo 0: %v", err)
+	}
+	txGit(t, fx.repoDirs[0], "reset", "--hard", entry.CandidateSHA)
+
+	if err := o.RunChildIntegration(fx.child.ID); err != nil {
+		t.Fatalf("RunChildIntegration() resume error = %v", err)
+	}
+
+	_, child = fx.reload()
+	if child.Parent.CloseOutcome != feature.ChildCloseOutcomeCompleted {
+		t.Fatalf("child close outcome = %q, want completed on resume", child.Parent.CloseOutcome)
+	}
+	if child.Parent.Transaction.Phase != feature.TransactionPhaseMerged {
+		t.Fatalf("transaction phase = %s, want merged", child.Parent.Transaction.Phase)
+	}
+	for i := range child.Parent.Transaction.Entries {
+		if got := child.Parent.Transaction.Entries[i].GateCode; got == feature.GateCodeParentDrift {
+			t.Fatalf("repo %d: resume tripped the drift gate", i)
+		}
+	}
+}
+
+// TestTransactionParentDriftRecheckAfterReset proves drift attention is
+// re-checkable: once the parent branch is reset back to its creation-time
+// base, re-running integration proceeds to completion.
+func TestTransactionParentDriftRecheckAfterReset(t *testing.T) {
+	if testing.Short() {
+		t.Skip("real-git integration test")
+	}
+	fx := newMultiRepoTransactionFixture(t, 2)
+	o := fx.orchestrator()
+
+	testutil.CommitFile(t, fx.repoDirs[0], "drift.txt", "external\n", "external parent commit")
+
+	if err := o.RunChildIntegration(fx.child.ID); err != nil {
+		t.Fatalf("runChildIntegration() error = %v, want nil with attention", err)
+	}
+	_, child := fx.reload()
+	tx := child.Parent.Transaction
+	if tx == nil || tx.Phase != feature.TransactionPhaseAttention {
+		t.Fatalf("transaction phase = %+v, want attention", tx)
+	}
+
+	// Restore the parent branch to its creation-time base and retry.
+	txGit(t, fx.repoDirs[0], "reset", "--hard", fx.parentSHA[0])
+
+	if err := o.RunChildIntegration(fx.child.ID); err != nil {
+		t.Fatalf("runChildIntegration() retry error = %v", err)
+	}
+	_, child = fx.reload()
+	if child.Parent.CloseOutcome != feature.ChildCloseOutcomeCompleted {
+		t.Fatalf("child close outcome = %q, want completed after reset", child.Parent.CloseOutcome)
+	}
+	if child.Parent.Transaction.Phase != feature.TransactionPhaseMerged {
+		t.Fatalf("transaction phase = %s, want merged", child.Parent.Transaction.Phase)
 	}
 }
 

--- a/internal/orchestrator/child_transaction_internal_test.go
+++ b/internal/orchestrator/child_transaction_internal_test.go
@@ -427,6 +427,51 @@ func TestTransactionExternalParentAdvancementParksDrift(t *testing.T) {
 	}
 }
 
+// TestTransactionParentDriftRetryAcknowledges proves drift parks integration
+// exactly once: retrying at the unchanged tip is the operator's acknowledgment
+// and the integration absorbs the moved tip and completes, while any further
+// movement parks again.
+func TestTransactionParentDriftRetryAcknowledges(t *testing.T) {
+	if testing.Short() {
+		t.Skip("real-git integration test")
+	}
+	fx := newMultiRepoTransactionFixture(t, 2)
+	o := fx.orchestrator()
+
+	testutil.CommitFile(t, fx.repoDirs[0], "parent-advance.txt", "external advance\n", "parent advanced")
+
+	if err := o.RunChildIntegration(fx.child.ID); err != nil {
+		t.Fatalf("first runChildIntegration() error = %v, want nil with attention", err)
+	}
+	_, child := fx.reload()
+	if tx := child.Parent.Transaction; tx == nil || tx.Phase != feature.TransactionPhaseAttention {
+		t.Fatalf("transaction phase = %+v, want attention after drift", tx)
+	}
+
+	// Further movement after the drift attention parks again.
+	testutil.CommitFile(t, fx.repoDirs[0], "parent-advance-2.txt", "more external\n", "parent advanced again")
+	if err := o.RunChildIntegration(fx.child.ID); err != nil {
+		t.Fatalf("second runChildIntegration() error = %v, want nil with attention", err)
+	}
+	_, child = fx.reload()
+	tx := child.Parent.Transaction
+	if tx == nil || tx.Phase != feature.TransactionPhaseAttention {
+		t.Fatalf("transaction phase = %+v, want attention after renewed drift", tx)
+	}
+	if entry := tx.EntryByRepo(child.Repos[0].Name); entry == nil || entry.GateCode != feature.GateCodeParentDrift {
+		t.Fatalf("repo 0: gate code = %+v, want %s", entry, feature.GateCodeParentDrift)
+	}
+
+	// Retry at the unchanged tip acknowledges the drift and completes.
+	if err := o.RunChildIntegration(fx.child.ID); err != nil {
+		t.Fatalf("acknowledging runChildIntegration() error = %v", err)
+	}
+	_, child = fx.reload()
+	if child.Parent.CloseOutcome != feature.ChildCloseOutcomeCompleted {
+		t.Fatalf("child close outcome = %q, want completed after acknowledgment", child.Parent.CloseOutcome)
+	}
+}
+
 // TestTransactionParentDriftMultiRepoAggregation proves drift is evaluated
 // for every repository in one preflight: drifted repos carry the typed gate
 // code, clean repos do not, and no candidate is staged for either.

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -324,6 +324,16 @@ func New(deps Deps, hooks Hooks) *Orchestrator {
 			}
 			return o.commitRound(input)
 		}
+		// Phase-exit gate: rebase children re-verify the mechanical rebase
+		// exit facts before the implement loop declares success, surfacing
+		// violations as fix-round feedback instead of failing later at the
+		// integration gate. Non-rebase features get no gate (nil = no-op).
+		o.deps.PhaseRunner.PhaseExitGateFor = func(f *feature.Feature) agent.PhaseExitGate {
+			if f == nil || f.Parent == nil || f.Parent.Kind != feature.ChildKindRebase {
+				return nil
+			}
+			return func() string { return o.rebaseGateFeedback(f) }
+		}
 	}
 	o.runMultiRepoImplFn = func(
 		f *feature.Feature,

--- a/internal/orchestrator/rebase_gate.go
+++ b/internal/orchestrator/rebase_gate.go
@@ -75,6 +75,54 @@ func (o *Orchestrator) rebaseIntegrationGate(child *feature.Feature) *feature.Tr
 	}
 }
 
+// rebaseGateFeedback runs the same per-repo mechanical checks as
+// rebaseIntegrationGate and formats any violations as fix-round feedback for
+// the implement loop, so a violation surfaces the moment the loop is about to
+// declare success instead of at integration. Empty string = every behind
+// repo satisfies the gate. Non-rebase features are never gated.
+func (o *Orchestrator) rebaseGateFeedback(child *feature.Feature) string {
+	if child == nil || child.Parent == nil || child.Parent.Kind != feature.ChildKindRebase {
+		return ""
+	}
+	var b strings.Builder
+	for _, repoName := range child.Parent.RebaseBehind {
+		entry, violation := o.evalRebaseGateRepo(child, repoName)
+		if !violation {
+			continue
+		}
+		fmt.Fprintf(&b, "- **Critical**: repo %s: %s\n", repoName, entry.Diagnostics)
+		if len(entry.ConflictFiles) > 0 {
+			fmt.Fprintf(&b, "  Conflicted files: %s\n", strings.Join(entry.ConflictFiles, ", "))
+		}
+		if fix := rebaseGateRemediation(entry.GateCode); fix != "" {
+			fmt.Fprintf(&b, "  Fix: %s\n", fix)
+		}
+	}
+	if b.Len() == 0 {
+		return ""
+	}
+	return "Mechanical rebase exit checks failed. Each finding below is a deterministic git-level fact " +
+		"verified against the targets persisted at creation time; resolve every violation in the named " +
+		"repo's own worktree before declaring this phase complete.\n\n" + b.String()
+}
+
+// rebaseGateRemediation states what to do about a gate violation as a general
+// principle, keyed by the stable gate code.
+func rebaseGateRemediation(code string) string {
+	switch code {
+	case feature.GateCodeNotAncestor:
+		return "merge the persisted creation-time target commit into the child branch and commit the " +
+			"result; do not substitute a newer or re-resolved target."
+	case feature.GateCodeMergeInProgress:
+		return "finish or abort the in-progress merge/rebase sequencer so the worktree ends on a " +
+			"committed, conflict-free state."
+	case feature.GateCodeConflictMarkers:
+		return "resolve every conflict hunk, remove the literal markers, and commit the resolution."
+	default:
+		return ""
+	}
+}
+
 // evalRebaseGateRepo evaluates the gate for a single behind repo. It returns
 // the journal entry recording any violation and a bool reporting whether the
 // repo violated the gate. The entry's GateCode and Diagnostics classify the

--- a/internal/orchestrator/rebase_gate_feedback_internal_test.go
+++ b/internal/orchestrator/rebase_gate_feedback_internal_test.go
@@ -1,0 +1,143 @@
+// Copyright 2026 DoorDash, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Real-git coverage of the phase-exit rebase gate feedback: the same per-repo
+// mechanical checks the integration gate runs, surfaced as fix-round feedback
+// at the moment the implement loop is about to declare success.
+
+package orchestrator
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/doordash-oss/agentic-orchestrator/internal/agent"
+	"github.com/doordash-oss/agentic-orchestrator/internal/feature"
+)
+
+// TestRebaseGateFeedback_ViolationNamesRepoAndFact verifies a child whose
+// branch does not contain the persisted target produces feedback naming the
+// repo and the violated mechanical fact.
+func TestRebaseGateFeedback_ViolationNamesRepoAndFact(t *testing.T) {
+	fx := newRebaseGateFixture(t, false) // target not merged -> ancestor violation
+	o := fx.orchestrator()
+
+	fb := o.rebaseGateFeedback(fx.child)
+	if fb == "" {
+		t.Fatalf("rebaseGateFeedback = empty, want a violation report")
+	}
+	if !strings.Contains(fb, fx.repos[0].name) {
+		t.Errorf("feedback does not name the violated repo %q:\n%s", fx.repos[0].name, fb)
+	}
+	if !strings.Contains(fb, "not an ancestor") {
+		t.Errorf("feedback does not state the violated mechanical fact:\n%s", fb)
+	}
+}
+
+// TestRebaseGateFeedback_ConflictMarkersListFiles verifies conflict-marker
+// violations carry the offending files in the feedback.
+func TestRebaseGateFeedback_ConflictMarkersListFiles(t *testing.T) {
+	fx := newRebaseGateFixture(t, true)
+	marked := strings.Join([]string{
+		"<" + "<<<<" + "<< ours",
+		"our change",
+		"=" + "=====" + "=",
+		"their change",
+		">" + ">>>>" + ">> theirs",
+	}, "\n") + "\n"
+	if err := os.WriteFile(filepath.Join(fx.repos[0].childWT, "conflicted.txt"), []byte(marked), 0o644); err != nil {
+		t.Fatalf("write conflicted file: %v", err)
+	}
+	childIntegrationGit(t, fx.repos[0].childWT, "add", "conflicted.txt")
+	childIntegrationGit(t, fx.repos[0].childWT, "commit", "-m", "add conflict markers")
+
+	o := fx.orchestrator()
+	fb := o.rebaseGateFeedback(fx.child)
+	if fb == "" {
+		t.Fatalf("rebaseGateFeedback = empty, want a conflict-marker violation")
+	}
+	if !strings.Contains(fb, "conflicted.txt") {
+		t.Errorf("feedback does not list the conflicted file:\n%s", fb)
+	}
+}
+
+// TestRebaseGateFeedback_SatisfiedChildReturnsEmpty verifies a child that
+// merged its persisted target cleanly produces no feedback.
+func TestRebaseGateFeedback_SatisfiedChildReturnsEmpty(t *testing.T) {
+	fx := newRebaseGateFixture(t, true)
+	o := fx.orchestrator()
+
+	if fb := o.rebaseGateFeedback(fx.child); fb != "" {
+		t.Errorf("rebaseGateFeedback = %q, want empty for a satisfied child", fb)
+	}
+}
+
+// TestRebaseGateFeedback_NonRebaseKindsEmpty verifies non-rebase features are
+// never gated.
+func TestRebaseGateFeedback_NonRebaseKindsEmpty(t *testing.T) {
+	fx := newRebaseGateFixture(t, false)
+	o := fx.orchestrator()
+
+	if fb := o.rebaseGateFeedback(nil); fb != "" {
+		t.Errorf("rebaseGateFeedback(nil) = %q, want empty", fb)
+	}
+	plain := &feature.Feature{ID: "plain"}
+	if fb := o.rebaseGateFeedback(plain); fb != "" {
+		t.Errorf("rebaseGateFeedback(non-child) = %q, want empty", fb)
+	}
+	refactor := &feature.Feature{
+		ID:     "refactor-child",
+		Parent: &feature.ChildRelationship{ParentID: "p", Kind: feature.ChildKindRefactor},
+	}
+	if fb := o.rebaseGateFeedback(refactor); fb != "" {
+		t.Errorf("rebaseGateFeedback(refactor child) = %q, want empty", fb)
+	}
+}
+
+// TestNew_PhaseExitGateWiredForRebaseChildrenOnly verifies orchestrator.New
+// installs the phase-exit gate factory: rebase children get a live gate
+// backed by rebaseGateFeedback, everything else gets nil (no-op).
+func TestNew_PhaseExitGateWiredForRebaseChildrenOnly(t *testing.T) {
+	fx := newRebaseGateFixture(t, false)
+	pr := &agent.PhaseRunner{}
+	New(Deps{Lifecycle: fx.mgr, Store: fx.store, Worktrees: fx.wm, PhaseRunner: pr}, Hooks{})
+
+	if pr.PhaseExitGateFor == nil {
+		t.Fatalf("PhaseExitGateFor not wired by New")
+	}
+	gate := pr.PhaseExitGateFor(fx.child)
+	if gate == nil {
+		t.Fatalf("gate = nil for a rebase child, want a live gate")
+	}
+	fb := gate()
+	if fb == "" || !strings.Contains(fb, fx.repos[0].name) {
+		t.Errorf("gate() = %q, want rebaseGateFeedback naming repo %q", fb, fx.repos[0].name)
+	}
+
+	if g := pr.PhaseExitGateFor(nil); g != nil {
+		t.Errorf("gate for nil feature = non-nil, want nil")
+	}
+	if g := pr.PhaseExitGateFor(&feature.Feature{ID: "plain"}); g != nil {
+		t.Errorf("gate for non-child feature = non-nil, want nil")
+	}
+	refactor := &feature.Feature{
+		ID:     "refactor-child",
+		Parent: &feature.ChildRelationship{ParentID: "p", Kind: feature.ChildKindRefactor},
+	}
+	if g := pr.PhaseExitGateFor(refactor); g != nil {
+		t.Errorf("gate for refactor child = non-nil, want nil")
+	}
+}

--- a/test/e2e/rebase_child_journey_test.go
+++ b/test/e2e/rebase_child_journey_test.go
@@ -49,21 +49,21 @@ type rebaseJourneyFixture struct {
 
 // setupRebaseJourneyFixture creates the shared infrastructure for a rebase
 // child journey test with the given number of repos. Each repo is a real git
-// repo with a bare remote. The parent feature is Published with the repos. The
-// scripted implement kernel merges the persisted rebase target into each
-// behind repo's child worktree so the happy path satisfies the mechanical
-// integration gate.
+// repo with a bare remote. The parent feature is Published with the repos.
+// Setup itself merges the persisted rebase target into each behind repo's
+// child worktree, so the happy path needs no rebase-specific stub behavior.
 func setupRebaseJourneyFixture(t *testing.T, parentID string, repos ...rebaseJourneyRepo) *rebaseJourneyFixture {
-	return setupRebaseJourneyFixtureWithOpts(t, parentID, rebaseJourneyFixtureOptions{mergeRebaseTarget: true}, repos...)
+	return setupRebaseJourneyFixtureWithOpts(t, parentID, rebaseJourneyFixtureOptions{}, repos...)
 }
 
 // rebaseJourneyFixtureOptions configures the rebase journey fixture.
 type rebaseJourneyFixtureOptions struct {
-	// mergeRebaseTarget controls the scripted implement kernel. When true the
-	// stub merges the persisted target so the gate passes (happy path). When
-	// false the child branch is left without the target, exercising the gate's
-	// not-ancestor failure.
-	mergeRebaseTarget bool
+	// resetRebaseWorktree makes the implement stub rewrite the child branch
+	// back to its fork point, discarding the setup merge (gate violation).
+	resetRebaseWorktree bool
+	// resolveRebaseConflicts makes the implement stub resolve the in-progress
+	// setup merge and complete the merge commit (conflicting target fixture).
+	resolveRebaseConflicts bool
 	// remote overrides the default failingPRRemoteOps. When nil,
 	// failingPRRemoteOps{} is used.
 	remote orchestrator.RemoteOps
@@ -131,7 +131,10 @@ func setupRebaseJourneyFixtureWithOpts(t *testing.T, parentID string, opts rebas
 
 	sm := session.NewManager(serverEvents)
 	t.Cleanup(sm.Shutdown)
-	pr := journeyChildPhaseRunnerWithOpts(t, sm, store, stateDir, journeyPhaseRunnerOptions{mergeRebaseTarget: opts.mergeRebaseTarget})
+	pr := journeyChildPhaseRunnerWithOpts(t, sm, store, stateDir, journeyPhaseRunnerOptions{
+		resetRebaseWorktree:    opts.resetRebaseWorktree,
+		resolveRebaseConflicts: opts.resolveRebaseConflicts,
+	})
 
 	var remote orchestrator.RemoteOps = failingPRRemoteOps{}
 	if opts.remote != nil {
@@ -235,6 +238,37 @@ func rebaseJourneyRepoSetup(t *testing.T, name, branch string, advanceBase bool)
 	}
 }
 
+// rebaseJourneyRepoSetupConflicting creates a real git repo with a bare
+// remote and a feature branch, then advances main on the remote with a change
+// to the same file the feature branch owns — so merging the resolved target
+// genuinely conflicts.
+func rebaseJourneyRepoSetupConflicting(t *testing.T, name, branch string) rebaseJourneyRepo {
+	t.Helper()
+	repoDir := testutil.InitGitRepo(t)
+	bareRemote := testutil.InitBareRemote(t, repoDir)
+	journeyGit(t, repoDir, "checkout", "-b", branch)
+	writeJourneyFile(t, repoDir, "base.txt", "feature v1\n")
+	journeyGit(t, repoDir, "add", "base.txt")
+	journeyGit(t, repoDir, "commit", "-m", "feature base commit")
+	journeyGit(t, repoDir, "push", "-u", "origin", branch)
+
+	journeyGit(t, repoDir, "checkout", "main")
+	writeJourneyFile(t, repoDir, "base.txt", "upstream conflicting v2\n")
+	journeyGit(t, repoDir, "add", "base.txt")
+	journeyGit(t, repoDir, "commit", "-m", "upstream conflicting change")
+	testutil.SimulatePush(t, repoDir, bareRemote, "main", "main")
+	journeyGit(t, repoDir, "checkout", branch)
+
+	return rebaseJourneyRepo{
+		name:        name,
+		repoDir:     repoDir,
+		branch:      branch,
+		baseBranch:  "main",
+		publishable: true,
+		touched:     true,
+	}
+}
+
 // TestRebaseChildHappyPathJourney verifies the complete rebase child flow:
 // behind feature → rebase action → child of kind "rebase" with medium
 // pipeline, generated content, persisted targets/behind set, fork-point-
@@ -313,16 +347,35 @@ func TestRebaseChildHappyPathJourney(t *testing.T) {
 		t.Fatalf("child base SHA = %v, want captured parent tip %s", baseEntry["sha"], capturedHEAD)
 	}
 
+	// Setup performed the merge mechanically: the merge task is Done and the
+	// child worktree already contains the persisted target.
+	child, err = fx.store.Load(childID)
+	if err != nil {
+		t.Fatalf("Load(child after setup) error = %v", err)
+	}
+	if task := child.Run().Setup.Tasks["merge:repoA"]; task.Status != feature.SetupStatusDone {
+		t.Fatalf("merge setup task = %+v, want done", task)
+	}
+	childWorktree := child.Repos[0].WorktreePath
+	if childWorktree == "" {
+		t.Fatalf("child worktree path missing after setup: %+v", child.Repos[0])
+	}
+	journeyGit(t, childWorktree, "merge-base", "--is-ancestor", target.TargetSHA, "HEAD")
+
 	// Assert generated content: description names the behind repo and target,
-	// contains merge instructions, forbids pushing and fetching.
+	// is worktree-anchored (never naming a branch), states the merge already
+	// happened, and forbids pushing and fetching.
 	if !strings.Contains(child.Description, "repoA") {
 		t.Fatalf("description missing repoA: %q", child.Description)
 	}
 	if !strings.Contains(child.Description, "main") {
 		t.Fatalf("description missing target 'main': %q", child.Description)
 	}
-	if !strings.Contains(child.Description, "merge") {
-		t.Fatalf("description missing merge instruction: %q", child.Description)
+	if !strings.Contains(child.Description, "already been merged into the branch checked out in this repository's worktree") {
+		t.Fatalf("description missing worktree-anchored merged-in-setup statement: %q", child.Description)
+	}
+	if strings.Contains(child.Description, branch) {
+		t.Fatalf("description names the parent branch %q: %q", branch, child.Description)
 	}
 	if !strings.Contains(child.Description, "Never push") {
 		t.Fatalf("description missing no-push instruction: %q", child.Description)
@@ -330,13 +383,25 @@ func TestRebaseChildHappyPathJourney(t *testing.T) {
 	if !strings.Contains(child.Description, "Do not fetch") {
 		t.Fatalf("description missing no-fetch instruction: %q", child.Description)
 	}
+	if !strings.Contains(child.Description, "worktrees provisioned for this pass") {
+		t.Fatalf("description missing worktree confinement invariant: %q", child.Description)
+	}
 
-	// Assert exit criteria contain the git-level completion facts.
-	if !strings.Contains(child.ExitCriteria, "ancestor") {
+	// Assert exit criteria contain the worktree-anchored git-level completion facts.
+	if !strings.Contains(child.ExitCriteria, "git merge-base --is-ancestor") {
 		t.Fatalf("exit criteria missing ancestor check: %q", child.ExitCriteria)
+	}
+	if !strings.Contains(child.ExitCriteria, "this repository's worktree") {
+		t.Fatalf("exit criteria missing worktree anchoring: %q", child.ExitCriteria)
+	}
+	if strings.Contains(child.ExitCriteria, branch) {
+		t.Fatalf("exit criteria name the parent branch %q: %q", branch, child.ExitCriteria)
 	}
 	if !strings.Contains(child.ExitCriteria, "conflict markers") {
 		t.Fatalf("exit criteria missing conflict markers check: %q", child.ExitCriteria)
+	}
+	if !strings.Contains(child.ExitCriteria, "No other checkout of any repository was modified") {
+		t.Fatalf("exit criteria missing other-checkout invariant: %q", child.ExitCriteria)
 	}
 	if !strings.Contains(child.ExitCriteria, "Nothing was pushed") {
 		t.Fatalf("exit criteria missing no-push invariant: %q", child.ExitCriteria)
@@ -720,9 +785,10 @@ func TestRebaseChildTargetPrecedenceDefaultBranch(t *testing.T) {
 // TestRebaseChildGateAncestorFailureJourney verifies the e2e gate failure: a
 // rebase child whose branch does not contain its persisted target commit
 // fails integration with the typed gate attention record, and every parent
-// ref is byte-identical before and after. The scripted implement kernel is
-// configured to NOT merge the target, so the child branch remains behind the
-// creation-time target and the gate's ancestor check fails.
+// ref is byte-identical before and after. Setup merges the target
+// mechanically, so the scripted implement kernel produces a violation setup
+// cannot prevent: it rewrites the child branch back to its fork point,
+// discarding the merge, and the gate's ancestor check fails.
 func TestRebaseChildGateAncestorFailureJourney(t *testing.T) {
 	if testing.Short() {
 		t.Skip("journey boots real-git setup and scripted provider subprocesses")
@@ -731,7 +797,7 @@ func TestRebaseChildGateAncestorFailureJourney(t *testing.T) {
 	const parentID = "rebase-gate-fail-parent"
 	const branch = "feature/rebase-gate-fail"
 	repo := rebaseJourneyRepoSetup(t, "repoA", branch, true)
-	fx := setupRebaseJourneyFixtureWithOpts(t, parentID, rebaseJourneyFixtureOptions{mergeRebaseTarget: false}, repo)
+	fx := setupRebaseJourneyFixtureWithOpts(t, parentID, rebaseJourneyFixtureOptions{resetRebaseWorktree: true}, repo)
 
 	// Capture the parent branch ref before the child runs integration.
 	parentRefBefore := journeyGit(t, repo.repoDir, "rev-parse", branch)
@@ -803,6 +869,80 @@ func TestRebaseChildGateAncestorFailureJourney(t *testing.T) {
 	}
 }
 
+// TestRebaseChildConflictResolutionJourney is the end-to-end proof of the
+// setup-merge design on the conflict path: a genuinely conflicting target
+// leaves an in-progress merge in the child worktree after setup (with the
+// merge task still Done and the child startable), the implement stub resolves
+// the conflicts and completes the merge commit, and the journey lands through
+// the integration gate.
+func TestRebaseChildConflictResolutionJourney(t *testing.T) {
+	if testing.Short() {
+		t.Skip("journey boots real-git setup and scripted provider subprocesses")
+	}
+
+	const parentID = "rebase-conflict-parent"
+	const branch = "feature/rebase-conflict"
+	repo := rebaseJourneyRepoSetupConflicting(t, "repoA", branch)
+	fx := setupRebaseJourneyFixtureWithOpts(t, parentID, rebaseJourneyFixtureOptions{resolveRebaseConflicts: true}, repo)
+
+	resp, err := fx.client.RebaseFeature(t.Context(), parentID)
+	if err != nil {
+		t.Fatalf("RebaseFeature() error = %v", err)
+	}
+	childID := resp.FeatureID
+
+	// Setup completes despite the conflicted merge and parks the child ready
+	// to start, with the in-progress merge left in the child worktree.
+	waitForJourneySetupComplete(t, fx.srv.URL, childID)
+	child, err := fx.store.Load(childID)
+	if err != nil {
+		t.Fatalf("Load(child) error = %v", err)
+	}
+	if task := child.Run().Setup.Tasks["merge:repoA"]; task.Status != feature.SetupStatusDone {
+		t.Fatalf("merge setup task = %+v, want done despite conflicts", task)
+	}
+	childWorktree := child.Repos[0].WorktreePath
+	if _, err := journeyGitIn(childWorktree, "rev-parse", "--verify", "MERGE_HEAD"); err != nil {
+		t.Fatalf("no in-progress merge (MERGE_HEAD) in child worktree after setup: %v", err)
+	}
+	conflicted, err := os.ReadFile(filepath.Join(childWorktree, "base.txt"))
+	if err != nil {
+		t.Fatalf("read conflicted file: %v", err)
+	}
+	if !strings.Contains(string(conflicted), "<<<<<<<") {
+		t.Fatalf("conflicted file has no conflict markers after setup:\n%s", conflicted)
+	}
+
+	// Drive the child to completion: the stub resolves the conflicts and
+	// completes the merge commit, so the gate passes.
+	postAction(t, fx.srv.URL, childID, "start", `{}`)
+	waitForJourneyGate(t, fx.srv.URL, childID, 0)
+	postReviewSessionProceed(t, fx.srv.URL, childID)
+	waitForJourneyGate(t, fx.srv.URL, childID, 1)
+	postReviewSessionProceed(t, fx.srv.URL, childID)
+	waitForJourneyChildClosed(t, fx.srv.URL, fx.store, childID)
+
+	// The parent branch contains the creation-time target and the resolved
+	// content, with no conflict markers or in-progress merge.
+	target := child.Parent.RebaseTargets[0]
+	journeyGit(t, repo.repoDir, "merge-base", "--is-ancestor", target.TargetSHA, "HEAD")
+	resolved, err := os.ReadFile(filepath.Join(repo.repoDir, "base.txt"))
+	if err != nil {
+		t.Fatalf("read resolved file in parent: %v", err)
+	}
+	if strings.Contains(string(resolved), "<<<<<<<") {
+		t.Fatalf("parent still has conflict markers:\n%s", resolved)
+	}
+	if _, err := os.Stat(filepath.Join(repo.repoDir, "child-output.txt")); err != nil {
+		t.Fatalf("child work missing from parent after integration: %v", err)
+	}
+
+	childDetail := getJourneyJSON(t, fx.srv.URL+"/api/v1/features/"+childID)["feature"].(map[string]any)
+	if childDetail["close_outcome"] != feature.ChildCloseOutcomeCompleted {
+		t.Fatalf("child close_outcome = %v, want completed", childDetail["close_outcome"])
+	}
+}
+
 // prBaseBranchRemoteOps wraps failingPRRemoteOps but returns a fixed PR base
 // branch, simulating a GitHub PR whose base is a non-default branch.
 type prBaseBranchRemoteOps struct {
@@ -845,8 +985,7 @@ func TestRebaseChildPRBaseBranchPrecedenceJourney(t *testing.T) {
 	repo.prURL = "https://github.com/example/repoA/pull/1"
 
 	fx := setupRebaseJourneyFixtureWithOpts(t, parentID, rebaseJourneyFixtureOptions{
-		mergeRebaseTarget: true,
-		remote:            prBaseBranchRemoteOps{baseBranch: prBase},
+		remote: prBaseBranchRemoteOps{baseBranch: prBase},
 	}, repo)
 
 	// Launch the rebase action.

--- a/test/e2e/refactor_child_execution_journey_helpers_test.go
+++ b/test/e2e/refactor_child_execution_journey_helpers_test.go
@@ -71,12 +71,15 @@ func journeyChildPhaseRunner(t *testing.T, sm *session.Manager, store *feature.S
 
 // journeyPhaseRunnerOptions configures the scripted phase runner.
 type journeyPhaseRunnerOptions struct {
-	// mergeRebaseTarget, when true, makes the implement stub merge the
-	// persisted creation-time target ref into each behind repo's child
-	// worktree so the rebase child satisfies the mechanical integration
-	// gate's ancestor check. False leaves the child branch without the
-	// target commit (used to exercise the gate's not-ancestor failure).
-	mergeRebaseTarget bool
+	// resetRebaseWorktree makes the implement stub rewrite each behind repo's
+	// child branch back to its captured fork point, discarding the merge
+	// setup performed — a violation setup cannot prevent, exercising the
+	// gate's not-ancestor failure.
+	resetRebaseWorktree bool
+	// resolveRebaseConflicts makes the implement stub resolve the in-progress
+	// merge setup left in each behind repo's child worktree (conflicting
+	// target fixture) and complete the merge commit.
+	resolveRebaseConflicts bool
 }
 
 // journeyChildPhaseRunnerWithOpts is the configurable core of
@@ -126,6 +129,34 @@ func journeyChildPhaseRunnerWithOpts(t *testing.T, sm *session.Manager, store *f
 		}, nil
 	}
 	pr.RunImplementFn = func(c agent.ImplementConfig, _ ports.SessionManager) (*agent.LoopResult, error) {
+		// Setup already merged each behind repo's rebase target, so the stub
+		// only manipulates the worktree when a journey needs a violation
+		// (reset to the fork point) or a conflict resolution.
+		if c.Feature.Parent != nil && c.Feature.Parent.Kind == feature.ChildKindRebase {
+			for _, repo := range c.Feature.Repos {
+				if !c.Feature.IsRebaseBehindRepo(repo.Name) {
+					continue
+				}
+				wt := repo.WorktreePath
+				if wt == "" {
+					wt = repo.Path
+				}
+				if opts.resetRebaseWorktree {
+					base := c.Feature.BaseSHA(repo.Name)
+					if base == "" {
+						return nil, fmt.Errorf("rebase journey stub: no captured base for %s", repo.Name)
+					}
+					if _, err := journeyGitIn(wt, "reset", "--hard", base); err != nil {
+						return nil, fmt.Errorf("rebase journey stub reset %s: %w", repo.Name, err)
+					}
+				}
+				if opts.resolveRebaseConflicts {
+					if err := journeyResolveRebaseConflicts(wt); err != nil {
+						return nil, fmt.Errorf("rebase journey stub resolve %s: %w", repo.Name, err)
+					}
+				}
+			}
+		}
 		// Stand in for the implement kernel: leave one real change in the
 		// child worktree for the integration boundary to commit and merge.
 		for _, repo := range c.Feature.Repos {
@@ -140,35 +171,6 @@ func journeyChildPhaseRunnerWithOpts(t *testing.T, sm *session.Manager, store *f
 			}
 			if err := os.WriteFile(filepath.Join(wt, "child-output.txt"), []byte("child work\n"), 0o644); err != nil {
 				return nil, fmt.Errorf("write child output: %w", err)
-			}
-		}
-		// For a rebase child, the implement kernel is expected to merge the
-		// creation-time target into each behind repo's working branch. The
-		// mechanical integration gate re-verifies the result, so the stub
-		// must actually land the merge (cleanly, against a non-conflicting
-		// target) for the happy path to pass the gate. When
-		// mergeRebaseTarget is false the stub leaves the branch without the
-		// target, exercising the gate's not-ancestor failure.
-		if opts.mergeRebaseTarget && c.Feature.Parent != nil && c.Feature.Parent.Kind == feature.ChildKindRebase {
-			behind := make(map[string]bool, len(c.Feature.Parent.RebaseBehind))
-			for _, r := range c.Feature.Parent.RebaseBehind {
-				behind[r] = true
-			}
-			for _, repo := range c.Feature.Repos {
-				if !behind[repo.Name] {
-					continue
-				}
-				wt := repo.WorktreePath
-				if wt == "" {
-					wt = repo.Path
-				}
-				tgt, ok := c.Feature.RebaseTargetForRepo(repo.Name)
-				if !ok || tgt.Ref == "" {
-					return nil, fmt.Errorf("rebase journey stub: no persisted target for %s", repo.Name)
-				}
-				if err := journeyMergeRebaseTarget(t, wt, tgt.Ref); err != nil {
-					return nil, fmt.Errorf("rebase journey stub merge %s: %w", repo.Name, err)
-				}
 			}
 		}
 		return &agent.LoopResult{FinalStatus: "review_passed", Iterations: 1}, nil
@@ -191,20 +193,43 @@ func journeyChildPhaseRunnerWithOpts(t *testing.T, sm *session.Manager, store *f
 	return pr
 }
 
-// journeyMergeRebaseTarget merges the persisted target ref into the child
-// worktree's current branch with a no-ff merge commit, using the test git
-// identity. It assumes a non-conflicting target (the journey repos diverge on
-// disjoint files).
-func journeyMergeRebaseTarget(t *testing.T, worktreePath, ref string) error {
-	t.Helper()
-	cmd := exec.Command("git", "-C", worktreePath, "merge", "--no-ff", "-m",
-		"journey stub: merge rebase target "+ref, ref)
+// journeyGitIn runs one git command in a worktree with the test identity,
+// returning trimmed combined output.
+func journeyGitIn(worktreePath string, args ...string) (string, error) {
+	cmd := exec.Command("git", append([]string{"-C", worktreePath}, args...)...)
 	cmd.Env = append(testutil.GitTestEnv(),
 		"GIT_AUTHOR_NAME=Test", "GIT_AUTHOR_EMAIL=test@test.com",
 		"GIT_COMMITTER_NAME=Test", "GIT_COMMITTER_EMAIL=test@test.com",
 	)
-	if out, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("git merge %s: %v\n%s", ref, err, out)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("git %s: %v\n%s", strings.Join(args, " "), err, out)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// journeyResolveRebaseConflicts completes the in-progress merge setup left in
+// the worktree: every conflicted file is rewritten with resolved content and
+// the merge commit is completed.
+func journeyResolveRebaseConflicts(worktreePath string) error {
+	conflicted, err := journeyGitIn(worktreePath, "diff", "--name-only", "--diff-filter=U")
+	if err != nil {
+		return err
+	}
+	files := strings.Fields(conflicted)
+	if len(files) == 0 {
+		return fmt.Errorf("no in-progress merge conflicts in %s", worktreePath)
+	}
+	for _, f := range files {
+		if err := os.WriteFile(filepath.Join(worktreePath, f), []byte("resolved by journey stub\n"), 0o644); err != nil {
+			return fmt.Errorf("resolve %s: %w", f, err)
+		}
+	}
+	if _, err := journeyGitIn(worktreePath, "add", "-A"); err != nil {
+		return err
+	}
+	if _, err := journeyGitIn(worktreePath, "commit", "--no-edit"); err != nil {
+		return err
 	}
 	return nil
 }

--- a/test/e2e/refactor_child_transactional_multirepo_journey_test.go
+++ b/test/e2e/refactor_child_transactional_multirepo_journey_test.go
@@ -421,9 +421,19 @@ func TestRefactorChildTransactionalMultiRepoStagedConflictRestartAndReviewRenewa
 		preRefs[i] = fx.refSHA(i, "refs/heads/feature/parent")
 	}
 
-	// Initial integration attempt: hits a conflict on repo 1.
+	// Initial integration attempt: parks once on parent-ref drift (the
+	// conflicting parent commit moved the tip); the retry acknowledges it.
 	if err := o.RunChildIntegration(fx.child.ID); err != nil {
-		t.Fatalf("RunChildIntegration() error = %v, want nil with attention", err)
+		t.Fatalf("RunChildIntegration() error = %v, want nil with drift attention", err)
+	}
+	_, child := fx.reload()
+	if entry := child.Parent.Transaction.EntryByRepo(child.Repos[1].Name); entry == nil || entry.GateCode != feature.GateCodeParentDrift {
+		t.Fatalf("repo 1: gate code = %+v, want %s", entry, feature.GateCodeParentDrift)
+	}
+
+	// Acknowledged retry: hits the staged conflict on repo 1.
+	if err := o.RunChildIntegration(fx.child.ID); err != nil {
+		t.Fatalf("RunChildIntegration() retry error = %v, want nil with attention", err)
 	}
 
 	// All parent refs unchanged.
@@ -433,7 +443,7 @@ func TestRefactorChildTransactionalMultiRepoStagedConflictRestartAndReviewRenewa
 		}
 	}
 
-	_, child := fx.reload()
+	_, child = fx.reload()
 	tx := child.Parent.Transaction
 	if tx == nil || tx.Phase != feature.TransactionPhaseAttention {
 		t.Fatalf("transaction phase = %+v, want attention", tx)
@@ -513,6 +523,16 @@ func TestRefactorChildTransactionalMultiRepoStagedConflictRestartAndReviewRenewa
 	// background cycle goroutine; wait for it before asserting the terminal
 	// integration outcome.
 	o.WaitForCycles()
+
+	// Review invalidation wiped the journal, so the moved parent tips are
+	// re-observed as drift and park once more; the retry acknowledges them.
+	_, child = fx.reload()
+	if tx := child.Parent.Transaction; tx == nil || tx.Phase != feature.TransactionPhaseAttention {
+		t.Fatalf("transaction phase = %+v, want drift attention after review renewal", tx)
+	}
+	if err := o.RunChildIntegration(fx.child.ID); err != nil {
+		t.Fatalf("RunChildIntegration() acknowledging retry error = %v", err)
+	}
 
 	// The transaction should complete: child is Completed, parent is
 	// CodeReady, and every repo has an explicit merge boundary.
@@ -1118,10 +1138,24 @@ func TestRefactorChildTransactionalMultiRepoCrashCutPointConvergence(t *testing.
 				t.Fatalf("ReconcileIntegrationTransactions after rollback fail at %d: %v", tc.failAt, err)
 			}
 
-			// Re-enter the integration boundary to complete any
-			// remaining work.
+			// Re-enter the integration boundary. The externally raced
+			// ref is re-observed as parent drift and parks once; the
+			// retry acknowledges it and completes the remaining work.
 			if err := freshO.RunChildIntegration(fx.child.ID); err != nil {
 				t.Fatalf("RunChildIntegration after rollback reconcile (fail at %d): %v", tc.failAt, err)
+			}
+			if _, c := fx.reload(); c.Parent.Transaction != nil &&
+				c.Parent.Transaction.Phase == feature.TransactionPhaseAttention {
+				drifted := false
+				for _, entry := range c.Parent.Transaction.Entries {
+					drifted = drifted || entry.GateCode == feature.GateCodeParentDrift
+				}
+				if !drifted {
+					t.Fatalf("rollback fail at %d: attention without drift entries: %+v", tc.failAt, c.Parent.Transaction)
+				}
+				if err := freshO.RunChildIntegration(fx.child.ID); err != nil {
+					t.Fatalf("RunChildIntegration acknowledging drift (fail at %d): %v", tc.failAt, err)
+				}
 			}
 
 			// Verify convergence: child is Completed, parent is


### PR DESCRIPTION
## Problem

A rebase pass failed its integration gate with `rebase gate: creation-time target main is not an ancestor of the child branch head` — after nine hours of green reviews. The post-mortem found four defects conspiring:

1. **The generated prompt named the parent's branch** as "the working branch" (`rebaseDescription` embedded `parent.Repos[i].Branch`), while the child works on its own branch/worktree. The agent obediently located that branch — checked out in the parent's worktree — merged there, and left the child worktree "untouched".
2. **The exit criteria verified the same wrong place** ("the working-branch head"), so every review pass honestly confirmed the wrong checkout.
3. **Nothing detected the parent ref moving mid-pass.** The parent is locked while a child runs, yet candidate preparation anchored to whatever tip it found — silently absorbing foreign commits.
4. **The mechanical truth only surfaced at integration**, hours after the divergence began.

## Fixes (defense in depth)

**A — the merge is mechanical now.** Setup runs a durable `merge:<repo>` task per behind repo: the creation-time pinned target SHA (exactly what the gate later checks) is merged into the child worktree via a new `git.MergeInto` helper. Clean merges commit; conflicted merges intentionally leave the sequencer in progress for the pass to resolve. Deterministic git surgery is no longer delegated to an agent.

**B — generated text anchors to worktrees, never branches.** `rebaseDescription`/`rebaseExitCriteria` state every instruction and completion fact against "this repository's worktree" / `HEAD` — byte-for-byte what the integration gate verifies — and all child prompt families now carry a confinement invariant: other checkouts of the same repositories are off-limits.

**C — parent-ref drift is a typed gate.** Candidate preparation compares each parent tip to its creation-time base (`Parent.Bases`) for every child kind. Movement the transaction didn't produce parks integration with `parent_ref_drift` and per-repo diagnostics. Drift parks exactly once per observation: retrying at the unchanged tip is the operator's explicit acknowledgment to absorb it (legitimate collaboration keeps a path forward; an escape surfaces loudly). Candidate provenance is carried across the journal overwrite so crash-recovery convergence stays bounded.

**D — the gate also runs at phase exit.** The implement loop invokes an orchestrator-installed `PhaseExitGate` at both success exits; violations become fix-round feedback with remediation hints instead of a dead pass at integration. Bounded by the existing no-progress/iteration rails; nil for non-rebase features.

## Behavior change

External parent movement during a pass was previously absorbed silently by rebuilding candidates. It now parks integration once with a typed attention record; one retry acknowledges and absorbs it. Crash-recovery journeys were updated accordingly.

## Testing

- TDD throughout: every new test observed failing before its implementation.
- New: `MergeInto` real-git suite (conflict-in-place, idempotent re-entry, identity fallback), setup merge-task suite (clean/conflict/retry/non-rebase), drift gate suite (park, aggregate, acknowledge-on-retry, partial-apply exemption), phase-exit gate loop tests (fix round, rail bound, nil no-op), gate feedback formatting, prompt-text pins (no branch names), and a new e2e conflict-resolution journey (setup leaves merge in progress → stub resolves → gate passes → resolved content lands in the parent).
- Updated: gate-failure journey (history rewrite instead of "forgot to merge"), crash cut-point convergence matrix, restart/review-renewal journey.
- `make test-fast`, `make lint`, `go test ./test/integration/...`, `go test ./test/e2e/... -race` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
