### PR TITLE
Offer auto-approve on Bash permission prompts

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1592,6 +1592,12 @@ components:
           enum: [allow_once, allow_remember, deny]
         remember_pattern:
           type: string
+        auto_approve_scope:
+          type: string
+          enum: [feature, workspace]
+          description: >-
+            Turn automatic Bash review on for the request's feature or for the
+            whole workspace before answering. Not allowed with deny.
         remember_scope:
           type: string
           description: Existing permission cache scope. Empty string means global.
@@ -4686,6 +4692,19 @@ components:
         remember:
           $ref: "#/components/schemas/PermissionRememberPreview"
           x-go-type-skip-optional-pointer: false
+        auto_approve:
+          $ref: "#/components/schemas/PermissionAutoApproveOffer"
+          x-go-type-skip-optional-pointer: false
+    PermissionAutoApproveOffer:
+      type: object
+      description: >-
+        Present when automatic Bash review is off for the session but would
+        have handled this request had it been on.
+      required: [would_fast_path]
+      properties:
+        would_fast_path:
+          type: boolean
+          description: The deterministic guardrail alone would have approved the command.
     SessionDetail:
       allOf:
         - $ref: "#/components/schemas/SessionSummary"

--- a/cmd/agentico/main.go
+++ b/cmd/agentico/main.go
@@ -1312,6 +1312,11 @@ func (t *serverMutationTarget) AnswerPermission(req serverruntime.PermissionAnsw
 	if err != nil {
 		return serverruntime.PermissionAnswerResponse{}, err
 	}
+	if req.AutoApproveScope != "" {
+		if err := t.enableAutomaticReview(req.AutoApproveScope, sess.FeatureID()); err != nil {
+			return serverruntime.PermissionAnswerResponse{}, err
+		}
+	}
 	rememberScope := ""
 	if req.RememberScope != nil {
 		rememberScope = *req.RememberScope
@@ -1340,6 +1345,44 @@ func (t *serverMutationTarget) AnswerPermission(req serverruntime.PermissionAnsw
 		AlreadyExisted: result.AlreadyExisted,
 		AuditWarning:   result.AuditWarning,
 	}, nil
+}
+
+// enableAutomaticReview turns automatic Bash review on for one feature or for
+// the workspace default. Running sessions read the setting live, so the change
+// applies to the next Bash request.
+func (t *serverMutationTarget) enableAutomaticReview(scope, featureID string) error {
+	switch scope {
+	case serverruntime.AutoApproveScopeWorkspace:
+		enabled := true
+		_, err := t.RuntimeConfig(serverruntime.RuntimeConfigMutationRequest{
+			Defaults: serverruntime.RuntimeDefaultsMutation{AutomaticReviewEnabled: &enabled},
+		})
+		return err
+	case serverruntime.AutoApproveScopeFeature:
+		if featureID == "" {
+			return errors.New("this request has no feature; enable auto-approve for the workspace instead")
+		}
+		if t.store == nil {
+			return errors.New("feature store is not available")
+		}
+		f, err := t.store.Load(featureID)
+		if err != nil {
+			return err
+		}
+		mode := string(feature.AutomaticReviewEnabled)
+		_, err = t.UpdateFeatureConfig(featureID, serverruntime.FeatureConfigMutationRequest{
+			Models:              f.Models,
+			Effort:              f.Effort,
+			Inquireness:         string(f.Inquireness),
+			Checkpoints:         f.Pipeline.NormalizeCheckpoints(f.Checkpoints, f.IsPublishable()),
+			Pipeline:            f.Pipeline,
+			InputNotifications:  string(feature.NormalizeInputNotificationsMode(f.InputNotifications)),
+			AutomaticReviewMode: &mode,
+		})
+		return err
+	default:
+		return fmt.Errorf("unknown auto_approve_scope %q", scope)
+	}
 }
 
 func (t *serverMutationTarget) permissionAnswerService() *permission.AnswerService {

--- a/cmd/agentico/server_mutation_target_test.go
+++ b/cmd/agentico/server_mutation_target_test.go
@@ -2804,3 +2804,141 @@ func jsonEqual(a, b json.RawMessage) bool {
 	}
 	return reflect.DeepEqual(av, bv)
 }
+
+func TestServerMutationTargetAnswerPermissionAutoApproveScopeEnablesBeforeAnswering(t *testing.T) {
+	newPending := func() *mutationTargetSessionView {
+		return &mutationTargetSessionView{
+			id:        testSessionPermissionID,
+			featureID: testFeaturePermissionID,
+			phase:     feature.PhaseImplement,
+			status:    ports.SessionWaitingPermission,
+			active:    true,
+			pending: []*llm.ControlRequestMessage{{
+				Type:      wireTypeControlRequest,
+				RequestID: testPermRequestID,
+				Request: llm.ControlRequest{
+					Subtype:  wireSubtypeCanUseTool,
+					ToolName: toolNameBash,
+					Input:    json.RawMessage(`{"command":"go test ./cmd/agentico"}`),
+				},
+			}},
+		}
+	}
+
+	t.Run("workspace", func(t *testing.T) {
+		runtimeDir := t.TempDir()
+		configPath := filepath.Join(runtimeDir, "config.yaml")
+		cfg := config.NewDefault()
+		if err := config.Save(configPath, cfg); err != nil {
+			t.Fatalf("Save config error = %v", err)
+		}
+		sess := newPending()
+		sessions := &mutationTargetSessionManager{sessions: []ports.SessionView{sess}}
+		target := serverMutationTarget{
+			orch:       mutationTargetOrchestrator(sessions),
+			sessions:   sessions,
+			cfg:        cfg,
+			configPath: configPath,
+		}
+
+		result, err := target.AnswerPermission(serverruntime.PermissionAnswerRequest{
+			RequestID:        testPermRequestID,
+			SessionID:        testSessionPermissionID,
+			Decision:         "allow_once",
+			AutoApproveScope: serverruntime.AutoApproveScopeWorkspace,
+		})
+		if err != nil {
+			t.Fatalf("AnswerPermission() error = %v", err)
+		}
+		if result.Decision != "allow_once" || len(sess.controlCalls) != 1 || !sess.controlCalls[0].allow {
+			t.Fatalf("AnswerPermission() = %+v, calls %+v; want allow", result, sess.controlCalls)
+		}
+		if !cfg.Defaults.AutomaticReviewEnabled {
+			t.Fatal("in-memory workspace default not enabled")
+		}
+		saved, err := config.Load(configPath)
+		if err != nil {
+			t.Fatalf("Load saved config: %v", err)
+		}
+		if !saved.Defaults.AutomaticReviewEnabled {
+			t.Fatal("saved workspace default not enabled")
+		}
+	})
+
+	t.Run("feature", func(t *testing.T) {
+		runtimeDir := t.TempDir()
+		configPath := filepath.Join(runtimeDir, "config.yaml")
+		cfg := config.NewDefault()
+		cfg.Repos[testRepoAName] = config.RepoConfig{Path: filepath.Join(runtimeDir, testRepoAName)}
+		if err := config.Save(configPath, cfg); err != nil {
+			t.Fatalf("Save config error = %v", err)
+		}
+		store := feature.NewStore(filepath.Join(runtimeDir, "features"))
+		manager := feature.NewManager(store, cfg)
+		f, err := manager.Create("auto-approve via prompt", "desc", []string{testRepoAName}, config.ModelConfig{Implementation: testModelClaudeSonnet}, "", "", nil, feature.CreateOptions{
+			Pipeline: feature.PipelineMedium,
+		})
+		if err != nil {
+			t.Fatalf("Create feature: %v", err)
+		}
+		if err := store.Modify(f.ID, func(f *feature.Feature) error {
+			f.Inquireness = feature.InquirenessHigh
+			return nil
+		}); err != nil {
+			t.Fatalf("set inquireness: %v", err)
+		}
+		sess := newPending()
+		sess.featureID = f.ID
+		sessions := &mutationTargetSessionManager{sessions: []ports.SessionView{sess}}
+		target := serverMutationTarget{
+			orch:       orchestrator.New(orchestrator.Deps{Lifecycle: manager, Store: store, Sessions: sessions}, orchestrator.Hooks{}),
+			sessions:   sessions,
+			cfg:        cfg,
+			configPath: configPath,
+			store:      store,
+		}
+
+		if _, err := target.AnswerPermission(serverruntime.PermissionAnswerRequest{
+			RequestID:        testPermRequestID,
+			SessionID:        testSessionPermissionID,
+			Decision:         "allow_once",
+			AutoApproveScope: serverruntime.AutoApproveScopeFeature,
+		}); err != nil {
+			t.Fatalf("AnswerPermission() error = %v", err)
+		}
+		if len(sess.controlCalls) != 1 || !sess.controlCalls[0].allow {
+			t.Fatalf("RespondToControl calls = %+v; want one allow", sess.controlCalls)
+		}
+		updated, err := store.Load(f.ID)
+		if err != nil {
+			t.Fatalf("Load feature: %v", err)
+		}
+		if feature.NormalizeAutomaticReviewMode(updated.AutomaticReviewMode) != feature.AutomaticReviewEnabled {
+			t.Fatalf("feature automatic review mode = %q, want enabled", updated.AutomaticReviewMode)
+		}
+		if updated.Models.Implementation != testModelClaudeSonnet || updated.Inquireness != feature.InquirenessHigh {
+			t.Fatalf("feature config changed beyond auto-approve: models %+v inquireness %q", updated.Models, updated.Inquireness)
+		}
+		if cfg.Defaults.AutomaticReviewEnabled {
+			t.Fatal("feature scope must not change the workspace default")
+		}
+	})
+
+	t.Run("feature scope without feature fails before answering", func(t *testing.T) {
+		sess := newPending()
+		sess.featureID = ""
+		sessions := &mutationTargetSessionManager{sessions: []ports.SessionView{sess}}
+		target := serverMutationTarget{orch: mutationTargetOrchestrator(sessions), sessions: sessions}
+		if _, err := target.AnswerPermission(serverruntime.PermissionAnswerRequest{
+			RequestID:        testPermRequestID,
+			SessionID:        testSessionPermissionID,
+			Decision:         "allow_once",
+			AutoApproveScope: serverruntime.AutoApproveScopeFeature,
+		}); err == nil {
+			t.Fatal("AnswerPermission() error = nil, want failure")
+		}
+		if len(sess.controlCalls) != 0 {
+			t.Fatalf("RespondToControl calls = %+v; want none", sess.controlCalls)
+		}
+	})
+}

--- a/desktop/src/main/attention.ts
+++ b/desktop/src/main/attention.ts
@@ -147,6 +147,9 @@ export class AttentionService {
                   scopeDisplay: request.remember.scope_display,
                 },
               }),
+          ...(request.auto_approve === undefined
+            ? {}
+            : { autoApprove: { wouldFastPath: request.auto_approve.would_fast_path } }),
         })),
       ...promptsRaw.ask_user_questions
         .filter(
@@ -283,6 +286,7 @@ export class AttentionService {
       ...(input.decision === 'allow_remember'
         ? { remember_pattern: input.rememberPattern, remember_scope: input.rememberScope }
         : {}),
+      ...(input.autoApproveScope === undefined ? {} : { auto_approve_scope: input.autoApproveScope }),
     });
   }
   async answerQuestions(request: AskUserAnswerRequest): Promise<AttentionActionResult> {

--- a/desktop/src/main/attention.ts
+++ b/desktop/src/main/attention.ts
@@ -286,7 +286,9 @@ export class AttentionService {
       ...(input.decision === 'allow_remember'
         ? { remember_pattern: input.rememberPattern, remember_scope: input.rememberScope }
         : {}),
-      ...(input.autoApproveScope === undefined ? {} : { auto_approve_scope: input.autoApproveScope }),
+      ...(input.autoApproveScope === undefined
+        ? {}
+        : { auto_approve_scope: input.autoApproveScope }),
     });
   }
   async answerQuestions(request: AskUserAnswerRequest): Promise<AttentionActionResult> {

--- a/desktop/src/renderer/src/components/icons.tsx
+++ b/desktop/src/renderer/src/components/icons.tsx
@@ -60,6 +60,15 @@ export function MinimizeIcon(props: SVGProps<SVGSVGElement>) {
   );
 }
 
