### PR TITLE
Stop badging the AMA chat's idle wait as attention

### DIFF
--- a/desktop/src/main/__tests__/notifications.test.ts
+++ b/desktop/src/main/__tests__/notifications.test.ts
@@ -65,6 +65,14 @@ describe('AttentionNotificationCoordinator', () => {
         },
         {
           kind: 'help',
+          id: '__chat__:',
+          sessionId: '__chat__',
+          waitingSince: '2026-07-22T12:00:30.000Z',
+          prompt: 'Agent has a question',
+          waitingKind: 'input',
+        },
+        {
+          kind: 'help',
           id: 'feature-2:sess-2',
           featureId: 'feature-2',
           waitingSince: '2026-07-22T12:01:00.000Z',

--- a/desktop/src/main/notifications.ts
+++ b/desktop/src/main/notifications.ts
@@ -99,7 +99,7 @@ function previewSummary(item: ActionableAttentionItem): string {
     case 'gate':
       return item.summary === undefined ? '' : ` · ${item.summary}`;
     case 'help':
-      // Synthetic (waitingKind 'input') items are filtered before notifying.
+      // Synthetic ('input'/'coordinating') items are filtered before notifying.
       return ' · Help request';
     case 'review':
       return ` · ${item.reviewKind} review`;

--- a/desktop/src/renderer/src/App.tsx
+++ b/desktop/src/renderer/src/App.tsx
@@ -66,6 +66,8 @@ export default function App() {
   // Owned here so the sidebar footer can show the mock's active-session state
   // while the panel itself owns the singleton chat session.
   const [amaSessionActive, setAmaSessionActive] = useState(false);
+  // A reply that landed while the panel was closed, echoed on the Ask chip.
+  const [amaUnread, setAmaUnread] = useState(false);
   const [updateDismissedVersion, setUpdateDismissedVersion] = useState<string | null>(null);
   const [schedulingUpdate, setSchedulingUpdate] = useState(false);
   const routeSequence = useRef(0);
@@ -214,6 +216,7 @@ export default function App() {
             onOpenAma={() => requestRoute({ target: 'ama' })}
             onOpenPalette={() => requestRoute({ target: 'palette' })}
             amaSessionActive={amaSessionActive}
+            amaUnread={amaUnread}
             onInstallUpdateWhenIdle={async () => {
               try {
                 setSchedulingUpdate(true);
@@ -230,6 +233,7 @@ export default function App() {
             setAttentionDrafts={setAttentionDrafts}
             routeRequest={routeRequest}
             onSessionActiveChange={setAmaSessionActive}
+            onUnreadChange={setAmaUnread}
           />
         </>
       ) : (

--- a/desktop/src/renderer/src/components/AmaPanel.test.tsx
+++ b/desktop/src/renderer/src/components/AmaPanel.test.tsx
@@ -241,6 +241,51 @@ describe('AmaPanel capabilities', () => {
     ).toBeInTheDocument();
   });
 
+  it('keeps the idle between-turn wait out of the pending strip and the suffix', async () => {
+    installAgenticoMock({
+      settings: settingsWithAma({ drawer: 'expanded' }),
+      session: activeChatSession(),
+    });
+    render(panelElement({ attentionItems: [chatIdleWaitItem()] }));
+
+    expect(await screen.findByText('Active')).toBeVisible();
+    expect(screen.queryByText(/pending/)).not.toBeInTheDocument();
+    expect(screen.queryByText('Agent is waiting')).not.toBeInTheDocument();
+  });
+
+  it('reports unread only for a reply that lands while the panel is closed', async () => {
+    const mock = installAgenticoMock();
+    const onUnreadChange = vi.fn();
+    const { rerender } = render(panelElement({ onUnreadChange }));
+    await waitFor(() => expect(mock.api.getSettings).toHaveBeenCalled());
+    expect(onUnreadChange).toHaveBeenLastCalledWith(false);
+
+    // A turn ends while closed: the wait appears with a fresh timestamp.
+    rerender(panelElement({ onUnreadChange, attentionItems: [chatIdleWaitItem()] }));
+    expect(onUnreadChange).toHaveBeenLastCalledWith(true);
+
+    // Opening the panel is what marks the reply as seen.
+    pressOptionSpace();
+    await screen.findByRole('complementary', { name: 'Ask Agentico' });
+    expect(onUnreadChange).toHaveBeenLastCalledWith(false);
+
+    // Closing again over the same wait stays read…
+    pressOptionSpace();
+    await waitFor(() =>
+      expect(screen.queryByRole('complementary', { name: 'Ask Agentico' })).not.toBeInTheDocument(),
+    );
+    expect(onUnreadChange).toHaveBeenLastCalledWith(false);
+
+    // …until the next turn ends while closed.
+    rerender(
+      panelElement({
+        onUnreadChange,
+        attentionItems: [chatIdleWaitItem('2026-07-21T00:10:00Z')],
+      }),
+    );
+    expect(onUnreadChange).toHaveBeenLastCalledWith(true);
+  });
+
   it('reads Read-only transcript once an ended session still has messages', async () => {
     installAgenticoMock({
       settings: settingsWithAma({ drawer: 'expanded' }),
@@ -557,6 +602,7 @@ function panelElement(
   overrides: {
     attentionItems?: AttentionItem[];
     routeRequest?: Parameters<typeof AmaPanel>[0]['routeRequest'];
+    onUnreadChange?: (unread: boolean) => void;
   } = {},
 ) {
   return (
@@ -565,6 +611,9 @@ function panelElement(
       refreshAttention={() => Promise.resolve(overrides.attentionItems ?? [])}
       setAttentionDrafts={vi.fn()}
       routeRequest={overrides.routeRequest ?? null}
+      {...(overrides.onUnreadChange === undefined
+        ? {}
+        : { onUnreadChange: overrides.onUnreadChange })}
     />
   );
 }
@@ -607,6 +656,18 @@ const chatQuestionItem: AttentionItem = {
     },
   ],
 };
+
+/** The chat's idle between-turn wait: a delivered reply, not a pending ask. */
+function chatIdleWaitItem(waitingSince = '2026-07-21T00:05:00Z'): AttentionItem {
+  return {
+    kind: 'help',
+    id: '__chat__:',
+    sessionId: '__chat__',
+    waitingSince,
+    prompt: 'Agent has a question',
+    waitingKind: 'input',
+  };
+}
 
 function activeChatSession(overrides: Record<string, unknown> = {}) {
   return {

--- a/desktop/src/renderer/src/components/AmaPanel.tsx
+++ b/desktop/src/renderer/src/components/AmaPanel.tsx
@@ -15,6 +15,7 @@ import {
   CHAT_SESSION_ID,
   CREATION_IMAGE_LIMIT,
   defaultAmaGeometry,
+  isSyntheticHelpItem,
   isTerminalChatStatus,
   type AmaGeometry,
   type AttentionItem,
@@ -94,6 +95,7 @@ export function AmaPanel({
   setAttentionDrafts,
   routeRequest,
   onSessionActiveChange,
+  onUnreadChange,
 }: {
   attentionItems: AttentionItem[];
   refreshAttention(): Promise<AttentionItem[]>;
@@ -102,6 +104,8 @@ export function AmaPanel({
   routeRequest: RoutedRequest | null;
   /** Lets the shell's sidebar footer show the active-session state. */
   onSessionActiveChange?(active: boolean): void;
+  /** Lets the shell's Ask chip mark a reply that landed while the panel was closed. */
+  onUnreadChange?(unread: boolean): void;
 }) {
   const [open, setOpen] = useState(false);
   const [geometry, setGeometry] = useState<AmaGeometry>(defaultAmaGeometry());
@@ -147,11 +151,25 @@ export function AmaPanel({
   // block sending until removed (or switched back to).
   const uploadsBlocking = imageUploads.some((item) => isBlockingStagedItem(item, serverKey));
 
+  // Real asks only (questions, permissions): the chat's idle wait between
+  // turns is its resting state, and the composer below is how it continues.
   const amaAttentionItems = useMemo(
     () =>
-      attentionItems.filter((item) => 'sessionId' in item && item.sessionId === CHAT_SESSION_ID),
+      attentionItems.filter(
+        (item) =>
+          'sessionId' in item && item.sessionId === CHAT_SESSION_ID && !isSyntheticHelpItem(item),
+      ),
     [attentionItems],
   );
+  // The chat's idle wait doubles as the reply-delivered signal: it appears
+  // exactly when a turn ends, with a fresh waitingSince per turn.
+  const idleWaitingSince = useMemo(() => {
+    const wait = attentionItems.find(
+      (item) =>
+        item.kind === 'help' && item.sessionId === CHAT_SESSION_ID && item.waitingKind === 'input',
+    );
+    return wait?.waitingSince ?? null;
+  }, [attentionItems]);
   const sessionActive = session !== null && !isTerminalChatStatus(session.status);
   const conversation = useMemo(
     () =>
@@ -176,6 +194,22 @@ export function AmaPanel({
   useEffect(() => {
     onSessionActiveChange?.(sessionActive);
   }, [onSessionActiveChange, sessionActive]);
+
+  // Unread means a reply landed while the panel was closed: an open panel
+  // marks the current turn's wait as seen, so only a wait the user hasn't had
+  // in front of them raises the chip dot. Session-local by design — a restart
+  // starts unseen.
+  const seenIdleWaitingSince = useRef<string | null>(null);
+  useEffect(() => {
+    if (open) {
+      if (idleWaitingSince !== null) seenIdleWaitingSince.current = idleWaitingSince;
+      onUnreadChange?.(false);
+      return;
+    }
+    onUnreadChange?.(
+      idleWaitingSince !== null && idleWaitingSince !== seenIdleWaitingSince.current,
+    );
+  }, [idleWaitingSince, onUnreadChange, open]);
 
   const persistPrefs = useCallback((next: { open?: boolean; geometry?: AmaGeometry }): void => {
     const nextOpen = next.open ?? openRef.current;

--- a/desktop/src/renderer/src/components/ReadinessGate.tsx
+++ b/desktop/src/renderer/src/components/ReadinessGate.tsx
@@ -41,6 +41,7 @@ export function ReadinessGate({
   onOpenAma = () => {},
   onOpenPalette = () => {},
   amaSessionActive = false,
+  amaUnread = false,
 }: {
   attentionDrafts?: AttentionDrafts;
   setAttentionDrafts?: Dispatch<SetStateAction<AttentionDrafts>>;
@@ -65,6 +66,7 @@ export function ReadinessGate({
   /** Owned by App: dispatches the same 'palette' routeRequest ⌘K resolves to. */
   onOpenPalette?(): void;
   amaSessionActive?: boolean;
+  amaUnread?: boolean;
 }) {
   const [state, setState] = useState<GateState>({ phase: 'loading' });
 
@@ -130,6 +132,7 @@ export function ReadinessGate({
         onOpenAma={onOpenAma}
         onOpenPalette={onOpenPalette}
         amaSessionActive={amaSessionActive}
+        amaUnread={amaUnread}
       />
     );
   }

--- a/desktop/src/renderer/src/features/AttentionInbox.test.tsx
+++ b/desktop/src/renderer/src/features/AttentionInbox.test.tsx
@@ -598,14 +598,15 @@ describe('AttentionInbox help detail', () => {
     expect(screen.getByText('No blocking input is waiting.')).toBeVisible();
   });
 
-  // A chat session's wait is the user's turn and the inbox is the only place to
-  // answer it — only phase coordination is filtered out.
-  it('keeps a chat session waiting on the user in the rows and the badge', async () => {
+  // A chat resting after a reply is its normal state, not blocking input: the
+  // AMA panel is its reply surface, so the inbox and the badge stay quiet.
+  it('keeps a chat session waiting on the user out of the rows and the badge', async () => {
     render(<Harness items={[{ ...helpWaitingItem, waitingKind: 'input' }]} onJump={vi.fn()} />);
     const user = userEvent.setup();
 
-    await user.click(screen.getByRole('button', { name: /Attention inbox, 1 pending/ }));
-    expect(screen.getByRole('button', { name: /Agent waiting/ })).toBeVisible();
+    await user.click(screen.getByRole('button', { name: /Attention inbox, 0 pending/ }));
+    expect(screen.queryByRole('button', { name: /Agent waiting/ })).not.toBeInTheDocument();
+    expect(screen.getByText('No blocking input is waiting.')).toBeVisible();
   });
 });
 

--- a/desktop/src/renderer/src/features/AttentionInbox.tsx
+++ b/desktop/src/renderer/src/features/AttentionInbox.tsx
@@ -114,9 +114,9 @@ export function AttentionInbox({
   open: controlledOpen,
   onOpenChange,
 }: AttentionInboxProps) {
-  // Synthetic help items (an interactive session idling between turns) are
-  // inline run-view status, never inbox rows. Memoized: effects key on the
-  // list's identity, so a fresh array every render would loop them.
+  // Synthetic help items (a session idling between turns — phase coordination
+  // or the chat resting after a reply) are never inbox rows. Memoized: effects
+  // key on the list's identity, so a fresh array every render would loop them.
   const items = useMemo(() => allItems.filter((item) => !isSyntheticHelpItem(item)), [allItems]);
   const [uncontrolledOpen, setUncontrolledOpen] = useState(false);
   const open = controlledOpen ?? uncontrolledOpen;

--- a/desktop/src/renderer/src/features/WorkspaceShell.test.tsx
+++ b/desktop/src/renderer/src/features/WorkspaceShell.test.tsx
@@ -850,6 +850,26 @@ describe('WorkspaceShell toolbar', () => {
     expect(await screen.findByText('Runtime ready')).toBeVisible();
   });
 
+  it('marks the Ask chip with an unread dot only while a reply is unseen', async () => {
+    installAgenticoMock({
+      settings: settingsWithActive(null),
+      features: [],
+      connection: {
+        status: 'ready',
+        stage: 'ready',
+        detail: 'Connected to the app-owned runtime.',
+        ownership: 'app-owned',
+        kind: 'local',
+      },
+    });
+    const { rerender } = render(<WorkspaceShell amaUnread />);
+
+    expect(await screen.findByRole('img', { name: 'Unread AMA reply' })).toBeVisible();
+
+    rerender(<WorkspaceShell amaUnread={false} />);
+    expect(screen.queryByRole('img', { name: 'Unread AMA reply' })).not.toBeInTheDocument();
+  });
+
   it('lets a runtime problem win the footer row over an active session', async () => {
     installAgenticoMock({
       settings: settingsWithActive(null),

--- a/desktop/src/renderer/src/features/WorkspaceShell.tsx
+++ b/desktop/src/renderer/src/features/WorkspaceShell.tsx
@@ -173,6 +173,7 @@ export function WorkspaceShell({
   onOpenAma = () => {},
   onOpenPalette = () => {},
   amaSessionActive = false,
+  amaUnread = false,
 }: {
   attentionItems?: AttentionItem[];
   refreshAttention?: () => Promise<AttentionItem[]>;
@@ -199,6 +200,8 @@ export function WorkspaceShell({
   onOpenPalette?(): void;
   /** True while the singleton AMA chat session is running. */
   amaSessionActive?: boolean;
+  /** True when an AMA reply landed while the panel was closed. */
+  amaUnread?: boolean;
 }) {
   // null while the local shell prefs are being restored.
   const [shell, setShell] = useState<ShellPrefs | null>(null);
@@ -864,6 +867,10 @@ export function WorkspaceShell({
           ) : null}
           <button type="button" className="sidebar__ama" onClick={onOpenAma}>
             Ask ⌥Space
+            {/* Ambient unread marker: opening the panel is what clears it. */}
+            {amaUnread ? (
+              <span className="sidebar__ama-dot" role="img" aria-label="Unread AMA reply" />
+            ) : null}
           </button>
         </div>
       </nav>

--- a/desktop/src/renderer/src/styles/app.css
+++ b/desktop/src/renderer/src/styles/app.css
@@ -5064,6 +5064,17 @@ body {
   color: var(--text);
 }
 
+/* Ambient only, like the update dot: an AMA reply landed while the panel was
+ * closed. The Ask button itself is the target that clears it. */
+.sidebar__ama-dot {
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  margin-left: 6px;
+  border-radius: 999px;
+  background: var(--accent);
+}
+
 /* The footer's server control: the connected server's name and status dot
  * acting as the switcher trigger. Same metrics as the passive runtime pill. */
 .sidebar__server {

--- a/desktop/src/shared/ipc.ts
+++ b/desktop/src/shared/ipc.ts
@@ -1971,13 +1971,16 @@ export function attentionOwnerFeatureId(item: AttentionItem): string | undefined
   return item.featureId;
 }
 /**
- * A synthetic help item: a phase session idling between turns
- * (waitingKind 'coordinating'). Inline run-view status, not blocking input — it
- * never badges, notifies, or holds the phase rail. A chat session's wait
- * ('input') is excluded: the inbox is the only place to answer it.
+ * A synthetic help item: a session idling between turns. 'coordinating' is a
+ * phase session parked mid-coordination; 'input' is the chat session resting
+ * after a reply, which the AMA panel surfaces (an idle chat is its normal
+ * state, not a request). Neither is blocking input — synthetic items never
+ * badge, notify, appear as inbox rows, or hold the phase rail.
  */
 export function isSyntheticHelpItem(item: AttentionItem): boolean {
-  return item.kind === 'help' && item.waitingKind === 'coordinating';
+  return (
+    item.kind === 'help' && (item.waitingKind === 'coordinating' || item.waitingKind === 'input')
+  );
 }
 
 /**

--- a/desktop/test/e2e/journeys/attention-resolution.spec.ts
+++ b/desktop/test/e2e/journeys/attention-resolution.spec.ts
@@ -526,7 +526,9 @@ test('packaged chat idle wait stays out of the inbox and resolves through the AM
     );
 
     persistAppLogs(handle, 'attention-help-app-server');
-    transcript.step('chat reply surfaced through the Ask chip and the panel composer continued the session');
+    transcript.step(
+      'chat reply surfaced through the Ask chip and the panel composer continued the session',
+    );
     transcript.codeBlock('provider help-response log', readProviderLog(world), 120);
     transcript.write(testInfo);
   } finally {

--- a/desktop/test/e2e/journeys/attention-resolution.spec.ts
+++ b/desktop/test/e2e/journeys/attention-resolution.spec.ts
@@ -454,10 +454,10 @@ test('packaged inbox and cockpit resolve real attention classes from the bundled
   }
 });
 
-test('packaged inbox resolves an interactive help request from chat', async ({}, testInfo) => {
+test('packaged chat idle wait stays out of the inbox and resolves through the AMA panel', async ({}, testInfo) => {
   const transcript = new Transcript(
     'attention-help',
-    'Interactive help attention resolution via packaged inbox',
+    'Chat idle wait attention contract via the packaged AMA panel',
   );
   const world = createWorld('attention-help', {
     auth: { loggedIn: true, authMethod: 'oauth', email: 'e2e@example.invalid' },
@@ -473,6 +473,9 @@ test('packaged inbox resolves an interactive help request from chat', async ({},
       timeout: 60_000,
     });
 
+    // A chat started with the panel closed delivers its reply in the
+    // background: the turn ends and the session rests between turns.
+    await expect(handle.page.getByRole('img', { name: 'Unread AMA reply' })).toHaveCount(0);
     const chatStart = await serverPost(world, '/api/v1/prompts/chat/start', {
       message: 'attention chat help',
     });
@@ -491,20 +494,39 @@ test('packaged inbox resolves an interactive help request from chat', async ({},
     await expect(handle.page.getByRole('navigation', { name: 'Feature sidebar' })).toBeVisible({
       timeout: 60_000,
     });
-    await expect(attentionBell(handle.page)).toHaveAccessibleName(/Attention inbox, 1 pending/);
 
+    // The resting wait never badges or rows: the inbox is for blocking input,
+    // and an idle chat is the chat's own normal state, not a request.
+    await expect(attentionBell(handle.page)).toHaveAccessibleName(/Attention inbox, 0 pending/);
     const inbox = await openInbox(handle);
-    const helpDetail = await expandInboxItem(handle, inbox, /Agent waiting/);
-    await helpDetail
-      .getByLabel('Message to the agent')
-      .fill('Continue with the compact packaged evidence path.');
-    await evidenceShot(handle, 'attention-help-reply');
-    await helpDetail.getByRole('button', { name: 'Send message' }).click();
-    await waitForProviderLog(world, 'help-response:');
+    await expect(inbox.getByText('No blocking input is waiting.')).toBeVisible();
+    await expect(inbox.getByRole('button', { name: /Agent waiting/ })).toHaveCount(0);
+    await evidenceShot(handle, 'attention-help-inbox-quiet');
     await closeInbox(handle.page);
 
+    // The reply-delivered signal is the Ask chip's unread dot, and opening
+    // the panel is what marks the reply as seen.
+    await expect(handle.page.getByRole('img', { name: 'Unread AMA reply' })).toBeVisible();
+    await handle.page.getByRole('button', { name: /Ask ⌥Space/ }).click();
+    const panel = handle.page.getByRole('complementary', { name: 'Ask Agentico' });
+    await expect(panel).toBeVisible();
+    await expect(handle.page.getByRole('img', { name: 'Unread AMA reply' })).toHaveCount(0);
+    await expect(panel).toContainText('Active', { timeout: 30_000 });
+    await expect(panel).not.toContainText('pending');
+    const composer = panel.getByRole('textbox', { name: 'Ask Agentico' });
+    await expect(composer).toBeFocused();
+    await composer.fill('Continue with the compact packaged evidence path.');
+    await evidenceShot(handle, 'attention-help-reply');
+    await panel.getByRole('button', { name: 'Send', exact: true }).click();
+    await waitForProviderLog(world, 'help-response:');
+    expect(readProviderLog(world)).toContain('Continue with the compact packaged evidence path.');
+    await expect(panel.getByLabel('AMA transcript')).toContainText(
+      'Continue with the compact packaged evidence path.',
+      { timeout: 30_000 },
+    );
+
     persistAppLogs(handle, 'attention-help-app-server');
-    transcript.step('chat help item accepted a reply and delivered it to the interactive session');
+    transcript.step('chat reply surfaced through the Ask chip and the panel composer continued the session');
     transcript.codeBlock('provider help-response log', readProviderLog(world), 120);
     transcript.write(testInfo);
   } finally {

--- a/desktop/test/e2e/journeys/background-ama-notifications.spec.ts
+++ b/desktop/test/e2e/journeys/background-ama-notifications.spec.ts
@@ -216,6 +216,12 @@ test('packaged attention notifications are private, deduplicated, bounded, passi
     expect(await capturedNotifications(handle)).toHaveLength(1);
 
     await activateNotification(handle, 0);
+    // The notification click only shows the window. On Linux CI the focus
+    // event does not reliably follow show(), and an unfocused-but-visible
+    // window still satisfies shouldNotify — every later pending item would
+    // notify before the preview-enabled setting below is enabled. Pin the
+    // focus state through the published test hook instead of assuming it.
+    await ensureMainWindowFocus(handle);
     const inbox = handle.page.getByRole('complementary', { name: 'Attention inbox' });
     await expect(inbox).not.toBeVisible();
     // Notification click only focuses the window (main/notifications.ts just
@@ -243,6 +249,9 @@ test('packaged attention notifications are private, deduplicated, bounded, passi
     await expect(palette.getByLabel('Search features and commands')).toBeFocused();
     await handle.page.keyboard.press('Escape');
     await expect(palette).not.toBeVisible();
+    // ask-bundle is pending from here on: keep the window deterministically
+    // focused so it cannot notify before the preview setting lands.
+    await ensureMainWindowFocus(handle);
 
     await handle.page.evaluate(() =>
       window.agentico.updateSettings({ notifications: { previewEnabled: true } }),
@@ -250,6 +259,10 @@ test('packaged attention notifications are private, deduplicated, bounded, passi
     await hideMainWindow(handle);
     await waitForNotificationCount(handle, 2);
     notifications = await capturedNotifications(handle);
+    // Exactly the two intended notifications: the hidden-window permission
+    // notice and the previewed question. A focus leak would surface here as
+    // extra no-preview notifications.
+    expect(notifications).toHaveLength(2);
     const askNotification = notifications[1];
     expect(askNotification?.body).toContain('Questions');
     expect(askNotification?.body).toContain('Background Notification Questions');

--- a/desktop/test/e2e/journeys/zero-gap-creation.spec.ts
+++ b/desktop/test/e2e/journeys/zero-gap-creation.spec.ts
@@ -114,9 +114,14 @@ test('the creation sheet covers scoped files, initialization, the contract, setu
     await setTheme(app, 'light');
     await evidenceShot(app, SHOTS.depth);
     await app.page.getByRole('button', { name: 'Next: Contract' }).click();
-    await app.page.getByLabel('Risk').selectOption('high');
-    await app.page.getByLabel('Inquireness').selectOption('high');
-    await app.page
+    // Scope the contract knobs to the creation sheet: getByLabel matches by
+    // substring, and a randomly generated server name (e.g. "frisky-lungo")
+    // can otherwise collide with the sidebar server control's aria-label and
+    // trip strict mode.
+    const creationSheet = app.page.getByRole('dialog', { name: 'New feature' });
+    await creationSheet.getByLabel('Risk').selectOption('high');
+    await creationSheet.getByLabel('Inquireness').selectOption('high');
+    await creationSheet
       .getByText('Exit criteria')
       .locator('..')
       .getByRole('textbox')

--- a/internal/server/read_model.go
+++ b/internal/server/read_model.go
@@ -1573,8 +1573,9 @@ func (h *apiHandler) featureQueues() ([]HelpQueue, []NeedUserInputGate, error) {
 			if sess == nil || sess.Status() != ports.SessionWaitingHelp || sessionHasPendingAskUserControl(sess) {
 				continue
 			}
-			// A chat session waiting between turns is waiting on the user —
-			// the inbox is its only reply surface. A phase session in the same
+			// A chat session waiting between turns has delivered its reply and
+			// rests until the next message — clients surface that in the chat
+			// panel, not as blocking attention. A phase session in the same
 			// state is mid-coordination and needs no human.
 			kind := helpKindCoordinating
 			if sess.Kind() == ports.KindChat {


### PR DESCRIPTION
## Summary

Every time the Ask Agentico chat finished a reply, its between-turn wait surfaced as a full attention item: a bell badge, an inbox row labeled "Agent waiting / Runtime" with a stale `waiting Nh` timer, an OS notification, and a duplicate card inside the AMA panel itself ("· 1 pending"). A chat resting after a reply is its normal state, not blocking input — the panel's composer is how it continues.

- **Reclassify the chat's `input` wait as synthetic** (`isSyntheticHelpItem` in `shared/ipc.ts`). The bell badge, inbox rows, tray count, and native notifications all share this predicate, so the false "Agent waiting" item disappears from all four surfaces at once. Real chat asks (AskUserQuestion, permissions) keep badging and notifying exactly as before.
- **Clean up the AMA panel**: the pending strip and the "· N pending" header suffix now show only genuine questions/permissions, not the idle wait card that sat directly above the composer.
- **Move the reply signal where chats signal replies**: the idle wait (fresh `waitingSince` per turn end) now drives an unread dot on the sidebar "Ask ⌥Space" chip, reported by the panel via a new `onUnreadChange` callback. The dot appears only for a reply that landed while the panel was closed; opening the panel marks it seen. Session-local by design.
- **Correct stale comments** that encoded the old assumption ("the inbox is its only reply surface") in `read_model.go`, `notifications.ts`, and the inbox filter.

The server still emits the `input` help kind unchanged — classification moved entirely client-side, so older/newer server–client pairings keep working.

## Test plan

- [x] `npx vitest run` — full desktop unit suite, 2154 tests / 149 files passing
- [x] New coverage: inbox/badge exclusion of the chat wait, notification suppression for `input` items, AMA panel pending-strip filter, unread lifecycle (lands-while-closed → dot, open → seen, next turn → dot again), chip dot rendering
- [x] `npm run typecheck`, `npm run lint`, `npm run format:check`
- [x] `go build ./internal/server/` (comment-only Go change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Journey alignment (follow-up commit)

The packaged journeys are the UX contract and two still encoded the old badge behavior, which is what failed `desktop (ubuntu-latest)`:

- `attention-resolution.spec.ts` "interactive help request from chat" (deterministic): rewrote as **"packaged chat idle wait stays out of the inbox and resolves through the AMA panel"** — quiet bell (`0 pending`), empty inbox state, the `Unread AMA reply` dot on the Ask chip as the reply-delivered signal, dot cleared by opening the panel, and the panel composer as the continuation surface (provider still receives the message via the session stdin path).
- `background-ama-notifications.spec.ts` notifications journey (Linux focus flake, not caused by the badge change): after the notification click re-shows the window, the focus event does not reliably follow `show()` on Linux, so `shouldNotify()` stayed true and later pending items notified before `previewEnabled` landed — `notifications[1]` then carried the no-preview body. The journey now pins focus through the published test hook after re-showing and while the ask bundle is pending, and requires exactly the two intended notifications.

### Verification

- Fast suite: `make test-fast` — Go packages green in CI (`test` job); two timing-sensitive tests (`internal/git TestProbeTimeoutKillsProcessGroup`, `internal/session TestPendingToolWatchdogAllowsPromptResultAfterCompletedTool`) flaked locally under full-suite parallel load on this machine but pass in isolation with the same flags; unrelated to this PR (Go diff is comment-only).
- Static analysis and build: `go vet ./...`, `go build ./...` — clean.
- Desktop typecheck/lint: `npm run typecheck --workspace desktop`, `eslint` on both touched specs — clean.
- Packaged E2E journeys (targeted, per the desktop gate): `attention-resolution.spec.ts -g "idle wait stays out of the inbox"` ✓ (7.6s) and `background-ama-notifications.spec.ts -g "private, deduplicated, bounded, passive"` ✓ (13.7s) against the packaged app.
- Skipped Race regression: TypeScript-only change in this commit.
- CI-hardening follow-up: `zero-gap-creation.spec.ts` — `getByLabel('Risk')` matches by substring, so a randomly generated server name like "frisky-lungo" made the sidebar server control's aria-label collide with the sheet's Risk select and trip strict mode (this exact flake failed `desktop (ubuntu-latest)` on main). The Risk/Inquireness/Exit criteria lookups are now scoped to the "New feature" sheet dialog; verified with a packaged run of the spec (15.3s).