### PR TITLE
Show progress indicator during repository cloning

### DIFF
--- a/desktop/src/renderer/src/features/CloneRepositorySection.test.tsx
+++ b/desktop/src/renderer/src/features/CloneRepositorySection.test.tsx
@@ -183,6 +183,15 @@ describe('CloneRepositorySection operations list', () => {
       renderSection();
       expect(await screen.findByText(`dest-${state}`)).toBeInTheDocument();
       expect(screen.getByText(label)).toBeInTheDocument();
+      const progress = screen.queryByRole('progressbar', {
+        name: `Clone progress for dest-${state}`,
+      });
+      if (['accepted', 'running', 'finalizing', 'cancelling'].includes(state)) {
+        expect(progress).toBeVisible();
+        expect(progress).not.toHaveAttribute('aria-valuenow');
+      } else {
+        expect(progress).not.toBeInTheDocument();
+      }
       if (action === undefined) {
         expect(
           screen.queryByRole('button', { name: /Cancel clone|Retry cleanup|Retry clone/ }),

--- a/desktop/src/renderer/src/features/cloneViews.tsx
+++ b/desktop/src/renderer/src/features/cloneViews.tsx
@@ -557,6 +557,16 @@ export function CloneOperationView({
           {STATE_LABELS[operation.state]}
         </span>
       </div>
+      {ACTIVE_STATES.includes(operation.state) ? (
+        <div
+          className="settings-panel__clone-progress-bar"
+          role="progressbar"
+          aria-label={`Clone progress for ${operation.destination}`}
+          aria-valuetext={operation.progress || STATE_LABELS[operation.state]}
+        >
+          <span />
+        </div>
+      ) : null}
       {operation.stage !== undefined && ACTIVE_STATES.includes(operation.state) ? (
         <p className="settings-panel__clone-operation-progress" role="status">
           {operation.progress !== undefined && operation.progress !== ''

--- a/desktop/src/renderer/src/styles/app.css
+++ b/desktop/src/renderer/src/styles/app.css
@@ -13780,6 +13780,38 @@ body {
   color: var(--bad);
 }
 
+.settings-panel__clone-progress-bar {
+  height: 4px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--accent) 15%, var(--content));
+}
+
+.settings-panel__clone-progress-bar > span {
+  display: block;
+  width: 35%;
+  height: 100%;
+  border-radius: inherit;
+  background: var(--accent);
+  animation: clone-progress 1.5s ease-in-out infinite alternate;
+}
+
+@keyframes clone-progress {
+  from {
+    transform: translateX(0);
+  }
+  to {
+    transform: translateX(185%);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .settings-panel__clone-progress-bar > span {
+    animation: none;
+    margin-inline: auto;
+  }
+}
+
 .settings-panel__clone-operation-progress,
 .settings-panel__clone-operation-issue {
   margin: 0;

--- a/desktop/test/e2e/journeys/picker-clone.spec.ts
+++ b/desktop/test/e2e/journeys/picker-clone.spec.ts
@@ -71,6 +71,7 @@ async function serveGitRemote(
   tmsDir: string,
   name: string,
   commits: number,
+  transferGate: Promise<void> = Promise.resolve(),
 ): Promise<{ url: string; close: () => void }> {
   const src = path.join(tmsDir, `${name}-src`);
   fs.mkdirSync(src, { recursive: true });
@@ -101,7 +102,7 @@ async function serveGitRemote(
       return;
     }
     res.writeHead(200, { 'Content-Type': 'application/octet-stream' });
-    res.end(fs.readFileSync(target));
+    void transferGate.then(() => res.end(fs.readFileSync(target)));
   });
   const listening = new Promise<void>((resolve) => server.once('listening', () => resolve()));
   server.listen(0, '127.0.0.1');
@@ -142,7 +143,11 @@ test('picker clone: real remote, identity-safe adoption, unborn result', async (
     auth: { loggedIn: true, authMethod: 'oauth', email: 'e2e@example.invalid' },
     presetWorkspaceRoot: true,
   });
-  const populated = await serveGitRemote(world.root, 'populated', 2);
+  let releaseTransfer = () => {};
+  const transferGate = new Promise<void>((resolve) => {
+    releaseTransfer = resolve;
+  });
+  const populated = await serveGitRemote(world.root, 'populated', 2, transferGate);
   const empty = await serveGitRemote(world.root, 'empty', 0);
   let handle: AppHandle | null = null;
 
@@ -175,12 +180,19 @@ test('picker clone: real remote, identity-safe adoption, unborn result', async (
     await expect(sheet).toBeVisible();
     transcript.step('Escape closed the clone view without discarding the draft');
 
-    // Clone a usable repository from the controlled remote. A local clone
-    // can complete before the operation view ever renders, so the
-    // authoritative outcome is the adoption itself: the view closes and the
-    // published repository is selected in the initiating draft.
+    // Hold the remote response until the active progress presentation is verified.
     await sheet.getByRole('button', { name: /clone a repository/i }).click();
     await cloneFromPicker(page, populated.url, 'widget', world.workspaceRoot);
+    const progress = cloneDialogReduced.getByRole('progressbar', {
+      name: 'Clone progress for widget',
+    });
+    await expect(progress).toBeVisible();
+    await expect(progress).not.toHaveAttribute('aria-valuenow');
+    await expect(progress.locator('span')).toHaveCSS('animation-name', 'clone-progress');
+    await page.emulateMedia({ reducedMotion: 'reduce' });
+    await expect(progress.locator('span')).toHaveCSS('animation-name', 'none');
+    await page.emulateMedia({ reducedMotion: 'no-preference' });
+    releaseTransfer();
     try {
       await expect(cloneDialogReduced).not.toBeVisible({ timeout: 120_000 });
     } catch (cloneFailure) {
@@ -201,6 +213,7 @@ test('picker clone: real remote, identity-safe adoption, unborn result', async (
       throw cloneFailure;
     }
     transcript.step('usable clone completed and the nested view closed through adoption');
+    await expect(progress).toHaveCount(0);
     const widgetRow = sheet.locator('.creation-sheet__row', { hasText: 'widget' });
     await expect(widgetRow).toBeVisible();
     const widgetCheckbox = widgetRow.getByRole('checkbox');
@@ -362,6 +375,7 @@ test('picker clone: real remote, identity-safe adoption, unborn result', async (
     await closeApp(handle);
     handle = null;
   } finally {
+    releaseTransfer();
     if (handle !== null) {
       await closeApp(handle).catch(() => undefined);
     }


### PR DESCRIPTION
Active repository clones currently show only status text, making it difficult to tell that work is ongoing. Add an animated, indeterminate progress bar to the shared clone operation view in the picker and Settings. Preserve Git's live status text, hide the bar for terminal states, and disable animation under reduced-motion preferences. The accessible progress bar deliberately omits a percentage because the server does not report overall completion.

Cover active and terminal states in component tests and hold the packaged journey's local Git remote response until visibility, animation, and reduced-motion behavior are verified.

### Verification

- **Fast suite:** passed (`make test-fast`, 98s). Earlier timing failures in clone/session tests also passed on targeted reruns.
- **Desktop static checks:** passed (`npm run check`).
- **Desktop unit/component/security tests:** 173 files passed initially; two unrelated files hit timeouts and passed on an isolated rerun (21 tests). Explicit security gate passed (123 tests).
- **Desktop packaged E2E:** unpacked package build/verification passed; `picker-clone.spec.ts` and `settings-clone.spec.ts` both passed.
- **Go static-analysis gate / Go build gate:** passed (`go vet ./...`, `go build ./...`).
- Skipped **Race regression**: renderer presentation and test-only changes; no concurrency implementation changes.

Generated with [Codex](https://openai.com/codex/).

Co-authored-by: Codex <noreply@openai.com>