+/** Disclosure chevron for split buttons and menus, shaped after SF Symbols' `chevron.down`. */
+export function ChevronDownIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <Icon {...props}>
+      <path d="M6 9l6 6 6-6" />
+    </Icon>
+  );
+}
+
 /** The toolbar attention trigger, shaped after SF Symbols' `bell`. */
 export function BellIcon(props: SVGProps<SVGSVGElement>) {
   return (

--- a/desktop/src/renderer/src/features/AttentionInbox.test.tsx
+++ b/desktop/src/renderer/src/features/AttentionInbox.test.tsx
@@ -193,15 +193,15 @@ function PermissionDetailHarness({
   );
 }
 
-describe('permission auto-approve offer', () => {
+describe('permission auto mode split button', () => {
   it('stays hidden when the server made no offer', () => {
     installAgenticoMock();
     render(<PermissionDetailHarness item={permissionItem} />);
-    expect(screen.queryByRole('group', { name: 'Auto-approve commands' })).toBeNull();
+    expect(screen.queryByRole('group', { name: 'Enable auto mode' })).toBeNull();
     expect(screen.getByRole('button', { name: 'Allow once' })).toBeVisible();
   });
 
-  it('allows and turns auto-approve on for the feature or the workspace', async () => {
+  it('allows and turns auto mode on for this feature, with all features behind the chevron', async () => {
     const mock = installAgenticoMock();
     const user = userEvent.setup();
     render(
@@ -209,12 +209,17 @@ describe('permission auto-approve offer', () => {
         item={{ ...permissionItem, autoApprove: { wouldFastPath: true } }}
       />,
     );
-    const offer = screen.getByRole('group', { name: 'Auto-approve commands' });
-    expect(within(offer).getByText(/would have run without asking/)).toBeVisible();
-
-    await user.click(
-      within(offer).getByRole('button', { name: 'Allow and auto-approve in this feature' }),
+    const split = screen.getByRole('group', { name: 'Enable auto mode' });
+    const main = within(split).getByRole('button', {
+      name: 'Enable auto mode (this feature only)',
+    });
+    expect(main).toHaveAttribute('title', expect.stringContaining('would have run without asking'));
+    // The split button sits in the same row as the other decisions.
+    expect(main.closest('.attention-detail__actions')).toBe(
+      screen.getByRole('button', { name: 'Deny' }).closest('.attention-detail__actions'),
     );
+
+    await user.click(main);
     expect(mock.api.answerPermission).toHaveBeenLastCalledWith({
       requestId: 'perm-1',
       sessionId: 'session-1',
@@ -222,9 +227,12 @@ describe('permission auto-approve offer', () => {
       autoApproveScope: 'feature',
     });
 
-    await user.click(
-      within(offer).getByRole('button', { name: 'Allow and auto-approve everywhere' }),
-    );
+    const menu = split.querySelector('details');
+    expect(menu?.open).toBe(false);
+    await user.click(within(split).getByLabelText('More auto mode options'));
+    expect(menu?.open).toBe(true);
+    const all = within(split).getByRole('menuitem', { name: 'Enable auto mode (all features)' });
+    await user.click(all);
     expect(mock.api.answerPermission).toHaveBeenLastCalledWith({
       requestId: 'perm-1',
       sessionId: 'session-1',
@@ -233,7 +241,7 @@ describe('permission auto-approve offer', () => {
     });
   });
 
-  it('omits the feature choice for a request without a feature', () => {
+  it('offers only the all-features choice for a request without a feature', () => {
     installAgenticoMock();
     const { featureId: _omit, ...ownerless } = permissionItem as Extract<
       AttentionItem,
@@ -242,14 +250,13 @@ describe('permission auto-approve offer', () => {
     render(
       <PermissionDetailHarness item={{ ...ownerless, autoApprove: { wouldFastPath: false } }} />,
     );
-    const offer = screen.getByRole('group', { name: 'Auto-approve commands' });
-    expect(within(offer).getByText(/reviewer model would have decided/)).toBeVisible();
-    expect(
-      within(offer).queryByRole('button', { name: 'Allow and auto-approve in this feature' }),
-    ).toBeNull();
-    expect(
-      within(offer).getByRole('button', { name: 'Allow and auto-approve everywhere' }),
-    ).toBeVisible();
+    const split = screen.getByRole('group', { name: 'Enable auto mode' });
+    const main = within(split).getByRole('button', { name: 'Enable auto mode (all features)' });
+    expect(main).toHaveAttribute(
+      'title',
+      expect.stringContaining('reviewer model would have decided'),
+    );
+    expect(within(split).queryByLabelText('More auto mode options')).toBeNull();
   });
 });
 

--- a/desktop/src/renderer/src/features/AttentionInbox.test.tsx
+++ b/desktop/src/renderer/src/features/AttentionInbox.test.tsx
@@ -231,7 +231,7 @@ describe('permission auto mode split button', () => {
     expect(menu?.open).toBe(false);
     await user.click(within(split).getByLabelText('More auto mode options'));
     expect(menu?.open).toBe(true);
-    const all = within(split).getByRole('menuitem', { name: 'Enable auto mode (all features)' });
+    const all = within(split).getByRole('menuitem', { name: /Enable auto mode \(all features\)/ });
     await user.click(all);
     expect(mock.api.answerPermission).toHaveBeenLastCalledWith({
       requestId: 'perm-1',

--- a/desktop/src/renderer/src/features/AttentionInbox.test.tsx
+++ b/desktop/src/renderer/src/features/AttentionInbox.test.tsx
@@ -176,6 +176,81 @@ function popover(): HTMLElement | null {
   return screen.queryByRole('complementary', { name: 'Attention inbox' });
 }
 
+function PermissionDetailHarness({
+  item,
+}: {
+  item: Extract<AttentionItem, { kind: 'permission' }>;
+}): React.ReactElement {
+  const [drafts, setDrafts] = useState<AttentionDrafts>(emptyAttentionDrafts);
+  return (
+    <AttentionDetail
+      item={item}
+      busy={false}
+      submit={(action) => void action()}
+      drafts={drafts}
+      setDrafts={setDrafts}
+    />
+  );
+}
+
+describe('permission auto-approve offer', () => {
+  it('stays hidden when the server made no offer', () => {
+    installAgenticoMock();
+    render(<PermissionDetailHarness item={permissionItem} />);
+    expect(screen.queryByRole('group', { name: 'Auto-approve commands' })).toBeNull();
+    expect(screen.getByRole('button', { name: 'Allow once' })).toBeVisible();
+  });
+
+  it('allows and turns auto-approve on for the feature or the workspace', async () => {
+    const mock = installAgenticoMock();
+    const user = userEvent.setup();
+    render(
+      <PermissionDetailHarness item={{ ...permissionItem, autoApprove: { wouldFastPath: true } }} />,
+    );
+    const offer = screen.getByRole('group', { name: 'Auto-approve commands' });
+    expect(within(offer).getByText(/would have run without asking/)).toBeVisible();
+
+    await user.click(
+      within(offer).getByRole('button', { name: 'Allow and auto-approve in this feature' }),
+    );
+    expect(mock.api.answerPermission).toHaveBeenLastCalledWith({
+      requestId: 'perm-1',
+      sessionId: 'session-1',
+      decision: 'allow_once',
+      autoApproveScope: 'feature',
+    });
+
+    await user.click(
+      within(offer).getByRole('button', { name: 'Allow and auto-approve everywhere' }),
+    );
+    expect(mock.api.answerPermission).toHaveBeenLastCalledWith({
+      requestId: 'perm-1',
+      sessionId: 'session-1',
+      decision: 'allow_once',
+      autoApproveScope: 'workspace',
+    });
+  });
+
+  it('omits the feature choice for a request without a feature', () => {
+    installAgenticoMock();
+    const { featureId: _omit, ...ownerless } = permissionItem as Extract<
+      AttentionItem,
+      { kind: 'permission' }
+    >;
+    render(
+      <PermissionDetailHarness item={{ ...ownerless, autoApprove: { wouldFastPath: false } }} />,
+    );
+    const offer = screen.getByRole('group', { name: 'Auto-approve commands' });
+    expect(within(offer).getByText(/reviewer model would have decided/)).toBeVisible();
+    expect(
+      within(offer).queryByRole('button', { name: 'Allow and auto-approve in this feature' }),
+    ).toBeNull();
+    expect(
+      within(offer).getByRole('button', { name: 'Allow and auto-approve everywhere' }),
+    ).toBeVisible();
+  });
+});
+
 describe('AttentionInbox popover presentation', () => {
   it('toggles from the bell, dismisses on Escape and outside pointer, and never offers a close control', async () => {
     render(<Harness items={[permissionItem]} onJump={vi.fn()} />);

--- a/desktop/src/renderer/src/features/AttentionInbox.test.tsx
+++ b/desktop/src/renderer/src/features/AttentionInbox.test.tsx
@@ -205,7 +205,9 @@ describe('permission auto-approve offer', () => {
     const mock = installAgenticoMock();
     const user = userEvent.setup();
     render(
-      <PermissionDetailHarness item={{ ...permissionItem, autoApprove: { wouldFastPath: true } }} />,
+      <PermissionDetailHarness
+        item={{ ...permissionItem, autoApprove: { wouldFastPath: true } }}
+      />,
     );
     const offer = screen.getByRole('group', { name: 'Auto-approve commands' });
     expect(within(offer).getByText(/would have run without asking/)).toBeVisible();

--- a/desktop/src/renderer/src/features/AttentionInbox.test.tsx
+++ b/desktop/src/renderer/src/features/AttentionInbox.test.tsx
@@ -213,7 +213,7 @@ describe('permission auto mode split button', () => {
     const main = within(split).getByRole('button', {
       name: 'Enable auto mode (this feature only)',
     });
-    expect(main).toHaveAttribute('title', expect.stringContaining('would have run without asking'));
+    expect(main).toHaveAttribute('title', expect.stringContaining('safe build and test fast path'));
     // The split button sits in the same row as the other decisions.
     expect(main.closest('.attention-detail__actions')).toBe(
       screen.getByRole('button', { name: 'Deny' }).closest('.attention-detail__actions'),
@@ -254,7 +254,7 @@ describe('permission auto mode split button', () => {
     const main = within(split).getByRole('button', { name: 'Enable auto mode (all features)' });
     expect(main).toHaveAttribute(
       'title',
-      expect.stringContaining('reviewer model would have decided'),
+      expect.stringContaining('sent this command to a reviewer model'),
     );
     expect(within(split).queryByLabelText('More auto mode options')).toBeNull();
   });

--- a/desktop/src/renderer/src/features/AttentionInbox.tsx
+++ b/desktop/src/renderer/src/features/AttentionInbox.tsx
@@ -20,7 +20,7 @@ import {
   type AutoApproveScope,
   type VerificationGateAction,
 } from '../../../shared/ipc';
-import { BellIcon } from '../components/icons';
+import { BellIcon, ChevronDownIcon } from '../components/icons';
 import { ToolbarPopover, ToolbarPopoverAnchor } from '../components/ToolbarPopover';
 import { useDetailsDismiss } from '../components/useDetailsDismiss';
 import {
@@ -411,7 +411,7 @@ function AutoModeSplitButton({
             aria-label="More auto mode options"
             aria-disabled={busy}
           >
-            <span aria-hidden="true">▾</span>
+            <ChevronDownIcon className="attention-split__chevron" aria-hidden="true" />
           </summary>
           <div className="attention-split__menu" role="menu" aria-label="Auto mode scope">
             <button
@@ -423,6 +423,7 @@ function AutoModeSplitButton({
               onClick={() => answer('workspace')}
             >
               Enable auto mode (all features)
+              <small>Stops asking for shell commands in every feature</small>
             </button>
           </div>
         </details>

--- a/desktop/src/renderer/src/features/AttentionInbox.tsx
+++ b/desktop/src/renderer/src/features/AttentionInbox.tsx
@@ -17,6 +17,7 @@ import {
   isSyntheticHelpItem,
   type AttentionActionResult,
   type AttentionItem,
+  type AutoApproveScope,
   type VerificationGateAction,
 } from '../../../shared/ipc';
 import { BellIcon } from '../components/icons';
@@ -351,6 +352,64 @@ export function AttentionInbox({
   );
 }
 
+/**
+ * Offered on a Bash prompt when auto-approve commands is off but would have
+ * handled the request. Each choice allows the current request and turns the
+ * setting on for the feature or the whole workspace; running sessions pick
+ * the change up on their next command.
+ */
+function AutoApproveOffer({
+  item,
+  busy,
+  submit,
+}: {
+  item: Extract<AttentionItem, { kind: 'permission' }>;
+  busy: boolean;
+  submit(action: AttentionAction, options?: AttentionSubmitOptions): void;
+}) {
+  const offer = item.autoApprove;
+  if (offer === undefined) return null;
+  const answer = (scope: AutoApproveScope, successNotice: string) =>
+    submit(
+      () =>
+        window.agentico.answerPermission({
+          requestId: item.id,
+          ...(item.sessionId === undefined ? {} : { sessionId: item.sessionId }),
+          decision: 'allow_once',
+          autoApproveScope: scope,
+        }),
+      { successNotice },
+    );
+  return (
+    <div className="attention-detail__auto-approve" role="group" aria-label="Auto-approve commands">
+      <p className="attention-detail__hint">
+        {offer.wouldFastPath
+          ? 'Auto-approve commands is off. With it on, this command would have run without asking.'
+          : 'Auto-approve commands is off. With it on, a reviewer model would have decided this without asking.'}{' '}
+        You can change it later in the feature configuration or in Settings › Workspace defaults.
+      </p>
+      <div className="attention-detail__actions">
+        {item.featureId !== undefined ? (
+          <button
+            className="attention-button"
+            disabled={busy}
+            onClick={() => answer('feature', 'Allowed. Auto-approve commands is on for this feature.')}
+          >
+            Allow and auto-approve in this feature
+          </button>
+        ) : null}
+        <button
+          className="attention-button"
+          disabled={busy}
+          onClick={() => answer('workspace', 'Allowed. Auto-approve commands is on for the workspace.')}
+        >
+          Allow and auto-approve everywhere
+        </button>
+      </div>
+    </div>
+  );
+}
+
 export function AttentionDetail({
   item,
   busy,
@@ -439,6 +498,9 @@ export function AttentionDetail({
           ) : null}
           <AttentionJumpAction item={item} onJump={onJump} />
         </div>
+        {item.autoApprove !== undefined ? (
+          <AutoApproveOffer item={item} busy={busy} submit={submit} />
+        ) : null}
       </div>
     );
 

--- a/desktop/src/renderer/src/features/AttentionInbox.tsx
+++ b/desktop/src/renderer/src/features/AttentionInbox.tsx
@@ -391,15 +391,15 @@ function AutoModeSplitButton({
     );
   };
   const why = offer.wouldFastPath
-    ? 'With auto mode on, this command would have run without asking.'
-    : 'With auto mode on, a reviewer model would have decided this without asking.';
+    ? 'Auto mode would have approved this command on its own: it matches the safe build and test fast path.'
+    : 'Auto mode would have sent this command to a reviewer model, which approves it or hands it back to you.';
   const featureScoped = item.featureId !== undefined;
   return (
     <div className="attention-split" role="group" aria-label="Enable auto mode">
       <button
         className="attention-button attention-split__main"
         disabled={busy}
-        title={`${why} Allows this command and stops asking for shell commands${featureScoped ? ' in this feature' : ''}.`}
+        title={`${why} Allows this command now and turns auto mode on${featureScoped ? ' for this feature' : ' for all features'}.`}
         onClick={() => answer(featureScoped ? 'feature' : 'workspace')}
       >
         {featureScoped ? 'Enable auto mode (this feature only)' : 'Enable auto mode (all features)'}
@@ -419,11 +419,11 @@ function AutoModeSplitButton({
               role="menuitem"
               className="attention-split__item"
               disabled={busy}
-              title={`${why} Allows this command and stops asking for shell commands in every feature.`}
+              title={`${why} Allows this command now and turns auto mode on for all features.`}
               onClick={() => answer('workspace')}
             >
               Enable auto mode (all features)
-              <small>Stops asking for shell commands in every feature</small>
+              <small>Safe commands run; a reviewer model screens the rest</small>
             </button>
           </div>
         </details>

--- a/desktop/src/renderer/src/features/AttentionInbox.tsx
+++ b/desktop/src/renderer/src/features/AttentionInbox.tsx
@@ -393,7 +393,9 @@ function AutoApproveOffer({
           <button
             className="attention-button"
             disabled={busy}
-            onClick={() => answer('feature', 'Allowed. Auto-approve commands is on for this feature.')}
+            onClick={() =>
+              answer('feature', 'Allowed. Auto-approve commands is on for this feature.')
+            }
           >
             Allow and auto-approve in this feature
           </button>
@@ -401,7 +403,9 @@ function AutoApproveOffer({
         <button
           className="attention-button"
           disabled={busy}
-          onClick={() => answer('workspace', 'Allowed. Auto-approve commands is on for the workspace.')}
+          onClick={() =>
+            answer('workspace', 'Allowed. Auto-approve commands is on for the workspace.')
+          }
         >
           Allow and auto-approve everywhere
         </button>

--- a/desktop/src/renderer/src/features/AttentionInbox.tsx
+++ b/desktop/src/renderer/src/features/AttentionInbox.tsx
@@ -22,6 +22,7 @@ import {
 } from '../../../shared/ipc';
 import { BellIcon } from '../components/icons';
 import { ToolbarPopover, ToolbarPopoverAnchor } from '../components/ToolbarPopover';
+import { useDetailsDismiss } from '../components/useDetailsDismiss';
 import {
   hasStructuredVerificationDecision,
   NeedUserInputVerificationDecision,
@@ -353,12 +354,12 @@ export function AttentionInbox({
 }
 
 /**
- * Offered on a Bash prompt when auto-approve commands is off but would have
- * handled the request. Each choice allows the current request and turns the
- * setting on for the feature or the whole workspace; running sessions pick
- * the change up on their next command.
+ * Split button offered on a Bash prompt when auto mode is off but would have
+ * handled the request. The main action allows the command and turns auto mode
+ * on for this feature; the chevron menu offers the workspace-wide choice.
+ * Running sessions pick the change up on their next command.
  */
-function AutoApproveOffer({
+function AutoModeSplitButton({
   item,
   busy,
   submit,
@@ -367,9 +368,12 @@ function AutoApproveOffer({
   busy: boolean;
   submit(action: AttentionAction, options?: AttentionSubmitOptions): void;
 }) {
+  const menuRef = useRef<HTMLDetailsElement>(null);
+  useDetailsDismiss(menuRef, '.attention-split__toggle');
   const offer = item.autoApprove;
   if (offer === undefined) return null;
-  const answer = (scope: AutoApproveScope, successNotice: string) =>
+  const answer = (scope: AutoApproveScope) => {
+    if (menuRef.current !== null) menuRef.current.open = false;
     submit(
       () =>
         window.agentico.answerPermission({
@@ -378,38 +382,51 @@ function AutoApproveOffer({
           decision: 'allow_once',
           autoApproveScope: scope,
         }),
-      { successNotice },
+      {
+        successNotice:
+          scope === 'feature'
+            ? 'Allowed. Auto mode is on for this feature.'
+            : 'Allowed. Auto mode is on for all features.',
+      },
     );
+  };
+  const why = offer.wouldFastPath
+    ? 'With auto mode on, this command would have run without asking.'
+    : 'With auto mode on, a reviewer model would have decided this without asking.';
+  const featureScoped = item.featureId !== undefined;
   return (
-    <div className="attention-detail__auto-approve" role="group" aria-label="Auto-approve commands">
-      <p className="attention-detail__hint">
-        {offer.wouldFastPath
-          ? 'Auto-approve commands is off. With it on, this command would have run without asking.'
-          : 'Auto-approve commands is off. With it on, a reviewer model would have decided this without asking.'}{' '}
-        You can change it later in the feature configuration or in Settings › Workspace defaults.
-      </p>
-      <div className="attention-detail__auto-approve-actions">
-        {item.featureId !== undefined ? (
-          <button
-            className="attention-button"
-            disabled={busy}
-            onClick={() =>
-              answer('feature', 'Allowed. Auto-approve commands is on for this feature.')
-            }
+    <div className="attention-split" role="group" aria-label="Enable auto mode">
+      <button
+        className="attention-button attention-split__main"
+        disabled={busy}
+        title={`${why} Allows this command and stops asking for shell commands${featureScoped ? ' in this feature' : ''}.`}
+        onClick={() => answer(featureScoped ? 'feature' : 'workspace')}
+      >
+        {featureScoped ? 'Enable auto mode (this feature only)' : 'Enable auto mode (all features)'}
+      </button>
+      {featureScoped ? (
+        <details ref={menuRef} className="attention-split__more">
+          <summary
+            className="attention-button attention-split__toggle"
+            aria-label="More auto mode options"
+            aria-disabled={busy}
           >
-            Allow and auto-approve in this feature
-          </button>
-        ) : null}
-        <button
-          className="attention-button"
-          disabled={busy}
-          onClick={() =>
-            answer('workspace', 'Allowed. Auto-approve commands is on for the workspace.')
-          }
-        >
-          Allow and auto-approve everywhere
-        </button>
-      </div>
+            <span aria-hidden="true">▾</span>
+          </summary>
+          <div className="attention-split__menu" role="menu" aria-label="Auto mode scope">
+            <button
+              type="button"
+              role="menuitem"
+              className="attention-split__item"
+              disabled={busy}
+              title={`${why} Allows this command and stops asking for shell commands in every feature.`}
+              onClick={() => answer('workspace')}
+            >
+              Enable auto mode (all features)
+            </button>
+          </div>
+        </details>
+      ) : null}
     </div>
   );
 }
@@ -481,6 +498,9 @@ export function AttentionDetail({
           >
             Deny
           </button>
+          {item.autoApprove !== undefined ? (
+            <AutoModeSplitButton item={item} busy={busy} submit={submit} />
+          ) : null}
           {item.remember !== undefined ? (
             <button
               className="attention-button"
@@ -502,9 +522,6 @@ export function AttentionDetail({
           ) : null}
           <AttentionJumpAction item={item} onJump={onJump} />
         </div>
-        {item.autoApprove !== undefined ? (
-          <AutoApproveOffer item={item} busy={busy} submit={submit} />
-        ) : null}
       </div>
     );
 

--- a/desktop/src/renderer/src/features/AttentionInbox.tsx
+++ b/desktop/src/renderer/src/features/AttentionInbox.tsx
@@ -388,7 +388,7 @@ function AutoApproveOffer({
           : 'Auto-approve commands is off. With it on, a reviewer model would have decided this without asking.'}{' '}
         You can change it later in the feature configuration or in Settings › Workspace defaults.
       </p>
-      <div className="attention-detail__actions">
+      <div className="attention-detail__auto-approve-actions">
         {item.featureId !== undefined ? (
           <button
             className="attention-button"

--- a/desktop/src/renderer/src/features/ConfigEditor.test.tsx
+++ b/desktop/src/renderer/src/features/ConfigEditor.test.tsx
@@ -149,7 +149,7 @@ describe('FeatureConfigPanel', () => {
     render(<FeatureConfigPanel featureId="feat-1" />);
     const user = userEvent.setup();
 
-    const picker = await screen.findByLabelText('Automatic review');
+    const picker = await screen.findByLabelText('Auto-approve commands');
     expect(picker).toHaveValue('default');
     await user.selectOptions(picker, 'enabled');
     await user.click(screen.getByRole('button', { name: 'Save changes' }));
@@ -333,10 +333,10 @@ describe('WorkspaceDefaultsPanel', () => {
     render(<WorkspaceDefaultsPanel />);
     const user = userEvent.setup();
 
-    const reviewer = await screen.findByLabelText('Automatic review model');
+    const reviewer = await screen.findByLabelText('Auto-approve reviewer model');
     expect(within(reviewer).getByRole('option', { name: /Automatic/ })).toBeVisible();
     await user.selectOptions(reviewer, 'claude:sonnet');
-    await user.selectOptions(screen.getByLabelText('Automatic review'), 'enabled');
+    await user.selectOptions(screen.getByLabelText('Auto-approve commands'), 'enabled');
     await user.click(screen.getByRole('button', { name: 'Save changes' }));
 
     await waitFor(() => expect(mock.api.updateWorkspaceDefaults).toHaveBeenCalledTimes(1));

--- a/desktop/src/renderer/src/features/ConfigEditor.test.tsx
+++ b/desktop/src/renderer/src/features/ConfigEditor.test.tsx
@@ -149,7 +149,7 @@ describe('FeatureConfigPanel', () => {
     render(<FeatureConfigPanel featureId="feat-1" />);
     const user = userEvent.setup();
 
-    const picker = await screen.findByLabelText('Auto-approve commands');
+    const picker = await screen.findByLabelText('Auto mode');
     expect(picker).toHaveValue('default');
     await user.selectOptions(picker, 'enabled');
     await user.click(screen.getByRole('button', { name: 'Save changes' }));
@@ -333,10 +333,10 @@ describe('WorkspaceDefaultsPanel', () => {
     render(<WorkspaceDefaultsPanel />);
     const user = userEvent.setup();
 
-    const reviewer = await screen.findByLabelText('Auto-approve reviewer model');
+    const reviewer = await screen.findByLabelText('Auto mode reviewer model');
     expect(within(reviewer).getByRole('option', { name: /Automatic/ })).toBeVisible();
     await user.selectOptions(reviewer, 'claude:sonnet');
-    await user.selectOptions(screen.getByLabelText('Auto-approve commands'), 'enabled');
+    await user.selectOptions(screen.getByLabelText('Auto mode'), 'enabled');
     await user.click(screen.getByRole('button', { name: 'Save changes' }));
 
     await waitFor(() => expect(mock.api.updateWorkspaceDefaults).toHaveBeenCalledTimes(1));

--- a/desktop/src/renderer/src/features/ConfigEditor.tsx
+++ b/desktop/src/renderer/src/features/ConfigEditor.tsx
@@ -63,9 +63,9 @@ export const PHASE_FIELDS: ReadonlyArray<PhaseField> = [
   { key: 'kbBuild', label: 'KB Build', role: 'kb_build', hint: 'Knowledge base construction' },
   {
     key: 'automaticReview',
-    label: 'Auto-approve reviewer',
+    label: 'Auto mode reviewer',
     role: 'automatic_review',
-    hint: 'Model that reviews shell commands when auto-approve is on',
+    hint: 'Model that reviews shell commands when auto mode is on',
     workspaceOnly: true,
     supportsEffort: false,
   },
@@ -569,11 +569,11 @@ function ConfigForm({
           </select>
         </label>
         <label className="config-editor__row">
-          <span className="config-editor__row-label">Auto-approve commands</span>
+          <span className="config-editor__row-label">Auto mode</span>
           <span className="config-editor__row-hint">{automaticReview.hint}</span>
           <select
             className="config-editor__select"
-            aria-label="Auto-approve commands"
+            aria-label="Auto mode"
             value={automaticReview.value}
             onChange={(event) => onAutomaticReviewChange(event.target.value)}
           >
@@ -921,7 +921,7 @@ export function WorkspaceDefaultsPanel({
         }}
         automaticReview={{
           value: draft.automaticReviewEnabled ? 'enabled' : 'disabled',
-          hint: 'Let a reviewer model approve shell commands instead of asking you',
+          hint: 'Approve shell commands automatically instead of asking you',
           options: WORKSPACE_AUTOMATIC_REVIEW_OPTIONS,
         }}
         onChange={(next) => setDraft({ ...draft, ...next })}

--- a/desktop/src/renderer/src/features/ConfigEditor.tsx
+++ b/desktop/src/renderer/src/features/ConfigEditor.tsx
@@ -63,9 +63,9 @@ export const PHASE_FIELDS: ReadonlyArray<PhaseField> = [
   { key: 'kbBuild', label: 'KB Build', role: 'kb_build', hint: 'Knowledge base construction' },
   {
     key: 'automaticReview',
-    label: 'Automatic review',
+    label: 'Auto-approve reviewer',
     role: 'automatic_review',
-    hint: 'Reviewer for unresolved Bash permission requests',
+    hint: 'Model that reviews shell commands when auto-approve is on',
     workspaceOnly: true,
     supportsEffort: false,
   },
@@ -569,11 +569,11 @@ function ConfigForm({
           </select>
         </label>
         <label className="config-editor__row">
-          <span className="config-editor__row-label">Automatic review</span>
+          <span className="config-editor__row-label">Auto-approve commands</span>
           <span className="config-editor__row-hint">{automaticReview.hint}</span>
           <select
             className="config-editor__select"
-            aria-label="Automatic review"
+            aria-label="Auto-approve commands"
             value={automaticReview.value}
             onChange={(event) => onAutomaticReviewChange(event.target.value)}
           >
@@ -795,7 +795,7 @@ export function FeatureConfigPanel({ featureId }: { featureId: string }) {
         inputAlerts={{ value: draft.inputNotifications, options: FEATURE_ALERT_OPTIONS }}
         automaticReview={{
           value: draft.automaticReviewMode,
-          hint: 'Override the workspace default for new sessions in this feature',
+          hint: 'Override the workspace setting for this feature',
           options: FEATURE_AUTOMATIC_REVIEW_OPTIONS,
         }}
         onChange={(next) => setDraft({ ...draft, ...next })}
@@ -921,7 +921,7 @@ export function WorkspaceDefaultsPanel({
         }}
         automaticReview={{
           value: draft.automaticReviewEnabled ? 'enabled' : 'disabled',
-          hint: 'Automatically review unresolved Bash requests for new sessions',
+          hint: 'Let a reviewer model approve shell commands instead of asking you',
           options: WORKSPACE_AUTOMATIC_REVIEW_OPTIONS,
         }}
         onChange={(next) => setDraft({ ...draft, ...next })}

--- a/desktop/src/renderer/src/features/CreateFeatureForm.test.tsx
+++ b/desktop/src/renderer/src/features/CreateFeatureForm.test.tsx
@@ -388,7 +388,7 @@ describe('the creation sheet across its four steps', () => {
     expect(screen.queryByLabelText('Clarify model')).toBeNull();
     expect(screen.queryByLabelText('KB Build model')).toBeNull();
     expect(screen.queryByLabelText('Utilities model')).toBeNull();
-    expect(screen.queryByLabelText('Automatic review model')).toBeNull();
+    expect(screen.queryByLabelText('Auto-approve reviewer model')).toBeNull();
 
     await user.click(screen.getByRole('button', { name: 'Back' }));
     await user.click(screen.getByRole('radio', { name: /Large/ }));
@@ -397,7 +397,7 @@ describe('the creation sheet across its four steps', () => {
     expect(screen.getByLabelText('KB Build model')).toBeVisible();
     // Utilities and the automatic reviewer stay workspace-scoped.
     expect(screen.queryByLabelText('Utilities model')).toBeNull();
-    expect(screen.queryByLabelText('Automatic review model')).toBeNull();
+    expect(screen.queryByLabelText('Auto-approve reviewer model')).toBeNull();
   });
 
   it('submits the contract without untouched model defaults, auto-starts the feature, and keeps one idempotency identity', async () => {

--- a/desktop/src/renderer/src/features/CreateFeatureForm.test.tsx
+++ b/desktop/src/renderer/src/features/CreateFeatureForm.test.tsx
@@ -388,7 +388,7 @@ describe('the creation sheet across its four steps', () => {
     expect(screen.queryByLabelText('Clarify model')).toBeNull();
     expect(screen.queryByLabelText('KB Build model')).toBeNull();
     expect(screen.queryByLabelText('Utilities model')).toBeNull();
-    expect(screen.queryByLabelText('Auto-approve reviewer model')).toBeNull();
+    expect(screen.queryByLabelText('Auto mode reviewer model')).toBeNull();
 
     await user.click(screen.getByRole('button', { name: 'Back' }));
     await user.click(screen.getByRole('radio', { name: /Large/ }));
@@ -397,7 +397,7 @@ describe('the creation sheet across its four steps', () => {
     expect(screen.getByLabelText('KB Build model')).toBeVisible();
     // Utilities and the automatic reviewer stay workspace-scoped.
     expect(screen.queryByLabelText('Utilities model')).toBeNull();
-    expect(screen.queryByLabelText('Auto-approve reviewer model')).toBeNull();
+    expect(screen.queryByLabelText('Auto mode reviewer model')).toBeNull();
   });
 
   it('submits the contract without untouched model defaults, auto-starts the feature, and keeps one idempotency identity', async () => {

--- a/desktop/src/renderer/src/features/FeatureCockpit.test.tsx
+++ b/desktop/src/renderer/src/features/FeatureCockpit.test.tsx
@@ -132,7 +132,7 @@ describe('FeatureCockpit snapshot rendering', () => {
     expect(header).not.toBeNull();
     expect(within(header!).getByLabelText('SettingUpWorktrees')).toBeInTheDocument();
     expect(within(header!).getByText('feature/search-revamp')).toBeInTheDocument();
-    expect(within(header!).queryByText('Automatic review')).not.toBeInTheDocument();
+    expect(within(header!).queryByText('Auto-approve commands')).not.toBeInTheDocument();
     expect(within(header!).queryByText('Repository')).not.toBeInTheDocument();
   });
 

--- a/desktop/src/renderer/src/features/FeatureCockpit.test.tsx
+++ b/desktop/src/renderer/src/features/FeatureCockpit.test.tsx
@@ -132,7 +132,7 @@ describe('FeatureCockpit snapshot rendering', () => {
     expect(header).not.toBeNull();
     expect(within(header!).getByLabelText('SettingUpWorktrees')).toBeInTheDocument();
     expect(within(header!).getByText('feature/search-revamp')).toBeInTheDocument();
-    expect(within(header!).queryByText('Auto-approve commands')).not.toBeInTheDocument();
+    expect(within(header!).queryByText('Auto mode')).not.toBeInTheDocument();
     expect(within(header!).queryByText('Repository')).not.toBeInTheDocument();
   });
 

--- a/desktop/src/renderer/src/styles/app.css
+++ b/desktop/src/renderer/src/styles/app.css
@@ -3667,6 +3667,19 @@ body {
   color: var(--muted);
 }
 
+.attention-detail__auto-approve {
+  display: grid;
+  gap: var(--space-2);
+  padding: var(--space-3);
+  border: 1px dashed var(--hairline);
+  border-radius: var(--radius);
+}
+
+.attention-detail__auto-approve > p {
+  margin: 0;
+  font-size: 13px;
+}
+
 .attention-detail__tasks {
   margin: 0;
   padding-left: var(--space-4);

--- a/desktop/src/renderer/src/styles/app.css
+++ b/desktop/src/renderer/src/styles/app.css
@@ -3681,11 +3681,23 @@ body {
   list-style: none;
   display: inline-flex;
   align-items: center;
+  justify-content: center;
   height: 100%;
-  padding-inline: var(--space-2);
+  min-width: 30px;
+  padding: 0 var(--space-2);
   border-left: 0;
   border-top-left-radius: 0;
   border-bottom-left-radius: 0;
+  color: var(--muted);
+  transition:
+    background 120ms ease,
+    color 120ms ease;
+}
+
+.attention-split__toggle:hover,
+.attention-split__more[open] > .attention-split__toggle {
+  color: var(--text);
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
 }
 
 .attention-split__toggle::-webkit-details-marker {
@@ -3696,30 +3708,65 @@ body {
   outline: var(--focus-ring);
 }
 
-/* Opens upward: the actions row is pinned to the bottom of its pane. */
+.attention-split__chevron {
+  width: 14px;
+  height: 14px;
+  transition: transform 140ms ease;
+}
+
+.attention-split__more[open] .attention-split__chevron {
+  transform: rotate(180deg);
+}
+
+/* Opens upward, spanning the whole control: the actions row is pinned to the
+   bottom of its pane. */
 .attention-split__menu {
   position: absolute;
   left: 0;
+  min-width: 100%;
   bottom: calc(100% + var(--space-1));
   z-index: 30;
-  min-width: 240px;
   padding: var(--space-1);
   border: 1px solid var(--hairline);
   border-radius: var(--radius);
   background: var(--raised);
-  box-shadow: 0 10px 30px color-mix(in srgb, var(--content) 60%, transparent);
+  box-shadow:
+    0 1px 2px color-mix(in srgb, var(--content) 40%, transparent),
+    0 12px 32px color-mix(in srgb, var(--content) 55%, transparent);
+  animation: attention-split-reveal 140ms ease-out;
+}
+
+@keyframes attention-split-reveal {
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
 }
 
 .attention-split__item {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
   width: 100%;
   text-align: left;
   border: 0;
   background: transparent;
-  padding: var(--space-2);
-  border-radius: var(--radius);
+  padding: var(--space-2) var(--space-3);
+  border-radius: calc(var(--radius) - 2px);
   color: var(--text);
   font: 700 13px var(--bench-font-text);
   cursor: pointer;
+}
+
+.attention-split__item > small {
+  color: var(--muted);
+  font-weight: 500;
+  font-size: 12px;
+  white-space: nowrap;
 }
 
 .attention-split__item:hover:not(:disabled) {

--- a/desktop/src/renderer/src/styles/app.css
+++ b/desktop/src/renderer/src/styles/app.css
@@ -3667,23 +3667,68 @@ body {
   color: var(--muted);
 }
 
-.attention-detail__auto-approve {
-  display: grid;
-  gap: var(--space-2);
-  padding: var(--space-3);
-  border: 1px dashed var(--hairline);
+.attention-split {
+  position: relative;
+  display: inline-flex;
+}
+
+.attention-split__main {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.attention-split__toggle {
+  list-style: none;
+  display: inline-flex;
+  align-items: center;
+  height: 100%;
+  padding-inline: var(--space-2);
+  border-left: 0;
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.attention-split__toggle::-webkit-details-marker {
+  display: none;
+}
+
+.attention-split__toggle:focus-visible {
+  outline: var(--focus-ring);
+}
+
+/* Opens upward: the actions row is pinned to the bottom of its pane. */
+.attention-split__menu {
+  position: absolute;
+  left: 0;
+  bottom: calc(100% + var(--space-1));
+  z-index: 30;
+  min-width: 240px;
+  padding: var(--space-1);
+  border: 1px solid var(--hairline);
   border-radius: var(--radius);
+  background: var(--raised);
+  box-shadow: 0 10px 30px color-mix(in srgb, var(--content) 60%, transparent);
 }
 
-.attention-detail__auto-approve > p {
-  margin: 0;
-  font-size: 13px;
+.attention-split__item {
+  width: 100%;
+  text-align: left;
+  border: 0;
+  background: transparent;
+  padding: var(--space-2);
+  border-radius: var(--radius);
+  color: var(--text);
+  font: 700 13px var(--bench-font-text);
+  cursor: pointer;
 }
 
-.attention-detail__auto-approve-actions {
-  display: flex;
-  gap: var(--space-2);
-  flex-wrap: wrap;
+.attention-split__item:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--accent) 10%, transparent);
+}
+
+.attention-split__item:focus-visible {
+  outline: var(--focus-ring);
+  outline-offset: -2px;
 }
 
 .attention-detail__tasks {

--- a/desktop/src/renderer/src/styles/app.css
+++ b/desktop/src/renderer/src/styles/app.css
@@ -3680,6 +3680,12 @@ body {
   font-size: 13px;
 }
 
+.attention-detail__auto-approve-actions {
+  display: flex;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+}
+
 .attention-detail__tasks {
   margin: 0;
   padding-left: var(--space-4);

--- a/desktop/src/shared/api/parse.ts
+++ b/desktop/src/shared/api/parse.ts
@@ -219,6 +219,7 @@ export const ServerControlRequestSchema = z.object({
   input: z.record(z.string().max(200), z.unknown()).optional(),
   questions: z.array(ServerAskUserQuestionSchema).max(100).optional(),
   remember: ServerRememberPreviewSchema.optional(),
+  auto_approve: z.object({ would_fast_path: z.boolean() }).optional(),
   waiting_since: z.string().max(100).optional(),
 });
 export const ServerHelpQueueSchema = z.object({

--- a/desktop/src/shared/api/schema.gen.ts
+++ b/desktop/src/shared/api/schema.gen.ts
@@ -925,6 +925,11 @@ export interface components {
             /** @enum {string} */
             decision: "allow_once" | "allow_remember" | "deny";
             remember_pattern?: string;
+            /**
+             * @description Turn automatic Bash review on for the request's feature or for the whole workspace before answering. Not allowed with deny.
+             * @enum {string}
+             */
+            auto_approve_scope?: "feature" | "workspace";
             /** @description Existing permission cache scope. Empty string means global. */
             remember_scope?: string;
         };
@@ -2226,6 +2231,12 @@ export interface components {
             };
             questions?: components["schemas"]["AskUserQuestion"][];
             remember?: components["schemas"]["PermissionRememberPreview"];
+            auto_approve?: components["schemas"]["PermissionAutoApproveOffer"];
+        };
+        /** @description Present when automatic Bash review is off for the session but would have handled this request had it been on. */
+        PermissionAutoApproveOffer: {
+            /** @description The deterministic guardrail alone would have approved the command. */
+            would_fast_path: boolean;
         };
         SessionDetail: components["schemas"]["SessionSummary"] & {
             transcript_cursor: components["schemas"]["Cursor"];

--- a/desktop/src/shared/ipc.ts
+++ b/desktop/src/shared/ipc.ts
@@ -1872,7 +1872,11 @@ export const AttentionPermissionSchema = z.strictObject({
       scopeDisplay: z.string().max(4096),
     })
     .optional(),
+  /** Present when auto-approve commands is off but would have handled this request. */
+  autoApprove: z.strictObject({ wouldFastPath: z.boolean() }).optional(),
 });
+export const AutoApproveScopeSchema = z.enum(['feature', 'workspace']);
+export type AutoApproveScope = z.output<typeof AutoApproveScopeSchema>;
 export const AttentionQuestionBundleSchema = z.strictObject({
   kind: z.literal('questions'),
   id: AttentionIDSchema,
@@ -2017,6 +2021,8 @@ export const PermissionDecisionRequestSchema = z.strictObject({
   decision: z.enum(['allow_once', 'allow_remember', 'deny']),
   rememberPattern: z.string().max(4096).optional(),
   rememberScope: z.string().max(4096).optional(),
+  /** Turn auto-approve commands on for the feature or workspace before allowing. */
+  autoApproveScope: AutoApproveScopeSchema.optional(),
 });
 export type PermissionDecisionRequest = z.output<typeof PermissionDecisionRequestSchema>;
 export const AskUserAnswerRequestSchema = z.strictObject({

--- a/desktop/test/e2e/screenshot-capture/auto-approve-offer-evidence.spec.ts
+++ b/desktop/test/e2e/screenshot-capture/auto-approve-offer-evidence.spec.ts
@@ -2,11 +2,12 @@ import { expect, test } from '@playwright/test';
 import { openScene, shoot, skipWithoutEvidenceDir } from './evidence-capture';
 
 /**
- * A Bash permission prompt that automatic review would have handled carries an
- * auto-approve offer. The cockpit's inline "Agent request" card shows the
- * offer under the usual Allow / Deny controls, then the notice after opting in.
+ * A Bash permission prompt that auto mode would have handled carries a split
+ * button beside Allow once and Deny: the main action enables auto mode for
+ * this feature, the chevron menu offers all features. Shots cover the closed
+ * button, the open menu, and the notice after opting in.
  */
-test('auto-approve offer on a permission prompt', async ({ page }) => {
+test('auto mode split button on a permission prompt', async ({ page }) => {
   skipWithoutEvidenceDir();
 
   for (const theme of ['dark', 'light'] as const) {
@@ -16,27 +17,28 @@ test('auto-approve offer on a permission prompt', async ({ page }) => {
     const card = page.getByRole('region', { name: 'Agent request' });
     await expect(card).toBeVisible({ timeout: 15_000 });
     await card.scrollIntoViewIfNeeded();
-    const offer = card.getByRole('group', { name: 'Auto-approve commands' });
-    await expect(offer).toBeVisible();
-    await expect(offer.getByText(/would have run without asking/)).toBeVisible();
-    await expect(
-      offer.getByRole('button', { name: 'Allow and auto-approve in this feature' }),
-    ).toBeVisible();
-    await expect(
-      offer.getByRole('button', { name: 'Allow and auto-approve everywhere' }),
-    ).toBeVisible();
+    const split = card.getByRole('group', { name: 'Enable auto mode' });
+    const main = split.getByRole('button', { name: 'Enable auto mode (this feature only)' });
+    await expect(main).toBeVisible();
     await page.mouse.move(130, 700);
     await page.waitForTimeout(300);
-    await shoot(page, `auto-approve-offer-permission-card-${theme}-1440x900`);
+    await shoot(page, `auto-mode-permission-card-${theme}-1440x900`);
     await card.screenshot({
-      path: `${process.env['AGENTICO_EVIDENCE_DIR']}/auto-approve-offer-card-only-${theme}.png`,
+      path: `${process.env['AGENTICO_EVIDENCE_DIR']}/auto-mode-card-only-${theme}.png`,
     });
 
+    await split.getByLabel('More auto mode options').click();
+    const all = card.getByRole('menuitem', { name: 'Enable auto mode (all features)' });
+    await expect(all).toBeVisible();
+    await page.waitForTimeout(200);
+    // The menu floats below the card box, so this one needs the full window.
+    await shoot(page, `auto-mode-menu-open-${theme}-1440x900`);
+
     if (theme === 'light') {
-      await offer.getByRole('button', { name: 'Allow and auto-approve in this feature' }).click();
-      await expect(page.getByText('Auto-approve commands is on for this feature')).toBeVisible();
+      await all.click();
+      await expect(page.getByText('Allowed. Auto mode is on for all features.')).toBeVisible();
       await page.waitForTimeout(300);
-      await shoot(page, `auto-approve-offer-after-opt-in-${theme}-1440x900`);
+      await shoot(page, `auto-mode-after-opt-in-${theme}-1440x900`);
     }
   }
 });

--- a/desktop/test/e2e/screenshot-capture/auto-approve-offer-evidence.spec.ts
+++ b/desktop/test/e2e/screenshot-capture/auto-approve-offer-evidence.spec.ts
@@ -1,0 +1,42 @@
+import { expect, test } from '@playwright/test';
+import { openScene, shoot, skipWithoutEvidenceDir } from './evidence-capture';
+
+/**
+ * A Bash permission prompt that automatic review would have handled carries an
+ * auto-approve offer. The cockpit's inline "Agent request" card shows the
+ * offer under the usual Allow / Deny controls, then the notice after opting in.
+ */
+test('auto-approve offer on a permission prompt', async ({ page }) => {
+  skipWithoutEvidenceDir();
+
+  for (const theme of ['dark', 'light'] as const) {
+    await openScene(page, 'attention-popover', theme, 1440, 900, '.cockpit', {
+      platform: 'darwin',
+    });
+    const card = page.getByRole('region', { name: 'Agent request' });
+    await expect(card).toBeVisible({ timeout: 15_000 });
+    await card.scrollIntoViewIfNeeded();
+    const offer = card.getByRole('group', { name: 'Auto-approve commands' });
+    await expect(offer).toBeVisible();
+    await expect(offer.getByText(/would have run without asking/)).toBeVisible();
+    await expect(
+      offer.getByRole('button', { name: 'Allow and auto-approve in this feature' }),
+    ).toBeVisible();
+    await expect(
+      offer.getByRole('button', { name: 'Allow and auto-approve everywhere' }),
+    ).toBeVisible();
+    await page.mouse.move(130, 700);
+    await page.waitForTimeout(300);
+    await shoot(page, `auto-approve-offer-permission-card-${theme}-1440x900`);
+    await card.screenshot({
+      path: `${process.env['AGENTICO_EVIDENCE_DIR']}/auto-approve-offer-card-only-${theme}.png`,
+    });
+
+    if (theme === 'light') {
+      await offer.getByRole('button', { name: 'Allow and auto-approve in this feature' }).click();
+      await expect(page.getByText('Auto-approve commands is on for this feature')).toBeVisible();
+      await page.waitForTimeout(300);
+      await shoot(page, `auto-approve-offer-after-opt-in-${theme}-1440x900`);
+    }
+  }
+});

--- a/desktop/test/e2e/screenshot-capture/mock-api.ts
+++ b/desktop/test/e2e/screenshot-capture/mock-api.ts
@@ -1365,6 +1365,7 @@ const ATTENTION_POPOVER_ITEMS: AttentionSnapshot['items'] = [
     summary: 'Run the bounded verification command for the rewind preview.',
     input: { command: 'npm run check -- --scope=rewind' },
     waitingSince: new Date(Date.now() - 4 * 60_000).toISOString(),
+    autoApprove: { wouldFastPath: true },
   },
   {
     kind: 'review',

--- a/internal/agent/autoreview.go
+++ b/internal/agent/autoreview.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/doordash-oss/agentic-orchestrator/internal/autoreview"
+	"github.com/doordash-oss/agentic-orchestrator/internal/llm"
 	"github.com/doordash-oss/agentic-orchestrator/internal/observe"
 	"github.com/doordash-oss/agentic-orchestrator/internal/permission"
 	"github.com/doordash-oss/agentic-orchestrator/internal/ports"
@@ -43,8 +44,10 @@ const (
 
 // autoReviewPermissionDecorator wraps the fully composed session permission
 // policy. It asks the existing handler first and returns every non-empty
-// decision or existing error unchanged. Only an empty decision for canonical
-// Bash first checks the deterministic guardrail fast path. Fast-path approvals
+// decision or existing error unchanged. The enabled setting is read live on
+// each request; while off, an empty decision for canonical Bash is annotated
+// with an AutoApproveOffer and deferred unchanged. While on, an empty decision
+// for canonical Bash first checks the deterministic guardrail fast path. Fast-path approvals
 // need no reviewer, mutex, cache, or circuit-breaker state. Every other
 // reviewable command reaches the hidden reviewer when one is available.
 // Successful model ALLOW and DEFER classifications are memoized by the
@@ -57,6 +60,7 @@ const (
 // is never decorated and cannot recurse.
 type autoReviewPermissionDecorator struct {
 	inner            ports.PermissionHandler
+	enabled          func() bool
 	reviewer         autoreview.Reviewer
 	workDir          string
 	writableRoots    []string
@@ -197,6 +201,12 @@ func (s *autoReviewSessionState) review(
 	return "", false, autoReviewBreakerUnchanged
 }
 
+// isEnabled reads the live automatic-review setting so a mid-session opt-in
+// takes effect on the next Bash request. A nil source means always on.
+func (d *autoReviewPermissionDecorator) isEnabled() bool {
+	return d.enabled == nil || d.enabled()
+}
+
 func (d *autoReviewPermissionDecorator) timeNow() time.Time {
 	if d.now != nil {
 		return d.now()
@@ -219,6 +229,14 @@ func (d *autoReviewPermissionDecorator) CanUseTool(req ports.ToolPermissionReque
 		return decision, nil
 	}
 	command := permission.ExtractBashCommand(req.Input)
+	if !d.isEnabled() {
+		if permission.ReviewableBashCommand(command) {
+			decision.AutoApproveOffer = &llm.AutoApproveOffer{
+				WouldFastPath: permission.GuardrailFastPath(command, d.workDir, d.writableRoots),
+			}
+		}
+		return decision, nil
+	}
 	if permission.GuardrailFastPath(command, d.workDir, d.writableRoots) {
 		d.recordFastPathAllow(req, command)
 		return ports.PermissionDecision{Behavior: permission.DecisionAllow}, nil

--- a/internal/agent/autoreview_internal_test.go
+++ b/internal/agent/autoreview_internal_test.go
@@ -1514,7 +1514,7 @@ func TestBuildSessionSurfacesEnabledWithoutReviewer(t *testing.T) {
 		t.Fatalf("SessionBuildNotices = %d, want one unavailable notice", len(sessOpts.SessionBuildNotices))
 	}
 	notice := sessOpts.SessionBuildNotices[0]
-	if !strings.Contains(notice.Status, "Automatic review enabled but no reviewer available:") ||
+	if !strings.Contains(notice.Status, "Auto-approve commands enabled but no reviewer available:") ||
 		!strings.Contains(notice.Status, "isolated tool-less review") {
 		t.Fatalf("notice status = %q", notice.Status)
 	}
@@ -1535,11 +1535,9 @@ func TestBuildSessionSurfacesEnabledWithoutReviewer(t *testing.T) {
 }
 
 // TestDecorateWithAutoReviewSnapshot verifies that the snapshot returned by
-// decorateWithAutoReview is used on crash-resume rather than the current
-// workspace config. This ensures a workspace edit between crash and resume
-// does not change the resumed session's reviewer policy. The snapshot must
-// also capture the resolved reviewer identity so crash-resume can restore
-// the same reviewer even if the provider/catalog state changed.
+// decorateWithAutoReview restores the reviewer identity on crash-resume rather
+// than re-resolving against the current catalog, while the enabled flag is
+// always read live from the current feature and workspace settings.
 func TestDecorateWithAutoReviewSnapshot(t *testing.T) {
 	dir := t.TempDir()
 	store := feature.NewStore(dir)
@@ -1550,7 +1548,7 @@ func TestDecorateWithAutoReviewSnapshot(t *testing.T) {
 		Models:                 config.ModelConfig{AutomaticReview: ""},
 	}}
 
-	original := permission.Guarded(&permission.AutoApproveHandler{})
+	original := permission.Guarded(&permission.AcceptEditsHandler{})
 	composed := permission.WrapGeneralPhaseHandlerWithSafeCreate(original, nil)
 
 	// First call: no snapshot in opts → reads from config, resolves reviewer,
@@ -1593,14 +1591,27 @@ func TestDecorateWithAutoReviewSnapshot(t *testing.T) {
 			snap2.ReviewerProvider, snap2.ReviewerModel, snap1.ReviewerProvider, snap1.ReviewerModel)
 	}
 
+	// The resumed handler reads the enabled flag live, so the edited config
+	// (disabled) turns Bash deferrals into auto-approve offers.
+	got, err := handler2.CanUseTool(bashReq(`{"command":"go test ./..."}`))
+	if err != nil || got.Behavior != "" || got.AutoApproveOffer == nil {
+		t.Fatalf("second call with disabled config: got %+v err %v; want deferral with offer", got, err)
+	}
+
 	// Third call without snapshot: should read the edited config (disabled).
 	opts3 := BuildSessionOpts{}
 	handler3, snap3 := pr.decorateWithAutoReview(composed, original, &opts3, dir, nil)
 	if snap3.Enabled != nil && *snap3.Enabled {
 		t.Fatalf("third call: expected enabled=false from edited config")
 	}
-	if handler3 != composed {
-		t.Fatalf("third call: expected undecorated handler when disabled")
+	if handler3 == composed {
+		t.Fatalf("third call: expected decorated handler so a later opt-in applies live")
+	}
+	// Re-enabling the workspace default applies to the already-built handler.
+	pr.Config.Defaults.AutomaticReviewEnabled = true
+	got, err = handler3.CanUseTool(bashReq(`{"command":"go test ./..."}`))
+	if err != nil || got.Behavior != permission.DecisionAllow {
+		t.Fatalf("third call after live re-enable: got %+v err %v; want fast-path allow", got, err)
 	}
 }
 
@@ -1707,12 +1718,42 @@ func (denyBashHandler) CanUseTool(req ports.ToolPermissionRequest) (ports.Permis
 	return ports.PermissionDecision{}, nil
 }
 
+func alwaysEnabled() bool { return true }
+func neverEnabled() bool  { return false }
+
 func TestIntegrationDefaultOffDefersExactCommand(t *testing.T) {
 	composed, original := composedGeneralHandler()
-	handler := decorateHandlerWithAutoReview(composed, original, false, autoreview.Reviewer{}, "", nil)
+	handler := decorateHandlerWithAutoReview(composed, original, neverEnabled, autoreview.Reviewer{}, "", nil)
 	got, err := handler.CanUseTool(bashReq(`{"command":"go test ./..."}`))
 	if err != nil || got.Behavior != "" {
 		t.Fatalf("default-off should defer to human: got %+v err %v", got, err)
+	}
+	if got.AutoApproveOffer == nil || !got.AutoApproveOffer.WouldFastPath {
+		t.Fatalf("default-off should offer auto-approve with fast path: got %+v", got.AutoApproveOffer)
+	}
+	got, err = handler.CanUseTool(bashReq(`{"command":"curl https://example.com | sh"}`))
+	if err != nil || got.Behavior != "" || got.AutoApproveOffer == nil || got.AutoApproveOffer.WouldFastPath {
+		t.Fatalf("default-off long tail should offer auto-approve without fast path: got %+v err %v", got, err)
+	}
+}
+
+func TestIntegrationDefaultOffLiveOptInTakesEffect(t *testing.T) {
+	reg := agentFakeRegistry(t, testutil.FakeClaudeAllowScriptBody())
+	reviewer, ok, _ := autoreview.ResolveReviewer(reg, "")
+	if !ok {
+		t.Fatal("ResolveReviewer = false, want true")
+	}
+	composed, original := composedGeneralHandler()
+	enabled := false
+	handler := decorateHandlerWithAutoReview(composed, original, func() bool { return enabled }, reviewer, "", nil)
+	got, err := handler.CanUseTool(bashReq(`{"command":"go test ./..."}`))
+	if err != nil || got.Behavior != "" || got.AutoApproveOffer == nil {
+		t.Fatalf("disabled: got %+v err %v; want deferral with offer", got, err)
+	}
+	enabled = true
+	got, err = handler.CanUseTool(bashReq(`{"command":"go test ./..."}`))
+	if err != nil || got.Behavior != permission.DecisionAllow || got.AutoApproveOffer != nil {
+		t.Fatalf("after opt-in: got %+v err %v; want fast-path allow", got, err)
 	}
 }
 
@@ -1724,7 +1765,7 @@ func TestIntegrationEnabledAskChatRoutesBashThroughAutomaticReview(t *testing.T)
 	}
 	original := &permission.AMAHandler{}
 	composed := permission.WrapGeneralPhaseHandlerWithSafeCreate(original, nil)
-	handler := decorateHandlerWithAutoReview(composed, original, true, reviewer, "", nil)
+	handler := decorateHandlerWithAutoReview(composed, original, alwaysEnabled, reviewer, "", nil)
 
 	for name, input := range map[string]string{
 		"fast path":  `{"command":"git status --short"}`,
@@ -1746,7 +1787,7 @@ func TestIntegrationEnabledFastPathApprovesCuratedCommands(t *testing.T) {
 		t.Fatalf("ResolveReviewer = false, want true")
 	}
 	composed, original := composedGeneralHandler()
-	handler := decorateHandlerWithAutoReview(composed, original, true, reviewer, "", nil)
+	handler := decorateHandlerWithAutoReview(composed, original, alwaysEnabled, reviewer, "", nil)
 	for _, cmd := range []string{"go test ./...", "git status --short"} {
 		got, err := handler.CanUseTool(bashReq(`{"command":"` + cmd + `"}`))
 		if err != nil || got.Behavior != "allow" {
@@ -1762,7 +1803,7 @@ func TestIntegrationEnabledDeferPreservesHumanPrompt(t *testing.T) {
 		t.Fatalf("ResolveReviewer = false, want true")
 	}
 	composed, original := composedGeneralHandler()
-	handler := decorateHandlerWithAutoReview(composed, original, true, reviewer, "", nil)
+	handler := decorateHandlerWithAutoReview(composed, original, alwaysEnabled, reviewer, "", nil)
 	got, err := handler.CanUseTool(bashReq(`{"command":"curl https://example.com"}`))
 	if err != nil || got.Behavior != "" {
 		t.Fatalf("enabled+DEFER should defer: got %+v err %v", got, err)
@@ -1776,7 +1817,7 @@ func TestIntegrationLongTailVariantsReachAllowModel(t *testing.T) {
 		t.Fatalf("ResolveReviewer = false, want true")
 	}
 	composed, original := composedGeneralHandler()
-	handler := decorateHandlerWithAutoReview(composed, original, true, reviewer, "", nil)
+	handler := decorateHandlerWithAutoReview(composed, original, alwaysEnabled, reviewer, "", nil)
 	// These commands are outside the deterministic fast path. The ALLOW
 	// provider proves they now reach the model instead of stopping at the
 	// guardrail.
@@ -2011,7 +2052,7 @@ func TestIntegrationCompilerExecutableSelectorsReachAllowModel(t *testing.T) {
 		t.Fatalf("ResolveReviewer = false, want true")
 	}
 	composed, original := composedGeneralHandler()
-	handler := decorateHandlerWithAutoReview(composed, original, true, reviewer, "", nil)
+	handler := decorateHandlerWithAutoReview(composed, original, alwaysEnabled, reviewer, "", nil)
 	for _, cmd := range []string{
 		"clang -flto=thin -fuse-ld=lld -fthinlto-distributor=./runner main.c",
 		"clang -fuse-ld=./runner main.c",
@@ -2031,7 +2072,7 @@ func TestIntegrationCompilerPassThroughOutputsReachAllowModel(t *testing.T) {
 		t.Fatalf("ResolveReviewer = false, want true")
 	}
 	composed, original := composedGeneralHandler()
-	handler := decorateHandlerWithAutoReview(composed, original, true, reviewer, "", nil)
+	handler := decorateHandlerWithAutoReview(composed, original, alwaysEnabled, reviewer, "", nil)
 	for _, cmd := range []string{
 		"gcc -Wp,-MD,/tmp/deps main.c",
 		"gcc -Wa,-o,/tmp/asm.o main.c",
@@ -2051,7 +2092,7 @@ func TestIntegrationCMakeNativePassThroughReachAllowModel(t *testing.T) {
 		t.Fatalf("ResolveReviewer = false, want true")
 	}
 	composed, original := composedGeneralHandler()
-	handler := decorateHandlerWithAutoReview(composed, original, true, reviewer, "", nil)
+	handler := decorateHandlerWithAutoReview(composed, original, alwaysEnabled, reviewer, "", nil)
 	for _, cmd := range []string{
 		"cmake --build build -- SHELL=./runner",
 		"cmake --build build -- clean",
@@ -2071,7 +2112,7 @@ func TestIntegrationCMakePresetsReachAllowModel(t *testing.T) {
 		t.Fatalf("ResolveReviewer = false, want true")
 	}
 	composed, original := composedGeneralHandler()
-	handler := decorateHandlerWithAutoReview(composed, original, true, reviewer, "", nil)
+	handler := decorateHandlerWithAutoReview(composed, original, alwaysEnabled, reviewer, "", nil)
 	for _, cmd := range []string{
 		"cmake --preset evil-compiler",
 		"cmake --preset=evil-include",
@@ -2090,7 +2131,7 @@ func TestIntegrationPackageScriptPassThroughReachesAllowModel(t *testing.T) {
 		t.Fatalf("ResolveReviewer = false, want true")
 	}
 	composed, original := composedGeneralHandler()
-	handler := decorateHandlerWithAutoReview(composed, original, true, reviewer, "", nil)
+	handler := decorateHandlerWithAutoReview(composed, original, alwaysEnabled, reviewer, "", nil)
 	for _, cmd := range []string{
 		"npm test -- --silent",
 		"pnpm test -- --quiet",
@@ -2113,7 +2154,7 @@ func TestIntegrationBazelProhibitedLabelsReachAllowModel(t *testing.T) {
 		t.Fatalf("ResolveReviewer = false, want true")
 	}
 	composed, original := composedGeneralHandler()
-	handler := decorateHandlerWithAutoReview(composed, original, true, reviewer, "", nil)
+	handler := decorateHandlerWithAutoReview(composed, original, alwaysEnabled, reviewer, "", nil)
 	for _, cmd := range []string{
 		"bazel build //:deploy",
 		"bazel build //tools:install",
@@ -2156,7 +2197,7 @@ func TestIntegrationSymlinkEscapesReachAllowModel(t *testing.T) {
 		t.Fatalf("ResolveReviewer = false, want true")
 	}
 	composed, original := composedGeneralHandler()
-	handler := decorateHandlerWithAutoReview(composed, original, true, reviewer, workDir, []string{workDir})
+	handler := decorateHandlerWithAutoReview(composed, original, alwaysEnabled, reviewer, workDir, []string{workDir})
 	for _, cmd := range []string{
 		"cd escape && make test",
 		"go test ./escape/...",
@@ -2177,7 +2218,7 @@ func TestIntegrationMissingReviewerStillFastPaths(t *testing.T) {
 	reg := llm.NewRegistry() // no claude
 	reviewer, _, _ := autoreview.ResolveReviewer(reg, "")
 	composed, original := composedGeneralHandler()
-	handler := decorateHandlerWithAutoReview(composed, original, true, reviewer, "", nil)
+	handler := decorateHandlerWithAutoReview(composed, original, alwaysEnabled, reviewer, "", nil)
 	got, err := handler.CanUseTool(bashReq(`{"command":"go test ./..."}`))
 	if err != nil || got.Behavior != permission.DecisionAllow {
 		t.Fatalf("missing reviewer fast path = %+v, %v; want allow", got, err)
@@ -2195,7 +2236,7 @@ func TestIntegrationExplicitNonClaudeModelNotSubstituted(t *testing.T) {
 		t.Fatalf("unresolvable model should not produce a reviewer")
 	}
 	composed, original := composedGeneralHandler()
-	handler := decorateHandlerWithAutoReview(composed, original, true, reviewer, "", nil)
+	handler := decorateHandlerWithAutoReview(composed, original, alwaysEnabled, reviewer, "", nil)
 	got, err := handler.CanUseTool(bashReq(`{"command":"go test ./..."}`))
 	if err != nil || got.Behavior != permission.DecisionAllow {
 		t.Fatalf("unresolvable model fast path = %+v, %v; want allow", got, err)
@@ -2213,7 +2254,7 @@ func TestIntegrationTimeoutDefers(t *testing.T) {
 		t.Fatalf("ResolveReviewer = false, want true")
 	}
 	composed, original := composedGeneralHandler()
-	handler := decorateHandlerWithAutoReview(composed, original, true, reviewer, "", nil)
+	handler := decorateHandlerWithAutoReview(composed, original, alwaysEnabled, reviewer, "", nil)
 	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 	req := bashReq(`{"command":"curl https://example.com"}`)
 	req.Ctx = ctx
@@ -2231,7 +2272,7 @@ func TestIntegrationMalformedOutputDefers(t *testing.T) {
 		t.Fatalf("ResolveReviewer = false, want true")
 	}
 	composed, original := composedGeneralHandler()
-	handler := decorateHandlerWithAutoReview(composed, original, true, reviewer, "", nil)
+	handler := decorateHandlerWithAutoReview(composed, original, alwaysEnabled, reviewer, "", nil)
 	got, err := handler.CanUseTool(bashReq(`{"command":"curl https://example.com"}`))
 	if err != nil || got.Behavior != "" {
 		t.Fatalf("malformed output should defer: got %+v err %v", got, err)
@@ -2245,7 +2286,7 @@ func TestIntegrationProviderFailureDefers(t *testing.T) {
 		t.Fatalf("ResolveReviewer = false, want true")
 	}
 	composed, original := composedGeneralHandler()
-	handler := decorateHandlerWithAutoReview(composed, original, true, reviewer, "", nil)
+	handler := decorateHandlerWithAutoReview(composed, original, alwaysEnabled, reviewer, "", nil)
 	got, err := handler.CanUseTool(bashReq(`{"command":"curl https://example.com"}`))
 	if err != nil || got.Behavior != "" {
 		t.Fatalf("provider failure should defer: got %+v err %v", got, err)
@@ -2257,7 +2298,7 @@ func TestIntegrationExistingAllowRemainsAuthoritative(t *testing.T) {
 	composed := permission.WrapGeneralPhaseHandlerWithSafeCreate(original, nil)
 	reg := agentFakeRegistry(t, testutil.FakeClaudeDeferScriptBody())
 	reviewer, _, _ := autoreview.ResolveReviewer(reg, "")
-	handler := decorateHandlerWithAutoReview(composed, original, true, reviewer, "", nil)
+	handler := decorateHandlerWithAutoReview(composed, original, alwaysEnabled, reviewer, "", nil)
 	got, err := handler.CanUseTool(bashReq(`{"command":"go test ./..."}`))
 	if err != nil || got.Behavior != "allow" {
 		t.Fatalf("existing allow should win without reviewer: got %+v err %v", got, err)
@@ -2270,7 +2311,7 @@ func TestIntegrationDirectDenyRemainsAuthoritative(t *testing.T) {
 	composed := permission.WrapGeneralPhaseHandlerWithSafeCreate(original, nil)
 	reg := agentFakeRegistry(t, testutil.FakeClaudeAllowScriptBody())
 	reviewer, _, _ := autoreview.ResolveReviewer(reg, "")
-	handler := decorateHandlerWithAutoReview(composed, original, true, reviewer, "", nil)
+	handler := decorateHandlerWithAutoReview(composed, original, alwaysEnabled, reviewer, "", nil)
 	got, err := handler.CanUseTool(bashReq(`{"command":"go test ./..."}`))
 	if err != nil || got.Behavior != "deny" {
 		t.Fatalf("existing deny should win without reviewer: got %+v err %v", got, err)
@@ -2281,7 +2322,7 @@ func TestIntegrationNonBashRequestUnchanged(t *testing.T) {
 	composed, original := composedGeneralHandler()
 	reg := agentFakeRegistry(t, testutil.FakeClaudeAllowScriptBody())
 	reviewer, _, _ := autoreview.ResolveReviewer(reg, "")
-	handler := decorateHandlerWithAutoReview(composed, original, true, reviewer, "", nil)
+	handler := decorateHandlerWithAutoReview(composed, original, alwaysEnabled, reviewer, "", nil)
 	got, err := handler.CanUseTool(ports.ToolPermissionRequest{ToolName: "Read", Input: `{}`})
 	if err != nil || got.Behavior != "allow" {
 		t.Fatalf("non-Bash read should be allowed by AcceptEdits: got %+v err %v", got, err)
@@ -2295,7 +2336,7 @@ func TestIntegrationPreservesOriginalCallbackInput(t *testing.T) {
 		t.Fatalf("ResolveReviewer = false, want true")
 	}
 	composed, original := composedGeneralHandler()
-	handler := decorateHandlerWithAutoReview(composed, original, true, reviewer, "", nil)
+	handler := decorateHandlerWithAutoReview(composed, original, alwaysEnabled, reviewer, "", nil)
 	originalInput := `{"command":"go test ./..."}`
 	req := ports.ToolPermissionRequest{ToolName: "Bash", Input: originalInput}
 	got, err := handler.CanUseTool(req)

--- a/internal/agent/autoreview_internal_test.go
+++ b/internal/agent/autoreview_internal_test.go
@@ -1514,7 +1514,7 @@ func TestBuildSessionSurfacesEnabledWithoutReviewer(t *testing.T) {
 		t.Fatalf("SessionBuildNotices = %d, want one unavailable notice", len(sessOpts.SessionBuildNotices))
 	}
 	notice := sessOpts.SessionBuildNotices[0]
-	if !strings.Contains(notice.Status, "Auto-approve commands enabled but no reviewer available:") ||
+	if !strings.Contains(notice.Status, "Auto mode enabled but no reviewer available:") ||
 		!strings.Contains(notice.Status, "isolated tool-less review") {
 		t.Fatalf("notice status = %q", notice.Status)
 	}

--- a/internal/agent/phase.go
+++ b/internal/agent/phase.go
@@ -1268,7 +1268,7 @@ func automaticReviewSessionBuildNotices(observer *observe.Observer, snap ports.A
 	if reason == "" {
 		reason = "reviewer resolution failed"
 	}
-	status := "Auto-approve commands enabled but no reviewer available: " + reason
+	status := "Auto mode enabled but no reviewer available: " + reason
 	return []ports.SessionBuildNotice{{
 		Status: status,
 		Emit: func(ctx ports.SessionBuildNoticeContext) {

--- a/internal/agent/phase.go
+++ b/internal/agent/phase.go
@@ -1183,24 +1183,39 @@ func permHandlerFor(skip bool, cache *permission.Cache, repoName string) ports.P
 }
 
 // decorateHandlerWithAutoReview wraps the fully composed permission handler
-// with the automatic Bash-review decorator when enabled and the handler is the
-// general-phase policy. Disabled sessions get the composed handler unchanged
-// (byte-identical to the pre-feature path). The reviewer is already resolved
-// by the caller, so the enabled flag and reviewer identity are snapshotted as
-// values and a running session is unaffected by later workspace edits or
-// provider/catalog changes.
-func decorateHandlerWithAutoReview(composed, original ports.PermissionHandler, enabled bool, reviewer autoreview.Reviewer, workDir string, writableRoots []string) ports.PermissionHandler {
-	if !enabled {
-		return composed
-	}
+// with the automatic Bash-review decorator when the handler is the
+// general-phase policy. The enabled setting is consulted live on every
+// deferred Bash request, so turning auto-approve on mid-session (for example
+// from a permission prompt) applies to the running session. The reviewer
+// identity stays snapshotted at build time.
+func decorateHandlerWithAutoReview(composed, original ports.PermissionHandler, enabled func() bool, reviewer autoreview.Reviewer, workDir string, writableRoots []string) ports.PermissionHandler {
 	if !permission.IsAutomaticReviewHandler(original) {
 		return composed
 	}
 	return &autoReviewPermissionDecorator{
 		inner:         composed,
+		enabled:       enabled,
 		reviewer:      reviewer,
 		workDir:       workDir,
 		writableRoots: append([]string(nil), writableRoots...),
+	}
+}
+
+// liveAutomaticReviewEnabled resolves the effective automatic-review setting
+// from the feature's current mode and the current workspace default. The
+// feature record is re-read on each call; fallbackMode applies when it cannot
+// be loaded.
+func (pr *PhaseRunner) liveAutomaticReviewEnabled(featureID string, fallbackMode feature.AutomaticReviewMode) func() bool {
+	return func() bool {
+		mode := fallbackMode
+		if pr != nil && pr.FeatureStore != nil && featureID != "" {
+			if f, err := pr.FeatureStore.Load(featureID); err == nil && f != nil {
+				mode = f.AutomaticReviewMode
+			}
+		}
+		globalEnabled := pr != nil && pr.Config != nil && pr.Config.Defaults.AutomaticReviewEnabled
+		enabled, _ := feature.ResolveAutomaticReview(mode, globalEnabled)
+		return enabled
 	}
 }
 
@@ -1211,21 +1226,22 @@ func decorateHandlerWithAutoReview(composed, original ports.PermissionHandler, e
 // retains the original session's reviewer even if the provider/catalog state
 // changed. Otherwise the current workspace defaults are read, the reviewer is
 // resolved, and the full snapshot is returned for the caller to store. The
-// hidden reviewer itself is launched via autoreview.Classify (never
-// BuildSession), so it is never decorated and cannot recurse.
+// enabled flag itself is read live by the decorator. The hidden reviewer is
+// launched via autoreview.Classify (never BuildSession), so it is never
+// decorated and cannot recurse.
 func (pr *PhaseRunner) decorateWithAutoReview(composed, original ports.PermissionHandler, opts *BuildSessionOpts, workDir string, writableRoots []string) (ports.PermissionHandler, ports.AutoReviewSnapshot) {
+	enabledFn := pr.liveAutomaticReviewEnabled(opts.FeatureID, opts.AutomaticReviewMode)
 	if opts.AutoReview.Enabled != nil {
 		reviewer := autoreview.RestoreReviewer(pr.Registry, opts.AutoReview.ReviewerProvider, opts.AutoReview.ReviewerModel)
 		snap := opts.AutoReview
 		if *snap.Enabled && reviewer.Provider == nil && strings.TrimSpace(snap.UnavailableReason) == "" {
 			snap.UnavailableReason = "snapshotted reviewer provider is no longer available"
 		}
-		handler := decorateHandlerWithAutoReview(composed, original, *snap.Enabled, reviewer, workDir, writableRoots)
+		handler := decorateHandlerWithAutoReview(composed, original, enabledFn, reviewer, workDir, writableRoots)
 		installAutoReviewObserver(handler, pr.Observer)
 		return handler, snap
 	}
-	globalEnabled := pr != nil && pr.Config != nil && pr.Config.Defaults.AutomaticReviewEnabled
-	enabled, _ := feature.ResolveAutomaticReview(opts.AutomaticReviewMode, globalEnabled)
+	enabled := enabledFn()
 	model := ""
 	if pr != nil && pr.Config != nil {
 		model = pr.Config.Defaults.Models.AutomaticReview
@@ -1239,7 +1255,7 @@ func (pr *PhaseRunner) decorateWithAutoReview(composed, original ports.Permissio
 		ReviewerModel:     revModel,
 		UnavailableReason: unavailableReason,
 	}
-	handler := decorateHandlerWithAutoReview(composed, original, enabled, reviewer, workDir, writableRoots)
+	handler := decorateHandlerWithAutoReview(composed, original, enabledFn, reviewer, workDir, writableRoots)
 	installAutoReviewObserver(handler, pr.Observer)
 	return handler, snap
 }
@@ -1252,7 +1268,7 @@ func automaticReviewSessionBuildNotices(observer *observe.Observer, snap ports.A
 	if reason == "" {
 		reason = "reviewer resolution failed"
 	}
-	status := "Automatic review enabled but no reviewer available: " + reason
+	status := "Auto-approve commands enabled but no reviewer available: " + reason
 	return []ports.SessionBuildNotice{{
 		Status: status,
 		Emit: func(ctx ports.SessionBuildNoticeContext) {

--- a/internal/llm/message.go
+++ b/internal/llm/message.go
@@ -343,6 +343,17 @@ type ControlRequestMessage struct {
 	Request      ControlRequest `json:"request"`
 	WaitingSince time.Time      `json:"-"`
 	Origin       EventOrigin    `json:"-"`
+	// AutoApproveOffer is set when automatic Bash review is off for the
+	// session but would have handled this request had it been on.
+	AutoApproveOffer *AutoApproveOffer `json:"-"`
+}
+
+// AutoApproveOffer describes how automatic Bash review would have treated a
+// deferred request, so the permission UI can offer to turn the feature on.
+type AutoApproveOffer struct {
+	// WouldFastPath is true when the deterministic guardrail alone would
+	// have approved the command without a reviewer model.
+	WouldFastPath bool
 }
 
 // ControlRequest is the inner request payload.

--- a/internal/ports/session.go
+++ b/internal/ports/session.go
@@ -202,6 +202,9 @@ type ToolPermissionRequest struct {
 type PermissionDecision struct {
 	Behavior string // "allow" | "deny" | "" (defer)
 	Reason   string
+	// AutoApproveOffer accompanies a deferral ("" behavior) for a Bash
+	// request that automatic review would have handled if enabled.
+	AutoApproveOffer *llm.AutoApproveOffer
 }
 
 // PermissionHandler decides whether a session may invoke a tool. Defined in

--- a/internal/server/handler_test.go
+++ b/internal/server/handler_test.go
@@ -342,6 +342,16 @@ func TestPermissionAnswerRejectsLegacyAndMissingRememberScope(t *testing.T) {
 			body:        map[string]string{requestIDKey: fixturePermissionRequestID, decisionKey: decisionAllowRemember, rememberPatternKey: testRememberPattern},
 			wantMessage: "remember_scope is required for allow_remember",
 		},
+		{
+			name:        "unknown auto approve scope",
+			body:        map[string]string{requestIDKey: fixturePermissionRequestID, decisionKey: decisionAllowOnce, "auto_approve_scope": "repo"},
+			wantMessage: "auto_approve_scope must be feature or workspace",
+		},
+		{
+			name:        "auto approve scope with deny",
+			body:        map[string]string{requestIDKey: fixturePermissionRequestID, decisionKey: decisionDeny, "auto_approve_scope": AutoApproveScopeFeature},
+			wantMessage: "auto_approve_scope cannot be combined with deny",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/server/mutation.go
+++ b/internal/server/mutation.go
@@ -260,7 +260,15 @@ type PermissionAnswerRequest struct {
 	Decision        string  `json:"decision"`
 	RememberPattern string  `json:"remember_pattern,omitempty"`
 	RememberScope   *string `json:"remember_scope,omitempty"`
+	// AutoApproveScope turns automatic Bash review on for the request's
+	// feature ("feature") or the workspace ("workspace") before answering.
+	AutoApproveScope string `json:"auto_approve_scope,omitempty"`
 }
+
+const (
+	AutoApproveScopeFeature   = "feature"
+	AutoApproveScopeWorkspace = "workspace"
+)
 
 type AskUserAnswerRequest struct {
 	RequestID string            `json:"request_id"`
@@ -1286,6 +1294,16 @@ func (h *apiHandler) handlePermissionMutationRoutes(w http.ResponseWriter, r *ht
 	}
 	if req.Decision == decisionAllowRemember && req.RememberScope == nil {
 		writeAPIError(w, http.StatusBadRequest, "bad_request", "remember_scope is required for allow_remember", nil)
+		return
+	}
+	switch req.AutoApproveScope {
+	case "", AutoApproveScopeFeature, AutoApproveScopeWorkspace:
+	default:
+		writeAPIError(w, http.StatusBadRequest, "bad_request", "auto_approve_scope must be feature or workspace", nil)
+		return
+	}
+	if req.AutoApproveScope != "" && req.Decision == decisionDeny {
+		writeAPIError(w, http.StatusBadRequest, "bad_request", "auto_approve_scope cannot be combined with deny", nil)
 		return
 	}
 	resp, err := h.mutations.AnswerPermission(req)

--- a/internal/server/read_api_contract_test.go
+++ b/internal/server/read_api_contract_test.go
@@ -1945,6 +1945,62 @@ func TestPermissionSnapshotIncludesRememberPreview(t *testing.T) {
 	}
 }
 
+func TestPermissionSnapshotIncludesAutoApproveOffer(t *testing.T) {
+	t.Parallel()
+
+	store, f := seedReadFeature(t)
+	sess := &fakeSessionView{
+		id: "sess-auto-approve", featureID: f.ID, phase: feature.PhaseImplement,
+		status:         ports.SessionWaitingPermission,
+		permCacheScope: repoNameSelf,
+		pending: []*llm.ControlRequestMessage{
+			{
+				Type:      transcriptTypeControlRequest,
+				RequestID: "perm-offer",
+				Request: llm.ControlRequest{
+					Subtype:  controlSubtypeCanUseTool,
+					ToolName: "Bash",
+					Input:    json.RawMessage(`{"command":"go test ./..."}`),
+				},
+				AutoApproveOffer: &llm.AutoApproveOffer{WouldFastPath: true},
+			},
+			{
+				Type:      transcriptTypeControlRequest,
+				RequestID: "perm-no-offer",
+				Request: llm.ControlRequest{
+					Subtype:  controlSubtypeCanUseTool,
+					ToolName: "Bash",
+					Input:    json.RawMessage(`{"command":"go vet ./..."}`),
+				},
+			},
+		},
+	}
+	opts := baseReadHandlerOptions(store)
+	opts.Sessions = fakeSessionManager{views: []ports.SessionView{sess}}
+	handler := NewHandler(opts)
+
+	permissions := getJSONMap(t, handler, "/api/v1/permissions")
+	requests := permissions["requests"].([]any)
+	if len(requests) != 2 {
+		t.Fatalf("permissions requests length = %d, want 2", len(requests))
+	}
+	byID := map[string]map[string]any{}
+	for _, raw := range requests {
+		req := raw.(map[string]any)
+		byID[req["request_id"].(string)] = req
+	}
+	offer, ok := byID["perm-offer"]["auto_approve"].(map[string]any)
+	if !ok {
+		t.Fatalf("perm-offer auto_approve = %v, want object", byID["perm-offer"]["auto_approve"])
+	}
+	if got := offer["would_fast_path"]; got != true {
+		t.Fatalf("auto_approve.would_fast_path = %v, want true", got)
+	}
+	if _, present := byID["perm-no-offer"]["auto_approve"]; present {
+		t.Fatalf("perm-no-offer should omit auto_approve, got %v", byID["perm-no-offer"]["auto_approve"])
+	}
+}
+
 func TestPermissionSnapshotRememberPreviewDoesNotLeakSensitiveInput(t *testing.T) {
 	t.Parallel()
 

--- a/internal/server/read_model.go
+++ b/internal/server/read_model.go
@@ -2040,6 +2040,9 @@ func controlRequestDTO(sess ports.SessionView, req *llm.ControlRequestMessage) C
 			Scope:        scope,
 			ScopeDisplay: permissionScopeDisplay(scope),
 		}
+		if req.AutoApproveOffer != nil {
+			dto.AutoApprove = &PermissionAutoApproveOffer{WouldFastPath: req.AutoApproveOffer.WouldFastPath}
+		}
 	}
 	return dto
 }

--- a/internal/server/serverapi.gen.go
+++ b/internal/server/serverapi.gen.go
@@ -70,16 +70,16 @@ func (e AutomaticReviewStateMode) Valid() bool {
 
 // Defines values for AutomaticReviewStateSource.
 const (
-	Feature AutomaticReviewStateSource = "feature"
-	Global  AutomaticReviewStateSource = "global"
+	AutomaticReviewStateSourceFeature AutomaticReviewStateSource = "feature"
+	AutomaticReviewStateSourceGlobal  AutomaticReviewStateSource = "global"
 )
 
 // Valid indicates whether the value is a known member of the AutomaticReviewStateSource enum.
 func (e AutomaticReviewStateSource) Valid() bool {
 	switch e {
-	case Feature:
+	case AutomaticReviewStateSourceFeature:
 		return true
-	case Global:
+	case AutomaticReviewStateSourceGlobal:
 		return true
 	default:
 		return false
@@ -224,6 +224,24 @@ func (e NeedUserInputVerificationAction) Valid() bool {
 	case RETRYAFTERAUTH:
 		return true
 	case WAIVE:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for PermissionAnswerRequestAutoApproveScope.
+const (
+	PermissionAnswerRequestAutoApproveScopeFeature   PermissionAnswerRequestAutoApproveScope = "feature"
+	PermissionAnswerRequestAutoApproveScopeWorkspace PermissionAnswerRequestAutoApproveScope = "workspace"
+)
+
+// Valid indicates whether the value is a known member of the PermissionAnswerRequestAutoApproveScope enum.
+func (e PermissionAnswerRequestAutoApproveScope) Valid() bool {
+	switch e {
+	case PermissionAnswerRequestAutoApproveScopeFeature:
+		return true
+	case PermissionAnswerRequestAutoApproveScopeWorkspace:
 		return true
 	default:
 		return false
@@ -1328,17 +1346,19 @@ type Context struct {
 
 // ControlRequest defines model for ControlRequest.
 type ControlRequest struct {
-	FeatureID    string                     `json:"feature_id,omitempty"`
-	Input        map[string]interface{}     `json:"input,omitempty"`
-	Phase        string                     `json:"phase,omitempty"`
-	Questions    []AskUserQuestion          `json:"questions,omitempty"`
-	Remember     *PermissionRememberPreview `json:"remember,omitempty"`
-	RequestID    string                     `json:"request_id"`
-	SessionID    string                     `json:"session_id,omitempty"`
-	Status       string                     `json:"status"`
-	Summary      string                     `json:"summary,omitempty"`
-	ToolName     string                     `json:"tool_name"`
-	WaitingSince time.Time                  `json:"waiting_since"`
+	// AutoApprove Present when automatic Bash review is off for the session but would have handled this request had it been on.
+	AutoApprove  *PermissionAutoApproveOffer `json:"auto_approve,omitempty"`
+	FeatureID    string                      `json:"feature_id,omitempty"`
+	Input        map[string]interface{}      `json:"input,omitempty"`
+	Phase        string                      `json:"phase,omitempty"`
+	Questions    []AskUserQuestion           `json:"questions,omitempty"`
+	Remember     *PermissionRememberPreview  `json:"remember,omitempty"`
+	RequestID    string                      `json:"request_id"`
+	SessionID    string                      `json:"session_id,omitempty"`
+	Status       string                      `json:"status"`
+	Summary      string                      `json:"summary,omitempty"`
+	ToolName     string                      `json:"tool_name"`
+	WaitingSince time.Time                   `json:"waiting_since"`
 }
 
 // Cost defines model for Cost.
@@ -1847,14 +1867,19 @@ type Owner struct {
 
 // PermissionAnswerSchema defines model for PermissionAnswerRequest.
 type PermissionAnswerSchema struct {
-	Decision        PermissionAnswerRequestDecision `json:"decision"`
-	RememberPattern string                          `json:"remember_pattern,omitempty"`
+	// AutoApproveScope Turn automatic Bash review on for the request's feature or for the whole workspace before answering. Not allowed with deny.
+	AutoApproveScope PermissionAnswerRequestAutoApproveScope `json:"auto_approve_scope,omitempty"`
+	Decision         PermissionAnswerRequestDecision         `json:"decision"`
+	RememberPattern  string                                  `json:"remember_pattern,omitempty"`
 
 	// RememberScope Existing permission cache scope. Empty string means global.
 	RememberScope *string `json:"remember_scope,omitempty"`
 	RequestID     string  `json:"request_id"`
 	SessionID     string  `json:"session_id,omitempty"`
 }
+
+// PermissionAnswerRequestAutoApproveScope Turn automatic Bash review on for the request's feature or for the whole workspace before answering. Not allowed with deny.
+type PermissionAnswerRequestAutoApproveScope string
 
 // PermissionAnswerRequestDecision defines model for PermissionAnswerRequest.Decision.
 type PermissionAnswerRequestDecision string
@@ -1869,6 +1894,12 @@ type PermissionAnswerResponse struct {
 	RequestID      string       `json:"request_id"`
 	Result         string       `json:"result"`
 	SessionID      string       `json:"session_id"`
+}
+
+// PermissionAutoApproveOffer Present when automatic Bash review is off for the session but would have handled this request had it been on.
+type PermissionAutoApproveOffer struct {
+	// WouldFastPath The deterministic guardrail alone would have approved the command.
+	WouldFastPath bool `json:"would_fast_path"`
 }
 
 // PermissionRememberPreview defines model for PermissionRememberPreview.

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -1446,6 +1446,7 @@ func (s *Session) tryHandleControlRequest(msg llm.SDKMessage) bool {
 		s.respondToControlViaProtocol(req.RequestID, false, nil, decision.Reason)
 		return true
 	case "":
+		req.AutoApproveOffer = decision.AutoApproveOffer
 		return false
 	default:
 		s.respondToControlViaProtocol(req.RequestID, true, req.Request.Input, "")

--- a/skills/chat/user-guide/configuration.md
+++ b/skills/chat/user-guide/configuration.md
@@ -36,8 +36,8 @@ defaults:
 
 ## Automatic Bash Review
 
-The desktop app labels this feature **Auto-approve commands**; the reviewer
-model row is **Auto-approve reviewer**. It uses two workspace keys:
+The desktop app labels this feature **Auto mode**; the reviewer model row is
+**Auto mode reviewer**. It uses two workspace keys:
 
 ```yaml
 defaults:
@@ -55,12 +55,12 @@ disabled. The enabled flag is read live: turning it on or off applies to
 running sessions from their next Bash request. Each session snapshots its
 resolved reviewer, so reviewer-model changes apply only to new sessions.
 
-Each feature can override the workspace setting with **Auto-approve
-commands** in its configuration (`automatic_review_mode`: `default`,
-`enabled`, or `disabled`). A Bash permission prompt that automatic review
-would have handled also offers **Allow and auto-approve in this feature** and
-**Allow and auto-approve everywhere**; either choice allows the pending
-command and enables the corresponding scope.
+Each feature can override the workspace setting with **Auto mode** in its
+configuration (`automatic_review_mode`: `default`, `enabled`, or `disabled`).
+A Bash permission prompt that automatic review would have handled also offers
+**Enable auto mode (this feature only)**, with **Enable auto mode (all
+features)** behind its chevron; either choice allows the pending command and
+enables the corresponding scope.
 
 Automatic selection uses the fixed provider order Claude → OpenCode → Codex
 and chooses the first eligible provider's preferred cheap model. A

--- a/skills/chat/user-guide/configuration.md
+++ b/skills/chat/user-guide/configuration.md
@@ -36,7 +36,8 @@ defaults:
 
 ## Automatic Bash Review
 
-Automatic Bash review uses two workspace keys:
+The desktop app labels this feature **Auto-approve commands**; the reviewer
+model row is **Auto-approve reviewer**. It uses two workspace keys:
 
 ```yaml
 defaults:
@@ -50,8 +51,16 @@ The full names are `defaults.automatic_review_enabled` and
 the enabled key is absent, as in a legacy config, it remains disabled; a
 missing reviewer-model key has the same empty **Automatic** value as a fresh
 config. The workspace Models row remains editable while automatic review is
-disabled; saved changes apply only to new sessions because each session
-snapshots the enabled flag and resolved reviewer.
+disabled. The enabled flag is read live: turning it on or off applies to
+running sessions from their next Bash request. Each session snapshots its
+resolved reviewer, so reviewer-model changes apply only to new sessions.
+
+Each feature can override the workspace setting with **Auto-approve
+commands** in its configuration (`automatic_review_mode`: `default`,
+`enabled`, or `disabled`). A Bash permission prompt that automatic review
+would have handled also offers **Allow and auto-approve in this feature** and
+**Allow and auto-approve everywhere**; either choice allows the pending
+command and enables the corresponding scope.
 
 Automatic selection uses the fixed provider order Claude → OpenCode → Codex
 and chooses the first eligible provider's preferred cheap model. A

--- a/skills/chat/user-guide/permissions.md
+++ b/skills/chat/user-guide/permissions.md
@@ -6,7 +6,7 @@ Agentic Orchestrator mediates provider tool use through session handlers and cac
 
 Permission request cards with **Allow once**, **Allow and remember**, and **Deny** controls are delivered in the Electron app. They surface in the global attention inbox and in the feature cockpit. The live **Signal trace** can show validated tool activity, but resolving a permission request uses the dedicated prompt cards.
 
-When **Auto-approve commands** is off and the pending Bash command is one that automatic review would have handled, the card also offers **Allow and auto-approve in this feature** and **Allow and auto-approve everywhere**. Both allow the pending command once and turn automatic review on for the chosen scope; the running session applies the change from its next Bash request. The card says whether the command would have run through the deterministic fast path or gone to the reviewer model.
+When **Auto mode** is off and the pending Bash command is one that automatic review would have handled, the card adds a split button beside Allow once and Deny: **Enable auto mode (this feature only)**, with **Enable auto mode (all features)** behind its chevron. Both allow the pending command once and turn automatic review on for the chosen scope; the running session applies the change from its next Bash request. The button tooltip says whether the command would have run through the deterministic fast path or gone to the reviewer model.
 
 Do not use superseded single-key permission shortcuts. When a workflow is blocked on a permission request, use the inbox or cockpit card to answer it, or start workflows with permission rules appropriate for the provider and repository, or use the server launch option described below in a trusted environment.
 
@@ -21,8 +21,7 @@ Session policy can approve categories such as:
 - delegated agent work; and
 - read-only git commands such as `git status`, `git diff`, `git log`, and `git show`.
 
-When the optional Automatic Bash review feature (**Auto-approve commands** in
-the app) is enabled, an unresolved canonical Bash request first checks a
+When the optional Automatic Bash review feature (**Auto mode** in the app) is enabled, an unresolved canonical Bash request first checks a
 deterministic fast path. Curated
 build/test commands auto-approve without a model. Every other reviewable
 command reaches one model review—including dangerous commands such as

--- a/skills/chat/user-guide/permissions.md
+++ b/skills/chat/user-guide/permissions.md
@@ -4,7 +4,9 @@ Agentic Orchestrator mediates provider tool use through session handlers and cac
 
 ## Desktop Availability
 
-Permission request cards with **Approve**, **Approve and remember**, and **Deny** controls are delivered in the Electron app. They surface in the global attention inbox and in the feature cockpit. The live **Signal trace** can show validated tool activity, but resolving a permission request uses the dedicated prompt cards.
+Permission request cards with **Allow once**, **Allow and remember**, and **Deny** controls are delivered in the Electron app. They surface in the global attention inbox and in the feature cockpit. The live **Signal trace** can show validated tool activity, but resolving a permission request uses the dedicated prompt cards.
+
+When **Auto-approve commands** is off and the pending Bash command is one that automatic review would have handled, the card also offers **Allow and auto-approve in this feature** and **Allow and auto-approve everywhere**. Both allow the pending command once and turn automatic review on for the chosen scope; the running session applies the change from its next Bash request. The card says whether the command would have run through the deterministic fast path or gone to the reviewer model.
 
 Do not use superseded single-key permission shortcuts. When a workflow is blocked on a permission request, use the inbox or cockpit card to answer it, or start workflows with permission rules appropriate for the provider and repository, or use the server launch option described below in a trusted environment.
 
@@ -19,8 +21,9 @@ Session policy can approve categories such as:
 - delegated agent work; and
 - read-only git commands such as `git status`, `git diff`, `git log`, and `git show`.
 
-When the optional Automatic Bash review feature is enabled, an unresolved
-canonical Bash request first checks a deterministic fast path. Curated
+When the optional Automatic Bash review feature (**Auto-approve commands** in
+the app) is enabled, an unresolved canonical Bash request first checks a
+deterministic fast path. Curated
 build/test commands auto-approve without a model. Every other reviewable
 command reaches one model review—including dangerous commands such as
 `rm -rf`, `sudo`, and `curl | sh`—and an exact `ALLOW` continues
@@ -123,7 +126,9 @@ For each tool request, the runtime evaluates:
 5. a user decision through a compatible permission client if no earlier step allows the request.
 
 Automatic review never overrides earlier decisions, stores no durable
-permission rule, and is not command sandboxing. Valid commands receive up to
+permission rule, and is not command sandboxing. Its enabled state is resolved
+live from the feature override and the workspace default on every deferred
+Bash request. Valid commands receive up to
 two model attempts sharing one overall one-minute timeout. Only transient
 launch, handshake, transport, rate-limit, and server failures receive the
 single retry. Two consecutive timeouts start a 30-second cooldown with a

--- a/test/e2e/automatic_review_evidence_journey_test.go
+++ b/test/e2e/automatic_review_evidence_journey_test.go
@@ -309,7 +309,7 @@ func assertAutomaticReviewUnavailableSessionNotice(t *testing.T) {
 	}
 	waitForAutomaticReviewSession(t, sess)
 
-	const noticePrefix = "Auto-approve commands enabled but no reviewer available:"
+	const noticePrefix = "Auto mode enabled but no reviewer available:"
 	notices := 0
 	for _, msg := range sess.MessageLog().Messages() {
 		if msg.Status != nil && strings.HasPrefix(msg.Status.Message, noticePrefix) {

--- a/test/e2e/automatic_review_evidence_journey_test.go
+++ b/test/e2e/automatic_review_evidence_journey_test.go
@@ -309,7 +309,7 @@ func assertAutomaticReviewUnavailableSessionNotice(t *testing.T) {
 	}
 	waitForAutomaticReviewSession(t, sess)
 
-	const noticePrefix = "Automatic review enabled but no reviewer available:"
+	const noticePrefix = "Auto-approve commands enabled but no reviewer available:"
 	notices := 0
 	for _, msg := range sess.MessageLog().Messages() {
 		if msg.Status != nil && strings.HasPrefix(msg.Status.Message, noticePrefix) {

--- a/test/e2e/default_off_claude_tracer_journey_test.go
+++ b/test/e2e/default_off_claude_tracer_journey_test.go
@@ -121,30 +121,26 @@ func TestDefaultOffClaudeTracerJourney(t *testing.T) {
 		}
 	})
 
-	t.Run("vertical_journey_snapshot_isolates_from_config_edit", func(t *testing.T) {
+	t.Run("vertical_journey_config_edit_applies_to_running_session", func(t *testing.T) {
 		// Build a session with auto-review enabled, then disable it in the
-		// config. The first session's handler must still auto-approve
-		// because the snapshot was taken at build time. A second session
-		// built after the edit must not auto-approve.
+		// config. The running session reads the enabled flag live, so it
+		// stops auto-approving and instead offers auto-approve on the
+		// deferral. Re-enabling restores auto-approval without a rebuild.
 		cfg := config.NewDefault()
 		cfg.Defaults.AutomaticReviewEnabled = true
 		reg := fakeRegistry(t, testutil.FakeClaudeAllowScriptBody())
 		handler1 := buildSessionViaPhaseRunner(t, cfg, reg, workDir)
 
-		// Edit config: disable auto-review.
 		cfg.Defaults.AutomaticReviewEnabled = false
-
-		// First session's handler is unaffected by the edit.
 		got1, err := handler1.CanUseTool(bashReq("go test ./..."))
-		if err != nil || got1.Behavior != "allow" {
-			t.Fatalf("first session should still auto-approve (snapshot): got %+v err %v", got1, err)
+		if err != nil || got1.Behavior != "" || got1.AutoApproveOffer == nil {
+			t.Fatalf("running session after disable should defer with an offer: got %+v err %v", got1, err)
 		}
 
-		// Second session built after the edit must not auto-approve.
-		handler2 := buildSessionViaPhaseRunner(t, cfg, reg, workDir)
-		got2, err := handler2.CanUseTool(bashReq("go test ./..."))
-		if err != nil || got2.Behavior != "" {
-			t.Fatalf("second session should defer after config disable: got %+v err %v", got2, err)
+		cfg.Defaults.AutomaticReviewEnabled = true
+		got2, err := handler1.CanUseTool(bashReq("go test ./..."))
+		if err != nil || got2.Behavior != "allow" {
+			t.Fatalf("running session after re-enable should auto-approve: got %+v err %v", got2, err)
 		}
 	})
 


### PR DESCRIPTION
## Summary

Agentico's "auto approve commands" feature (automatic Bash review) is off by default and hidden in configuration, so users keep answering permission prompts without knowing it exists. This PR surfaces it where they feel the pain and renames it.

- **Offer on the prompt card.** When auto-approve is off and the pending Bash command is one automatic review would have handled, the permission card adds **Allow and auto-approve in this feature** and **Allow and auto-approve everywhere**. Either allows the pending command once and enables the chosen scope in a single server call. The card says whether the command would have used the deterministic fast path or the reviewer model, and points to where the setting lives. The feature choice is hidden for ownerless requests. The offer renders wherever the card does (inbox, cockpit, refactor pass, AMA).
- **Live enable flag.** The decorator is now always installed for eligible handlers and resolves the enabled flag from the feature override and workspace default on every deferred Bash request, so an opt-in takes effect in the running session. Reviewer identity remains snapshotted for crash-resume. Disabling also applies live. Two tests that asserted the old snapshot isolation were rewritten; the user guide is updated.
- **Rename.** "Automatic review" → **Auto-approve commands** (feature config and workspace defaults) with clearer hints; the model row is **Auto-approve reviewer**. The missing-reviewer status line uses the same wording.

### Wire changes

- `GET /api/v1/permissions`: optional `auto_approve: { would_fast_path }` on a request, set by the decorator when it defers while disabled.
- `POST /api/v1/permissions/answer`: optional `auto_approve_scope` (`feature` | `workspace`); rejected with `deny`. Feature scope reuses the paired-config update path.

### Caveat

The live check reads the shared config struct without a lock, matching how the existing session-build path already reads it.

## Verification

- Fast suite: `go build ./...`, `go vet`, and tests for `internal/agent`, `internal/session`, `internal/server`, `internal/permission`, `internal/llm`, `cmd/agentico` pass. `TestSession_StreamBackpressurePreservesCritical` failed once under parallel package load and passes on its own.
- Go e2e: auto-review evidence and default-off tracer journeys pass.
- Desktop: `npm run typecheck`, eslint on changed files, and the full vitest suite (150 files) pass; new tests cover the offer buttons, scope payloads, and route validation.
- Skipped packaged Playwright: no journey asserts any string changed here (verified by grep).
- Skipped Race regression: no new concurrency primitives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
