### PR TITLE
fix(session): capture auto-picked AskUserQuestion answer when provider stdin is dead

### DIFF
--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -1547,7 +1547,17 @@ func (s *Session) tryAutoPickAskUser(req *llm.ControlRequestMessage) bool {
 		confidenceByQuestion[selection.Question] = selection.Confidence
 	}
 	if err := s.respondToAskUserAutoPicked(req.RequestID, req.Request.Input, decision.Answers, confidenceByQuestion); err != nil {
-		return false
+		// The answer could not be delivered — the provider's stdin is
+		// closed (broken pipe), so the session that asked the question is
+		// gone and nothing will ever consume a pending gate for it. The
+		// auto-pick decision was already made, so record it locally to
+		// keep the QA log faithful, and treat the request as handled:
+		// falling through would register a pending root question that
+		// outlives its session and flips the run to a phantom
+		// "user input requested after exit" failure.
+		s.captureAskUserResponse(req.RequestID, req.Request.Input, decision.Answers, nil, confidenceByQuestion)
+		s.appendAskUserMessages(req.Request.Input, decision.Answers, confidenceByQuestion)
+		return true
 	}
 
 	if s.askUserAutoPick.OnQuestionAutoPicked != nil {


### PR DESCRIPTION
## Root cause

respondToAskUserAutoPicked writes the auto-picked answer to the provider's stdin FIRST and only captures it locally on success. When the root agent exits immediately after asking, the pipe is already dead, writeJSON fails with broken pipe, and the early return skips capture - so takePendingAskUser keeps the question pending and the wait-loop classification (TurnAwaitingUser + sessionDone) fails the run: "root agent requested user input after the provider session exited". The manual-answer path is asymmetric: it captures first and restores on error.

## Fix

On write failure, capture the auto-picked answer locally (captureAskUserResponse + appendAskUserMessages) and treat the request as handled. The harness itself is the answerer; a provider whose pipe is dead is exiting anyway, so no pending gate should outlive it. QA log stays faithful to what the run actually decided.

## Verification

- TestRoadmapPlanningLoopWritesFirstAttemptQALog: 0/65 failures post-patch vs ~15% baseline flake.
- Full internal/session + internal/agent suites green (only pre-existing env artifact remains: TestExecuteTestingContractClassifiesCommandNotFoundAsContractError - unrelated sandbox dash behavior).

Fixes #161

> Built by breken, your AI support engineer - breken.ai - this one's on us.
