### PR TITLE
Add remote server via connection-string deep link

### DIFF
--- a/desktop/src/main/__tests__/externalRoutes.test.ts
+++ b/desktop/src/main/__tests__/externalRoutes.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { SafeErrorException, safeError } from '../../shared/errors';
+import type { AppRouteEvent, RemoteServerAddResult } from '../../shared/ipc';
+import {
+  addServerFromLink,
+  routeFromArgv,
+  routeFromUrl,
+  type AddServerLinkDeps,
+} from '../externalRoutes';
+
+const TOKEN = 'tok-secret-xyz';
+const CONNECTION_STRING = `agentico://${TOKEN}@10.1.2.3:8080`;
+const SERVER_KEY = 'a'.repeat(32);
+
+function appRouteOf(route: ReturnType<typeof routeFromUrl>): AppRouteEvent {
+  if (route === null || route.kind !== 'app-route') {
+    throw new Error(`expected an app-route, got ${route === null ? 'null' : route.kind}`);
+  }
+  return route.event;
+}
+
+describe('routeFromUrl', () => {
+  it('recognizes a full connection string as an add-server intent', () => {
+    expect(routeFromUrl(CONNECTION_STRING)).toEqual({
+      kind: 'add-server',
+      connectionString: CONNECTION_STRING,
+    });
+  });
+
+  it('recognizes a named connection string with an IPv6 host', () => {
+    const raw = `agentico://${TOKEN}@[fe80::1]:9090?name=lab`;
+    expect(routeFromUrl(raw)).toEqual({ kind: 'add-server', connectionString: raw });
+  });
+
+  it('prefers the connection-string reading when userinfo shadows a named route', () => {
+    const raw = `agentico://${TOKEN}@updates:8080`;
+    expect(routeFromUrl(raw)).toEqual({ kind: 'add-server', connectionString: raw });
+  });
+
+  it.each([
+    ['agentico://updates', { target: 'settings', settingsSection: 'updates' }],
+    ['agentico://diagnostics', { target: 'settings', settingsSection: 'diagnostics' }],
+    ['agentico://servers', { target: 'settings', settingsSection: 'servers' }],
+    [
+      'agentico://servers/add',
+      { target: 'settings', settingsSection: 'servers', settingsFocus: 'add-server' },
+    ],
+  ] as const)('keeps the named route %s working', (raw, expected) => {
+    expect(appRouteOf(routeFromUrl(raw))).toEqual(expected);
+  });
+
+  it('keeps the settings fallback for an unknown route', () => {
+    expect(appRouteOf(routeFromUrl('agentico://something-else'))).toEqual({ target: 'settings' });
+  });
+
+  it('falls back to settings for a near-miss connection string (no port)', () => {
+    expect(appRouteOf(routeFromUrl(`agentico://${TOKEN}@10.1.2.3`))).toEqual({
+      target: 'settings',
+    });
+  });
+
+  it('falls back to settings for a wildcard-host connection string', () => {
+    expect(appRouteOf(routeFromUrl(`agentico://${TOKEN}@0.0.0.0:8080`))).toEqual({
+      target: 'settings',
+    });
+  });
+
+  it('returns null for foreign schemes and unparseable input', () => {
+    expect(routeFromUrl('https://example.com')).toBeNull();
+    expect(routeFromUrl('not a url')).toBeNull();
+  });
+});
+
+describe('routeFromArgv', () => {
+  it('maps the relaunch flag to the updates pane', () => {
+    expect(routeFromArgv(['app', '--agentico-route=updates'])).toEqual({
+      kind: 'app-route',
+      event: { target: 'settings', settingsSection: 'updates' },
+    });
+  });
+
+  it('routes an agentico:// argument through routeFromUrl', () => {
+    expect(routeFromArgv(['app', CONNECTION_STRING])).toEqual({
+      kind: 'add-server',
+      connectionString: CONNECTION_STRING,
+    });
+  });
+
+  it('returns null when no route is present', () => {
+    expect(routeFromArgv(['app', '--flag'])).toBeNull();
+  });
+});
+
+function makeDeps(overrides: Partial<AddServerLinkDeps> = {}): {
+  deps: AddServerLinkDeps;
+  routes: AppRouteEvent[];
+  notifications: string[];
+  logs: string[];
+  switched: Array<{ serverKey: string }>;
+} {
+  const routes: AppRouteEvent[] = [];
+  const notifications: string[] = [];
+  const logs: string[] = [];
+  const switched: Array<{ serverKey: string }> = [];
+  const deps: AddServerLinkDeps = {
+    addServer: vi.fn(async (): Promise<RemoteServerAddResult> => {
+      return { status: 'added', serverKey: SERVER_KEY };
+    }),
+    switchServer: async (request) => {
+      switched.push(request);
+      return {};
+    },
+    route: (event) => {
+      routes.push(event);
+    },
+    notify: (body) => {
+      notifications.push(body);
+    },
+    log: (line) => {
+      logs.push(line);
+    },
+    ...overrides,
+  };
+  return { deps, routes, notifications, logs, switched };
+}
+
+describe('addServerFromLink', () => {
+  it('adds, switches to the new server, and routes to the Servers pane', async () => {
+    const { deps, routes, notifications, switched } = makeDeps();
+    await addServerFromLink(CONNECTION_STRING, deps);
+    expect(deps.addServer).toHaveBeenCalledWith({ connectionString: CONNECTION_STRING });
+    expect(switched).toEqual([{ serverKey: SERVER_KEY }]);
+    expect(routes).toEqual([{ target: 'settings', settingsSection: 'servers' }]);
+    expect(notifications).toEqual([]);
+  });
+
+  it('treats duplicate-local as success and switches to the existing entry', async () => {
+    const { deps, routes, switched } = makeDeps({
+      addServer: async () => ({ status: 'duplicate-local', serverKey: SERVER_KEY }),
+    });
+    await addServerFromLink(CONNECTION_STRING, deps);
+    expect(switched).toEqual([{ serverKey: SERVER_KEY }]);
+    expect(routes).toEqual([{ target: 'settings', settingsSection: 'servers' }]);
+  });
+
+  it('still switches on session-only and says nothing was saved', async () => {
+    const { deps, notifications, switched } = makeDeps({
+      addServer: async () => ({ status: 'session-only', serverKey: SERVER_KEY }),
+    });
+    await addServerFromLink(CONNECTION_STRING, deps);
+    expect(switched).toEqual([{ serverKey: SERVER_KEY }]);
+    expect(notifications).toEqual([
+      'Server connected for this session only — the OS keychain is unavailable, so it was not saved.',
+    ]);
+  });
+
+  it('routes a failed switch to the Servers pane anyway', async () => {
+    const { deps, routes } = makeDeps({
+      switchServer: async () => {
+        throw new Error('switch failed');
+      },
+    });
+    await addServerFromLink(CONNECTION_STRING, deps);
+    expect(routes).toEqual([{ target: 'settings', settingsSection: 'servers' }]);
+  });
+
+  it('surfaces a pipeline failure on the add form with the pane error copy', async () => {
+    const { deps, routes, notifications, switched } = makeDeps({
+      addServer: async () => {
+        throw new SafeErrorException(
+          safeError('E_REMOTE_AUTH_REJECTED', 'The server rejected the token.'),
+        );
+      },
+    });
+    await addServerFromLink(CONNECTION_STRING, deps);
+    expect(switched).toEqual([]);
+    expect(routes).toEqual([
+      { target: 'settings', settingsSection: 'servers', settingsFocus: 'add-server' },
+    ]);
+    expect(notifications).toEqual(['The token was rejected. The server rejected the token.']);
+  });
+
+  it('never leaks the link or token into logs, routes, or notifications', async () => {
+    const failing = makeDeps({
+      addServer: async () => {
+        throw new SafeErrorException(
+          safeError('E_REMOTE_UNREACHABLE', 'Could not reach the server.'),
+        );
+      },
+    });
+    await addServerFromLink(CONNECTION_STRING, failing.deps);
+    const succeeding = makeDeps();
+    await addServerFromLink(CONNECTION_STRING, succeeding.deps);
+    for (const surface of [failing, succeeding]) {
+      const serialized = JSON.stringify([surface.logs, surface.notifications, surface.routes]);
+      expect(serialized).not.toContain(TOKEN);
+      expect(serialized).not.toContain('agentico://');
+    }
+    expect(failing.logs).toEqual(['add-server link failed: E_REMOTE_UNREACHABLE']);
+  });
+});

