### PR TITLE
Make the desktop sidebar resizable

### DIFF
--- a/desktop/src/renderer/src/features/SidebarResizeHandle.tsx
+++ b/desktop/src/renderer/src/features/SidebarResizeHandle.tsx
@@ -1,0 +1,103 @@
+/*
+Copyright 2026 DoorDash, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { useEffect, useRef, useState } from 'react';
+
+/** Pointer capture keeps resizing active outside the narrow divider. */
+export function SidebarResizeHandle({
+  width,
+  onPreview,
+  onCommit,
+}: {
+  width: number;
+  onPreview(width: number | null): void;
+  onCommit(width: number): void;
+}) {
+  const [maximum, setMaximum] = useState(() => Math.min(520, Math.floor(window.innerWidth / 2)));
+  const [resizing, setResizing] = useState(false);
+  const gesture = useRef<{ pointerId: number; x: number; width: number; next: number } | null>(
+    null,
+  );
+  useEffect(() => {
+    const resize = () => setMaximum(Math.min(520, Math.floor(window.innerWidth / 2)));
+    window.addEventListener('resize', resize);
+    return () => window.removeEventListener('resize', resize);
+  }, []);
+  const clamp = (value: number) => Math.max(200, Math.min(maximum, Math.round(value)));
+  return (
+    <div
+      className="sidebar__resize-handle"
+      role="separator"
+      aria-label="Resize sidebar"
+      aria-controls="feature-sidebar"
+      aria-orientation="vertical"
+      aria-valuemin={200}
+      aria-valuemax={maximum}
+      aria-valuenow={clamp(gesture.current?.next ?? width)}
+      tabIndex={0}
+      data-resizing={resizing}
+      onPointerDown={(event) => {
+        if (event.button !== 0) return;
+        event.preventDefault();
+        event.currentTarget.focus();
+        event.currentTarget.setPointerCapture(event.pointerId);
+        gesture.current = {
+          pointerId: event.pointerId,
+          x: event.clientX,
+          width: clamp(width),
+          next: clamp(width),
+        };
+        setResizing(true);
+      }}
+      onPointerMove={(event) => {
+        const active = gesture.current;
+        if (!active || active.pointerId !== event.pointerId) return;
+        active.next = clamp(active.width + event.clientX - active.x);
+        onPreview(active.next);
+      }}
+      onPointerUp={(event) => {
+        const active = gesture.current;
+        if (!active || active.pointerId !== event.pointerId) return;
+        gesture.current = null;
+        setResizing(false);
+        onCommit(active.next);
+        event.currentTarget.releasePointerCapture(event.pointerId);
+      }}
+      onLostPointerCapture={() => {
+        gesture.current = null;
+        setResizing(false);
+        onPreview(null);
+      }}
+      onDoubleClick={() => onCommit(260)}
+      onKeyDown={(event) => {
+        const current = clamp(width);
+        const next =
+          event.key === 'ArrowLeft'
+            ? current - 10
+            : event.key === 'ArrowRight'
+              ? current + 10
+              : event.key === 'Home'
+                ? 200
+                : event.key === 'End'
+                  ? maximum
+                  : null;
+        if (next === null) return;
+        event.preventDefault();
+        onCommit(clamp(next));
+      }}
+    />
+  );
+}

--- a/desktop/src/renderer/src/features/WorkspaceShell.tsx
+++ b/desktop/src/renderer/src/features/WorkspaceShell.tsx
@@ -34,6 +34,7 @@ import {
   useMemo,
   useRef,
   useState,
+  type CSSProperties,
   type Dispatch,
   type SetStateAction,
 } from 'react';
@@ -62,6 +63,7 @@ import { runFeatureCommand, toggleActiveInspector } from './featureCommands';
 import { parseIpcError } from '../wizard/ipcError';
 import { ErrorSurface } from '../components/ErrorSurface';
 import { isEditingShortcutTarget } from '../components/CommandPalette';
+import { SidebarResizeHandle } from './SidebarResizeHandle';
 import { CreateFeatureForm } from './CreateFeatureForm';
 import { FeatureCockpit } from './FeatureCockpit';
 import { PipRail } from '../components/Pip';
