### PR TITLE
Auto-approve safe shell commands by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,8 +197,8 @@ defaults:
     review: "gpt-5.4[272K]"      # Model for review phase (Codex)
     utilities: "sonnet[200K]"    # Model for chat and utility tasks
     kb_build: "sonnet[200K]"     # Model for knowledge base builds
-    automatic_review: ""         # Empty selects Automatic
-  automatic_review_enabled: false
+    automatic_review: ""         # Reviewer that screens shell commands; empty selects Automatic
+  automatic_review_enabled: true # Auto-approve safe shell commands (default on)
   exit_criteria: |
     - Feature fully implemented per plan
     - Unit tests added/updated as needed

--- a/desktop/src/main/configService.ts
+++ b/desktop/src/main/configService.ts
@@ -303,7 +303,7 @@ export class ConfigService {
       checkpoints: toCheckpoints(defaults.checkpoints ?? {}),
       pipeline: defaults.pipeline ?? '',
       muteFeatureInput: parsed.data.notifications?.mute_feature_input ?? false,
-      automaticReviewEnabled: defaults.automatic_review_enabled ?? false,
+      automaticReviewEnabled: defaults.automatic_review_enabled ?? true,
     };
   }
 

--- a/desktop/src/renderer/src/features/ConfigEditor.test.tsx
+++ b/desktop/src/renderer/src/features/ConfigEditor.test.tsx
@@ -149,7 +149,7 @@ describe('FeatureConfigPanel', () => {
     render(<FeatureConfigPanel featureId="feat-1" />);
     const user = userEvent.setup();
 
-    const picker = await screen.findByLabelText('Automatic review');
+    const picker = await screen.findByLabelText('Auto-approve safe commands');
     expect(picker).toHaveValue('default');
     await user.selectOptions(picker, 'enabled');
     await user.click(screen.getByRole('button', { name: 'Save changes' }));
@@ -333,10 +333,10 @@ describe('WorkspaceDefaultsPanel', () => {
     render(<WorkspaceDefaultsPanel />);
     const user = userEvent.setup();
 
-    const reviewer = await screen.findByLabelText('Automatic review model');
+    const reviewer = await screen.findByLabelText('Command reviewer model');
     expect(within(reviewer).getByRole('option', { name: /Automatic/ })).toBeVisible();
     await user.selectOptions(reviewer, 'claude:sonnet');
-    await user.selectOptions(screen.getByLabelText('Automatic review'), 'enabled');
+    await user.selectOptions(screen.getByLabelText('Auto-approve safe commands'), 'enabled');
     await user.click(screen.getByRole('button', { name: 'Save changes' }));
 
     await waitFor(() => expect(mock.api.updateWorkspaceDefaults).toHaveBeenCalledTimes(1));

--- a/desktop/src/renderer/src/features/ConfigEditor.tsx
+++ b/desktop/src/renderer/src/features/ConfigEditor.tsx
@@ -63,9 +63,9 @@ export const PHASE_FIELDS: ReadonlyArray<PhaseField> = [
   { key: 'kbBuild', label: 'KB Build', role: 'kb_build', hint: 'Knowledge base construction' },
   {
     key: 'automaticReview',
-    label: 'Automatic review',
+    label: 'Command reviewer',
     role: 'automatic_review',
-    hint: 'Reviewer for unresolved Bash permission requests',
+    hint: 'Model that screens shell commands for auto-approval',
     workspaceOnly: true,
     supportsEffort: false,
   },
@@ -569,11 +569,11 @@ function ConfigForm({
           </select>
         </label>
         <label className="config-editor__row">
-          <span className="config-editor__row-label">Automatic review</span>
+          <span className="config-editor__row-label">Auto-approve safe commands</span>
           <span className="config-editor__row-hint">{automaticReview.hint}</span>
           <select
             className="config-editor__select"
-            aria-label="Automatic review"
+            aria-label="Auto-approve safe commands"
             value={automaticReview.value}
             onChange={(event) => onAutomaticReviewChange(event.target.value)}
           >
@@ -795,7 +795,7 @@ export function FeatureConfigPanel({ featureId }: { featureId: string }) {
         inputAlerts={{ value: draft.inputNotifications, options: FEATURE_ALERT_OPTIONS }}
         automaticReview={{
           value: draft.automaticReviewMode,
-          hint: 'Override the workspace default for new sessions in this feature',
+          hint: 'Override the workspace setting for new sessions in this feature',
           options: FEATURE_AUTOMATIC_REVIEW_OPTIONS,
         }}
         onChange={(next) => setDraft({ ...draft, ...next })}
@@ -921,7 +921,7 @@ export function WorkspaceDefaultsPanel({
         }}
         automaticReview={{
           value: draft.automaticReviewEnabled ? 'enabled' : 'disabled',
-          hint: 'Automatically review unresolved Bash requests for new sessions',
+          hint: 'A separate reviewer model screens shell commands that would pause for you. Safe ones run; risky ones still ask.',
           options: WORKSPACE_AUTOMATIC_REVIEW_OPTIONS,
         }}
         onChange={(next) => setDraft({ ...draft, ...next })}

--- a/desktop/src/renderer/src/features/CreateFeatureForm.test.tsx
+++ b/desktop/src/renderer/src/features/CreateFeatureForm.test.tsx
@@ -388,7 +388,7 @@ describe('the creation sheet across its four steps', () => {
     expect(screen.queryByLabelText('Clarify model')).toBeNull();
     expect(screen.queryByLabelText('KB Build model')).toBeNull();
     expect(screen.queryByLabelText('Utilities model')).toBeNull();
-    expect(screen.queryByLabelText('Automatic review model')).toBeNull();
+    expect(screen.queryByLabelText('Command reviewer model')).toBeNull();
 
     await user.click(screen.getByRole('button', { name: 'Back' }));
     await user.click(screen.getByRole('radio', { name: /Large/ }));
@@ -397,7 +397,7 @@ describe('the creation sheet across its four steps', () => {
     expect(screen.getByLabelText('KB Build model')).toBeVisible();
     // Utilities and the automatic reviewer stay workspace-scoped.
     expect(screen.queryByLabelText('Utilities model')).toBeNull();
-    expect(screen.queryByLabelText('Automatic review model')).toBeNull();
+    expect(screen.queryByLabelText('Command reviewer model')).toBeNull();
   });
 
   it('submits the contract without untouched model defaults, auto-starts the feature, and keeps one idempotency identity', async () => {

--- a/desktop/src/renderer/src/features/FeatureCockpit.test.tsx
+++ b/desktop/src/renderer/src/features/FeatureCockpit.test.tsx
@@ -132,7 +132,7 @@ describe('FeatureCockpit snapshot rendering', () => {
     expect(header).not.toBeNull();
     expect(within(header!).getByLabelText('SettingUpWorktrees')).toBeInTheDocument();
     expect(within(header!).getByText('feature/search-revamp')).toBeInTheDocument();
-    expect(within(header!).queryByText('Automatic review')).not.toBeInTheDocument();
+    expect(within(header!).queryByText('Auto-approve safe commands')).not.toBeInTheDocument();
     expect(within(header!).queryByText('Repository')).not.toBeInTheDocument();
   });
 

--- a/internal/config/autoreview_test.go
+++ b/internal/config/autoreview_test.go
@@ -21,17 +21,17 @@ import (
 	"testing"
 )
 
-func TestAutomaticReviewDefaultsDisabledAndEmpty(t *testing.T) {
+func TestAutomaticReviewDefaultsEnabledAndEmpty(t *testing.T) {
 	cfg := NewDefault()
-	if cfg.Defaults.AutomaticReviewEnabled {
-		t.Errorf("NewDefault AutomaticReviewEnabled = true, want false")
+	if !cfg.Defaults.AutomaticReviewEnabled {
+		t.Errorf("NewDefault AutomaticReviewEnabled = false, want true")
 	}
 	if cfg.Defaults.Models.AutomaticReview != "" {
 		t.Errorf("NewDefault AutomaticReview = %q, want empty (Automatic)", cfg.Defaults.Models.AutomaticReview)
 	}
 }
 
-func TestAutomaticReviewAbsentLegacyLoadsDisabled(t *testing.T) {
+func TestAutomaticReviewAbsentLegacyLoadsEnabled(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.yaml")
 	legacy := `
@@ -47,8 +47,8 @@ defaults:
 	if err != nil {
 		t.Fatalf("Load: %v", err)
 	}
-	if cfg.Defaults.AutomaticReviewEnabled {
-		t.Errorf("absent legacy AutomaticReviewEnabled = true, want false")
+	if !cfg.Defaults.AutomaticReviewEnabled {
+		t.Errorf("absent legacy AutomaticReviewEnabled = false, want true")
 	}
 	if cfg.Defaults.Models.AutomaticReview != "" {
 		t.Errorf("absent legacy AutomaticReview = %q, want empty", cfg.Defaults.Models.AutomaticReview)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -101,11 +101,31 @@ type DefaultsConfig struct {
 	MaxConsecutiveNoProgress int                           `yaml:"max_consecutive_no_progress" json:"max_consecutive_no_progress,omitempty"`
 	MaxPhasePlanIterations   int                           `yaml:"max_phase_plan_iterations,omitempty" json:"max_phase_plan_iterations,omitempty"`
 	Checkpoints              Checkpoints                   `yaml:"checkpoints" json:"checkpoints"`
-	// AutomaticReviewEnabled controls the default-off workspace behavior that
-	// lets an isolated reviewer classify a narrow set of Bash commands. An
-	// absent or false flag means disabled; it is never seeded by applyDefaults so
-	// legacy configs load as disabled without altering established defaults.
-	AutomaticReviewEnabled bool `yaml:"automatic_review_enabled,omitempty" json:"automatic_review_enabled,omitempty"`
+	// AutomaticReviewEnabled lets an isolated reviewer model screen Bash
+	// commands the session would otherwise pause on, auto-approving safe ones.
+	// Default-on: an absent key loads as enabled (see UnmarshalYAML), so the
+	// key is always written explicitly to keep a saved false stable.
+	AutomaticReviewEnabled bool `yaml:"automatic_review_enabled" json:"automatic_review_enabled"`
+}
+
+// UnmarshalYAML defaults an omitted automatic_review_enabled to true.
+func (d *DefaultsConfig) UnmarshalYAML(value *yaml.Node) error {
+	type plain DefaultsConfig
+	var p plain
+	if err := value.Decode(&p); err != nil {
+		return err
+	}
+	var probe struct {
+		AutomaticReviewEnabled *bool `yaml:"automatic_review_enabled"`
+	}
+	if err := value.Decode(&probe); err != nil {
+		return err
+	}
+	*d = DefaultsConfig(p)
+	if probe.AutomaticReviewEnabled == nil {
+		d.AutomaticReviewEnabled = true
+	}
+	return nil
 }
 
 // PipelinePreference stores the last-used feature-creation settings for a

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -41,6 +41,7 @@ func NewDefault() *Config {
 				PhasePlanReview: true,
 				ManualPublish:   true,
 			},
+			AutomaticReviewEnabled:   true,
 			ExitCriteria:             defaultExitCriteria,
 			Inquireness:              "high",
 			Pipeline:                 "large",

--- a/skills/chat/user-guide/configuration.md
+++ b/skills/chat/user-guide/configuration.md
@@ -36,22 +36,24 @@ defaults:
 
 ## Automatic Bash Review
 
-Automatic Bash review uses two workspace keys:
+The desktop app labels this **Auto-approve safe commands** and its reviewer
+model **Command reviewer**. It uses two workspace keys:
 
 ```yaml
 defaults:
-  automatic_review_enabled: false
+  automatic_review_enabled: true
   models:
     automatic_review: ""
 ```
 
 The full names are `defaults.automatic_review_enabled` and
-`defaults.models.automatic_review`. The feature is disabled by default. When
-the enabled key is absent, as in a legacy config, it remains disabled; a
-missing reviewer-model key has the same empty **Automatic** value as a fresh
-config. The workspace Models row remains editable while automatic review is
-disabled; saved changes apply only to new sessions because each session
-snapshots the enabled flag and resolved reviewer.
+`defaults.models.automatic_review`. The feature is enabled by default. When
+the enabled key is absent, as in a legacy config, it loads as enabled; set it
+to `false` explicitly to opt out. A missing reviewer-model key has the same
+empty **Automatic** value as a fresh config. The workspace Models row remains
+editable while automatic review is disabled; saved changes apply only to new
+sessions because each session snapshots the enabled flag and resolved
+reviewer.
 
 Automatic selection uses the fixed provider order Claude → OpenCode → Codex
 and chooses the first eligible provider's preferred cheap model. A
@@ -94,8 +96,8 @@ everything else, the reviewer model's judgment is the boundary before the
 human, and that reviewer is a fallible, promptable component. Repo-controlled
 build and test code is trusted-by-design: a fast-pathed command such as
 `make test` or `go generate` may execute Makefiles, `package.json` scripts,
-`//go:generate` directives, or `conftest.py`. Enable automatic review only
-when that tradeoff is acceptable.
+`//go:generate` directives, or `conftest.py`. Disable automatic review if
+that tradeoff is not acceptable.
 
 ### Reviewer and lifecycle contract
 

--- a/skills/chat/user-guide/permissions.md
+++ b/skills/chat/user-guide/permissions.md
@@ -19,7 +19,7 @@ Session policy can approve categories such as:
 - delegated agent work; and
 - read-only git commands such as `git status`, `git diff`, `git log`, and `git show`.
 
-When the optional Automatic Bash review feature is enabled, an unresolved
+With Automatic Bash review (on by default), an unresolved
 canonical Bash request first checks a deterministic fast path. Curated
 build/test commands auto-approve without a model. Every other reviewable
 command reaches one model review—including dangerous commands such as


### PR DESCRIPTION
## What

Turns automatic Bash review on by default and renames it in the desktop UI.

- `defaults.automatic_review_enabled` now defaults to `true`. An absent key loads as enabled (new `DefaultsConfig.UnmarshalYAML`), and the key is always serialized so a saved `false` survives reload.
- Desktop workspace settings row is now **Auto-approve safe commands** with a hint describing the behavior. The reviewer model row is **Command reviewer**.
- Desktop fallback for a server that omits the field is now `true`.
- README and user guide updated; config tests flipped to the new default.

## Why

New users were not getting the reviewer because nothing told them it existed, so every shell command paused for a human. "Automatic review" also did not say what the setting does.

## How to test

```
go test ./internal/config/ ./cmd/agentico/ ./internal/server/ ./internal/agent/ ./internal/feature/
go test ./test/e2e/ -run 'AutomaticReview|DefaultOff|AutoReview'
cd desktop && npx vitest run src/renderer/src/features/ConfigEditor.test.tsx src/renderer/src/features/CreateFeatureForm.test.tsx src/renderer/src/features/FeatureCockpit.test.tsx src/main/__tests__/configService.test.ts
```

All green locally. Also verify a config with no `automatic_review_enabled` key loads as enabled, and one with `automatic_review_enabled: false` stays disabled after save/reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