--- a/desktop/src/main/externalRoutes.ts
+++ b/desktop/src/main/externalRoutes.ts
@@ -1,0 +1,127 @@
+/**
+ * agentico:// deep-link routing (main process only).
+ *
+ * A deep link is either one of the named app routes (updates, diagnostics,
+ * servers, servers/add) or a full connection string
+ * (agentico://<token>@<host>:<port>[?name=<name>]) — the same string the
+ * Settings → Servers add form accepts. The connection-string variant embeds
+ * the server's bearer token, so an ExternalRoute must never be logged,
+ * serialized into diagnostics, or forwarded to a renderer; only the
+ * `app-route` variant's event may leave the main process as an IPC event.
+ */
+import { toSafeError } from '../shared/errors';
+import {
+  addServerErrorTitle,
+  type AppRouteEvent,
+  type RemoteServerAddRequest,
+  type RemoteServerAddResult,
+  type SwitchServerRequest,
+} from '../shared/ipc';
+import { parseConnectionString } from './connectionString';
+
+export type ExternalRoute =
+  { kind: 'app-route'; event: AppRouteEvent } | { kind: 'add-server'; connectionString: string };
+
+/** Fallback code when the add pipeline throws something untyped. */
+export const E_LINK_ADD_FAILED = 'E_LINK_ADD_FAILED';
+
+export function routeFromArgv(argv: readonly string[]): ExternalRoute | null {
+  if (argv.some((arg) => arg === '--agentico-route=updates')) {
+    return appRoute({ target: 'settings', settingsSection: 'updates' });
+  }
+  const url = argv.find((arg) => arg.startsWith('agentico://'));
+  return url === undefined ? null : routeFromUrl(url);
+}
+
+export function routeFromUrl(raw: string): ExternalRoute | null {
+  // A link that is itself a connection string (URL userinfo carrying the
+  // bearer token, explicit port) is an add-server intent. The strict parser
+  // decides; anything it rejects falls through to the named routes.
+  try {
+    parseConnectionString(raw);
+    return { kind: 'add-server', connectionString: raw };
+  } catch {
+    // Not a connection string — try the named routes below.
+  }
+  let parsed: URL;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    return null;
+  }
+  if (parsed.protocol !== 'agentico:') {
+    return null;
+  }
+  if (parsed.hostname === 'updates' || parsed.pathname === '/updates') {
+    return appRoute({ target: 'settings', settingsSection: 'updates' });
+  }
+  if (parsed.hostname === 'diagnostics' || parsed.pathname === '/diagnostics') {
+    return appRoute({ target: 'settings', settingsSection: 'diagnostics' });
+  }
+  // agentico://servers and agentico://servers/add — the latter carries the
+  // within-pane intent to focus the Servers pane's add-server form.
+  const isServers =
+    parsed.hostname === 'servers' ||
+    parsed.pathname === '/servers' ||
+    parsed.pathname === '/servers/add';
+  if (isServers) {
+    const addIntent = parsed.pathname === '/add' || parsed.pathname === '/servers/add';
+    return appRoute({
+      target: 'settings',
+      settingsSection: 'servers',
+      ...(addIntent ? { settingsFocus: 'add-server' as const } : {}),
+    });
+  }
+  return appRoute({ target: 'settings' });
+}
+
+function appRoute(event: AppRouteEvent): ExternalRoute {
+  return { kind: 'app-route', event };
+}
+
+export interface AddServerLinkDeps {
+  /** The Settings → Servers add pipeline (probe, compat gate, verify, persist). */
+  addServer(request: RemoteServerAddRequest): Promise<RemoteServerAddResult>;
+  switchServer(request: SwitchServerRequest): Promise<unknown>;
+  route(event: AppRouteEvent): void;
+  /** Native notification; the body must already be redaction-safe. */
+  notify(body: string): void;
+  /** Redacted diagnostics sink; never receives the link or the token. */
+  log(line: string): void;
+}
+
+/**
+ * Runs a connection-string deep link through the exact add pipeline the
+ * Settings → Servers form uses, then switches the active connection to the
+ * added server. `duplicate-local` is success here — the server is already
+ * known, so the link just switches to it. Failures land on the Servers pane
+ * with the add form focused, the error carried by a native notification
+ * (SafeError messages never echo the link or its token).
+ */
+export async function addServerFromLink(
+  connectionString: string,
+  deps: AddServerLinkDeps,
+): Promise<void> {
+  let result: RemoteServerAddResult;
+  try {
+    result = await deps.addServer({ connectionString });
+  } catch (err) {
+    const safe = toSafeError(err, E_LINK_ADD_FAILED);
+    deps.log(`add-server link failed: ${safe.code}`);
+    deps.notify(`${addServerErrorTitle(safe.code)} ${safe.message}`);
+    deps.route({ target: 'settings', settingsSection: 'servers', settingsFocus: 'add-server' });
+    return;
+  }
+  try {
+    await deps.switchServer({ serverKey: result.serverKey });
+  } catch {
+    // The connection shell owns a switch's failure surface, exactly as the
+    // Servers pane treats it.
+  }
+  if (result.status === 'session-only') {
+    deps.notify(
+      'Server connected for this session only — the OS keychain is unavailable, so it was not saved.',
+    );
+  }
+  deps.route({ target: 'settings', settingsSection: 'servers' });
+}

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -26,6 +26,12 @@ import { createRuntimeGateway, fetchJson, MAX_PROBE_RESPONSE_BYTES } from './gat
 import { ServerListService } from './gateway/serverListService';
 import { addRemoteServer } from './gateway/addRemoteServer';
 import { removeKnownServer, serverTokenStatus } from './gateway/removeServer';