@@ -223,6 +225,7 @@ export function WorkspaceShell({
   amaUnread?: boolean;
 }) {
   // null while the local shell prefs are being restored.
+  const [sidebarPreviewWidth, setSidebarPreviewWidth] = useState<number | null>(null);
   const [shell, setShell] = useState<ShellPrefs | null>(null);
   // A purely visual auto-collapse below ~700px: it never writes
   // `shell.sidebarCollapsed` (only the toolbar button and ⌘⌃S do that), so
@@ -848,10 +851,16 @@ export function WorkspaceShell({
   return (
     <section
       className="workspace"
+      style={
+        {
+          '--sidebar-width': `${sidebarPreviewWidth ?? shell?.sidebarWidth ?? 260}px`,
+        } as CSSProperties
+      }
       aria-label="Workspace"
       data-sidebar-collapsed={effectiveSidebarCollapsed}
     >
       <nav
+        id="feature-sidebar"
         className="sidebar"
         aria-label="Feature sidebar"
         data-collapsed={effectiveSidebarCollapsed}
@@ -926,6 +935,16 @@ export function WorkspaceShell({
             ) : null}
           </button>
         </div>
+        {!effectiveSidebarCollapsed && (
+          <SidebarResizeHandle
+            width={shell?.sidebarWidth ?? 260}
+            onPreview={setSidebarPreviewWidth}
+            onCommit={(sidebarWidth) => {
+              setSidebarPreviewWidth(null);
+              persistPatch({ sidebarWidth });
+            }}
+          />
+        )}
       </nav>
 
       <div className="content-column">

--- a/desktop/src/renderer/src/styles/app.css
+++ b/desktop/src/renderer/src/styles/app.css
@@ -4826,7 +4826,7 @@ body {
   min-height: 0;
   flex: 1;
   display: grid;
-  grid-template-columns: 260px minmax(0, 1fr);
+  grid-template-columns: min(var(--sidebar-width, 260px), 50vw) minmax(0, 1fr);
   background: var(--content);
 }
 
@@ -4840,6 +4840,7 @@ body {
 /* The translucent Bench source list: a pinned Overview row above five
  * disclosable lane sections. Built on the Bench material/hairline token set. */
 .sidebar {
+  position: relative;
   display: flex;
   flex-direction: column;
   min-height: 0;
@@ -13624,4 +13625,28 @@ body {
   margin: 0;
   color: var(--bad);
   font-size: 12px;
+}
+
+.sidebar__resize-handle {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  right: -4px;
+  width: 8px;
+  z-index: 5;
+  cursor: col-resize;
+  touch-action: none;
+  -webkit-app-region: no-drag;
+}
+
+.sidebar__resize-handle:hover,
+.sidebar__resize-handle:focus-visible,
+.sidebar__resize-handle[data-resizing='true'] {
+  background: var(--material-edge);
+  outline: none;
+}
+
+.workspace:has(.sidebar__resize-handle[data-resizing='true']) {
+  user-select: none;
+  cursor: col-resize;
 }

--- a/desktop/src/shared/ipc.test.ts
+++ b/desktop/src/shared/ipc.test.ts
@@ -33,6 +33,8 @@ import {
   FeatureActionResultSchema,
   RepositoryDiffResultSchema,
   RecoveryItemViewSchema,
+  applyShellPatch,
+  ShellPatchSchema,
   SettingsPatchSchema,
   SettingsSchema,
   FeatureActionRequestSchema,
@@ -1584,5 +1586,24 @@ describe('UpdateStateSchema canonical error presence', () => {
     expect(
       UpdateStateSchema.safeParse({ ...base, status: 'failed', error: canonicalError }).success,
     ).toBe(true);
+  });
+});
+
+describe('sidebar width preferences', () => {
+  it('accepts bounded widths and preserves them through unrelated shell updates', () => {
+    const resized = applyShellPatch(
+      defaultShellPrefs(),
+      ShellPatchSchema.parse({ sidebarWidth: 370 }),
+    );
+    expect(applyShellPatch(resized, { sidebarCollapsed: true }).sidebarWidth).toBe(370);
+    expect(SettingsSchema.parse({ ...defaultSettings(), shell: resized }).shell.sidebarWidth).toBe(
+      370,
+    );
+  });
+
+  it('rejects invalid widths at the settings boundary', () => {
+    for (const sidebarWidth of [199, 521, 260.5, NaN, Infinity, '300']) {
+      expect(SettingsPatchSchema.safeParse({ shell: { sidebarWidth } }).success).toBe(false);
+    }
   });
 });

--- a/desktop/src/shared/ipc.ts
+++ b/desktop/src/shared/ipc.ts
@@ -2994,6 +2994,8 @@ export function defaultNotificationPrefs(): NotificationPrefs {
  * ('__settings__') is dropped by the migration chain in settings.ts and must
  * never be stored in this map.
  */
+export const SidebarWidthSchema = z.number().int().min(200).max(520);
+
 export const ShellPrefsSchema = z.strictObject({
   featureByServer: z
     .record(z.string().min(1).max(64), FeatureIdSchema)
@@ -3001,6 +3003,7 @@ export const ShellPrefsSchema = z.strictObject({
       message: `featureByServer must not exceed ${String(MAX_KNOWN_SERVERS)} entries`,
     }),
   sidebarCollapsed: z.boolean(),
+  sidebarWidth: SidebarWidthSchema.optional(),
 });
 
 export type ShellPrefs = z.output<typeof ShellPrefsSchema>;
@@ -3018,6 +3021,7 @@ export function defaultShellPrefs(): ShellPrefs {
 export const ShellPatchSchema = z
   .strictObject({
     sidebarCollapsed: z.boolean().optional(),
+    sidebarWidth: SidebarWidthSchema.optional(),
     setActiveFeature: z
       .strictObject({
         serverKey: z.string().min(1).max(64),
@@ -3025,9 +3029,15 @@ export const ShellPatchSchema = z
       })
       .optional(),
   })
-  .refine((patch) => patch.sidebarCollapsed !== undefined || patch.setActiveFeature !== undefined, {
-    message: 'shell patch must carry sidebarCollapsed and/or setActiveFeature',
-  });
+  .refine(
+    (patch) =>
+      patch.sidebarCollapsed !== undefined ||
+      patch.sidebarWidth !== undefined ||
+      patch.setActiveFeature !== undefined,
+    {
+      message: 'shell patch must carry sidebarCollapsed, sidebarWidth, or setActiveFeature',
+    },
+  );
 
 export type ShellPatch = z.output<typeof ShellPatchSchema>;
 
@@ -3052,6 +3062,9 @@ export function applyShellPatch(current: ShellPrefs, patch: ShellPatch): ShellPr
   return {
     featureByServer,
     sidebarCollapsed: patch.sidebarCollapsed ?? current.sidebarCollapsed,
+    ...((patch.sidebarWidth ?? current.sidebarWidth) !== undefined
+      ? { sidebarWidth: patch.sidebarWidth ?? current.sidebarWidth }
+      : {}),
   };
 }
 

--- a/desktop/test/e2e/journeys/workspace-sidebar.spec.ts
+++ b/desktop/test/e2e/journeys/workspace-sidebar.spec.ts
@@ -58,6 +58,32 @@ test('workspace sidebar: pointer, keyboard, ⌘2-9, and collapse against the pac
     });
     transcript.step('app launched and reached the ready workspace');
 
+    transcript.section('Resize the sidebar with pointer and keyboard');
+    const divider = handle.page.getByRole('separator', { name: 'Resize sidebar' });
+    const sidebar = handle.page.locator('nav.sidebar');
+    const grip = await divider.boundingBox();
+    if (!grip) throw new Error('Sidebar resize handle has no bounds');
+    await handle.page.mouse.move(grip.x + grip.width / 2, grip.y + 100);
+    await handle.page.mouse.down();
+    await handle.page.mouse.move(grip.x + grip.width / 2 + 100, grip.y + 100, { steps: 10 });
+    await handle.page.mouse.up();
+    await expect(sidebar).toHaveCSS('width', '360px');
+    await divider.press('ArrowRight');
+    await expect(sidebar).toHaveCSS('width', '370px');
+    await divider.press('Home');
+    await expect(sidebar).toHaveCSS('width', '200px');
+    await divider.press('End');
+    await expect(sidebar).toHaveCSS('width', '520px');
+    await divider.dblclick();
+    await expect(sidebar).toHaveCSS('width', '260px');
+    await divider.press('ArrowRight');
+    await expect
+      .poll(
+        async () =>
+          (await handle!.page.evaluate(() => window.agentico.getSettings())).shell.sidebarWidth,
+      )
+      .toBe(270);
+
     transcript.section('Create three features — they land together in the At rest lane');
     const names = ['Sidebar Alpha', 'Sidebar Beta', 'Sidebar Gamma'];
     for (const name of names) {
@@ -182,6 +208,7 @@ test('workspace sidebar: pointer, keyboard, ⌘2-9, and collapse against the pac
     });
     const restoredSettings = await handle.page.evaluate(() => window.agentico.getSettings());
     expect(restoredSettings.shell.sidebarCollapsed).toBe(true);
+    expect(restoredSettings.shell.sidebarWidth).toBe(270);
     transcript.step('relaunch against the same state dir restored the explicit collapse');
 
     // Un-collapse before the narrow-viewport check so the breakpoint's own
@@ -199,6 +226,7 @@ test('workspace sidebar: pointer, keyboard, ⌘2-9, and collapse against the pac
 
     await setWindowSize(handle, 1440, 900);
     await expect(handle.page.locator('nav.sidebar')).toHaveAttribute('data-collapsed', 'false');
+    await expect(handle.page.locator('nav.sidebar')).toHaveCSS('width', '270px');
     transcript.step(
       'narrow-viewport auto-collapse was purely visual and re-expanded above the breakpoint',
     );


### PR DESCRIPTION
The desktop feature sidebar was fixed at 260px, truncating longer feature names. Drag its right edge to resize it between 200px and 520px, capped at half the window width. The chosen width survives collapse and app restarts.

The divider supports Left/Right arrows, Home/End, and double-click to restore the default width. Saved settings remain compatible with documents that have no width preference.

Verification:
- Fast suite: `make test-fast`.
- Go static-analysis gate and Go build gate: `go vet ./...` and `go build ./...`.
- Desktop static checks: `npm run check`.
- Desktop unit/component/security tests: 2,470 tests passed; explicit security gate: 111 passed.
- Desktop packaged E2E: `npm run package:verify` and the targeted `workspace-sidebar.spec.ts` journey, covering drag, keyboard limits, reset, collapse, restart persistence, and narrow-window behavior.
- Skipped Race regression and server integration tiers: this change only affects desktop presentation preferences and layout.

Generated with [Codex](https://openai.com/codex/).

Co-authored-by: Codex <noreply@openai.com>
