### PR TITLE
Raise GoReleaser publication timeout to six hours

### DIFF
--- a/desktop/scripts/release-goreleaser.mjs
+++ b/desktop/scripts/release-goreleaser.mjs
@@ -22,8 +22,11 @@ import { isMainModule } from './lib/main-entry.mjs';
 import { verifyReleaseProvenance } from './release-preflight.mjs';
 import { goreleaserEnvironment, readPublicationSnapshot } from './release-workspace.mjs';
 
+// Desktop assets total ~800 MB; slow operator uplinks need far more than the default timeout.
+const RELEASE_TIMEOUT = '6h';
+
 export function goreleaserArguments(notesFile) {
-  const args = ['release', '--clean'];
+  const args = ['release', '--clean', '--timeout', RELEASE_TIMEOUT];
   if (notesFile !== undefined && notesFile !== '') args.push('--release-notes', notesFile);
   return args;
 }

--- a/desktop/scripts/release-goreleaser.test.mjs
+++ b/desktop/scripts/release-goreleaser.test.mjs
@@ -24,13 +24,15 @@ import { goreleaserArguments, runGoreleaserRelease } from './release-goreleaser.
 
 describe('GoReleaser release wrapper', () => {
   it('uses only the fixed release command when no notes file is supplied', () => {
-    expect(goreleaserArguments()).toEqual(['release', '--clean']);
+    expect(goreleaserArguments()).toEqual(['release', '--clean', '--timeout', '6h']);
   });
 
   it('passes a notes file as one argument rather than accepting arbitrary flags', () => {
     expect(goreleaserArguments('/tmp/release notes.md')).toEqual([
       'release',
       '--clean',
+      '--timeout',
+      '6h',
       '--release-notes',
       '/tmp/release notes.md',
     ]);
@@ -61,7 +63,7 @@ describe('GoReleaser release wrapper', () => {
     expect(calls).toEqual([
       {
         command: 'goreleaser',
-        args: ['release', '--clean', '--release-notes', '/tmp/notes.md'],
+        args: ['release', '--clean', '--timeout', '6h', '--release-notes', '/tmp/notes.md'],
         options: expect.objectContaining({
           cwd: '/release/workspace',
           env: expect.objectContaining({ GOWORK: 'off', GOFLAGS: '-mod=readonly' }),
@@ -162,7 +164,12 @@ writeFileSync(process.argv[2], JSON.stringify(args));
         cwd: root,
         env: { ...process.env, AGENTICO_RELEASE_NOTES_FILE: '/ambient/poison.md' },
       });
-      expect(JSON.parse(readFileSync(output, 'utf8'))).toEqual(['release', '--clean']);
+      expect(JSON.parse(readFileSync(output, 'utf8'))).toEqual([
+        'release',
+        '--clean',
+        '--timeout',
+        '6h',
+      ]);
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/docs/desktop/release-support.md
+++ b/docs/desktop/release-support.md
@@ -52,7 +52,9 @@ GoReleaser subsequently consumes the validated operator key to sign
 validated before GoReleaser can create a GitHub release. The optional
 `AGENTICO_RELEASE_NOTES_FILE` is deliberately the sole operator-controlled
 GoReleaser input: raw GoReleaser flags are not accepted, so a shell variable
-cannot bypass the release checks.
+cannot bypass the release checks. The fixed command sets a six-hour publication
+timeout because the desktop assets total hundreds of megabytes and slow
+operator uplinks routinely exceed GoReleaser's one-hour default.
 
 1. `npm ci` runs unconditionally inside the detached release worktree after
    preflight, so the captured commit's root lockfile is the


### PR DESCRIPTION
## Summary

- Add a fixed `--timeout 6h` to the GoReleaser release command. The desktop assets total hundreds of megabytes, and slow operator uplinks routinely exceed GoReleaser's one-hour default — the v0.153.0 release timed out mid-upload and stranded a draft release that required manual completion.
- The timeout stays part of the fixed command; `AGENTICO_RELEASE_NOTES_FILE` remains the sole operator-controlled GoReleaser input.
- Document the timeout in `docs/desktop/release-support.md`.

## Verification

- `npx vitest run scripts/release-goreleaser.test.mjs` (8 tests pass; arg assertions updated)
- `goreleaser release --help` confirms `--timeout` with a `1h0m0s` default

🤖 Generated with [Claude Code](https://claude.com/claude-code)