+import {
+  addServerFromLink,
+  routeFromArgv,
+  routeFromUrl,
+  type ExternalRoute,
+} from './externalRoutes';
 import { AccentController, type AccentColorSource } from './accent';
 import {
   resolveTestOutputFile,
@@ -73,6 +79,8 @@ import {
   type AppEvent,
   type AppRouteEvent,
   type FeatureSnapshot,
+  type RemoteServerAddRequest,
+  type RemoteServerAddResult,
   type SettingsFocus,
   type SettingsSection,
   type WindowPurpose,
@@ -838,15 +846,53 @@ if (!hasSingleInstanceLock) {
     nativeCommands.install();
     publishNativeCommandTestState(nativeCommands);
 
+    // The single add pipeline (probe → compat gate → token verify → persist),
+    // shared verbatim by the Settings add-server IPC and connection-string
+    // deep links.
+    const performRemoteServerAdd = (
+      request: RemoteServerAddRequest,
+    ): Promise<RemoteServerAddResult> =>
+      addRemoteServer(request, {
+        fetchJson: (url, options) =>
+          fetchJson(url, { ...options, maxResponseBytes: MAX_PROBE_RESPONSE_BYTES }),
+        scanRegistry,
+        knownServers: () => settings.get().servers,
+        upsertRemoteEntry: (entry) => {
+          settings.update({ servers: { upsertKnown: entry } });
+          void refreshBackgroundState();
+        },
+        remoteTokens,
+        registerSecret: (secret) => logBuffer.addSecret(secret),
+        log: (line) => console.warn(`[agentico-servers] ${redactText(line)}`),
+      });
+
     // A settings-targeted relaunch or deep link raises only the Settings
     // window — a hidden main window stays hidden. Anything else (including an
-    // argv with no route at all) shows the main window as before.
-    const dispatchExternalRoute = (requestedRoute: AppRouteEvent | null): void => {
+    // argv with no route at all) shows the main window as before. A
+    // connection-string link carries the server's bearer token: it is consumed
+    // here by the add pipeline and never logged or forwarded as a route event.
+    const dispatchExternalRoute = (requestedRoute: ExternalRoute | null): void => {
       if (requestedRoute === null) {
         showMainWindow();
         return;
       }
-      route(requestedRoute);
+      if (requestedRoute.kind === 'add-server') {
+        void addServerFromLink(requestedRoute.connectionString, {
+          addServer: performRemoteServerAdd,
+          switchServer: (request) => gateway.switchServer(request),
+          route,
+          notify: (body) => {
+            if (electronNotificationSink.isSupported()) {
+              electronNotificationSink
+                .create({ title: 'Agentico', body: redactText(body).slice(0, 180) })
+                .show();
+            }
+          },
+          log: (line) => console.warn(`[agentico-servers] ${redactText(line)}`),
+        });
+        return;
+      }
+      route(requestedRoute.event);
     };
 
     app.on('second-instance', (_event, argv) => {
@@ -1175,20 +1221,7 @@ if (!hasSingleInstanceLock) {
       switchConnectionServer: (request) => gateway.switchServer(request),
       listServers: () => serverList.list(),
       probeServers: (request) => serverList.setOpen(request.open),
-      addRemoteServer: (request) =>
-        addRemoteServer(request, {
-          fetchJson: (url, options) =>
-            fetchJson(url, { ...options, maxResponseBytes: MAX_PROBE_RESPONSE_BYTES }),
-          scanRegistry,
-          knownServers: () => settings.get().servers,
-          upsertRemoteEntry: (entry) => {
-            settings.update({ servers: { upsertKnown: entry } });
-            void refreshBackgroundState();
-          },
-          remoteTokens,
-          registerSecret: (secret) => logBuffer.addSecret(secret),
-          log: (line) => console.warn(`[agentico-servers] ${redactText(line)}`),
-        }),
+      addRemoteServer: performRemoteServerAdd,
       removeServer: (request) =>
         removeKnownServer(request, {
           knownServers: () => settings.get().servers,
@@ -1366,7 +1399,7 @@ if (!hasSingleInstanceLock) {
     showMainWindow();
     const initialRoute = routeFromArgv(process.argv);
     if (initialRoute !== null) {
-      route(initialRoute);
+      dispatchExternalRoute(initialRoute);
     }
 
     app.on('activate', () => {
@@ -1411,47 +1444,6 @@ function publishMainWindowFocusTestState(focused: boolean): void {
     __agenticoMainWindowFocusState?: { focused: boolean };
   };
   global.__agenticoMainWindowFocusState = { focused };
-}
-
-function routeFromArgv(argv: readonly string[]): AppRouteEvent | null {
-  if (argv.some((arg) => arg === '--agentico-route=updates')) {
-    return { target: 'settings', settingsSection: 'updates' };
-  }
-  const url = argv.find((arg) => arg.startsWith('agentico://'));
-  return url === undefined ? null : routeFromUrl(url);
-}
-
-function routeFromUrl(raw: string): AppRouteEvent | null {
-  let parsed: URL;
-  try {
-    parsed = new URL(raw);
-  } catch {
-    return null;
-  }
-  if (parsed.protocol !== 'agentico:') {
-    return null;
-  }
-  if (parsed.hostname === 'updates' || parsed.pathname === '/updates') {
-    return { target: 'settings', settingsSection: 'updates' };
-  }
-  if (parsed.hostname === 'diagnostics' || parsed.pathname === '/diagnostics') {
-    return { target: 'settings', settingsSection: 'diagnostics' };
-  }
-  // agentico://servers and agentico://servers/add — the latter carries the
-  // within-pane intent to focus the Servers pane's add-server form.
-  const isServers =
-    parsed.hostname === 'servers' ||
-    parsed.pathname === '/servers' ||
-    parsed.pathname === '/servers/add';
-  if (isServers) {
-    const addIntent = parsed.pathname === '/add' || parsed.pathname === '/servers/add';
-    return {
-      target: 'settings',
-      settingsSection: 'servers',
-      ...(addIntent ? { settingsFocus: 'add-server' as const } : {}),
-    };
-  }
-  return { target: 'settings' };
 }
 
 function consumeForcedStopFailure(

--- a/desktop/src/renderer/src/features/SettingsPanel.tsx
+++ b/desktop/src/renderer/src/features/SettingsPanel.tsx
@@ -17,6 +17,7 @@ import { useConnectionState, useTheme } from '../hooks';
 import { parseIpcError } from '../wizard/ipcError';
 import { WorkspaceDefaultsPanel } from './ConfigEditor';
 import type { PaneFocusIntent } from './settingsPanes';
+import { addServerErrorTitle } from '../../../shared/ipc';
 import type {
   KnownServer,
   ReadinessSnapshot,
@@ -983,15 +984,6 @@ const SERVERS_PANE_HEALTH_LABEL: Record<ServerListRow['health'], string> = {
   unreachable: 'Unreachable',
   probing: 'Checking…',
 };
-
-/** Distinct lead-ins per failure class of the add-server flow. */
-function addServerErrorTitle(code: string): string {
-  if (code.startsWith('E_CONNECTION_STRING_')) return 'The connection string could not be parsed.';
-  if (code === 'E_REMOTE_UNREACHABLE') return 'The server could not be reached.';
-  if (code === 'E_REMOTE_INCOMPATIBLE') return 'The server is not compatible with this app.';
-  if (code === 'E_REMOTE_AUTH_REJECTED') return 'The token was rejected.';
-  return 'The server could not be added.';
-}
 
 function serverDisplayName(entry: KnownServer): string {
   return entry.nickname ?? (entry.name === '' ? 'Unnamed server' : entry.name);

--- a/desktop/src/shared/ipc.ts
+++ b/desktop/src/shared/ipc.ts
@@ -568,6 +568,18 @@ export const RemoteServerAddResultSchema = z.discriminatedUnion('status', [
 ]);
 export type RemoteServerAddResult = z.output<typeof RemoteServerAddResultSchema>;
 
+/**
+ * Distinct lead-ins per failure class of the add-server flow, shared by the
+ * Servers pane's inline error and the deep-link add's notification.
+ */
+export function addServerErrorTitle(code: string): string {
+  if (code.startsWith('E_CONNECTION_STRING_')) return 'The connection string could not be parsed.';
+  if (code === 'E_REMOTE_UNREACHABLE') return 'The server could not be reached.';
+  if (code === 'E_REMOTE_INCOMPATIBLE') return 'The server is not compatible with this app.';
+  if (code === 'E_REMOTE_AUTH_REJECTED') return 'The token was rejected.';
+  return 'The server could not be added.';
+}
+
 // --- Remove-server flow / stored-token status --------------------------------
 // Removal is main-side orchestrated: the dedicated channel deletes the token
 // blob (remote only), drops the settings entry via removeKnown, and tears

--- a/docs/desktop/remote-servers.md
+++ b/docs/desktop/remote-servers.md
@@ -72,6 +72,35 @@ Details of the paste flow:
   runtime identity, not its address), the app doesn't add a duplicate — it
   steers you to the existing local entry.
 
+## Adding by deep link
+
+The connection string is itself an `agentico://` URL, so opening it as a
+link (for example `open 'agentico://<token>@10.9.8.7:8080?name=my+server'`
+on macOS, or clicking it wherever your OS treats it as a link) hands it to a
+running Agentico app, which runs the exact same add flow as the paste form:
+
+- On success the server is added (or, if the address turns out to be an
+  already-known server, the existing entry is used), the app switches to it,
+  and **Settings → Servers** opens showing the entry.
+- On failure (unreachable, incompatible, rejected token) nothing is saved;
+  the app shows a notification with the same error copy as the add form and
+  opens **Settings → Servers** with the form focused so you can re-paste.
+- When the OS keychain is unavailable the app still connects for this
+  session only and a notification says nothing was saved, matching the
+  paste flow.
+
+The link is treated with the same care as a paste: the embedded token is
+never logged or echoed anywhere. Only links that parse as a full connection
+string (token before the `@`, explicit port) take this path; the app's other
+`agentico://` deep links are unaffected.
+
+Deep-link add is reliable while the app is already running (warm start). A
+link that has to launch the app first is delivered best-effort: on macOS the
+launching URL can be dropped before the app is ready, and on any platform
+the result surface may not appear until the app has finished starting up. If
+nothing happens on a cold start, open the running app and click the link
+again — or paste the string into **Settings → Servers**.
+
 ## Network expectations
 
 - Hold connection strings to **trusted networks** — your LAN, a VPN, or


### PR DESCRIPTION
## What

An `agentico://` deep link that is itself a full connection string — `agentico://<token>@<host>:<port>[?name=<name>]`, the same grammar the server prints and the Settings → Servers add form accepts — now adds the server and switches to it, end to end, with no manual paste:

- `routeFromUrl`/`routeFromArgv` moved into a new testable `desktop/src/main/externalRoutes.ts`; connection-string-ness is decided by the existing strict `parseConnectionString` (no regex). Named routes (`updates`, `diagnostics`, `servers`, `servers/add`) and the settings fallback are unchanged, with precedence covered by tests.
- The link runs the exact Settings add pipeline (probe → compat gate → token verify → safeStorage persist) via a single shared `performRemoteServerAdd` used verbatim by the IPC handler — no duplicated logic. `duplicate-local` counts as success (switch to the known server). `session-only` (no keychain) surfaces a notification.
- Failures (`E_REMOTE_UNREACHABLE` / `E_REMOTE_INCOMPATIBLE` / `E_REMOTE_AUTH_REJECTED`) land on Settings → Servers with the add form focused, reusing the pane's exact error lead-ins (`addServerErrorTitle` moved to shared ipc.ts) in a native notification.
- Both delivery paths work warm: macOS `open-url` and `second-instance` argv; the cold-start argv route now flows through the same dispatcher. Cold-start limits (routes are no-ops before the gateway is ready; macOS may drop a launching URL since `open-url` registers at `whenReady`) are pre-existing and documented in `docs/desktop/remote-servers.md` (new "Adding by deep link" section).

## Security

The token never leaves the main process: the `add-server` route variant cannot be serialized as an IPC route event, logs carry only SafeError codes through `redactText`, the token is registered with the log buffer's secret redaction, and a dedicated leak test serializes all logs/routes/notifications and asserts neither the token nor the link appears. The existing `desktop/test/security/remoteToken.test.ts` suite stays green.

## Why

Setup automation (e.g. the DoorDash `setup-remote-agentico` skill that provisions Agentico on a Flux VM) can now hand the printed connection string straight to the app with `open "agentico://…"` instead of asking the user to paste it into Settings.

## Testing

- `npm run check` (typecheck + eslint + prettier + api-drift): pass
- `npx vitest run` (full suite incl. security project): 150 files, 2174 tests, pass — includes 20 new tests in `desktop/src/main/__tests__/externalRoutes.test.ts` (recognition, precedence, malformed fallback, duplicate→switch, failure routing, token-leak assertion)
- Packaged Playwright journeys unchanged per AGENTS.md (no renderer copy/role/label changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
