### PR TITLE
Reconcile Codex usage costs and add GPT-6 Astra support

### DIFF
--- a/desktop/src/main/configService.ts
+++ b/desktop/src/main/configService.ts
@@ -160,7 +160,15 @@ function toServerModels(models: PhaseModels): Record<string, string> {
   };
 }
 
-const EFFORT_LEVELS = new Set<EffortLevel>(['auto', 'low', 'medium', 'high', 'xhigh', 'max']);
+const EFFORT_LEVELS = new Set<EffortLevel>([
+  'auto',
+  'low',
+  'medium',
+  'high',
+  'xhigh',
+  'max',
+  'ultra',
+]);
 
 function effortEntry(value: string | undefined): EffortLevel | undefined {
   return value !== undefined && EFFORT_LEVELS.has(value as EffortLevel)

--- a/desktop/src/main/features.ts
+++ b/desktop/src/main/features.ts
@@ -129,7 +129,15 @@ const PHASE_MODEL_LABELS: ReadonlyArray<readonly [string, string]> = [
   ['kb_build', 'Knowledge base'],
 ];
 
-const EFFORT_LEVELS = new Set<EffortLevel>(['auto', 'low', 'medium', 'high', 'xhigh', 'max']);
+const EFFORT_LEVELS = new Set<EffortLevel>([
+  'auto',
+  'low',
+  'medium',
+  'high',
+  'xhigh',
+  'max',
+  'ultra',
+]);
 
 /**
  * Remote submit guard: while remotely connected, a locally shaped path

--- a/desktop/src/renderer/src/features/ConfigEditor.test.tsx
+++ b/desktop/src/renderer/src/features/ConfigEditor.test.tsx
@@ -253,6 +253,47 @@ describe('FeatureConfigPanel', () => {
     ).toBeVisible();
   });
 
+  it('saves Astra ultra effort and hides it for models that do not support it', async () => {
+    const mock = installAgenticoMock();
+    mock.api.getFeatureConfig.mockResolvedValue(SNAPSHOT);
+    mock.api.updateFeatureConfig.mockResolvedValue(SNAPSHOT);
+    mock.api.getModelCatalogue.mockResolvedValue({
+      ...CATALOGUE,
+      providerModels: {
+        ...CATALOGUE.providerModels,
+        codex: [
+          {
+            id: 'gpt-6-astra[872K]',
+            displayName: 'GPT-6 Astra (872K)',
+            aliases: ['gpt-6-astra'],
+            effortCapabilities: ['low', 'medium', 'high', 'xhigh', 'max', 'ultra'],
+          },
+        ],
+      },
+      phaseProviderModels: {
+        implementation: { claude: ['sonnet', 'opus'], codex: ['gpt-6-astra[872K]'] },
+      },
+    });
+    render(<FeatureConfigPanel featureId="feat-1" />);
+    const user = userEvent.setup();
+    const model = await screen.findByLabelText('Implementation model');
+    const effort = screen.getByLabelText('Implementation effort');
+    expect(within(effort).queryByRole('option', { name: 'Ultra' })).toBeNull();
+    await user.selectOptions(model, 'codex:gpt-6-astra[872K]');
+    await user.selectOptions(effort, 'ultra');
+    await user.click(screen.getByRole('button', { name: 'Save changes' }));
+    await waitFor(() =>
+      expect(mock.api.updateFeatureConfig).toHaveBeenCalledWith({
+        featureId: 'feat-1',
+        config: {
+          ...SNAPSHOT.current,
+          models: { implementation: 'codex:gpt-6-astra[872K]' },
+          effort: { implementation: 'ultra' },
+        },
+      }),
+    );
+  });
+
   it('links roadmap review to phase plan review and hides gates the pipeline drops', async () => {
     const mock = installAgenticoMock();
     mock.api.getFeatureConfig.mockResolvedValue({

--- a/desktop/src/renderer/src/features/ConfigEditor.tsx
+++ b/desktop/src/renderer/src/features/ConfigEditor.tsx
@@ -323,6 +323,7 @@ const EFFORT_LABELS: Record<EffortLevel, string> = {
   high: 'High',
   xhigh: 'XHigh',
   max: 'Max',
+  ultra: 'Ultra',
 };
 
 function automaticEffort(field: (typeof PHASE_FIELDS)[number], pipeline: string): EffortLevel {

--- a/desktop/src/shared/ipc.ts
+++ b/desktop/src/shared/ipc.ts
@@ -2476,7 +2476,7 @@ export const RepositoryFileRefSchema = z.strictObject({
 });
 export type RepositoryFileRef = z.output<typeof RepositoryFileRefSchema>;
 
-export const EffortLevelSchema = z.enum(['auto', 'low', 'medium', 'high', 'xhigh', 'max']);
+export const EffortLevelSchema = z.enum(['auto', 'low', 'medium', 'high', 'xhigh', 'max', 'ultra']);
 export type EffortLevel = z.output<typeof EffortLevelSchema>;
 
 /** The narrow creation input, validated at both IPC boundaries. */

--- a/desktop/test/e2e/journeys/configuration-workspace-restart.spec.ts
+++ b/desktop/test/e2e/journeys/configuration-workspace-restart.spec.ts
@@ -122,6 +122,12 @@ test('configuration, workspace, and restart journey against the packaged app', a
     expect(optionValues.length).toBeGreaterThan(0);
     const chosenModel = optionValues[0] as string;
     await implementationPicker.selectOption(chosenModel);
+    // The fixture's Claude catalog must not inherit Codex/Astra-only effort.
+    await expect(
+      editor
+        .getByLabel('Implementation effort')
+        .getByRole('option', { name: 'Ultra', exact: true }),
+    ).toHaveCount(0);
     await editor.locator('.config-editor__segment', { hasText: 'High' }).click();
     const researchGate = editor.getByRole('checkbox', { name: /Research review/ });
     const researchGateWasChecked = await researchGate.isChecked();

--- a/docs/codex-pricing.md
+++ b/docs/codex-pricing.md
@@ -1,0 +1,68 @@
+# Codex usage and pricing
+
+Agentico uses the app-server connection for usage accounting. It does not poll
+Codex's files or launch a second CLI for pricing.
+
+## Live estimates and reconciliation
+
+`thread/tokenUsage/updated` supplies cumulative token counts. Agentico prices
+only new input, cached input, cache-write input, and output tokens. Reasoning
+output is already part of output and is not charged again. `last.inputTokens`
+selects short- versus long-context rates for each update. Duplicate and
+regressing counters do not charge tokens again, and child-thread counters do
+not replace root-thread counters.
+
+After a root turn completes (including failed/interrupted turns), and after
+resuming a thread, Agentico sends `account/usage/read` with `threadId`. In
+Codex CLI 0.153.2 this non-experimental request can return:
+
+- `threadUsage.estimatedUsageUsdMicros`: optional estimated USD cost.
+- `threadUsage.estimatedUsageCreditsMicros`: estimated credits, kept separately.
+
+An available USD estimate replaces the cumulative local estimate, including
+when the provider returns zero. New inference then adds only new token costs.
+Replies that cross new turn/inference activity, superseded replies, malformed
+results, and mismatched thread IDs cannot replace newer usage. The endpoint
+has no billing watermark, so Agentico conservatively discards such replies.
+
+Lookup errors never fail an agent turn. Method-not-found disables subsequent
+lookups for that connection; missing billing data leaves the local estimate.
+Final accounting waits at most two seconds for an outstanding lookup and then
+uses the available snapshot. Native tool-less review sessions retain their
+isolated protocol and use token estimates only.
+
+The terminal result remains immutable: a billing update must not be mistaken
+for another agent completion. Cumulative usage, final accounting, and live
+session/run cost responses use the reconciled value. Session ledger records
+and session-ended events preserve `cost_source` and `cost_credits_micros`;
+credits are never converted to dollars. These are estimates, not invoices.
+
+The initial cumulative token snapshot on resume is historical and seeds the
+baseline without charging those tokens again. If thread billing is unavailable,
+Agentico can estimate new usage but cannot reconstruct historical cost across
+model, tier, or rate changes from aggregate token counts alone.
+
+## Rate fallback and Astra
+
+The standard API fallback table is dated in `internal/llm/codex/rates.go`.
+It includes GPT-6 Astra and the current GPT-5.6 rates. Unknown models receive
+`cost_source: unavailable` instead of another model's rate. Known service tiers
+and model-rerouting notifications affect live estimates; provider estimates
+remain preferable for account-specific billing. The internal-only raw-response
+schema is not used.
+
+Astra is classified as capable and has offline Codex context choices of 272K
+and 872K, taken from the installed 0.153.2 harness catalog. Live discovery
+supersedes these values and respects model visibility/access. Context suffixes
+stay in Agentico's selection IDs and are stripped before sending the model to
+Codex. Effort discovery uses the harness's advertised levels, including `ultra`
+when available; other models do not inherit Astra's effort capabilities.
+
+Sources checked September 4, 2026:
+
+- [OpenAI API pricing](https://developers.openai.com/api/docs/pricing)
+- [GPT-6 Astra](https://developers.openai.com/api/docs/models/gpt-6-astra)
+- [Codex app-server](https://learn.chatgpt.com/docs/app-server)
+- [Codex plan and credit pricing](https://learn.chatgpt.com/docs/pricing)
+- Local `codex app-server generate-json-schema --out <directory>` and
+  `codex debug models --bundled`, using `codex-cli 0.153.2`.

--- a/internal/agent/cost.go
+++ b/internal/agent/cost.go
@@ -56,8 +56,17 @@ func ExtractSessionCost(sess ports.SessionView) SessionCost {
 		Usage: sess.AccumulatedUsage(),
 	}
 	sc.TotalCostUSD = sc.Usage.CostUSD
-	if sess.Cost() != nil {
-		sc.TotalCostUSD = sess.Cost().TotalCostUSD
+	if result := sess.Cost(); result != nil && sc.Usage.CostSource == "" {
+		sc.TotalCostUSD = result.TotalCostUSD
+	}
+	if provider, ok := sess.(llm.SessionUsageReconciler); ok {
+		ctx, cancel := context.WithTimeout(context.Background(), additionalSessionCostTimeout)
+		usage := provider.ReconciledUsage(ctx)
+		cancel()
+		if usage != nil {
+			sc.Usage = *usage
+			sc.TotalCostUSD = usage.CostUSD
+		}
 	}
 	if provider, ok := sess.(additionalSessionCostProvider); ok {
 		ctx, cancel := context.WithTimeout(context.Background(), additionalSessionCostTimeout)
@@ -87,6 +96,8 @@ func applySessionCostAdjustment(cost *SessionCost, adjustment llm.SessionCostAdj
 func toSessionUsage(cost SessionCost) observe.SessionUsage {
 	return observe.SessionUsage{
 		TotalCostUSD:             cost.TotalCostUSD,
+		CostSource:               cost.Usage.CostSource,
+		CostCreditsMicros:        cost.Usage.CostCreditsMicros,
 		InputTokens:              cost.Usage.InputTokens,
 		OutputTokens:             cost.Usage.OutputTokens,
 		CacheReadInputTokens:     cost.Usage.CacheReadInputTokens,
@@ -116,7 +127,7 @@ func firstSessionCostMetadata(metadata []SessionCostMetadata) SessionCostMetadat
 }
 
 func accumulateSessionCost(store ports.FeatureStore, featureID, fallbackKey string, cost SessionCost, preferActiveKey bool, metadata SessionCostMetadata) error {
-	if store == nil || strings.TrimSpace(featureID) == "" || cost.TotalCostUSD <= 0 {
+	if store == nil || strings.TrimSpace(featureID) == "" || (cost.TotalCostUSD <= 0 && cost.Usage.CostCreditsMicros == nil) {
 		return nil
 	}
 	return store.Modify(featureID, func(f *feature.Feature) error {
@@ -131,11 +142,13 @@ func accumulateSessionCost(store ports.FeatureStore, featureID, fallbackKey stri
 			return nil
 		}
 		f.RecordSessionCost(feature.SessionCostRecord{
-			SessionID:     metadata.SessionID,
-			PhaseKey:      costKey,
-			ObserverPhase: metadata.ObserverPhase,
-			RepoName:      metadata.RepoName,
-			CostUSD:       cost.TotalCostUSD,
+			SessionID:         metadata.SessionID,
+			PhaseKey:          costKey,
+			ObserverPhase:     metadata.ObserverPhase,
+			RepoName:          metadata.RepoName,
+			CostUSD:           cost.TotalCostUSD,
+			CostSource:        cost.Usage.CostSource,
+			CostCreditsMicros: cost.Usage.CostCreditsMicros,
 		})
 		return nil
 	})

--- a/internal/agent/cost_test.go
+++ b/internal/agent/cost_test.go
@@ -371,3 +371,43 @@ func TestExtractSessionCostNoUsage(t *testing.T) {
 		t.Errorf("Usage = %+v, want zero value", sc.Usage)
 	}
 }
+
+type reconciledCostSession struct {
+	*mocks.MockSessionView
+	snapshot *llm.Usage
+}
+
+func (s *reconciledCostSession) ReconciledUsage(context.Context) *llm.Usage { return s.snapshot }
+
+func TestExtractSessionCostPrefersReconciledSnapshotIncludingZero(t *testing.T) {
+	for _, amount := range []float64{0, 0.125} {
+		base := mocks.NewMockSessionView("cost", "feature")
+		base.CostVal = &llm.ResultMessage{TotalCostUSD: 2}
+		credits := int64(987)
+		sess := &reconciledCostSession{MockSessionView: base, snapshot: &llm.Usage{CostUSD: amount, CostSource: "provider_estimate", CostCreditsMicros: &credits, CacheCreationInputTokens: 42}}
+		got := ExtractSessionCost(sess)
+		if got.TotalCostUSD != amount || got.Usage.CacheCreationInputTokens != 42 || got.Usage.CostCreditsMicros == nil || *got.Usage.CostCreditsMicros != 987 {
+			t.Fatalf("extraction retained provisional price: %+v", got)
+		}
+	}
+}
+
+func TestCreditOnlyCostPersistsWithoutInventingDollars(t *testing.T) {
+	store := feature.NewStore(t.TempDir())
+	f := &feature.Feature{ID: "credit-only", Name: "credit-only", Status: feature.StatusImplementing, SchemaVersion: feature.SchemaVersionCurrent}
+	if err := store.Save(f); err != nil {
+		t.Fatal(err)
+	}
+	credits := int64(42)
+	cost := SessionCost{Usage: llm.Usage{CostSource: "unavailable", CostCreditsMicros: &credits}}
+	if err := accumulateSessionCostToFeatureKey(store, f.ID, "implement", cost, SessionCostMetadata{SessionID: "session"}); err != nil {
+		t.Fatal(err)
+	}
+	updated, err := store.Load(f.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(updated.SessionCosts) != 1 || updated.SessionCosts[0].CostUSD != 0 || updated.SessionCosts[0].CostCreditsMicros == nil || *updated.SessionCosts[0].CostCreditsMicros != 42 {
+		t.Fatalf("credit-only ledger: %+v", updated.SessionCosts)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -133,7 +133,7 @@ type ModelConfig struct {
 }
 
 // EffortConfig holds per-role reasoning-effort configuration alongside
-// ModelConfig. Each field accepts the closed set auto|low|medium|high|xhigh|max.
+// ModelConfig. Each field accepts the closed set auto|low|medium|high|xhigh|max|ultra.
 // Empty or missing values load as Auto without triggering a load-time rewrite.
 // Every field corresponds to the same-named field on ModelConfig, except
 // Utilities which mirrors ModelConfig.Utilities (the "chat" role).

--- a/internal/config/effort_config_test.go
+++ b/internal/config/effort_config_test.go
@@ -72,7 +72,7 @@ func TestEffortConfigExplicitAutoRoundTrips(t *testing.T) {
 }
 
 func TestEffortConfigEveryExplicitLevelRoundTrips(t *testing.T) {
-	levels := []string{"low", "medium", "high", "xhigh", "max"}
+	levels := []string{"low", "medium", "high", "xhigh", "max", "ultra"}
 	for _, role := range allEffortRoles {
 		for _, level := range levels {
 			t.Run(role+"_"+level, func(t *testing.T) {

--- a/internal/feature/feature.go
+++ b/internal/feature/feature.go
@@ -1104,7 +1104,7 @@ func (f *Feature) AddPhaseCost(key string, cost float64) {
 // phase-level aggregate used by existing dashboard and summary readers.
 func (f *Feature) RecordSessionCost(record SessionCostRecord) {
 	record.PhaseKey = strings.TrimSpace(record.PhaseKey)
-	if record.CostUSD <= 0 || record.PhaseKey == "" {
+	if (record.CostUSD <= 0 && record.CostCreditsMicros == nil) || record.PhaseKey == "" {
 		return
 	}
 	record.SessionID = strings.TrimSpace(record.SessionID)

--- a/internal/feature/run.go
+++ b/internal/feature/run.go
@@ -205,11 +205,13 @@ type Run struct {
 // the phase-level aggregate used by dashboards; this slice preserves the
 // session-level ledger behind that aggregate.
 type SessionCostRecord struct {
-	SessionID     string  `yaml:"session_id"`
-	PhaseKey      string  `yaml:"phase_key"`
-	ObserverPhase string  `yaml:"observer_phase,omitempty"`
-	RepoName      string  `yaml:"repo_name,omitempty"`
-	CostUSD       float64 `yaml:"cost_usd"`
+	SessionID         string  `yaml:"session_id"`
+	PhaseKey          string  `yaml:"phase_key"`
+	ObserverPhase     string  `yaml:"observer_phase,omitempty"`
+	RepoName          string  `yaml:"repo_name,omitempty"`
+	CostUSD           float64 `yaml:"cost_usd"`
+	CostSource        string  `yaml:"cost_source,omitempty"`
+	CostCreditsMicros *int64  `yaml:"cost_credits_micros,omitempty"`
 }
 
 // IsSealed reports whether this run has been sealed (rewound past).

--- a/internal/llm/codex/discovery.go
+++ b/internal/llm/codex/discovery.go
@@ -29,13 +29,16 @@ type codexModelCatalogPayload struct {
 }
 
 type codexDiscoveredModel struct {
-	Slug             string `json:"slug"`
-	DisplayName      string `json:"display_name"`
-	Description      string `json:"description"`
-	Visibility       string `json:"visibility"`
-	SupportedInAPI   *bool  `json:"supported_in_api"`
-	ContextWindow    int    `json:"context_window"`
-	MaxContextWindow int    `json:"max_context_window"`
+	Slug                     string `json:"slug"`
+	DisplayName              string `json:"display_name"`
+	Description              string `json:"description"`
+	Visibility               string `json:"visibility"`
+	SupportedInAPI           *bool  `json:"supported_in_api"`
+	ContextWindow            int    `json:"context_window"`
+	MaxContextWindow         int    `json:"max_context_window"`
+	SupportedReasoningLevels []struct {
+		Effort llm.EffortLevel `json:"effort"`
+	} `json:"supported_reasoning_levels"`
 }
 
 // DiscoverModelCatalog refreshes Codex's local model catalog via
@@ -110,7 +113,7 @@ func parseCodexModelCatalogWithProgress(out []byte, report llm.ModelDiscoveryRep
 				DisplayName:        displayName,
 				ContextWindow:      window,
 				Category:           codexCategoryForDiscoveredModel(id),
-				EffortCapabilities: []llm.EffortLevel{llm.EffortLow, llm.EffortMedium, llm.EffortHigh, llm.EffortXHigh, llm.EffortMax},
+				EffortCapabilities: codexEffortCapabilities(raw),
 			}
 			if label := llm.ContextWindowLabel(window); label != "" {
 				info.ID = llm.ModelWithContextWindow(id, window)
@@ -180,11 +183,29 @@ func codexCategoryForDiscoveredModel(id string) string {
 		return "balanced"
 	case lower == "gpt-5.3-codex":
 		return "balanced"
-	case strings.HasPrefix(lower, "gpt-5."):
+	case strings.HasPrefix(lower, "gpt-5."), strings.HasPrefix(lower, "gpt-6"):
 		return "capable"
 	case strings.Contains(lower, "codex"):
 		return "balanced"
 	default:
 		return ""
 	}
+}
+
+// Use the installed harness's advertised effort levels. Older catalogs omit
+// this field, so preserve their existing five-level fallback.
+func codexEffortCapabilities(model codexDiscoveredModel) []llm.EffortLevel {
+	if model.SupportedReasoningLevels == nil {
+		return []llm.EffortLevel{llm.EffortLow, llm.EffortMedium, llm.EffortHigh, llm.EffortXHigh, llm.EffortMax}
+	}
+	var result []llm.EffortLevel
+	for _, level := range llm.AllEffortLevels {
+		for _, supported := range model.SupportedReasoningLevels {
+			if supported.Effort == level {
+				result = append(result, level)
+				break
+			}
+		}
+	}
+	return result
 }

--- a/internal/llm/codex/protocol.go
+++ b/internal/llm/codex/protocol.go
@@ -76,28 +76,32 @@ type Protocol struct {
 	threadReady   chan struct{}
 
 	// Session state
-	threadID           string
-	turnID             string
-	model              string
-	approvalPolicy     string
-	dangerFullAccess   bool
-	inputTokens        int
-	cachedInputTokens  int
-	outputTokens       int
-	totalCostUSD       float64
-	modelContextWindow int
-	deltaBuf           map[string]string
-	questionIDs        map[string]string
-	turnHadToolUse     bool
-	lastAssistantText  string
-	lastAssistantDraft string
-	formatRetryCount   int
-	fileReadSeen       map[string]struct{}
-	turnStarted        bool
-	nativeReviewTurnID string
-	nativeDecisionSeen bool
-	nativeReviewFailed bool
-	tasksByThread      map[string]codexTaskRef
+	threadID              string
+	turnID                string
+	model                 string
+	approvalPolicy        string
+	dangerFullAccess      bool
+	inputTokens           int
+	cachedInputTokens     int
+	cacheWriteInputTokens int
+	pricingModel          string
+	serviceTier           string
+	usageState            usageState
+	outputTokens          int
+	totalCostUSD          float64
+	modelContextWindow    int
+	deltaBuf              map[string]string
+	questionIDs           map[string]string
+	turnHadToolUse        bool
+	lastAssistantText     string
+	lastAssistantDraft    string
+	formatRetryCount      int
+	fileReadSeen          map[string]struct{}
+	turnStarted           bool
+	nativeReviewTurnID    string
+	nativeDecisionSeen    bool
+	nativeReviewFailed    bool
+	tasksByThread         map[string]codexTaskRef
 
 	logFunc func(string, ...interface{})
 }
@@ -125,6 +129,7 @@ func NewProtocol(opts llm.ProtocolOpts) *Protocol {
 	}
 	return &Protocol{
 		opts:             opts,
+		usageState:       usageState{resumeBaselinePending: opts.ResumeSessionID != ""},
 		model:            llm.StripModelContextWindow(opts.Model),
 		approvalPolicy:   policy,
 		dangerFullAccess: opts.DSP,
@@ -208,6 +213,15 @@ func (p *Protocol) ParseLine(line []byte) ([]llm.SDKMessage, error) {
 
 	// Response to our request (has id but no method)
 	if env.ID != nil && env.Method == "" {
+		// Negative IDs are reserved for optional billing lookups. Their failures
+		// must never turn a successful agent turn into a protocol error.
+		if *env.ID < 0 && !p.opts.NativeToollessReview {
+			msg, emit := p.handleUsageResponse(*env.ID, env.Result, env.Error)
+			if emit {
+				return []llm.SDKMessage{p.stampMessage(msg)}, nil
+			}
+			return nil, nil
+		}
 		if p.opts.NativeToollessReview && len(env.Error) > 0 && string(env.Error) != "null" {
 			return []llm.SDKMessage{p.nativeToollessViolation("JSON-RPC error response")}, nil
 		}
@@ -320,6 +334,10 @@ func (p *Protocol) SessionID() string {
 func (p *Protocol) TranscriptPath() string { return "" }
 
 func (p *Protocol) Close() error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.usageState.closed = true
+	p.finishUsageReadLocked()
 	return nil
 }
 
@@ -519,6 +537,8 @@ func (p *Protocol) sendFollowUpTurn(text string) error {
 	id := int(nextID.Add(1))
 
 	p.mu.Lock()
+	p.usageState.revision++
+	p.pricingModel = p.model
 	threadID := p.threadID
 	policy := p.approvalPolicy
 	model := p.model
@@ -667,6 +687,10 @@ func (p *Protocol) handleResponse(id int, result, errData json.RawMessage) (msg 
 	if err := json.Unmarshal(result, &threadResult); err == nil && threadResult.Thread.ID != "" {
 		p.mu.Lock()
 		p.threadID = threadResult.Thread.ID
+		if threadResult.Model != "" {
+			p.pricingModel = threadResult.Model
+		}
+		p.serviceTier = threadResult.ServiceTier
 		if effectivePolicy := strings.TrimSpace(threadResult.ApprovalPolicy); effectivePolicy != "" && !p.opts.NativeToollessReview {
 			p.approvalPolicy = effectivePolicy
 		}
@@ -678,6 +702,9 @@ func (p *Protocol) handleResponse(id int, result, errData json.RawMessage) (msg 
 			}
 		}
 		p.mu.Unlock()
+		if p.opts.ResumeSessionID != "" {
+			p.requestUsageRead()
+		}
 		p.logDebug("[codex] thread started: %s", threadResult.Thread.ID)
 		return llm.SDKMessage{}, false, true
 	}
@@ -1095,6 +1122,8 @@ func (p *Protocol) parseNotification(method string, params json.RawMessage) (llm
 			return p.taskProgressForChildThread(completed.ThreadID, "", "", "child turn "+completed.Turn.Status)
 		}
 
+		p.requestUsageRead()
+
 		switch completed.Turn.Status {
 		case "completed":
 			p.mu.Lock()
@@ -1115,7 +1144,7 @@ func (p *Protocol) parseNotification(method string, params json.RawMessage) (llm
 				if !decisionSeen || (decision != "ALLOW" && decision != "DEFER") {
 					return p.nativeToollessViolation("malformed reviewer decision"), true
 				}
-				return p.successResult(inTok, cachedInTok, outTok, costUSD), true
+				return p.withUsage(p.successResult(inTok, cachedInTok, outTok, costUSD)), true
 			}
 
 			// The entire text-parsed AskUserQuestion pipeline below exists only to
@@ -1174,7 +1203,7 @@ func (p *Protocol) parseNotification(method string, params json.RawMessage) (llm
 			p.formatRetryCount = 0
 			p.mu.Unlock()
 
-			return p.successResult(inTok, cachedInTok, outTok, costUSD), true
+			return p.withUsage(p.successResult(inTok, cachedInTok, outTok, costUSD)), true
 
 		case "failed":
 			if p.opts.NativeToollessReview {
@@ -1220,7 +1249,7 @@ func (p *Protocol) parseNotification(method string, params json.RawMessage) (llm
 					OutputTokens:         outTok,
 				}
 			}
-			return msg, true
+			return p.withUsage(msg), true
 
 		case "interrupted":
 			if p.opts.NativeToollessReview {
@@ -1251,7 +1280,7 @@ func (p *Protocol) parseNotification(method string, params json.RawMessage) (llm
 					OutputTokens:         outTok,
 				}
 			}
-			return msg, true
+			return p.withUsage(msg), true
 
 		default:
 			p.logDebug("[codex] turn/completed with unknown status: %s", completed.Turn.Status)
@@ -1277,54 +1306,15 @@ func (p *Protocol) parseNotification(method string, params json.RawMessage) (llm
 				return p.nativeToollessViolation(detail), true
 			}
 		}
-		// Total = lifetime cumulative (for cost calculation on turn completion).
-		// Last = current context fill (resets on compaction; use for context %).
 		p.mu.Lock()
-		inputDelta := usage.TokenUsage.Total.InputTokens - p.inputTokens
-		cachedInputDelta := usage.TokenUsage.Total.CachedInputTokens - p.cachedInputTokens
-		outputDelta := usage.TokenUsage.Total.OutputTokens - p.outputTokens
-		if inputDelta >= 0 && cachedInputDelta >= 0 && outputDelta >= 0 {
-			// The app-server protocol does not expose cache-write token counts,
-			// so cache writes remain zero until that telemetry becomes available.
-			p.totalCostUSD += computeCostForContext(
-				p.model,
-				inputDelta,
-				cachedInputDelta,
-				0,
-				outputDelta,
-				usage.TokenUsage.Last.InputTokens,
-			)
+		defer p.mu.Unlock()
+		// Child threads have independent cumulative counters. Mixing them
+		// with the root would corrupt both deltas and context usage.
+		if !p.isMainThread(usage.ThreadID) {
+			return llm.SDKMessage{}, false
 		}
-		p.inputTokens = usage.TokenUsage.Total.InputTokens
-		p.cachedInputTokens = usage.TokenUsage.Total.CachedInputTokens
-		p.outputTokens = usage.TokenUsage.Total.OutputTokens
-		if usage.TokenUsage.ModelContextWindow != nil {
-			p.modelContextWindow = *usage.TokenUsage.ModelContextWindow
-		}
-		ctxWindow := p.modelContextWindow
-		costUSD := p.totalCostUSD
-		p.mu.Unlock()
-
-		// Surface as synthetic SDKMessage so session layer can accumulate.
-		// Total = lifetime cumulative (for cost); Last = current context fill
-		// (resets on compaction, for context % display).
-		//
-		// ContextTotalTokens carries Last.TotalTokens (input + output +
-		// reasoning) so the session's ContextPercentage() can match Codex's
-		// own `/status` formula: (total - baseline) / (window - baseline).
-		return llm.SDKMessage{
-			Type: "usage_update",
-			UsageUpdate: &llm.Usage{
-				InputTokens:          usage.TokenUsage.Total.InputTokens,
-				CacheReadInputTokens: usage.TokenUsage.Total.CachedInputTokens,
-				OutputTokens:         usage.TokenUsage.Total.OutputTokens,
-				ContextInputTokens:   usage.TokenUsage.Last.InputTokens,
-				ContextTotalTokens:   usage.TokenUsage.Last.TotalTokens,
-				ContextBaseline:      codexContextBaselineTokens,
-				ContextWindow:        ctxWindow,
-				CostUSD:              costUSD,
-			},
-		}, true
+		p.updateTokenUsageLocked(usage.TokenUsage)
+		return p.usageMessageLocked(), true
 
 	case "item/commandExecution/outputDelta":
 		var delta CommandOutputDelta
@@ -1648,6 +1638,24 @@ func (p *Protocol) parseNotification(method string, params json.RawMessage) (llm
 			return llm.SDKMessage{}, false
 		}
 
+	case "model/rerouted":
+		if p.opts.NativeToollessReview {
+			return p.nativeToollessViolation("unexpected model rerouting"), true
+		}
+		var rerouted struct {
+			ThreadID string `json:"threadId"`
+			ToModel  string `json:"toModel"`
+		}
+		if json.Unmarshal(params, &rerouted) != nil {
+			return llm.SDKMessage{}, false
+		}
+		p.mu.Lock()
+		if p.isMainThread(rerouted.ThreadID) && rerouted.ToModel != "" {
+			p.pricingModel = rerouted.ToModel
+		}
+		p.mu.Unlock()
+		return llm.SDKMessage{}, false
+
 	case "turn/started":
 		var turnStarted struct {
 			ThreadID string `json:"threadId"`
@@ -1665,6 +1673,9 @@ func (p *Protocol) parseNotification(method string, params json.RawMessage) (llm
 		p.mu.Lock()
 		isMain := turnStarted.ThreadID == "" || p.threadID == "" || turnStarted.ThreadID == p.threadID
 		alreadyStarted := p.turnStarted
+		if isMain {
+			p.usageState.revision++
+		}
 		if isMain && !alreadyStarted {
 			p.turnStarted = true
 			p.nativeReviewTurnID = turnStarted.Turn.ID

--- a/internal/llm/codex/protocol_test.go
+++ b/internal/llm/codex/protocol_test.go
@@ -1519,9 +1519,9 @@ func TestTurnCompletedAccumulatesShortAndLongContextRates(t *testing.T) {
 	if !ok || msg.Result == nil {
 		t.Fatal("turn completed did not return a result")
 	}
-	// First update uses short-context rates ($0.242); the 100K/10K/10K
-	// deltas in the second update use long-context rates ($0.272).
-	const want = 0.514
+	// First update uses short-context rates ($0.0484); the 100K/10K/10K
+	// deltas in the second update use long-context rates ($0.0544).
+	const want = 0.1028
 	if diff := msg.Result.TotalCostUSD - want; diff < -0.001 || diff > 0.001 {
 		t.Fatalf("TotalCostUSD = %.6f, want %.3f", msg.Result.TotalCostUSD, want)
 	}
@@ -1565,7 +1565,7 @@ func TestTurnCompleted_WellFormedQuestionSurfacesOptions(t *testing.T) {
 	if msg.Type != "control_request" || msg.ControlRequest == nil {
 		t.Fatalf("got Type=%q ControlRequest=%v, want control_request", msg.Type, msg.ControlRequest)
 	}
-	if buf.Len() != 0 {
+	if strings.Contains(buf.String(), `"method":"turn/start"`) {
 		t.Errorf("unexpected follow-up turn written to stdin: %s", buf.String())
 	}
 	p.mu.Lock()
@@ -1618,7 +1618,7 @@ func TestTurnCompleted_MultiSentenceStemQuestionSurfacesOptions(t *testing.T) {
 	if !strings.HasPrefix(parsed.Questions[0].Question, "How should the opt-in notification preview setting be scoped?") {
 		t.Errorf("question = %q", parsed.Questions[0].Question)
 	}
-	if buf.Len() != 0 {
+	if strings.Contains(buf.String(), `"method":"turn/start"`) {
 		t.Errorf("unexpected follow-up turn written to stdin: %s", buf.String())
 	}
 }
@@ -1791,7 +1791,7 @@ func TestTurnCompleted_BlankAgentMessageDoesNotEraseWellFormedQuestion(t *testin
 	if len(parsed.Questions[0].Options) != 3 {
 		t.Errorf("options len = %d, want 3", len(parsed.Questions[0].Options))
 	}
-	if buf.Len() != 0 {
+	if strings.Contains(buf.String(), `"method":"turn/start"`) {
 		t.Errorf("unexpected follow-up turn written to stdin: %s", buf.String())
 	}
 }
@@ -1810,7 +1810,7 @@ func TestTurnCompleted_IllFormedQuestionTriggersReformatRetry(t *testing.T) {
 	if ok {
 		t.Fatalf("parseNotification ok = true, want false (got msg=%+v)", msg)
 	}
-	if buf.Len() == 0 {
+	if !strings.Contains(buf.String(), `"method":"turn/start"`) {
 		t.Fatal("expected a follow-up turn to be written to stdin")
 	}
 	if !strings.Contains(buf.String(), "not in the required question format") {
@@ -1845,7 +1845,7 @@ func TestTurnCompleted_IllFormedFallsThroughAfterCap(t *testing.T) {
 	if msg.Type != "control_request" || msg.ControlRequest == nil {
 		t.Fatalf("got Type=%q, want control_request", msg.Type)
 	}
-	if buf.Len() != 0 {
+	if strings.Contains(buf.String(), `"method":"turn/start"`) {
 		t.Errorf("no follow-up should be written after cap; got %s", buf.String())
 	}
 	// Options should be empty in the fall-through path.
@@ -1882,7 +1882,7 @@ func TestTurnCompleted_FreeFormSentinelSkipsRetry(t *testing.T) {
 	if !ok {
 		t.Fatal("parseNotification ok = false, want true")
 	}
-	if buf.Len() != 0 {
+	if strings.Contains(buf.String(), `"method":"turn/start"`) {
 		t.Errorf("no follow-up should be written for FREE_FORM; got %s", buf.String())
 	}
 	var parsed struct {
@@ -1992,7 +1992,7 @@ APPROVED`
 	if msg.ControlRequest != nil {
 		t.Errorf("unexpected ControlRequest on validator verdict: %+v", msg.ControlRequest)
 	}
-	if buf.Len() != 0 {
+	if strings.Contains(buf.String(), `"method":"turn/start"`) {
 		t.Errorf("unexpected reformat follow-up written to stdin: %s", buf.String())
 	}
 	p.mu.Lock()
@@ -2031,7 +2031,7 @@ func TestTurnCompleted_NumberedOptionsAfterToolUseSurfacesQuestion(t *testing.T)
 	if msg.Type != "control_request" || msg.ControlRequest == nil {
 		t.Fatalf("got Type=%q ControlRequest=%v, want control_request (tool-use turn ended in well-formed question)", msg.Type, msg.ControlRequest)
 	}
-	if buf.Len() != 0 {
+	if strings.Contains(buf.String(), `"method":"turn/start"`) {
 		t.Errorf("unexpected follow-up turn written to stdin: %s", buf.String())
 	}
 
@@ -2072,7 +2072,7 @@ func TestTurnCompleted_FreeFormSentinelAfterToolUse(t *testing.T) {
 	if msg.Type != "control_request" || msg.ControlRequest == nil {
 		t.Fatalf("got Type=%q ControlRequest=%v, want control_request", msg.Type, msg.ControlRequest)
 	}
-	if buf.Len() != 0 {
+	if strings.Contains(buf.String(), `"method":"turn/start"`) {
 		t.Errorf("unexpected follow-up turn written to stdin: %s", buf.String())
 	}
 }
@@ -2105,7 +2105,7 @@ func TestTurnCompleted_LooseQuestionAfterToolUseEmitsSuccess(t *testing.T) {
 	if msg.ControlRequest != nil {
 		t.Errorf("unexpected ControlRequest on loose-question tool-use turn: %+v", msg.ControlRequest)
 	}
-	if buf.Len() != 0 {
+	if strings.Contains(buf.String(), `"method":"turn/start"`) {
 		t.Errorf("unexpected reformat follow-up written to stdin: %s", buf.String())
 	}
 }
@@ -2134,7 +2134,7 @@ func TestTurnCompleted_InformationalNumberedListIsCleanSuccess(t *testing.T) {
 	if msg.Type != "result" || msg.Subtype != "success" {
 		t.Fatalf("got Type=%q Subtype=%q ControlRequest=%v, want result/success", msg.Type, msg.Subtype, msg.ControlRequest)
 	}
-	if buf.Len() != 0 {
+	if strings.Contains(buf.String(), `"method":"turn/start"`) {
 		t.Errorf("unexpected follow-up turn written to stdin: %s", buf.String())
 	}
 }
@@ -2177,7 +2177,7 @@ func TestTurnCompleted_InteractiveNeverSynthesizesQuestion(t *testing.T) {
 			if msg.Type != "result" || msg.Subtype != "success" {
 				t.Fatalf("got Type=%q Subtype=%q ControlRequest=%v, want result/success", msg.Type, msg.Subtype, msg.ControlRequest)
 			}
-			if buf.Len() != 0 {
+			if strings.Contains(buf.String(), `"method":"turn/start"`) {
 				t.Errorf("sent a reformat reminder, want none: %s", buf.String())
 			}
 		})

--- a/internal/llm/codex/provider.go
+++ b/internal/llm/codex/provider.go
@@ -448,7 +448,8 @@ func (p *Provider) OutputPricePerMToken(model string) float64 {
 // as an offline fallback so the Session.ContextPercentage() signal works from
 // session start even when discovery is unavailable.
 //
-// Sources (verified 2026-04-18):
+// Astra windows/efforts: codex-cli 0.153.2 bundled catalog (2026-09-04).
+// Other sources (verified 2026-04-18):
 //   - https://developers.openai.com/api/docs/models/gpt-5.5
 //   - https://developers.openai.com/api/docs/models/gpt-5.4
 //   - https://developers.openai.com/api/docs/models/gpt-5.4-mini
@@ -456,6 +457,11 @@ func (p *Provider) OutputPricePerMToken(model string) float64 {
 //   - https://developers.openai.com/api/docs/models/gpt-5.2
 func (p *Provider) defaultModelInfos() []llm.ModelInfo {
 	return []llm.ModelInfo{
+		{ID: "gpt-6-astra[272K]", DisplayName: "GPT-6 Astra (272K)", ContextWindow: 272_000, Aliases: []string{"gpt-6-astra"}, Category: "capable",
+			EffortCapabilities: []llm.EffortLevel{llm.EffortLow, llm.EffortMedium, llm.EffortHigh, llm.EffortXHigh, llm.EffortMax, llm.EffortUltra}},
+		{ID: "gpt-6-astra[872K]", DisplayName: "GPT-6 Astra (872K)", ContextWindow: 872_000, Category: "capable",
+			EffortCapabilities: []llm.EffortLevel{llm.EffortLow, llm.EffortMedium, llm.EffortHigh, llm.EffortXHigh, llm.EffortMax, llm.EffortUltra}},
+
 		{ID: "gpt-5.5[272K]", DisplayName: "GPT-5.5 (272K)", ContextWindow: 272_000, Aliases: []string{"gpt-5.5"}, Category: "capable",
 			EffortCapabilities: []llm.EffortLevel{llm.EffortLow, llm.EffortMedium, llm.EffortHigh, llm.EffortXHigh, llm.EffortMax}},
 		{ID: "gpt-5.4[272K]", DisplayName: "GPT-5.4 (272K)", ContextWindow: 272_000, Aliases: []string{"gpt-5.4"}, Category: "balanced",

--- a/internal/llm/codex/provider_test.go
+++ b/internal/llm/codex/provider_test.go
@@ -880,3 +880,56 @@ func TestProviderSupportsSessionResume(t *testing.T) {
 		t.Error("SupportsSessionResume() = false, want true")
 	}
 }
+
+func TestAstraCatalogRoutingWindowsAndEffort(t *testing.T) {
+	p := &Provider{}
+	for _, selection := range []string{"gpt-6-astra", "gpt-6-astra[272K]", "gpt-6-astra[872K]"} {
+		if !p.MatchesModel(selection) {
+			t.Fatalf("Astra not routed to Codex: %s", selection)
+		}
+		if p.OutputPricePerMToken(selection) != 50 {
+			t.Fatalf("Astra priced as a different model: %s", selection)
+		}
+		wantWindow := 272_000
+		if strings.Contains(selection, "872K") {
+			wantWindow = 872_000
+		}
+		if p.ContextWindowForModel(selection) != wantWindow {
+			t.Fatalf("wrong window for %s", selection)
+		}
+	}
+	raw := []byte(`{"models":[{"slug":"gpt-6-astra","visibility":"list","supported_in_api":true,"context_window":272000,"max_context_window":872000,"supported_reasoning_levels":[{"effort":"low"},{"effort":"max"},{"effort":"ultra"}]}]}`)
+	catalog, err := parseCodexModelCatalog(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(catalog) != 2 {
+		t.Fatalf("Astra windows: %+v", catalog)
+	}
+	p.SetModelCatalog(catalog)
+	for _, model := range catalog {
+		if model.Category != "capable" || !slices.Equal(model.EffortCapabilities, []llm.EffortLevel{llm.EffortLow, llm.EffortMax, llm.EffortUltra}) {
+			t.Fatalf("discovered capabilities: %+v", model)
+		}
+	}
+	if !p.MatchesModel("gpt-6-astra") {
+		t.Fatal("lost bare Astra alias after discovery")
+	}
+	t.Setenv("CODEX_HOME", t.TempDir())
+	command, _, err := p.BuildCommand(llm.CommandBuildOpts{Model: "gpt-6-astra[872K]", EffortLevel: llm.EffortUltra})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertConfigOverride(t, command, "model_context_window=872000")
+	assertReasoningOverride(t, command, "model_reasoning_effort=ultra")
+	var out bytes.Buffer
+	protocol := NewProtocol(llm.ProtocolOpts{Model: "gpt-6-astra[872K]"})
+	protocol.SetStdin(&out)
+	protocol.SetThreadIDForTest("root")
+	if err := protocol.startTurn("hello"); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), `"model":"gpt-6-astra"`) || strings.Contains(out.String(), "872K") {
+		t.Fatalf("model suffix leaked onto wire: %s", out.String())
+	}
+}

--- a/internal/llm/codex/rates.go
+++ b/internal/llm/codex/rates.go
@@ -33,23 +33,27 @@ type tokenRate struct {
 }
 
 // modelRates maps canonical model names to their token pricing.
-// Source: https://developers.openai.com/api/docs/pricing (July 2026)
+// Source: https://developers.openai.com/api/docs/pricing (verified 2026-09-04; standard API estimates, not ChatGPT credit prices)
 var modelRates = map[string]tokenRate{
+	"gpt-6-astra": {
+		inputPerMToken: 10, cachedInputPerMToken: 1, cacheWritePerMToken: 12.5, outputPerMToken: 50,
+		longInputPerMToken: 20, longCachedInputPerMToken: 2, longCacheWritePerMToken: 25, longOutputPerMToken: 75,
+	},
 	"gpt-5.6": {
-		inputPerMToken: 5.00, cachedInputPerMToken: 0.50, cacheWritePerMToken: 6.25, outputPerMToken: 30.00,
-		longInputPerMToken: 10.00, longCachedInputPerMToken: 1.00, longCacheWritePerMToken: 12.50, longOutputPerMToken: 45.00,
+		inputPerMToken: 4, cachedInputPerMToken: 0.4, cacheWritePerMToken: 5, outputPerMToken: 20,
+		longInputPerMToken: 8, longCachedInputPerMToken: 0.8, longCacheWritePerMToken: 10, longOutputPerMToken: 30,
 	},
 	"gpt-5.6-sol": {
-		inputPerMToken: 5.00, cachedInputPerMToken: 0.50, cacheWritePerMToken: 6.25, outputPerMToken: 30.00,
-		longInputPerMToken: 10.00, longCachedInputPerMToken: 1.00, longCacheWritePerMToken: 12.50, longOutputPerMToken: 45.00,
+		inputPerMToken: 4, cachedInputPerMToken: 0.4, cacheWritePerMToken: 5, outputPerMToken: 20,
+		longInputPerMToken: 8, longCachedInputPerMToken: 0.8, longCacheWritePerMToken: 10, longOutputPerMToken: 30,
 	},
 	"gpt-5.6-terra": {
-		inputPerMToken: 2.50, cachedInputPerMToken: 0.25, cacheWritePerMToken: 3.125, outputPerMToken: 15.00,
-		longInputPerMToken: 5.00, longCachedInputPerMToken: 0.50, longCacheWritePerMToken: 6.25, longOutputPerMToken: 22.50,
+		inputPerMToken: 2, cachedInputPerMToken: 0.2, cacheWritePerMToken: 2.5, outputPerMToken: 12,
+		longInputPerMToken: 4, longCachedInputPerMToken: 0.4, longCacheWritePerMToken: 5, longOutputPerMToken: 18,
 	},
 	"gpt-5.6-luna": {
-		inputPerMToken: 1.00, cachedInputPerMToken: 0.10, cacheWritePerMToken: 1.25, outputPerMToken: 6.00,
-		longInputPerMToken: 2.00, longCachedInputPerMToken: 0.20, longCacheWritePerMToken: 2.50, longOutputPerMToken: 9.00,
+		inputPerMToken: 0.2, cachedInputPerMToken: 0.02, cacheWritePerMToken: 0.25, outputPerMToken: 1.2,
+		longInputPerMToken: 0.4, longCachedInputPerMToken: 0.04, longCacheWritePerMToken: 0.5, longOutputPerMToken: 1.8,
 	},
 	"gpt-5.5":       {inputPerMToken: 5.00, cachedInputPerMToken: 0.50, outputPerMToken: 30.00, longInputPerMToken: 10.00, longCachedInputPerMToken: 1.00, longOutputPerMToken: 45.00},
 	"gpt-5.4":       {inputPerMToken: 2.50, cachedInputPerMToken: 0.25, outputPerMToken: 15.00, longInputPerMToken: 5.00, longCachedInputPerMToken: 0.50, longOutputPerMToken: 22.50},
@@ -60,12 +64,12 @@ var modelRates = map[string]tokenRate{
 // OpenAI applies long-context rates when a request exceeds 272K input tokens.
 const longContextInputThreshold = 272_000
 
-// defaultModel is the fallback when a model string doesn't match any rate entry.
+// defaultModel is the model requested when no model is configured.
 const defaultModel = "gpt-5.4"
 
 // lookupRate resolves a model string to its token rate.
-// It strips explicit context-window suffixes and falls back to the default
-// model rate for unrecognized gpt-* variants.
+// It strips context-window suffixes. Unknown models have no price; substituting
+// another model would produce a misleading estimate.
 func lookupRate(model string) (tokenRate, bool) {
 	m := strings.ToLower(llm.StripModelContextWindow(model))
 
@@ -78,11 +82,22 @@ func lookupRate(model string) (tokenRate, bool) {
 		return modelRates[defaultModel], true
 	}
 
-	// Any gpt-* variant we don't have specific rates for:
-	// fall back to the default model rate so cost is never silently zero.
-	if strings.HasPrefix(m, "gpt-") {
-		return modelRates[defaultModel], true
-	}
-
 	return tokenRate{}, false
+}
+
+// computeCostForServiceTier applies known API tier prices to the live fallback.
+// Provider billing reconciliation remains authoritative for account-specific
+// credits, promotions, and tiers not represented by this rate card.
+func computeCostForServiceTier(model, tier string, input, cached, writes, output, contextInput int) float64 {
+	cost := computeCostForContext(model, input, cached, writes, output, contextInput)
+	switch strings.ToLower(tier) {
+	case "flex", "batch":
+		return cost * 0.5
+	case "fast", "priority":
+		switch strings.ToLower(llm.StripModelContextWindow(model)) {
+		case "gpt-6-astra", "gpt-5.6", "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna":
+			return cost * 2
+		}
+	}
+	return cost
 }

--- a/internal/llm/codex/rates_test.go
+++ b/internal/llm/codex/rates_test.go
@@ -32,12 +32,14 @@ func TestLookupRate(t *testing.T) {
 		wantLongWrite  float64
 		wantLongOut    float64
 	}{
+		{"gpt-6-astra", true, 10, 1, 12.5, 50, 20, 2, 25, 75},
+		{"GPT-6-ASTRA[872K]", true, 10, 1, 12.5, 50, 20, 2, 25, 75},
 		// GPT-5.6 family, including the generic alias.
-		{"gpt-5.6", true, 5.00, 0.50, 6.25, 30.00, 10.00, 1.00, 12.50, 45.00},
-		{"gpt-5.6[1M]", true, 5.00, 0.50, 6.25, 30.00, 10.00, 1.00, 12.50, 45.00},
-		{"gpt-5.6-sol", true, 5.00, 0.50, 6.25, 30.00, 10.00, 1.00, 12.50, 45.00},
-		{"gpt-5.6-terra", true, 2.50, 0.25, 3.125, 15.00, 5.00, 0.50, 6.25, 22.50},
-		{"gpt-5.6-luna", true, 1.00, 0.10, 1.25, 6.00, 2.00, 0.20, 2.50, 9.00},
+		{"gpt-5.6", true, 4.00, 0.40, 5.00, 20.00, 8.00, 0.80, 10.00, 30.00},
+		{"gpt-5.6[1M]", true, 4.00, 0.40, 5.00, 20.00, 8.00, 0.80, 10.00, 30.00},
+		{"gpt-5.6-sol", true, 4.00, 0.40, 5.00, 20.00, 8.00, 0.80, 10.00, 30.00},
+		{"gpt-5.6-terra", true, 2.00, 0.20, 2.50, 12.00, 4.00, 0.40, 5.00, 18.00},
+		{"gpt-5.6-luna", true, 0.20, 0.02, 0.25, 1.20, 0.40, 0.04, 0.50, 1.80},
 
 		// Direct matches
 		{"gpt-5.5", true, 5.00, 0.50, 0, 30.00, 10.00, 1.00, 0, 45.00},
@@ -51,11 +53,11 @@ func TestLookupRate(t *testing.T) {
 		// Empty model uses the default model rate.
 		{"", true, 2.50, 0.25, 0, 15.00, 5.00, 0.50, 0, 22.50},
 
-		// Unknown gpt-* variants fall back to default
-		{"gpt-future-model", true, 2.50, 0.25, 0, 15.00, 5.00, 0.50, 0, 22.50},
+		// Unknown models must not inherit an unrelated model's price.
+		{"gpt-future-model", false, 0, 0, 0, 0, 0, 0, 0, 0},
 
 		// Case insensitive
-		{"GPT-5.6-LUNA", true, 1.00, 0.10, 1.25, 6.00, 2.00, 0.20, 2.50, 9.00},
+		{"GPT-5.6-LUNA", true, 0.20, 0.02, 0.25, 1.20, 0.40, 0.04, 0.50, 1.80},
 		// Non-matching models
 		{"codex", false, 0, 0, 0, 0, 0, 0, 0, 0},
 		{"opus", false, 0, 0, 0, 0, 0, 0, 0, 0},
@@ -135,8 +137,8 @@ func TestComputeCost(t *testing.T) {
 
 	// Cache reads and writes replace full-price input tokens.
 	costCacheWrite := computeCost("gpt-5.6-luna", 200_000, 50_000, 50_000, 10_000)
-	if math.Abs(costCacheWrite-0.2275) > 0.001 {
-		t.Errorf("computeCost(gpt-5.6-luna, cache write) = %f, want 0.2275", costCacheWrite)
+	if math.Abs(costCacheWrite-0.0455) > 0.001 {
+		t.Errorf("computeCost(gpt-5.6-luna, cache write) = %f, want 0.0455", costCacheWrite)
 	}
 	// Models without separate cache-write pricing keep those tokens at the
 	// ordinary input rate instead of treating them as free.
@@ -148,12 +150,12 @@ func TestComputeCost(t *testing.T) {
 	// The threshold itself remains short-context pricing; only larger requests
 	// use the 2x input and 1.5x output rates.
 	costAtThreshold := computeCost("gpt-5.6-luna", 272_000, 0, 0, 1_000)
-	if math.Abs(costAtThreshold-0.278) > 0.001 {
-		t.Errorf("computeCost(gpt-5.6-luna, threshold) = %f, want 0.278", costAtThreshold)
+	if math.Abs(costAtThreshold-0.0556) > 0.001 {
+		t.Errorf("computeCost(gpt-5.6-luna, threshold) = %f, want 0.0556", costAtThreshold)
 	}
 	costAboveThreshold := computeCost("gpt-5.6-luna", 273_000, 0, 0, 1_000)
-	if math.Abs(costAboveThreshold-0.555) > 0.001 {
-		t.Errorf("computeCost(gpt-5.6-luna, long context) = %f, want 0.555", costAboveThreshold)
+	if math.Abs(costAboveThreshold-0.111) > 0.001 {
+		t.Errorf("computeCost(gpt-5.6-luna, long context) = %f, want 0.111", costAboveThreshold)
 	}
 }
 
@@ -171,5 +173,24 @@ func TestProviderComputeCost(t *testing.T) {
 	expected := 0.75 + 4.50
 	if math.Abs(costMini-expected) > 0.001 {
 		t.Errorf("Provider.ComputeCost(gpt-5.4-mini, 1M, 1M) = %f, want %f", costMini, expected)
+	}
+}
+
+func TestAstraCostBoundaryAndServiceTiers(t *testing.T) {
+	for _, tc := range []struct {
+		tier  string
+		input int
+		want  float64
+	}{
+		{"default", 272_000, 2.77},
+		{"default", 273_000, 5.535},
+		{"fast", 273_000, 11.07},
+		{"priority", 273_000, 11.07},
+		{"flex", 273_000, 2.7675},
+	} {
+		got := computeCostForServiceTier("gpt-6-astra[872K]", tc.tier, tc.input, 0, 0, 1_000, tc.input)
+		if math.Abs(got-tc.want) > 0.00000001 {
+			t.Errorf("%s/%d = %v, want %v", tc.tier, tc.input, got, tc.want)
+		}
 	}
 }

--- a/internal/llm/codex/types.go
+++ b/internal/llm/codex/types.go
@@ -110,6 +110,8 @@ type ThreadResumeParams struct {
 type ThreadStartResult struct {
 	Thread         Thread `json:"thread"`
 	ApprovalPolicy string `json:"approvalPolicy,omitempty"`
+	Model          string `json:"model,omitempty"`
+	ServiceTier    string `json:"serviceTier,omitempty"`
 }
 
 // Thread identifies a conversation thread.
@@ -223,6 +225,7 @@ type ThreadTokenUsage struct {
 type TokenUsageBreakdown struct {
 	InputTokens           int `json:"inputTokens"`
 	CachedInputTokens     int `json:"cachedInputTokens"`
+	CacheWriteInputTokens int `json:"cacheWriteInputTokens"`
 	OutputTokens          int `json:"outputTokens"`
 	ReasoningOutputTokens int `json:"reasoningOutputTokens"`
 	TotalTokens           int `json:"totalTokens"`

--- a/internal/llm/codex/usage.go
+++ b/internal/llm/codex/usage.go
@@ -1,0 +1,228 @@
+// Copyright 2026 DoorDash, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package codex
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/doordash-oss/agentic-orchestrator/internal/llm"
+)
+
+// usageState is protected by Protocol.mu. Only the latest lookup is retained;
+// negative request IDs let us harmlessly discard superseded replies and errors.
+type usageState struct {
+	resumeBaselinePending bool
+	revision              uint64
+	pending               *usageRead
+	disabled              bool
+	closed                bool
+	seen                  bool
+	source                string
+	creditsMicros         *int64
+	last                  TokenUsageBreakdown
+}
+
+type usageRead struct {
+	id       int
+	revision uint64
+	done     chan struct{}
+}
+
+type accountUsageResult struct {
+	ThreadUsage *struct {
+		ThreadID      string `json:"threadId"`
+		USDMicros     *int64 `json:"estimatedUsageUsdMicros"`
+		CreditsMicros *int64 `json:"estimatedUsageCreditsMicros"`
+	} `json:"threadUsage"`
+}
+
+// requestUsageRead sends one optional request on the existing RPC connection.
+// It never waits for the server, starts another process, or polls account data.
+func (p *Protocol) requestUsageRead() {
+	p.mu.Lock()
+	if p.opts.NativeToollessReview || p.usageState.disabled || p.usageState.closed || p.threadID == "" || p.stdin == nil {
+		p.mu.Unlock()
+		return
+	}
+	p.finishUsageReadLocked()
+	request := &usageRead{id: -int(nextID.Add(1)), revision: p.usageState.revision, done: make(chan struct{})}
+	p.usageState.pending = request
+	threadID := p.threadID
+	p.mu.Unlock()
+	err := p.writeJSON(Request{
+		JSONRPC: "2.0", ID: request.id, Method: "account/usage/read",
+		Params: struct {
+			ThreadID string `json:"threadId"`
+		}{threadID},
+	})
+	if err != nil {
+		p.mu.Lock()
+		if p.usageState.pending == request {
+			p.finishUsageReadLocked()
+		}
+		p.mu.Unlock()
+		p.logDebug("[codex] optional usage lookup unavailable: %v", err)
+	}
+}
+
+func (p *Protocol) finishUsageReadLocked() {
+	if pending := p.usageState.pending; pending != nil {
+		close(pending.done)
+		p.usageState.pending = nil
+	}
+}
+
+func (p *Protocol) handleUsageResponse(id int, result, errData json.RawMessage) (llm.SDKMessage, bool) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	request := p.usageState.pending
+	if request == nil || request.id != id {
+		return llm.SDKMessage{}, false
+	}
+	defer p.finishUsageReadLocked()
+	if len(errData) > 0 && string(errData) != "null" {
+		var rpcError struct {
+			Code int `json:"code"`
+		}
+		if json.Unmarshal(errData, &rpcError) == nil && rpcError.Code == -32601 {
+			// Older Codex versions do not implement account/usage/read.
+			p.usageState.disabled = true
+		}
+		return llm.SDKMessage{}, false
+	}
+	// A response crossing new inference activity cannot safely replace its
+	// cost: the API has no usage watermark. Keep the live estimate until the
+	// next turn's lookup instead of double-counting or losing newer tokens.
+	if request.revision != p.usageState.revision {
+		return llm.SDKMessage{}, false
+	}
+	var response accountUsageResult
+	if json.Unmarshal(result, &response) != nil || response.ThreadUsage == nil {
+		return llm.SDKMessage{}, false
+	}
+	usage := response.ThreadUsage
+	if usage.ThreadID != p.threadID {
+		return llm.SDKMessage{}, false
+	}
+	if usage.USDMicros != nil && *usage.USDMicros < 0 || usage.CreditsMicros != nil && *usage.CreditsMicros < 0 {
+		return llm.SDKMessage{}, false
+	}
+	if usage.USDMicros == nil && usage.CreditsMicros == nil {
+		return llm.SDKMessage{}, false
+	}
+	p.usageState.seen = true
+	p.usageState.creditsMicros = usage.CreditsMicros
+	if usage.USDMicros != nil {
+		// Zero is a valid provider estimate. Never add a cumulative cost twice.
+		p.totalCostUSD = float64(*usage.USDMicros) / 1_000_000
+		p.usageState.source = "provider_estimate"
+	}
+	return p.usageMessageLocked(), true
+}
+
+// ReconciledUsage lets final accounting wait for an already-issued lookup.
+// Cancellation, unsupported billing, and process closure retain the estimate.
+func (p *Protocol) ReconciledUsage(ctx context.Context) *llm.Usage {
+	p.mu.Lock()
+	pending := p.usageState.pending
+	p.mu.Unlock()
+	if pending != nil {
+		select {
+		case <-pending.done:
+		case <-ctx.Done():
+		}
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if !p.usageState.seen {
+		return nil
+	}
+	usage := p.usageSnapshotLocked()
+	return &usage
+}
+
+func (p *Protocol) updateTokenUsageLocked(usage ThreadTokenUsage) {
+	total := usage.Total
+	inputDelta := total.InputTokens - p.inputTokens
+	cachedDelta := total.CachedInputTokens - p.cachedInputTokens
+	writeDelta := total.CacheWriteInputTokens - p.cacheWriteInputTokens
+	outputDelta := total.OutputTokens - p.outputTokens
+	// Replayed or regressing snapshots must not reset the baseline: the next
+	// ordinary update would otherwise charge those same tokens again.
+	if inputDelta < 0 || cachedDelta < 0 || writeDelta < 0 || outputDelta < 0 {
+		return
+	}
+	historical := p.usageState.resumeBaselinePending
+	p.usageState.resumeBaselinePending = false
+	if !historical && (inputDelta > 0 || cachedDelta > 0 || writeDelta > 0 || outputDelta > 0) {
+		p.usageState.revision++
+		model := p.pricingModel
+		if model == "" {
+			model = p.model
+		}
+		p.totalCostUSD += computeCostForServiceTier(model, p.serviceTier, inputDelta, cachedDelta, writeDelta, outputDelta, usage.Last.InputTokens)
+		if _, ok := lookupRate(model); ok {
+			p.usageState.source = "token_estimate"
+		} else {
+			p.usageState.source = "unavailable"
+		}
+	}
+	p.inputTokens = total.InputTokens
+	p.cachedInputTokens = total.CachedInputTokens
+	p.cacheWriteInputTokens = total.CacheWriteInputTokens
+	p.outputTokens = total.OutputTokens
+	p.usageState.last = usage.Last
+	p.usageState.seen = true
+	if usage.ModelContextWindow != nil {
+		p.modelContextWindow = *usage.ModelContextWindow
+	}
+}
+
+func (p *Protocol) usageSnapshotLocked() llm.Usage {
+	source := p.usageState.source
+	if source == "" {
+		source = "unavailable"
+	}
+	return llm.Usage{
+		InputTokens:              p.inputTokens,
+		CacheReadInputTokens:     p.cachedInputTokens,
+		CacheCreationInputTokens: p.cacheWriteInputTokens,
+		OutputTokens:             p.outputTokens,
+		ContextInputTokens:       p.usageState.last.InputTokens,
+		ContextTotalTokens:       p.usageState.last.TotalTokens,
+		ContextBaseline:          codexContextBaselineTokens,
+		ContextWindow:            p.modelContextWindow,
+		CostUSD:                  p.totalCostUSD,
+		CostSource:               source,
+		CostCreditsMicros:        p.usageState.creditsMicros,
+	}
+}
+
+func (p *Protocol) usageMessageLocked() llm.SDKMessage {
+	usage := p.usageSnapshotLocked()
+	return llm.SDKMessage{Type: "usage_update", UsageUpdate: &usage}
+}
+
+func (p *Protocol) withUsage(msg llm.SDKMessage) llm.SDKMessage {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if msg.Result != nil && p.usageState.seen {
+		usage := p.usageSnapshotLocked()
+		msg.Result.Usage = &usage
+		msg.Result.TotalCostUSD = usage.CostUSD
+	}
+	return msg
+}

--- a/internal/llm/codex/usage_test.go
+++ b/internal/llm/codex/usage_test.go
@@ -1,0 +1,246 @@
+// Copyright 2026 DoorDash, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package codex
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"math"
+	"testing"
+
+	"github.com/doordash-oss/agentic-orchestrator/internal/llm"
+)
+
+func parseUsageLine(t *testing.T, p *Protocol, line string) []llm.SDKMessage {
+	t.Helper()
+	messages, err := p.ParseLine([]byte(line))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return messages
+}
+
+func sendUsage(t *testing.T, p *Protocol, thread string, input, cached, writes, output int) llm.SDKMessage {
+	t.Helper()
+	breakdown := TokenUsageBreakdown{InputTokens: input, CachedInputTokens: cached, CacheWriteInputTokens: writes, OutputTokens: output, TotalTokens: input + output}
+	raw, err := json.Marshal(TokenUsageUpdatedParams{ThreadID: thread, TurnID: "turn-1", TokenUsage: ThreadTokenUsage{Total: breakdown, Last: breakdown}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	messages := parseUsageLine(t, p, `{"method":"thread/tokenUsage/updated","params":`+string(raw)+`}`)
+	if len(messages) == 0 {
+		return llm.SDKMessage{}
+	}
+	return messages[0]
+}
+
+func completeForUsage(t *testing.T, p *Protocol, out *bytes.Buffer, status string) int {
+	t.Helper()
+	out.Reset()
+	messages := parseUsageLine(t, p, fmt.Sprintf(`{"method":"turn/completed","params":{"threadId":"root","turn":{"id":"turn-1","status":%q}}}`, status))
+	if len(messages) != 1 || messages[0].Result == nil {
+		t.Fatalf("expected one terminal result: %+v", messages)
+	}
+	var request struct {
+		ID     int
+		Method string
+		Params struct {
+			ThreadID string `json:"threadId"`
+		}
+	}
+	if err := json.Unmarshal(bytes.TrimSpace(out.Bytes()), &request); err != nil {
+		t.Fatal(err)
+	}
+	if request.Method != "account/usage/read" || request.Params.ThreadID != "root" {
+		t.Fatalf("wrong lookup: %+v", request)
+	}
+	return request.ID
+}
+
+func replyUsage(t *testing.T, p *Protocol, id int, body string) []llm.SDKMessage {
+	t.Helper()
+	return parseUsageLine(t, p, fmt.Sprintf(`{"id":%d,"result":%s}`, id, body))
+}
+
+func assertUsageCost(t *testing.T, p *Protocol, want float64) *llm.Usage {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Read current fallback even if a request remains outstanding.
+	usage := p.ReconciledUsage(ctx)
+	if usage == nil || math.Abs(usage.CostUSD-want) > 0.00000001 {
+		t.Fatalf("usage = %+v, want cost %.8f", usage, want)
+	}
+	return usage
+}
+
+func TestUsageReconciliationReplacesEstimateAndRetainsCredits(t *testing.T) {
+	for _, status := range []string{"completed", "failed", "interrupted"} {
+		t.Run(status, func(t *testing.T) {
+			p := NewProtocol(llm.ProtocolOpts{Model: "gpt-6-astra", Interactive: true})
+			var out bytes.Buffer
+			p.SetStdin(&out)
+			p.SetThreadIDForTest("root")
+			// 100K regular + 50K cached + 50K writes + 10K output.
+			sendUsage(t, p, "root", 200_000, 50_000, 50_000, 10_000)
+			assertUsageCost(t, p, 2.175)
+			id := completeForUsage(t, p, &out, status)
+			messages := replyUsage(t, p, id, `{"threadUsage":{"threadId":"root","estimatedUsageUsdMicros":1234567,"estimatedUsageCreditsMicros":9876543}}`)
+			if len(messages) != 1 || messages[0].Type != "usage_update" || messages[0].Result != nil {
+				t.Fatalf("billing created a terminal event: %+v", messages)
+			}
+			usage := assertUsageCost(t, p, 1.234567)
+			if usage.CacheCreationInputTokens != 50_000 || usage.CostSource != "provider_estimate" || usage.CostCreditsMicros == nil || *usage.CostCreditsMicros != 9876543 {
+				t.Fatalf("lost billing metadata: %+v", usage)
+			}
+			// Replay cannot apply a cumulative estimate twice.
+			replyUsage(t, p, id, `{"threadUsage":{"threadId":"root","estimatedUsageUsdMicros":1234567}}`)
+			assertUsageCost(t, p, 1.234567)
+			// Same token snapshot must not undo the reconciled cost.
+			sendUsage(t, p, "root", 200_000, 50_000, 50_000, 10_000)
+			assertUsageCost(t, p, 1.234567)
+			// New inference adds only its incremental cost to the reconciled base.
+			sendUsage(t, p, "root", 210_000, 50_000, 50_000, 11_000)
+			assertUsageCost(t, p, 1.384567)
+		})
+	}
+}
+
+func TestUsageReconciliationMissingMalformedAndZeroUSD(t *testing.T) {
+	for _, tc := range []struct {
+		name, body string
+		want       float64
+		credits    bool
+	}{
+		{"missing", `{}`, 1, false},
+		{"unavailable", `{"threadUsage":null}`, 1, false},
+		{"credits only", `{"threadUsage":{"threadId":"root","estimatedUsageUsdMicros":null,"estimatedUsageCreditsMicros":42}}`, 1, true},
+		{"zero", `{"threadUsage":{"threadId":"root","estimatedUsageUsdMicros":0,"estimatedUsageCreditsMicros":0}}`, 0, true},
+		{"wrong thread", `{"threadUsage":{"threadId":"child","estimatedUsageUsdMicros":10}}`, 1, false},
+		{"malformed", `{"threadUsage":{"threadId":"root","estimatedUsageUsdMicros":"1.5"}}`, 1, false},
+		{"negative", `{"threadUsage":{"threadId":"root","estimatedUsageUsdMicros":-1}}`, 1, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			p := NewProtocol(llm.ProtocolOpts{Model: "gpt-6-astra", Interactive: true})
+			var out bytes.Buffer
+			p.SetStdin(&out)
+			p.SetThreadIDForTest("root")
+			sendUsage(t, p, "root", 100_000, 0, 0, 0)
+			id := completeForUsage(t, p, &out, "completed")
+			replyUsage(t, p, id, tc.body)
+			usage := assertUsageCost(t, p, tc.want)
+			if (usage.CostCreditsMicros != nil) != tc.credits {
+				t.Fatalf("credits: %+v", usage)
+			}
+		})
+	}
+}
+
+func TestUsageStaleRepliesAndChildCountersDoNotCorruptRoot(t *testing.T) {
+	p := NewProtocol(llm.ProtocolOpts{Model: "gpt-6-astra", Interactive: true})
+	var out bytes.Buffer
+	p.SetStdin(&out)
+	p.SetThreadIDForTest("root")
+	sendUsage(t, p, "root", 100_000, 0, 0, 0)
+	first := completeForUsage(t, p, &out, "completed")
+	sendUsage(t, p, "child", 900_000, 0, 0, 0)
+	assertUsageCost(t, p, 1)
+	sendUsage(t, p, "root", 110_000, 0, 0, 0)
+	replyUsage(t, p, first, `{"threadUsage":{"threadId":"root","estimatedUsageUsdMicros":99}}`)
+	assertUsageCost(t, p, 1.1)
+	// Regression must not lower the token baseline then charge it again.
+	sendUsage(t, p, "root", 100_000, 0, 0, 0)
+	sendUsage(t, p, "root", 110_000, 0, 0, 0)
+	assertUsageCost(t, p, 1.1)
+	old := completeForUsage(t, p, &out, "completed")
+	latest := completeForUsage(t, p, &out, "completed")
+	replyUsage(t, p, old, `{"threadUsage":{"threadId":"root","estimatedUsageUsdMicros":99}}`)
+	assertUsageCost(t, p, 1.1)
+	replyUsage(t, p, latest, `{"threadUsage":{"threadId":"root","estimatedUsageUsdMicros":500000}}`)
+	assertUsageCost(t, p, 0.5)
+}
+
+func TestUsageLookupUnsupportedAndClosedNeverFailTurn(t *testing.T) {
+	p := NewProtocol(llm.ProtocolOpts{Model: "gpt-6-astra", Interactive: true})
+	var out bytes.Buffer
+	p.SetStdin(&out)
+	p.SetThreadIDForTest("root")
+	sendUsage(t, p, "root", 100_000, 0, 0, 0)
+	id := completeForUsage(t, p, &out, "completed")
+	messages := parseUsageLine(t, p, fmt.Sprintf(`{"id":%d,"error":{"code":-32601,"message":"Method not found"}}`, id))
+	if len(messages) != 0 {
+		t.Fatalf("optional lookup became agent error: %+v", messages)
+	}
+	assertUsageCost(t, p, 1)
+	out.Reset()
+	p.requestUsageRead()
+	if out.Len() != 0 {
+		t.Fatal("retried unsupported billing method")
+	}
+	p.Close()
+	assertUsageCost(t, p, 1)
+}
+
+func TestUsageLookupWaitIsBoundedAndCloseUnblocks(t *testing.T) {
+	p := NewProtocol(llm.ProtocolOpts{Model: "gpt-6-astra", Interactive: true})
+	var out bytes.Buffer
+	p.SetStdin(&out)
+	p.SetThreadIDForTest("root")
+	sendUsage(t, p, "root", 100_000, 0, 0, 0)
+	completeForUsage(t, p, &out, "completed")
+	assertUsageCost(t, p, 1) // Canceled context returns fallback immediately.
+	result := make(chan *llm.Usage, 1)
+	go func() { result <- p.ReconciledUsage(context.Background()) }()
+	p.Close()
+	usage := <-result
+	if usage.CostUSD != 1 {
+		t.Fatalf("lost fallback on close: %+v", usage)
+	}
+}
+
+func TestResumeUsageDoesNotChargeHistoricalTokensAgain(t *testing.T) {
+	p := NewProtocol(llm.ProtocolOpts{Model: "gpt-6-astra", ResumeSessionID: "root", Interactive: true})
+	var out bytes.Buffer
+	p.SetStdin(&out)
+	parseUsageLine(t, p, `{"id":1,"result":{"thread":{"id":"root"},"model":"gpt-6-astra","serviceTier":"fast"}}`)
+	var request Request
+	if err := json.Unmarshal(bytes.TrimSpace(out.Bytes()), &request); err != nil {
+		t.Fatal(err)
+	}
+	replyUsage(t, p, request.ID, `{"threadUsage":{"threadId":"root","estimatedUsageUsdMicros":500000}}`)
+	sendUsage(t, p, "root", 200_000, 0, 0, 0)
+	assertUsageCost(t, p, 0.5)
+	sendUsage(t, p, "root", 210_000, 0, 0, 0)
+	assertUsageCost(t, p, 0.7) // Only 10K new tokens at fast rates.
+}
+
+func TestAstraReroutingAndTierAffectLiveEstimate(t *testing.T) {
+	p := NewProtocol(llm.ProtocolOpts{Model: "gpt-6-astra"})
+	parseUsageLine(t, p, `{"id":1,"result":{"thread":{"id":"root"},"model":"gpt-6-astra","serviceTier":"priority"}}`)
+	sendUsage(t, p, "root", 100_000, 0, 0, 0)
+	assertUsageCost(t, p, 2)
+	parseUsageLine(t, p, `{"method":"model/rerouted","params":{"threadId":"root","turnId":"turn-1","toModel":"gpt-5.6-luna"}}`)
+	sendUsage(t, p, "root", 200_000, 0, 0, 0)
+	assertUsageCost(t, p, 2.04)
+}
+
+func TestUnknownModelHasNoInventedPrice(t *testing.T) {
+	p := NewProtocol(llm.ProtocolOpts{Model: "gpt-future"})
+	sendUsage(t, p, "root", 100_000, 0, 0, 0)
+	if usage := assertUsageCost(t, p, 0); usage.CostSource != "unavailable" {
+		t.Fatalf("unknown rate: %+v", usage)
+	}
+}

--- a/internal/llm/effort_capabilities_test.go
+++ b/internal/llm/effort_capabilities_test.go
@@ -52,6 +52,9 @@ func TestCodexCatalogHasEffortCapabilities(t *testing.T) {
 			t.Errorf("model %s: expected non-empty EffortCapabilities", m.ID)
 		}
 		want := []llm.EffortLevel{llm.EffortLow, llm.EffortMedium, llm.EffortHigh, llm.EffortXHigh, llm.EffortMax}
+		if llm.StripModelContextWindow(m.ID) == "gpt-6-astra" {
+			want = append(want, llm.EffortUltra)
+		}
 		if !equalEffortLevels(m.EffortCapabilities, want) {
 			t.Errorf("model %s: got %v, want %v", m.ID, m.EffortCapabilities, want)
 		}
@@ -166,13 +169,13 @@ func TestEffortCapabilitySupported(t *testing.T) {
 }
 
 func TestIsValidExplicitEffort(t *testing.T) {
-	valid := []llm.EffortLevel{llm.EffortAuto, llm.EffortLow, llm.EffortMedium, llm.EffortHigh, llm.EffortXHigh, llm.EffortMax}
+	valid := []llm.EffortLevel{llm.EffortAuto, llm.EffortLow, llm.EffortMedium, llm.EffortHigh, llm.EffortXHigh, llm.EffortMax, llm.EffortUltra}
 	for _, level := range valid {
 		if !llm.IsValidExplicitEffort(level) {
 			t.Errorf("expected %q to be valid", level)
 		}
 	}
-	invalid := []llm.EffortLevel{"", "ultra", "extreme"}
+	invalid := []llm.EffortLevel{"", "invalid", "extreme"}
 	for _, level := range invalid {
 		if llm.IsValidExplicitEffort(level) {
 			t.Errorf("expected %q to be invalid", level)

--- a/internal/llm/effort_resolver.go
+++ b/internal/llm/effort_resolver.go
@@ -20,7 +20,7 @@ package llm
 //
 //   - When configured is empty or EffortAuto, the pipeline effort is used with
 //     source auto. This preserves current pipeline behavior.
-//   - When configured is an explicit level (low|medium|high|xhigh|max) and the model
+//   - When configured is an explicit level (low|medium|high|xhigh|max|ultra) and the model
 //     supports it, the configured value is used unchanged with source explicit.
 //   - When configured is explicit but the model no longer supports it
 //     (capability drift), the pipeline effort is used with source auto. The

--- a/internal/llm/effort_resolver_test.go
+++ b/internal/llm/effort_resolver_test.go
@@ -96,7 +96,7 @@ func TestEffortDrifted(t *testing.T) {
 	if llm.EffortDrifted(llm.EffortHigh, nil) {
 		t.Error("high with nil caps should not be drifted (model lacks effort control, not drift)")
 	}
-	if llm.EffortDrifted(llm.EffortLevel("ultra"), caps) {
+	if llm.EffortDrifted(llm.EffortLevel("invalid"), caps) {
 		t.Error("invalid effort should not be drifted (it's malformed, not drift)")
 	}
 }

--- a/internal/llm/message.go
+++ b/internal/llm/message.go
@@ -249,6 +249,12 @@ type Usage struct {
 	// session. Providers without live cost telemetry leave it zero; their final
 	// ResultMessage remains authoritative.
 	CostUSD float64 `json:"cost_usd,omitempty"`
+	// CostSource distinguishes a local token estimate from a provider estimate
+	// or an unavailable price. Empty preserves other providers' cost semantics.
+	CostSource string `json:"cost_source,omitempty"`
+	// CostCreditsMicros is the provider's credit estimate, when available.
+	// Credits have account-specific value and must not be converted to USD.
+	CostCreditsMicros *int64 `json:"cost_credits_micros,omitempty"`
 
 	// ContextInputTokens is the current context fill (post-compaction)
 	// expressed as input tokens only. Kept for informational purposes;

--- a/internal/llm/provider.go
+++ b/internal/llm/provider.go
@@ -144,6 +144,13 @@ type SessionCostAugmenter interface {
 	AdditionalSessionCost(ctx context.Context) (SessionCostAdjustment, error)
 }
 
+// SessionUsageReconciler supplies a cumulative usage snapshot after waiting for
+// an outstanding provider billing lookup, bounded by ctx. It returns nil when
+// no usage is available. The snapshot replaces, rather than augments, usage.
+type SessionUsageReconciler interface {
+	ReconciledUsage(ctx context.Context) *Usage
+}
+
 // CatalogProvider exposes the model catalog populated by discovery.
 // Providers implementing this interface allow the Registry to perform
 // category-based model selection from the live catalog.
@@ -316,7 +323,7 @@ type ProtocolOpts struct {
 
 // EffortLevel is a provider-agnostic effort/reasoning level that each provider
 // maps to its own CLI-specific naming. The canonical ordered set is
-// low < medium < high < xhigh < max. Not every provider exposes all five;
+// low < medium < high < xhigh < max < ultra. Providers advertise supported levels;
 // each provider's ModelInfo.EffortCapabilities advertises only the levels it
 // supports. Utility sessions can request Low directly; pipeline profiles
 // determine phase effort as Medium → Medium and Large/Moonshot → High.
@@ -328,6 +335,7 @@ const (
 	EffortHigh   EffortLevel = "high"
 	EffortXHigh  EffortLevel = "xhigh"
 	EffortMax    EffortLevel = "max"
+	EffortUltra  EffortLevel = "ultra"
 )
 
 // EffortAuto is the configuration value that means "derive the effective effort
@@ -349,14 +357,14 @@ const (
 // AllEffortLevels is the canonical ordered set of explicit effort levels from
 // lowest to highest, excluding Auto. Providers use this to build
 // EffortCapabilities slices and the resolver uses it for validation.
-var AllEffortLevels = []EffortLevel{EffortLow, EffortMedium, EffortHigh, EffortXHigh, EffortMax}
+var AllEffortLevels = []EffortLevel{EffortLow, EffortMedium, EffortHigh, EffortXHigh, EffortMax, EffortUltra}
 
 // IsValidExplicitEffort reports whether level is one of the closed set
-// auto|low|medium|high|xhigh|max. It accepts EffortAuto in addition to the five
+// auto|low|medium|high|xhigh|max|ultra. It accepts EffortAuto in addition to the six
 // explicit levels.
 func IsValidExplicitEffort(level EffortLevel) bool {
 	switch level {
-	case EffortAuto, EffortLow, EffortMedium, EffortHigh, EffortXHigh, EffortMax:
+	case EffortAuto, EffortLow, EffortMedium, EffortHigh, EffortXHigh, EffortMax, EffortUltra:
 		return true
 	}
 	return false
@@ -399,7 +407,7 @@ func EffortCapabilitySupported(capabilities []EffortLevel, level EffortLevel) bo
 
 // MapStandardEffortLevel maps a provider-agnostic EffortLevel to the CLI
 // --effort/model_reasoning_effort value shared by Claude and Codex: low,
-// medium, high, xhigh, max, defaulting to high for unrecognized levels.
+// medium, high, xhigh, max, ultra (Codex), defaulting to high for unrecognized levels.
 func MapStandardEffortLevel(level EffortLevel) string {
 	switch level {
 	case EffortLow:
@@ -412,6 +420,8 @@ func MapStandardEffortLevel(level EffortLevel) string {
 		return "xhigh"
 	case EffortMax:
 		return "max"
+	case EffortUltra:
+		return "ultra"
 	default:
 		return "high" // safe default
 	}

--- a/internal/observe/observer.go
+++ b/internal/observe/observer.go
@@ -254,6 +254,8 @@ func (o *Observer) SessionStarted(sc SpanContext, phase, sessionID, provider, mo
 // SessionUsage carries cost and token data for a completed session.
 // Defined in observe to avoid importing llm — callers convert from llm.Usage.
 type SessionUsage struct {
+	CostSource               string
+	CostCreditsMicros        *int64
 	TotalCostUSD             float64
 	InputTokens              int
 	OutputTokens             int
@@ -286,6 +288,13 @@ func (o *Observer) SessionEnded(sc SpanContext, phase, sessionID, repoName strin
 			"cache_creation_input_tokens": usage.CacheCreationInputTokens,
 		},
 	}
+	if usage.CostSource != "" {
+		evt.Data["cost_source"] = usage.CostSource
+	}
+	if usage.CostCreditsMicros != nil {
+		evt.Data["cost_credits_micros"] = *usage.CostCreditsMicros
+	}
+
 	if err != nil {
 		evt.Status = "error"
 		evt.Error = err.Error()

--- a/internal/server/mutation.go
+++ b/internal/server/mutation.go
@@ -1631,7 +1631,7 @@ func validateEffortConfig(w http.ResponseWriter, effort config.EffortConfig, mod
 		}
 		if !llm.IsValidExplicitEffort(llm.EffortLevel(r.val)) {
 			writeAPIError(w, http.StatusBadRequest, errcat.BadRequest,
-				errcat.WithDiagnostics("effort."+r.label+" must be one of: auto, low, medium, high, xhigh, max"))
+				errcat.WithDiagnostics("effort."+r.label+" must be one of: auto, low, medium, high, xhigh, max, ultra"))
 			return false
 		}
 		if r.val == "auto" {

--- a/internal/server/run_history.go
+++ b/internal/server/run_history.go
@@ -300,8 +300,9 @@ func (h *apiHandler) runCostWithActiveSessions(featureID string, run *feature.Ru
 		if sess == nil || sess.FeatureID() != featureID || sessionRunNumber(sess) != run.RunNumber {
 			continue
 		}
-		runningCost := sess.AccumulatedUsage().CostUSD
-		if result := sess.Cost(); result != nil && result.TotalCostUSD > runningCost {
+		usage := sess.AccumulatedUsage()
+		runningCost := usage.CostUSD
+		if result := sess.Cost(); result != nil && usage.CostSource == "" && result.TotalCostUSD > runningCost {
 			runningCost = result.TotalCostUSD
 		}
 		if runningCost <= 0 {

--- a/internal/server/run_history_test.go
+++ b/internal/server/run_history_test.go
@@ -415,3 +415,38 @@ func decodeBodyMap(t *testing.T, resp *http.Response) map[string]any {
 	}
 	return out
 }
+
+type pricedSessionView struct {
+	*fakeSessionView
+	result *llm.ResultMessage
+}
+
+func (s *pricedSessionView) Cost() *llm.ResultMessage { return s.result }
+
+func TestReconciledCostCanLowerSessionAndRunEstimates(t *testing.T) {
+	t.Parallel()
+	for _, amount := range []float64{0, 0.25} {
+		store, f := seedHistoryFeature(t)
+		if err := store.Modify(f.ID, func(current *feature.Feature) error {
+			current.PhaseCosts = map[string]float64{}
+			current.ActiveTimingKey = "research"
+			return nil
+		}); err != nil {
+			t.Fatal(err)
+		}
+		sess := &pricedSessionView{fakeSessionView: &fakeSessionView{
+			id: "reconciled", featureID: f.ID, runNumber: 1, phase: feature.PhaseResearch, kind: ports.KindPhase, status: ports.SessionRunning,
+			usage: &llm.Usage{CostUSD: amount, CostSource: "provider_estimate"},
+		}, result: &llm.ResultMessage{TotalCostUSD: 2}}
+		if got := sessionSummaryDTO(sess).Usage.CostUSD; got != amount {
+			t.Fatalf("session retained old estimate: %v", got)
+		}
+		opts := baseReadHandlerOptions(store)
+		opts.Sessions = fakeSessionManager{views: []ports.SessionView{sess}}
+		body := getJSONMap(t, NewHandler(opts), "/api/v1/features/"+f.ID+"/runs/1")
+		cost := body["run"].(map[string]any)["cost"].(map[string]any)
+		if got := cost["total_usd"].(float64); got != amount {
+			t.Fatalf("run retained old estimate: %v", got)
+		}
+	}
+}

--- a/internal/server/session_model.go
+++ b/internal/server/session_model.go
@@ -295,7 +295,7 @@ func sessionSummaryDTO(sess ports.SessionView) SessionSummary {
 		usage = *latest
 	}
 	cost := accumulatedUsage.CostUSD
-	if result := sess.Cost(); result != nil {
+	if result := sess.Cost(); result != nil && accumulatedUsage.CostSource == "" {
 		cost = result.TotalCostUSD
 	}
 	taskActivities, runningTaskCount := sessionTaskActivities(sess)

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -430,6 +430,15 @@ func (s *Session) AdditionalSessionCost(ctx context.Context) (llm.SessionCostAdj
 	return augmenter.AdditionalSessionCost(ctx)
 }
 
+// ReconciledUsage waits only for a provider's outstanding usage lookup; it does
+// not create another turn or terminal result.
+func (s *Session) ReconciledUsage(ctx context.Context) *llm.Usage {
+	if reconciler, ok := s.protocol.(llm.SessionUsageReconciler); ok {
+		return reconciler.ReconciledUsage(ctx)
+	}
+	return nil
+}
+
 // LastControlRequest returns the most recently arrived pending
 // control_request, or nil if none are outstanding. Preserves the historical
 // "single-slot" semantics: callers that just want "is there one to deal
@@ -1108,6 +1117,14 @@ func (s *Session) readMessages(onMessage func(llm.SDKMessage)) {
 				s.accumulatedUsage.InputTokens = msg.UsageUpdate.InputTokens
 				s.accumulatedUsage.OutputTokens = msg.UsageUpdate.OutputTokens
 				s.accumulatedUsage.CostUSD = msg.UsageUpdate.CostUSD
+				if msg.UsageUpdate.CostSource != "" {
+					s.accumulatedUsage.CostSource = msg.UsageUpdate.CostSource
+					s.accumulatedUsage.CostCreditsMicros = msg.UsageUpdate.CostCreditsMicros
+					// Cost() is an immutable terminal record: outcome
+					// consumers also use its identity to detect new results.
+					// Reconciliation updates cumulative usage only.
+
+				}
 				if msg.UsageUpdate.CacheReadInputTokens > 0 {
 					s.accumulatedUsage.CacheReadInputTokens = msg.UsageUpdate.CacheReadInputTokens
 				}

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -3397,3 +3397,28 @@ func TestCostAndResultSeq_AreRaceFree(t *testing.T) {
 		t.Fatalf("ResultSeq() = %d, want %d", got, results)
 	}
 }
+
+func TestLateCostReconciliationPreservesTerminalOutcome(t *testing.T) {
+	t.Parallel()
+	credits := int64(123)
+	terminal := &llm.ResultMessage{Type: "result", Subtype: "success", Result: "finished", TotalCostUSD: 2}
+	s := NewSession("late-billing", "feat-1", feature.PhaseImplement)
+	s.providerName = "codex"
+	runMockSession(t, s, []llm.SDKMessage{
+		{Type: "result", Result: terminal},
+		{Type: "usage_update", UsageUpdate: &llm.Usage{InputTokens: 100, CacheCreationInputTokens: 25, CostUSD: 0, CostSource: "provider_estimate", CostCreditsMicros: &credits}},
+	}, nil)
+	if s.ResultSeq() != 1 {
+		t.Fatalf("billing advanced result sequence: %d", s.ResultSeq())
+	}
+	if got := s.Cost(); got != terminal || got.TotalCostUSD != 2 || got.Result != "finished" || got.Subtype != "success" {
+		t.Fatalf("reconciled terminal: %+v", got)
+	}
+	if terminal.TotalCostUSD != 2 {
+		t.Fatal("mutated an already-published result")
+	}
+	usage := s.AccumulatedUsage()
+	if usage.CostUSD != 0 || usage.CacheCreationInputTokens != 25 || usage.CostCreditsMicros == nil || *usage.CostCreditsMicros != 123 {
+		t.Fatalf("lost usage: %+v", usage)
+	}
+}


### PR DESCRIPTION
Codex costs previously relied on local token estimates that omitted cache writes and could price unrecognized models as GPT-5.4. Reconcile thread costs with the optional app-server usage estimate, retain a bounded fallback when unavailable, and support GPT-6 Astra throughout model selection, pricing, and effort configuration.

- Account for cache writes, resume baselines, duplicate snapshots, model rerouting, and service tiers. Persist cost provenance and credits separately from USD.
- Apply late billing corrections, including zero and lower estimates, without changing the terminal result identity or triggering another completion. Ignore stale replies and preserve compatibility with servers that lack the optional usage method.
- Add Astra discovery and offline 272K/872K choices, refresh GPT-5.6-family rates, and expose `ultra` only for models that advertise it. Unknown model prices remain unavailable.
- Document the protocol behavior and estimate limitations in `docs/codex-pricing.md`. Validate against the installed Codex CLI v0.153.2 schema/catalog and synthetic protocol coverage; no paid Codex task was run.

## Verification

- **Go static-analysis gate** and **Go build gate**: passed (`go vet ./...`, `go build ./...`).
- **Desktop static checks**: passed (`npm run check`).
- **Desktop unit/component/security tests**: passed (2,421 unit/component tests and 111 explicit security tests).
- **Desktop packaged E2E**: package verification and the affected `configuration-workspace-restart.spec.ts` journey passed. The full journey suite was not run; coverage was scoped to the affected configuration flow.
- **Isolated integration** and **E2E Go (process-launch / API-driven)**: their packages passed within the all-package race run, rather than separate tier invocations.
- Focused accounting race tests passed. Codex, session, server, feature, and observability packages also passed the all-package race run.
- **Fast suite**: ran and failed in `TestWaitForPhaseOutcome_DefersCommitUntilDelegatedTasksFinish` (root did not resume within the timeout) and `TestProbeTimeoutKillsProcessGroup` (missing child PID file). These tests and their implementation paths are unchanged; the Git timeout was also observed during the initial read-only review.
- **Race regression**: ran and failed in the same background-task/Git tests, with additional races involving test-mutated background-task timeout globals and leaked waiter activity. The overall suite is not green.

Generated with [Codex](https://openai.com/codex/).

Co-authored-by: Codex <noreply@openai.com>
