### PR TITLE
test(session): register attach consumer in stream backpressure stress test

### DIFF
--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -2888,6 +2888,16 @@ func TestSession_StreamBackpressurePreservesCritical(t *testing.T) {
 	s.protocol = claude.NewProtocol(llm.ProtocolOpts{WorkDir: dir})
 	s.SetAttachDropReporter(reporter)
 
+	// The drainer below is a real consumer: register it. Without
+	// registration the session treats attachCh as headless and drops
+	// Results non-blockingly the moment the buffer is full (see
+	// TestSession_NoAttachConsumerSuppressesCriticalDropReport), so the
+	// flood can overrun the stream-ring reserve between drainer wake-ups
+	// and silently lose Results — a test artifact, not a product path
+	// this test means to exercise.
+	unregister := registerAttachConsumerForTest(t, s)
+	defer unregister()
+
 	// Slow consumer — targets ~1/10 the producer's line-read rate.
 	// The exact ratio is not load-bearing: we only need enough
 	// backpressure to keep attachCh near its cap throughout the run.


### PR DESCRIPTION
## Root cause

TestSession_StreamBackpressurePreservesCritical drains AttachCh but never calls RegisterAttachConsumer, so readMessages routes Results through the headless path: non-blocking send, instant silent drop when the buffer is full (session.go:1338). The 25-slot attachStreamReserve is probabilistic, not a guarantee: with the consumer at 1/10 producer speed, the drainer wakes on a 10ms poll while readMessages can parse thousands of buffered pipe lines per wake, clumping 25+ direct Result sends into a full channel - hence the ~80% flake.

The test's expectation contradicts the pinned product contract: TestSession_NoAttachConsumerSuppressesCriticalDropReport requires headless drops to be immediate AND unreported. So the test is wrong, not the contract.

## Fix

Register the consumer (registerAttachConsumerForTest). Registered consumers get the 5s bounded-blocking path and the flood delivers 100/100.

Design note: any embedder who drains AttachCh without RegisterAttachConsumer silently loses Results under load - worth a doc note on AttachCh(), or a log line on headless drops (which would not violate the pinned no-wait/no-report contract).

## Verification

- 0/20 failures post-fix vs 10/12 baseline.
- Full internal/session suite green; suppress-contract test untouched and passing.

Fixes #162

> Built by breken, your AI support engineer - breken.ai - this one's on us.
