### PR TITLE
Report OTEL export status and collector reachability at startup

### DIFF
--- a/internal/observe/otel.go
+++ b/internal/observe/otel.go
@@ -18,7 +18,10 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"fmt"
 	"log"
+	"net"
+	"os"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -126,6 +129,87 @@ func (h *otelErrorHandler) Handle(err error) {
 	}
 }
 
+// otelStartupLogf receives the one-time startup report (enabled/disabled,
+// effective endpoint, exporter construction failures, reachability probe).
+// Without it a misconfigured or unroutable collector is invisible until the
+// first batch export fails, and even then only one suppressed summary line
+// ever appears. Package-level so tests can capture it.
+var otelStartupLogf = log.Printf
+
+// otelStartupProbe runs the asynchronous reachability check against the
+// effective endpoint. Tests replace it to keep the constructor synchronous.
+var otelStartupProbe = func(endpoint string) {
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), collectorProbeTimeout)
+		defer cancel()
+		if reason := defaultCollectorProber.probe(ctx, endpoint); reason != "" {
+			otelStartupLogf("otel: collector unreachable at startup: %s — traces will be dropped until it becomes reachable", reason)
+			return
+		}
+		otelStartupLogf("otel: collector reachable: %s", endpoint)
+	}()
+}
+
+const collectorProbeTimeout = 5 * time.Second
+
+// collectorProber checks whether the OTLP endpoint can be reached at all,
+// separating "the name does not resolve" from "the port is closed" so the
+// operator knows whether to fix DNS/routing or start the collector.
+type collectorProber struct {
+	lookupHost func(ctx context.Context, host string) ([]string, error)
+	dial       func(ctx context.Context, network, addr string) (net.Conn, error)
+}
+
+var defaultCollectorProber = collectorProber{
+	lookupHost: net.DefaultResolver.LookupHost,
+	dial:       (&net.Dialer{}).DialContext,
+}
+
+// probe returns "" when a TCP connection to endpoint succeeds, otherwise a
+// human-readable reason.
+func (p collectorProber) probe(ctx context.Context, endpoint string) string {
+	host, _, err := net.SplitHostPort(endpoint)
+	if err != nil {
+		return fmt.Sprintf("invalid endpoint %q: %v", endpoint, err)
+	}
+	if net.ParseIP(host) == nil {
+		if _, err := p.lookupHost(ctx, host); err != nil {
+			return fmt.Sprintf("%s does not resolve: %v", host, err)
+		}
+	}
+	conn, err := p.dial(ctx, "tcp", endpoint)
+	if err != nil {
+		return fmt.Sprintf("%s is not accepting connections: %v", endpoint, err)
+	}
+	_ = conn.Close()
+	return ""
+}
+
+// effectiveOTLPEndpoint mirrors the otlptracegrpc resolution order so the
+// startup report names the host:port the exporter will actually dial: the
+// configured value, then OTEL_EXPORTER_OTLP_TRACES_ENDPOINT, then
+// OTEL_EXPORTER_OTLP_ENDPOINT, then the SDK default. Any scheme or path on
+// the env form is stripped.
+func effectiveOTLPEndpoint(configured string) string {
+	ep := configured
+	if ep == "" {
+		ep = os.Getenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT")
+	}
+	if ep == "" {
+		ep = os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT")
+	}
+	if ep == "" {
+		return "localhost:4317"
+	}
+	if i := strings.Index(ep, "://"); i >= 0 {
+		ep = ep[i+3:]
+	}
+	if i := strings.IndexByte(ep, '/'); i >= 0 {
+		ep = ep[:i]
+	}
+	return ep
+}
+
 // otelBridge manages OTel span lifecycle. It maps roadmap SpanID values to
 // real OTel spans using an in-memory store, without requiring context.Context
 // propagation through the application.
