### PR TITLE
Keep the server picker in the sidebar footer during an active AMA session

### DIFF
--- a/desktop/src/renderer/src/App.tsx
+++ b/desktop/src/renderer/src/App.tsx
@@ -63,9 +63,6 @@ export default function App() {
   } | null>(null);
   const [routeRequest, setRouteRequest] = useState<RoutedRequest | null>(null);
   const [updateState, setUpdateState] = useState<UpdateState | null>(null);
-  // Owned here so the sidebar footer can show the mock's active-session state
-  // while the panel itself owns the singleton chat session.
-  const [amaSessionActive, setAmaSessionActive] = useState(false);
   // A reply that landed while the panel was closed, echoed on the Ask chip.
   const [amaUnread, setAmaUnread] = useState(false);
   const [updateDismissedVersion, setUpdateDismissedVersion] = useState<string | null>(null);
@@ -215,7 +212,6 @@ export default function App() {
             }
             onOpenAma={() => requestRoute({ target: 'ama' })}
             onOpenPalette={() => requestRoute({ target: 'palette' })}
-            amaSessionActive={amaSessionActive}
             amaUnread={amaUnread}
             onInstallUpdateWhenIdle={async () => {
               try {
@@ -232,7 +228,6 @@ export default function App() {
             attentionDrafts={attentionDrafts}
             setAttentionDrafts={setAttentionDrafts}
             routeRequest={routeRequest}
-            onSessionActiveChange={setAmaSessionActive}
             onUnreadChange={setAmaUnread}
           />
         </>

--- a/desktop/src/renderer/src/components/ReadinessGate.tsx
+++ b/desktop/src/renderer/src/components/ReadinessGate.tsx
@@ -40,7 +40,6 @@ export function ReadinessGate({
   onInstallUpdateWhenIdle = async () => {},
   onOpenAma = () => {},
   onOpenPalette = () => {},
-  amaSessionActive = false,
   amaUnread = false,
 }: {
   attentionDrafts?: AttentionDrafts;
@@ -65,7 +64,6 @@ export function ReadinessGate({
   onOpenAma?(): void;
   /** Owned by App: dispatches the same 'palette' routeRequest ⌘K resolves to. */
   onOpenPalette?(): void;
-  amaSessionActive?: boolean;
   amaUnread?: boolean;
 }) {
   const [state, setState] = useState<GateState>({ phase: 'loading' });
@@ -131,7 +129,6 @@ export function ReadinessGate({
         onInstallUpdateWhenIdle={onInstallUpdateWhenIdle}
         onOpenAma={onOpenAma}
         onOpenPalette={onOpenPalette}
-        amaSessionActive={amaSessionActive}
         amaUnread={amaUnread}
       />
     );

--- a/desktop/src/renderer/src/features/WorkspaceShell.test.tsx
+++ b/desktop/src/renderer/src/features/WorkspaceShell.test.tsx
@@ -829,7 +829,7 @@ describe('WorkspaceShell toolbar', () => {
     expect(onOpenPalette).toHaveBeenCalledTimes(1);
   });
 
-  it('shows the active-session footer state only while the runtime is healthy', async () => {
+  it('keeps runtime identity and the Ask action distinct in the footer', async () => {
     installAgenticoMock({
       settings: settingsWithActive(null),
       features: [],
@@ -841,13 +841,12 @@ describe('WorkspaceShell toolbar', () => {
         kind: 'local',
       },
     });
-    const { rerender } = render(<WorkspaceShell amaSessionActive />);
+    render(<WorkspaceShell />);
 
-    expect(await screen.findByText('Ask Agentico is active')).toBeVisible();
+    expect(
+      await screen.findByRole('button', { name: 'Runtime ready — switch server' }),
+    ).toBeVisible();
     expect(screen.getByRole('button', { name: 'Ask ⌥Space' })).toBeVisible();
-
-    rerender(<WorkspaceShell amaSessionActive={false} />);
-    expect(await screen.findByText('Runtime ready')).toBeVisible();
   });
 
   it('marks the Ask chip with an unread dot only while a reply is unseen', async () => {
@@ -870,7 +869,7 @@ describe('WorkspaceShell toolbar', () => {
     expect(screen.queryByRole('img', { name: 'Unread AMA reply' })).not.toBeInTheDocument();
   });
 
-  it('lets a runtime problem win the footer row over an active session', async () => {
+  it('shows runtime problems as passive status instead of a server picker', async () => {
     installAgenticoMock({
       settings: settingsWithActive(null),
       features: [],
@@ -882,10 +881,10 @@ describe('WorkspaceShell toolbar', () => {
         error: { code: 'E_CONNECT', message: 'The runtime is unreachable.' },
       },
     });
-    render(<WorkspaceShell amaSessionActive />);
+    render(<WorkspaceShell />);
 
     expect(await screen.findByText('Runtime needs attention')).toBeVisible();
-    expect(screen.queryByText('Ask Agentico is active')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /switch server/ })).not.toBeInTheDocument();
   });
 
   it('shows the named server in the footer instead of the generic ready label', async () => {
@@ -946,25 +945,6 @@ describe('WorkspaceShell toolbar', () => {
     render(<WorkspaceShell />);
 
     expect(await screen.findByText('Connecting')).toBeVisible();
-    expect(screen.queryByText('frothy-macchiato')).toBeNull();
-  });
-
-  it('keeps the active-session label over a named server', async () => {
-    installAgenticoMock({
-      settings: settingsWithActive(null),
-      features: [],
-      connection: {
-        status: 'ready',
-        stage: 'ready',
-        detail: 'Connected to an externally managed Agentico runtime.',
-        ownership: 'external',
-        kind: 'remote',
-        serverName: 'frothy-macchiato',
-      },
-    });
-    render(<WorkspaceShell amaSessionActive />);
-
-    expect(await screen.findByText('Ask Agentico is active')).toBeVisible();
     expect(screen.queryByText('frothy-macchiato')).toBeNull();
   });
 

--- a/desktop/src/renderer/src/features/WorkspaceShell.tsx
+++ b/desktop/src/renderer/src/features/WorkspaceShell.tsx
@@ -172,7 +172,6 @@ export function WorkspaceShell({
   onInstallUpdateWhenIdle = async () => {},
   onOpenAma = () => {},
   onOpenPalette = () => {},
-  amaSessionActive = false,
   amaUnread = false,
 }: {
   attentionItems?: AttentionItem[];
@@ -198,8 +197,6 @@ export function WorkspaceShell({
   onOpenAma?(): void;
   /** Owned by App: dispatches the same 'palette' routeRequest ⌘K resolves to. */
   onOpenPalette?(): void;
-  /** True while the singleton AMA chat session is running. */
-  amaSessionActive?: boolean;
   /** True when an AMA reply landed while the panel was closed. */
   amaUnread?: boolean;
 }) {
@@ -232,11 +229,6 @@ export function WorkspaceShell({
     : isConnectionErrorState(connection)
       ? 'error'
       : 'progress';
-  // A connection problem always wins the footer row: an active assistant must
-  // never mask a runtime that needs attention.
-  const showAmaActive = runtimeReady && amaSessionActive;
-  const footerLabel = showAmaActive ? 'Ask Agentico is active' : runtimeLabel;
-  const footerTone = showAmaActive ? 'ama' : runtimeTone;
   // The footer dot and the toolbar update button share one predicate, so they
   // appear and disappear together.
   const updatePending = updateNoticePending(updateState, updateDismissedVersion);
@@ -781,16 +773,15 @@ export function WorkspaceShell({
    * explicit choice hides the whole footer — and with it the only landing
    * spot for the routed "Switch Server…" command — otherwise).
    */
-  const serverSwitcher =
-    runtimeReady && !showAmaActive ? (
-      <ServerSwitcher
-        currentLabel={runtimeLabel}
-        tone={runtimeTone}
-        enabled
-        openRequest={switcherRoute}
-        onRouteHandled={clearSwitcherRoute}
-      />
-    ) : null;
+  const serverSwitcher = runtimeReady ? (
+    <ServerSwitcher
+      currentLabel={runtimeLabel}
+      tone={runtimeTone}
+      enabled
+      openRequest={switcherRoute}
+      onRouteHandled={clearSwitcherRoute}
+    />
+  ) : null;
 
   return (
     <section
@@ -849,14 +840,14 @@ export function WorkspaceShell({
             );
           })}
         </div>
-        <div className="sidebar__footer" data-tone={footerTone}>
-          {/* The runtime pill is the server control while connected; the
-           * AMA-active label and every non-ready state keep the passive pill. */}
+        <div className="sidebar__footer" data-tone={runtimeTone}>
+          {/* The runtime pill is the server control while connected; every
+           * non-ready state keeps the passive pill. */}
           {!effectiveSidebarCollapsed && serverSwitcher !== null ? (
             serverSwitcher
           ) : (
             <span className="sidebar__runtime" role="status">
-              <span aria-hidden="true">●</span> {footerLabel}
+              <span aria-hidden="true">●</span> {runtimeLabel}
             </span>
           )}
           {/* Indicator only, never a target: the toolbar button stays the one

--- a/desktop/src/renderer/src/styles/app.css
+++ b/desktop/src/renderer/src/styles/app.css
@@ -5029,17 +5029,6 @@ body {
   color: var(--bad);
 }
 
-/* The assistant's own footer state, per the mock: an accent dot beside
-   "Ask Agentico is active". Any non-ready runtime tone replaces it, so a
-   connection problem is never masked by a running chat. */
-.sidebar__footer[data-tone='ama'] .sidebar__runtime span {
-  color: var(--accent);
-}
-
-.sidebar__footer[data-tone='ama'] .sidebar__runtime {
-  color: var(--text);
-}
-
 /* Ambient only: the update popover's presence, echoed on the status row. It is
  * deliberately not a control — the toolbar button is the single trigger. */
 .sidebar__update-dot {

--- a/desktop/test/e2e/journeys/background-ama-notifications.spec.ts
+++ b/desktop/test/e2e/journeys/background-ama-notifications.spec.ts
@@ -71,6 +71,11 @@ test('packaged AMA panel floats, toggles, drags, persists, and ends the session'
       window.agentico.startChat({ message: 'Follow up in the active AMA session.' }),
     );
     expect(followUp).toMatchObject({ sessionId: '__chat__', result: 'sent' });
+    // AMA activity never displaces the footer's connection identity or its
+    // switcher; the Ask control remains the session's single entry point.
+    await expect(handle.page.getByRole('button', { name: / — switch server$/ })).toBeVisible();
+    await expect(handle.page.getByRole('button', { name: 'Ask ⌥Space' })).toBeVisible();
+    await expect(handle.page.getByText('Ask Agentico is active')).toHaveCount(0);
     const chatSessions = await handle.page.evaluate(() =>
       window.agentico
         .listSessions()

--- a/desktop/test/e2e/screenshot-capture/ama-panel-evidence.spec.ts
+++ b/desktop/test/e2e/screenshot-capture/ama-panel-evidence.spec.ts
@@ -6,7 +6,7 @@ async function openPanel(page: Page, theme: 'light' | 'dark'): Promise<void> {
   await openScene(page, 'ama-panel', theme, 1440, 900, '.ama-panel', { platform: 'darwin' });
   await expect(page.getByRole('complementary', { name: 'Ask Agentico' })).toBeVisible();
   await expect(page.getByText('Which features still touch the old polled preview?')).toBeVisible();
-  await expect(page.getByText('Ask Agentico is active')).toBeVisible();
+  await expect(page.getByRole('button', { name: / — switch server$/ })).toBeVisible();
 }
 
 /** Pastes the fixture image into the composer, producing the chip. */
@@ -37,7 +37,7 @@ test('ama panel visual evidence', async ({ page }) => {
   skipWithoutEvidenceDir();
 
   // The default bottom-trailing placement over a running cockpit, with the
-  // accent-ruled "You" turn and the active-session sidebar footer.
+  // accent-ruled "You" turn and the server-identity sidebar footer.
   await openPanel(page, 'dark');
   await page.mouse.move(700, 300);
   await page.waitForTimeout(400);

--- a/desktop/test/e2e/screenshot-capture/capture.tsx
+++ b/desktop/test/e2e/screenshot-capture/capture.tsx
@@ -1527,15 +1527,14 @@ function CreationSheetScene(): React.ReactElement {
 
 /**
  * The floating AMA panel inside the real shell: the same WorkspaceShell the app
- * mounts (so the panel floats over a live cockpit and the sidebar footer shows
- * its own active-session state) plus the real AmaPanel, opened from the
- * persisted preference exactly as the app opens it. The evidence spec drives
- * the attachment, confirmation, drag, resize, and expand states from here.
+ * mounts (so the panel floats over a live cockpit and the sidebar footer keeps
+ * its server identity) plus the real AmaPanel, opened from the persisted
+ * preference exactly as the app opens it. The evidence spec drives the
+ * attachment, confirmation, drag, resize, and expand states from here.
  */
 function AmaPanelScene(): React.ReactElement {
   const [drafts, setDrafts] = React.useState(emptyAttentionDrafts());
   const [attentionItems, setAttentionItems] = React.useState<AttentionItem[]>([]);
-  const [amaSessionActive, setAmaSessionActive] = React.useState(false);
 
   React.useEffect(() => {
     void window.agentico.getAttention().then((snapshot) => setAttentionItems(snapshot.items));
@@ -1554,7 +1553,6 @@ function AmaPanelScene(): React.ReactElement {
         refreshAttention={refreshAttention}
         attentionDrafts={drafts}
         setAttentionDrafts={setDrafts}
-        amaSessionActive={amaSessionActive}
       />
       <AmaPanel
         attentionItems={attentionItems}
@@ -1562,7 +1560,6 @@ function AmaPanelScene(): React.ReactElement {
         attentionDrafts={drafts}
         setAttentionDrafts={setDrafts}
         routeRequest={null}
-        onSessionActiveChange={setAmaSessionActive}
       />
     </div>
   );


### PR DESCRIPTION
## What

While the singleton AMA chat session ran, the footer swapped its runtime identity for the "Ask Agentico is active" label, which also displaced the server switcher — the only landing spot for the routed "Switch Server…" command. This removes the `amaSessionActive` plumbing through App, ReadinessGate, and WorkspaceShell (plus the `ama` footer tone and its CSS). The footer now always shows runtime identity: the switcher pill while connected, the passive status pill otherwise. The Ask chip remains the session's single entry point.

Aligned tests with the change: WorkspaceShell unit tests, the background-ama-notifications packaged journey, and the screenshot-capture AMA scene and evidence spec (which still asserted the removed footer label).

## Verification

- Fast suite (`make test-fast`) — 41s
- Desktop static checks (`npm run check`)
- Desktop unit/component/security tests (`npm test && npm run test:security`) — 2153 + 111 passed
- Desktop packaged E2E (targeted): `background-ama-notifications.spec.ts` — 2 passed (one focus-timing flake on the first run, green on rerun and in isolation)
- Skipped Go extended tiers: no Go code changed
- Skipped full packaged E2E suite: targeted spec covers the changed UX contract