### PR TITLE
Stream update downloads with an idle timeout

### DIFF
--- a/desktop/src/main/__tests__/updates.test.ts
+++ b/desktop/src/main/__tests__/updates.test.ts
@@ -25,6 +25,7 @@ import {
   createUpdateFixtureFetch,
   detectCanInstallInApp,
   detectPackageFormat,
+  fetchBytesStreaming,
 } from '../updates';
 
 const RELEASES_API = 'https://api.github.com/repos/doordash-oss/agentic-orchestrator/releases';
@@ -750,6 +751,127 @@ describe('UpdateCoordinator', () => {
     expect(fs.existsSync(path.join(dir, 'updates', 'v0.2.0'))).toBe(false);
   });
 
+  it('keeps a slow but flowing package download alive past the idle window', async () => {
+    const fixture = signedFixture('v0.2.0', 'Agentico-mac-universal.dmg', 'macos package bytes');
+    const clock = fakeClock();
+    const stream = streamedPackage(fixture, 'Agentico-mac-universal.dmg', 'macos package bytes');
+    const update = makeCoordinator({
+      platform: 'darwin',
+      arch: 'arm64',
+      packageFormat: 'macos',
+      fixture: { ...fixture, fetch: stream.fetch },
+      clock,
+    });
+
+    const check = update.checkNow();
+    const controller = await stream.controller();
+    for (const part of stream.parts(4)) {
+      clock.advance(45_000);
+      controller.enqueue(part);
+      await flush();
+    }
+    controller.close();
+
+    await expect(check).resolves.toMatchObject({
+      status: 'ready',
+      targetVersion: '0.2.0',
+      signatureStatus: 'verified',
+    });
+  });
+
+  it('aborts a package download that receives no bytes for the idle window', async () => {
+    const fixture = signedFixture('v0.2.0', 'Agentico-mac-universal.dmg', 'macos package bytes');
+    const clock = fakeClock();
+    const stream = streamedPackage(fixture, 'Agentico-mac-universal.dmg', 'macos package bytes');
+    const update = makeCoordinator({
+      platform: 'darwin',
+      arch: 'arm64',
+      packageFormat: 'macos',
+      fixture: { ...fixture, fetch: stream.fetch },
+      clock,
+    });
+
+    const check = update.checkNow();
+    const controller = await stream.controller();
+    controller.enqueue(stream.parts(4)[0]!);
+    await flush();
+    clock.advance(60_000);
+    await flush();
+
+    await expect(check).resolves.toMatchObject({
+      status: 'failed',
+      error: { code: 'E_UPDATE_DOWNLOAD_FAILED' },
+    });
+  });
+
+  it('reports advancing download progress while the package streams', async () => {
+    const fixture = signedFixture('v0.2.0', 'Agentico-mac-universal.dmg', 'macos package bytes');
+    const clock = fakeClock();
+    const stream = streamedPackage(fixture, 'Agentico-mac-universal.dmg', 'macos package bytes');
+    const downloadedBytes: number[] = [];
+    const update = makeCoordinator({
+      platform: 'darwin',
+      arch: 'arm64',
+      packageFormat: 'macos',
+      fixture: { ...fixture, fetch: stream.fetch },
+      clock,
+      onStateChanged: (state) => {
+        if (state.status === 'downloading' && state.progress !== undefined) {
+          downloadedBytes.push(state.progress.downloadedBytes);
+        }
+      },
+    });
+
+    const check = update.checkNow();
+    const controller = await stream.controller();
+    for (const part of stream.parts(4)) {
+      clock.advance(1000);
+      controller.enqueue(part);
+      await flush();
+    }
+    controller.close();
+    await expect(check).resolves.toMatchObject({ status: 'ready' });
+
+    const total = Buffer.byteLength('macos package bytes');
+    expect(downloadedBytes[0]).toBe(0);
+    expect(downloadedBytes.length).toBeGreaterThan(2);
+    expect([...downloadedBytes]).toEqual([...downloadedBytes].sort((a, b) => a - b));
+    expect(downloadedBytes[downloadedBytes.length - 1]).toBe(total);
+  });
+
+  it('keeps the total deadline for small metadata fetches', async () => {
+    vi.useFakeTimers();
+    try {
+      const fixture = signedFixture('v0.2.0', 'Agentico-mac-universal.dmg', 'macos package bytes');
+      const hangingFetch: typeof fetch = (input, init) => {
+        if (fetchUrl(input).includes('desktop-release.json')) {
+          return new Promise<Response>((_, reject) => {
+            init?.signal?.addEventListener('abort', () =>
+              reject(new DOMException('This operation was aborted', 'AbortError')),
+            );
+          });
+        }
+        return fixture.fetch(input, init);
+      };
+      const update = makeCoordinator({
+        platform: 'darwin',
+        arch: 'arm64',
+        packageFormat: 'macos',
+        fixture: { ...fixture, fetch: hangingFetch },
+      });
+
+      const check = update.checkNow();
+      await vi.advanceTimersByTimeAsync(8000);
+      await expect(check).resolves.toMatchObject({
+        status: 'failed',
+        error: { code: 'E_UPDATE_CHECK_FAILED' },
+      });
+      expect(fixture.requestedPackage).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('marks a failed install as failed with the canonical install error and redacted diagnostics', async () => {
     const fixture = signedFixture('v0.2.0', 'Agentico-mac-universal.dmg', 'package bytes');
     const update = makeCoordinator({
@@ -961,6 +1083,30 @@ describe('createUpdateFixtureFetch', () => {
   });
 });
 
+describe('fetchBytesStreaming', () => {
+  it('aborts a streamed download that exceeds the byte limit mid-stream', async () => {
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new Uint8Array(4));
+        controller.enqueue(new Uint8Array(4));
+        controller.close();
+      },
+    });
+    const fetchImpl: typeof fetch = () => Promise.resolve(new Response(body, { status: 200 }));
+
+    await expect(
+      fetchBytesStreaming(
+        fetchImpl,
+        'https://github.com/doordash-oss/agentic-orchestrator/releases/download/v0.2.0/x',
+        6,
+        60_000,
+        { setTimeout, clearTimeout },
+        () => undefined,
+      ),
+    ).rejects.toThrow('The update response exceeded the size limit.');
+  });
+});
+
 function makeCoordinator({
   platform,
   arch,
@@ -968,6 +1114,7 @@ function makeCoordinator({
   fixture,
   activeWork = { featureCount: 0, amaActive: false, detectionFailed: false },
   canInstallInApp,
+  clock,
   onStateChanged,
   stopActiveWork = vi.fn(() => Promise.resolve({ stopped: true })),
   restart = vi.fn(),
@@ -978,6 +1125,7 @@ function makeCoordinator({
   fixture: SignedFixture;
   activeWork?: { featureCount: number; amaActive: boolean; detectionFailed: boolean };
   canInstallInApp?: boolean;
+  clock?: FakeClock;
   onStateChanged?: (state: ReturnType<UpdateCoordinator['getState']>) => void;
   stopActiveWork?: (active: {
     featureCount: number;
@@ -1000,14 +1148,102 @@ function makeCoordinator({
     userDataDir: dir,
     fetch: fixture.fetch,
     releasePublicKey: createPublicKey(PUBLIC_KEY),
-    now: () => new Date('2026-07-20T10:00:00.000Z'),
-    setTimeout: (() => 1) as unknown as typeof setTimeout,
-    clearTimeout: vi.fn(),
+    now: clock?.now ?? (() => new Date('2026-07-20T10:00:00.000Z')),
+    setTimeout: clock?.setTimeout ?? ((() => 1) as unknown as typeof setTimeout),
+    clearTimeout: clock?.clearTimeout ?? vi.fn(),
     onStateChanged,
     detectActiveWork: vi.fn(() => Promise.resolve(activeWork)),
     stopActiveWork,
     restart,
   });
+}
+
+interface FakeClock {
+  now: () => Date;
+  setTimeout: typeof setTimeout;
+  clearTimeout: typeof clearTimeout;
+  advance(ms: number): void;
+}
+
+function fakeClock(): FakeClock {
+  let nowMs = 0;
+  let nextId = 1;
+  const timers = new Map<number, { at: number; fn: () => void }>();
+  return {
+    now: () => new Date(nowMs),
+    setTimeout: ((fn: () => void, delay: number) => {
+      const id = nextId;
+      nextId += 1;
+      timers.set(id, { at: nowMs + delay, fn });
+      return id;
+    }) as unknown as typeof setTimeout,
+    clearTimeout: ((id: number) => {
+      timers.delete(id);
+    }) as unknown as typeof clearTimeout,
+    advance(ms: number): void {
+      const target = nowMs + ms;
+      for (;;) {
+        const due = [...timers.entries()]
+          .filter(([, timer]) => timer.at <= target)
+          .sort(([, a], [, b]) => a.at - b.at)[0];
+        if (due === undefined) break;
+        nowMs = due[1].at;
+        timers.delete(due[0]);
+        due[1].fn();
+      }
+      nowMs = target;
+    },
+  };
+}
+
+function flush(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+function streamedPackage(
+  fixture: SignedFixture,
+  packageName: string,
+  packageText: string,
+): {
+  fetch: typeof fetch;
+  controller(): Promise<ReadableStreamDefaultController<Uint8Array>>;
+  parts(count: number): Uint8Array[];
+} {
+  const packageBytes = Buffer.from(packageText);
+  let streamController: ReadableStreamDefaultController<Uint8Array> | undefined;
+  const streamingFetch: typeof fetch = (input, init) => {
+    if (fetchUrl(input).includes(packageName)) {
+      const body = new ReadableStream<Uint8Array>({
+        start(controller) {
+          streamController = controller;
+        },
+      });
+      return Promise.resolve(
+        new Response(body, {
+          status: 200,
+          headers: { 'content-length': String(packageBytes.byteLength) },
+        }),
+      );
+    }
+    return fixture.fetch(input, init);
+  };
+  return {
+    fetch: streamingFetch,
+    async controller(): Promise<ReadableStreamDefaultController<Uint8Array>> {
+      while (streamController === undefined) {
+        await flush();
+      }
+      return streamController;
+    },
+    parts(count: number): Uint8Array[] {
+      const size = Math.ceil(packageBytes.byteLength / count);
+      const parts: Uint8Array[] = [];
+      for (let offset = 0; offset < packageBytes.byteLength; offset += size) {
+        parts.push(new Uint8Array(packageBytes.subarray(offset, offset + size)));
+      }
+      return parts;
+    },
+  };
 }
 
 function fetchUrl(input: Parameters<typeof fetch>[0]): string {

--- a/desktop/src/main/updates.ts
+++ b/desktop/src/main/updates.ts
@@ -36,6 +36,8 @@ const RELEASE_NOTES = 'https://github.com/doordash-oss/agentic-orchestrator/rele
 const CHECK_INTERVAL_MS = 6 * 60 * 60 * 1000;
 const CHECK_JITTER_MS = 20 * 60 * 1000;
 const FETCH_TIMEOUT_MS = 8000;
+const DOWNLOAD_IDLE_TIMEOUT_MS = 60_000;
+const DOWNLOAD_PROGRESS_NOTIFY_MS = 250;
 const MAX_RELEASE_BYTES = 1024 * 1024;
 const MAX_RELEASE_ENVELOPE_BYTES = 1024 * 1024;
 const MAX_SIGNATURE_BYTES = 64 * 1024;
@@ -638,11 +640,24 @@ export class UpdateCoordinator {
       message: 'Downloading the verified update package.',
     };
     this.notify();
-    const packageBytes = await fetchBytes(
+    let lastProgressNotifyMs = 0;
+    const packageBytes = await fetchBytesStreaming(
       this.fetchImpl,
       selected.packageAsset.browser_download_url,
       MAX_PACKAGE_BYTES,
-      60_000,
+      DOWNLOAD_IDLE_TIMEOUT_MS,
+      { setTimeout: this.setTimer, clearTimeout: this.clearTimer },
+      (downloadedBytes) => {
+        this.state = {
+          ...this.state,
+          progress: { downloadedBytes, totalBytes: selected.packageAsset.size },
+        };
+        const nowMs = this.now().getTime();
+        if (nowMs - lastProgressNotifyMs >= DOWNLOAD_PROGRESS_NOTIFY_MS) {
+          lastProgressNotifyMs = nowMs;
+          this.notify();
+        }
+      },
     );
     if (packageBytes.byteLength !== selected.packageAsset.size) {
       // An incomplete transfer is a download failure, not a verification
@@ -1073,6 +1088,71 @@ async function fetchBytes(
     return bytes;
   } finally {
     clearTimeout(timer);
+  }
+}
+
+/**
+ * Streamed download for the large update package. A total deadline would
+ * abort slow-but-flowing transfers, so it aborts only when no bytes arrive
+ * for `idleTimeoutMs`, and enforces `maxBytes` as chunks accumulate.
+ */
+export async function fetchBytesStreaming(
+  fetchImpl: typeof fetch,
+  url: string,
+  maxBytes: number,
+  idleTimeoutMs: number,
+  timers: { setTimeout: typeof setTimeout; clearTimeout: typeof clearTimeout },
+  onChunk: (downloadedBytes: number) => void,
+): Promise<Buffer> {
+  const controller = new AbortController();
+  let idleTimer: ReturnType<typeof setTimeout> | null = null;
+  const armIdleTimer = () => {
+    if (idleTimer !== null) timers.clearTimeout(idleTimer);
+    idleTimer = timers.setTimeout(() => controller.abort(), idleTimeoutMs);
+  };
+  // Injected fetch mocks may not honor the abort signal, so every await is
+  // raced against the stall rejection.
+  const stalled = new Promise<never>((_, reject) => {
+    controller.signal.addEventListener(
+      'abort',
+      () => reject(new Error('The update download stalled without receiving data.')),
+      { once: true },
+    );
+  });
+  void stalled.catch(() => undefined);
+  armIdleTimer();
+  try {
+    const response = await Promise.race([
+      fetchWithTrustedRedirect(fetchImpl, url, controller.signal, {}),
+      stalled,
+    ]);
+    const length = response.headers.get('content-length');
+    if (length !== null && Number(length) > maxBytes) {
+      throw new Error('The update response exceeded the size limit.');
+    }
+    if (!response.ok) {
+      throw new Error(`GitHub Releases returned HTTP ${response.status}.`);
+    }
+    if (response.body === null) {
+      throw new Error('The update download returned no response body.');
+    }
+    const reader = response.body.getReader();
+    const chunks: Buffer[] = [];
+    let downloadedBytes = 0;
+    for (;;) {
+      const { done, value } = await Promise.race([reader.read(), stalled]);
+      if (done) break;
+      armIdleTimer();
+      downloadedBytes += value.byteLength;
+      if (downloadedBytes > maxBytes) {
+        throw new Error('The update response exceeded the size limit.');
+      }
+      chunks.push(Buffer.from(value));
+      onChunk(downloadedBytes);
+    }
+    return Buffer.concat(chunks);
+  } finally {
+    if (idleTimer !== null) timers.clearTimeout(idleTimer);
   }
 }
 


### PR DESCRIPTION
## Summary

- The updater downloaded the update package with a total 60-second AbortController deadline and buffered the whole body via `arrayBuffer()`. Any download slower than ~4.25 MB/s sustained deterministically aborted with `E_UPDATE_DOWNLOAD_FAILED` ("This operation was aborted"), and `progress.downloadedBytes` never moved during the transfer.
- The package download now streams: chunks accumulate with the `MAX_PACKAGE_BYTES` cap enforced incrementally, and the abort fires only after 60 seconds with **no bytes received** (idle timeout, re-armed per chunk), so slow-but-flowing transfers complete. Progress updates flow to the UI, throttled to every 250 ms.
- Metadata fetches (release JSON, envelope, signature) keep their short 8-second total deadline; `fetchWithTrustedRedirect` and all URL trust checks run unchanged before any body is read, and the post-download size and sha256 verification are untouched.

## Tests

- Trickled chunks with 45 s gaps succeed over a 180 s total (past the old deadline).
- A 60 s stall with no bytes fails with `E_UPDATE_DOWNLOAD_FAILED`.
- `progress.downloadedBytes` advances monotonically to the total during a stream.
- Exceeding the byte cap mid-stream rejects.
- The 8 s metadata-fetch deadline is unchanged.

## Verification

- `npx vitest run src/main/__tests__/updates.test.ts` — 48 passed
- `npm run check` (typecheck, eslint, prettier, check:api-drift, check:error-markup) — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