@@ -184,6 +268,7 @@ func (roadmapIDGen) NewSpanID(ctx context.Context, _ trace.TraceID) trace.SpanID
 // gracefully to a bare provider.
 func newOtelBridge(enabled bool, endpoint string, insecure bool, serviceName string, grpcOpts ...otlptracegrpc.Option) *otelBridge {
 	if !enabled {
+		otelStartupLogf("otel: trace export disabled (observability.otel_enabled is off)")
 		return &otelBridge{
 			enabled: false,
 			spans:   make(map[string]activeSpan),
@@ -193,6 +278,8 @@ func newOtelBridge(enabled bool, endpoint string, insecure bool, serviceName str
 	if serviceName == "" {
 		serviceName = "agentico"
 	}
+	effective := effectiveOTLPEndpoint(endpoint)
+	otelStartupLogf("otel: trace export enabled: endpoint=%s insecure=%t service=%s", effective, insecure, serviceName)
 
 	if endpoint != "" {
 		grpcOpts = append([]otlptracegrpc.Option{otlptracegrpc.WithEndpoint(endpoint)}, grpcOpts...)
@@ -204,7 +291,9 @@ func newOtelBridge(enabled bool, endpoint string, insecure bool, serviceName str
 	ctx := context.Background()
 	exporter, err := otlptracegrpc.New(ctx, grpcOpts...)
 	if err != nil {
-		// Graceful degradation: create bridge with bare provider.
+		// Graceful degradation: create bridge with bare provider — but say
+		// so, since nothing downstream will ever report the missing export.
+		otelStartupLogf("otel: create OTLP exporter: %v — traces will not be exported", err)
 		tp := sdktrace.NewTracerProvider(sdktrace.WithIDGenerator(roadmapIDGen{}))
 		return &otelBridge{
 			enabled: true,
@@ -236,6 +325,9 @@ func newOtelBridge(enabled bool, endpoint string, insecure bool, serviceName str
 		sdktrace.WithResource(res),
 		sdktrace.WithIDGenerator(roadmapIDGen{}),
 	)
+	// The exporter dials lazily, so a wrong hostname or blocked route would
+	// otherwise surface only as the first (suppressed) batch failure.
+	otelStartupProbe(effective)
 	return &otelBridge{
 		enabled: true,
 		tracer:  tp.Tracer(serviceName),

--- a/internal/observe/otel_startup_test.go
+++ b/internal/observe/otel_startup_test.go
@@ -1,0 +1,217 @@
+// Copyright 2026 DoorDash, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package observe
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	collectortracepb "go.opentelemetry.io/proto/otlp/collector/trace/v1"
+	"google.golang.org/grpc"
+)
+
+// captureStartup swaps the startup log sink and probe for the test's
+// lifetime. The probe is disabled so the constructor stays synchronous and
+// the captured lines are deterministic.
+func captureStartup(t *testing.T) *[]string {
+	t.Helper()
+	var lines []string
+	prevLog, prevProbe := otelStartupLogf, otelStartupProbe
+	otelStartupLogf = func(format string, args ...any) {
+		lines = append(lines, fmt.Sprintf(format, args...))
+	}
+	otelStartupProbe = func(string) {}
+	t.Cleanup(func() {
+		otelStartupLogf, otelStartupProbe = prevLog, prevProbe
+	})
+	return &lines
+}
+
+func requireLine(t *testing.T, lines []string, want string) {
+	t.Helper()
+	for _, l := range lines {
+		if strings.Contains(l, want) {
+			return
+		}
+	}
+	t.Fatalf("no startup line contains %q; got %q", want, lines)
+}
+
+func TestEffectiveOTLPEndpoint(t *testing.T) {
+	cases := []struct {
+		name       string
+		configured string
+		traces     string
+		generic    string
+		want       string
+	}{
+		{name: "configured wins", configured: "collector.internal:4317", traces: "x:1", generic: "y:2", want: "collector.internal:4317"},
+		{name: "traces env before generic", traces: "http://traces.internal:4318/v1/traces", generic: "y:2", want: "traces.internal:4318"},
+		{name: "generic env strips scheme", generic: "https://generic.internal:4317", want: "generic.internal:4317"},
+		{name: "sdk default", want: "localhost:4317"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", tc.traces)
+			t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", tc.generic)
+			if got := effectiveOTLPEndpoint(tc.configured); got != tc.want {
+				t.Fatalf("effectiveOTLPEndpoint(%q) = %q, want %q", tc.configured, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCollectorProber(t *testing.T) {
+	t.Parallel()
+	resolveOK := func(context.Context, string) ([]string, error) { return []string{"127.0.0.1"}, nil }
+	realDial := (&net.Dialer{}).DialContext
+
+	t.Run("reachable endpoint returns no reason", func(t *testing.T) {
+		t.Parallel()
+		lis, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatalf("listen: %v", err)
+		}
+		defer lis.Close()
+		go func() {
+			for {
+				c, err := lis.Accept()
+				if err != nil {
+					return
+				}
+				_ = c.Close()
+			}
+		}()
+		p := collectorProber{lookupHost: resolveOK, dial: realDial}
+		if reason := p.probe(context.Background(), lis.Addr().String()); reason != "" {
+			t.Fatalf("expected reachable, got %q", reason)
+		}
+	})
+
+	t.Run("closed port names the endpoint", func(t *testing.T) {
+		t.Parallel()
+		lis, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatalf("listen: %v", err)
+		}
+		addr := lis.Addr().String()
+		_ = lis.Close()
+		p := collectorProber{lookupHost: resolveOK, dial: realDial}
+		reason := p.probe(context.Background(), addr)
+		if !strings.Contains(reason, addr) || !strings.Contains(reason, "not accepting connections") {
+			t.Fatalf("unexpected reason %q", reason)
+		}
+	})
+
+	t.Run("unresolvable host is reported as DNS, not as a closed port", func(t *testing.T) {
+		t.Parallel()
+		p := collectorProber{
+			lookupHost: func(context.Context, string) ([]string, error) {
+				return nil, errors.New("no such host")
+			},
+			dial: func(context.Context, string, string) (net.Conn, error) {
+				t.Fatal("dial must not run when the name does not resolve")
+				return nil, nil
+			},
+		}
+		reason := p.probe(context.Background(), "otel-collector.invalid:4317")
+		if !strings.Contains(reason, "otel-collector.invalid does not resolve") {
+			t.Fatalf("unexpected reason %q", reason)
+		}
+	})
+
+	t.Run("literal IP skips resolution", func(t *testing.T) {
+		t.Parallel()
+		p := collectorProber{
+			lookupHost: func(context.Context, string) ([]string, error) {
+				t.Fatal("lookup must not run for an IP literal")
+				return nil, nil
+			},
+			dial: func(context.Context, string, string) (net.Conn, error) {
+				return nil, errors.New("connection refused")
+			},
+		}
+		if reason := p.probe(context.Background(), "127.0.0.1:1"); !strings.Contains(reason, "connection refused") {
+			t.Fatalf("unexpected reason %q", reason)
+		}
+	})
+
+	t.Run("malformed endpoint", func(t *testing.T) {
+		t.Parallel()
+		p := collectorProber{lookupHost: resolveOK, dial: realDial}
+		if reason := p.probe(context.Background(), "no-port"); !strings.Contains(reason, "invalid endpoint") {
+			t.Fatalf("unexpected reason %q", reason)
+		}
+	})
+}
+
+func TestNewOtelBridgeStartupReport(t *testing.T) {
+	t.Run("disabled says so", func(t *testing.T) {
+		lines := captureStartup(t)
+		_ = newOtelBridge(false, "", false, "agentico")
+		requireLine(t, *lines, "trace export disabled")
+	})
+
+	t.Run("enabled reports the effective endpoint and service", func(t *testing.T) {
+		lines := captureStartup(t)
+		collector := &mockTraceCollector{}
+		lis, err := net.Listen("tcp", "localhost:0")
+		if err != nil {
+			t.Fatalf("listen: %v", err)
+		}
+		srv := grpc.NewServer()
+		collectortracepb.RegisterTraceServiceServer(srv, collector)
+		go func() { _ = srv.Serve(lis) }()
+		defer srv.Stop()
+
+		b := newOtelBridge(true, lis.Addr().String(), true, "svc-under-test")
+		defer b.Shutdown()
+		requireLine(t, *lines, "trace export enabled: endpoint="+lis.Addr().String()+" insecure=true service=svc-under-test")
+		for _, l := range *lines {
+			if strings.Contains(l, "create OTLP exporter") {
+				t.Fatalf("unexpected exporter failure line: %q", l)
+			}
+		}
+	})
+
+	t.Run("probe outcome is logged asynchronously", func(t *testing.T) {
+		got := make(chan string, 4)
+		prevLog := otelStartupLogf
+		otelStartupLogf = func(format string, args ...any) { got <- fmt.Sprintf(format, args...) }
+		t.Cleanup(func() { otelStartupLogf = prevLog })
+
+		lis, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatalf("listen: %v", err)
+		}
+		addr := lis.Addr().String()
+		_ = lis.Close()
+
+		otelStartupProbe(addr)
+		select {
+		case line := <-got:
+			if !strings.Contains(line, "collector unreachable at startup") || !strings.Contains(line, addr) {
+				t.Fatalf("unexpected probe line %q", line)
+			}
+		case <-time.After(collectorProbeTimeout + time.Second):
+			t.Fatal("probe never reported")
+		}
+	})
+}


### PR DESCRIPTION
## What

The server now reports OTEL export status at startup instead of staying silent until the first (suppressed) batch failure:

- `otel: trace export enabled: endpoint=<host:port> insecure=<bool> service=<name>` or `otel: trace export disabled (…)`.
- Exporter construction failures are logged instead of being swallowed into the bare-provider fallback.
- A bounded (5s), asynchronous reachability probe of the effective endpoint logs one line distinguishing **DNS failure** (`<host> does not resolve`) from **closed port** (`<endpoint> is not accepting connections`), or `collector reachable`.

`effectiveOTLPEndpoint` mirrors the otlptracegrpc resolution order (configured → `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` → `OTEL_EXPORTER_OTLP_ENDPOINT` → `localhost:4317`) so the log names the endpoint actually dialed.

## Why

The OTLP exporter dials lazily and the error handler intentionally suppresses collector-unreachable errors after one summary line. A wrong hostname or a Flux VM without internal DNS therefore produced no diagnostic at all; the only signal was the absence of traces in dashboards. Found while setting up remote Agentico on a Flux VM where `otel-collector-v2.svc.ddnw.net` did not resolve.

## Verification

- `go vet ./... && go build ./...` ✅
- Fast suite `make test-fast`: `internal/observe` ✅ (new `otel_startup_test.go`: endpoint resolution table, prober DNS/closed-port/IP-literal/malformed cases with injected resolver and dialer, startup report lines, async probe). Two unrelated failures observed in the full run: `internal/git TestProbeTimeoutKillsProcessGroup` fails identically on a clean `main` in this environment, and `internal/agent TestWaitForPhaseOutcome_LaterResultDoesNotReadjudicateOutcome` passed on 5 isolated reruns with this change (load-induced flake).
- Skipped Race regression / E2E tiers: single-package logging change with no concurrency-sensitive shared state beyond the two test-injectable package vars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
